### PR TITLE
Make startup errors a bit friendlier

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,6 @@ func main() {
 	// default action is to execute a container
 	app.Action = func(context *cli.Context) {
 		if os.Geteuid() != 0 {
-			cli.ShowAppHelp(context)
 			logrus.Fatal("runc should be run as root")
 		}
 		spec, err := loadSpec(context.Args().First())
@@ -88,7 +87,7 @@ func main() {
 		}
 		status, err := execContainer(context, spec)
 		if err != nil {
-			fatal(err)
+			logrus.Fatalf("Container start failed: %v", err)
 		}
 		// exit with the container's exit status so any external supervisor is
 		// notified of the exit with the correct exit status.

--- a/run.go
+++ b/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -14,6 +15,12 @@ func execContainer(context *cli.Context, spec *LinuxSpec) (int, error) {
 	}
 	config, err := createLibcontainerConfig(spec)
 	if err != nil {
+		return -1, err
+	}
+	if _, err := os.Stat(config.Rootfs); err != nil {
+		if os.IsNotExist(err) {
+			return -1, fmt.Errorf("Rootfs (%q) does not exist", config.Rootfs)
+		}
 		return -1, err
 	}
 	rootuid, err := config.HostUID()


### PR DESCRIPTION
A couple minor changes to error handling in startup:
1. Don't dump full help/usage text when the only problem is `runc` wasn't started under
root privileges
2. Check for rootfs and make error clear to user when it doesn't exist
3. Change fatal to logrus.Fatal to get nicer output with simple error
message

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)