### PR TITLE
allow to exec as command

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 
@@ -98,6 +99,12 @@ func main() {
 		os.Exit(status)
 	}
 
+	// allow "runc" command
+	if cmdPath, err := exec.LookPath(os.Args[0]); err != nil {
+		logrus.Fatal("Cannot find runc: %v", err)
+	} else {
+		os.Args[0] = cmdPath
+	}
 	//allow for relative path for the runC binary
 	if absPath, err := filepath.Abs(os.Args[0]); err != nil {
 		logrus.Fatal("Cannot convert runc path to absolute: %v", err)


### PR DESCRIPTION
Fix #35.

Expand runc path with following step.
- 1st Step: "command name" | "absolute path" | "relative path" -> "absolute path" | "relative path"
- 2nd Step: "absolute path" | "relative path" -> "absolute path"
