### PR TITLE
Update usage content and fix typos

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,13 +13,16 @@ import (
 
 const (
 	version = "0.1"
-	usage   = `open container runtime
+	usage   = `Open Container Project runtime
+
+runc is a command line client for running applications packaged according to the Open Container Format (OCF) and is
+a compliant implementation of the Open Container Project specification.
 
 runc integrates well with existing process supervisors to provide a production container runtime environment for
-applications.  It can be used with your existing process monitoring tools and the container will be spawned as direct 
-child of the process supervisor.  nsinit can be used to manage the lifetime of a single container.
+applications. It can be used with your existing process monitoring tools and the container will be spawned as a direct
+child of the process supervisor.
 
-Execute a simple container in your shell by running: 
+After creating a spec for your root filesystem with runc, you can execute a simple container in your shell by running:
 
     cd /mycontainer
     runc
@@ -34,7 +37,7 @@ func init() {
 		if err := factory.StartInitialization(); err != nil {
 			fatal(err)
 		}
-		panic("--this line should never been executed, congradulations--")
+		panic("--this line should never been executed, congratulations--")
 	}
 }
 


### PR DESCRIPTION
1. Remove mention of nsinit (removed from the repo)
2. Make basic usage text a bit more informative; fix typo
3. Fix typo in panic() message (that should never be seen) :)

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)