### PR TITLE
Initialize memory.swappiness cgroup to -1

### DIFF
--- a/spec_linux.go
+++ b/spec_linux.go
@@ -186,12 +186,13 @@ func createCgroupConfig(spec *LinuxSpec, devices []*configs.Device) (*configs.Cg
 		return nil, err
 	}
 	c := &configs.Cgroup{
-		Name:           getDefaultID(),
-		Parent:         myCgroupPath,
-		AllowedDevices: append(devices, allowedDevices...),
-		CpuQuota:       getCPUQuota(spec.Cpus),
-		Memory:         spec.Memory * 1024 * 1024,
-		MemorySwap:     -1,
+		Name:             getDefaultID(),
+		Parent:           myCgroupPath,
+		AllowedDevices:   append(devices, allowedDevices...),
+		CpuQuota:         getCPUQuota(spec.Cpus),
+		Memory:           spec.Memory * 1024 * 1024,
+		MemorySwap:       -1,
+		MemorySwappiness: -1,
 	}
 	if r := spec.Resources; r != nil {
 		c.MemoryReservation = r.MemoryReservation


### PR DESCRIPTION
Fixes: #16
Set up memory.swappiness in cgroup config so write is not attempted
unless specifically set.  Fixes running runc on kernels which still have
the cgroup hierarchy write limitation.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)