### PR TITLE
linux: Default to use MS_MOVE if rootfs is read only

### DIFF
--- a/spec_linux.go
+++ b/spec_linux.go
@@ -130,6 +130,9 @@ func createLibcontainerConfig(spec *LinuxSpec) (*configs.Config, error) {
 		Hostname:     spec.Hostname,
 		Privatefs:    true,
 	}
+	if spec.Root.Readonly {
+		config.NoPivotRoot = true
+	}
 	for _, ns := range spec.Namespaces {
 		t, exists := namespaceMapping[ns.Type]
 		if !exists {


### PR DESCRIPTION
For our case of spawning containers, I don't see an advantage of using
`pivot_root`.  Both nspawn and linux-user-chroot use `mount(MS_MOVE)`.

It won't work if the rootfs is mounted read only anyways, so let's
automatically handle that case.