### PR TITLE
Windows: Remove nsenter dependency

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/opencontainers/runc/libcontainer"
-	_ "github.com/opencontainers/runc/libcontainer/nsenter"
 )
 
 const (

--- a/main_unix.go
+++ b/main_unix.go
@@ -1,0 +1,5 @@
+// +build linux
+
+package main
+
+import _ "github.com/opencontainers/runc/libcontainer/nsenter"


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Removes the dependency of nsenter on Windows.