### PR TITLE
linux: Don't prepend process' cwd if rootfs path is already absolute

### DIFF
--- a/spec_linux.go
+++ b/spec_linux.go
@@ -123,9 +123,13 @@ func createLibcontainerConfig(spec *LinuxSpec) (*configs.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	rootfsPath := spec.Root.Path
+	if !filepath.IsAbs(rootfsPath) {
+		rootfsPath = filepath.Join(cwd, rootfsPath)
+	}
 	config := &configs.Config{
 		Capabilities: spec.Capabilities,
-		Rootfs:       filepath.Join(cwd, spec.Root.Path),
+		Rootfs:       rootfsPath,
 		Readonlyfs:   spec.Root.Readonly,
 		Hostname:     spec.Hostname,
 		Privatefs:    true,


### PR DESCRIPTION
If I provide a path starting with `/` I expect that to be honored;
otherwise I have to explicitly `(cd /; /path/to/runc)`.