### PR TITLE
Add the ability to specify user for the spec file

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -53,6 +53,9 @@ type PortableSpec struct {
 var specCommand = cli.Command{
 	Name:  "spec",
 	Usage: "create a new specification file",
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "user", Value: "daemon", Usage: "User for container process (default: daemon)"},
+	},
 	Action: func(context *cli.Context) {
 		spec := PortableSpec{
 			Version: version,
@@ -65,7 +68,7 @@ var specCommand = cli.Command{
 			Processes: []*Process{
 				{
 					TTY:  true,
-					User: "daemon",
+					User: context.String("user"),
 					Args: []string{
 						"sh",
 					},


### PR DESCRIPTION
Currently the code defaults to **user: daemon** and you have to manually edit the
spec to change this.  This patch introduces a `--user` flag for the
`spec` command allowing a user to be specified. No validation is
performed that this is a valid user in the container's `/etc/passwd`
file, but an error is generated by libcontainer if the user is not
found.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)