### PR TITLE
Added all dependency to install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 	go get github.com/tools/godep
 	godep go build -o runc .
 
-install:
+install: all
 	cp runc /usr/local/bin/runc
 	rm runc
 


### PR DESCRIPTION
This allows for just needing to run `make install` and it will install even if you hadn't build the project.