### PR TITLE
Windows: Factor out seccomp

### DIFF
--- a/libcontainer/seccomp/bpf.go
+++ b/libcontainer/seccomp/bpf.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package seccomp
 
 import "strings"

--- a/libcontainer/seccomp/context.go
+++ b/libcontainer/seccomp/context.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package seccomp
 
 import (

--- a/libcontainer/seccomp/filter.go
+++ b/libcontainer/seccomp/filter.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package seccomp
 
 import (

--- a/libcontainer/seccomp/seccomp_unix.go
+++ b/libcontainer/seccomp/seccomp_unix.go
@@ -1,3 +1,5 @@
+// +build linux
+
 // Package seccomp provides native seccomp ( https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt ) support for go.
 package seccomp
 

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package seccomp


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Factors out seccomp on the Windows platform where not applicable.