### PR TITLE
Allow hyphen in "id" (based on `cwd` pathname)

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	idRegex  = regexp.MustCompile(`^[\w_]+$`)
+	idRegex  = regexp.MustCompile(`^[\w_-]+$`)
 	maxIdLen = 1024
 )
 


### PR DESCRIPTION
A directory with a hyphen currently generates an `InvalidId` error because
of the regex in libcontainer.  I don't believe there is any reason a
hyphen should be disallowed.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)