### PR TITLE
libcontainer: user: fix GetAdditionalGroups* API

### DIFF
--- a/libcontainer/user/user_test.go
+++ b/libcontainer/user/user_test.go
@@ -1,9 +1,7 @@
 package user
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"sort"
 	"strconv"
@@ -355,7 +353,7 @@ this is just some garbage data
 	}
 }
 
-func TestGetAdditionalGroupsPath(t *testing.T) {
+func TestGetAdditionalGroups(t *testing.T) {
 	const groupContent = `
 root:x:0:root
 adm:x:43:
@@ -419,14 +417,9 @@ this is just some garbage data
 	}
 
 	for _, test := range tests {
-		tmpFile, err := ioutil.TempFile("", "get-additional-groups-path")
-		if err != nil {
-			t.Error(err)
-		}
-		fmt.Fprint(tmpFile, groupContent)
-		tmpFile.Close()
+		group := strings.NewReader(groupContent)
 
-		gids, err := GetAdditionalGroupsPath(test.groups, tmpFile.Name())
+		gids, err := GetAdditionalGroups(test.groups, group)
 		if test.hasError && err == nil {
 			t.Errorf("Parse(%#v) expects error but has none", test)
 			continue


### PR DESCRIPTION
I wasn't originally ping'd on docker/libcontainer#603, so here's a PR to fix the API. If we want nice testability, we should always provide an `io.Reader`.  It also makes it much nicer if we ever want to make generators for `/etc/group` and `/etc/passwd` formatted data that we get from other sources (like generating it from an Active Directory user list or smth similar).

Fixes: d4ece29c0bd38d680af6a2544a5ce705c3daeb24
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>