### PR TITLE
Enable build on unsupported platforms

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/events.go
+++ b/events.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (
@@ -56,7 +58,7 @@ var eventsCommand = cli.Command{
 			return
 		}
 		go func() {
-			for _ = range time.Tick(context.Duration("interval")) {
+			for range time.Tick(context.Duration("interval")) {
 				s, err := container.Stats()
 				if err != nil {
 					logrus.Error(err)

--- a/main_unsupported.go
+++ b/main_unsupported.go
@@ -1,0 +1,22 @@
+// +build !linux
+
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
+
+func getDefaultID() string {
+	return ""
+}
+
+var (
+	checkpointCommand cli.Command
+	eventsCommand     cli.Command
+	restoreCommand    cli.Command
+)
+
+func runAction(*cli.Context) {
+	logrus.Fatal("Current OS is not supported yet")
+}

--- a/restore.go
+++ b/restore.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/signals.go
+++ b/signals.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/spec.go
+++ b/spec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
 
@@ -111,7 +112,7 @@ var specCommand = cli.Command{
 		}
 		data, err := json.MarshalIndent(&spec, "", "\t")
 		if err != nil {
-			fatal(err)
+			logrus.Fatal(err)
 		}
 		fmt.Printf("%s", data)
 	},

--- a/tty.go
+++ b/tty.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/utils.go
+++ b/utils.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (


### PR DESCRIPTION
Should compile now without errors but changes needed to be added for each system so it actually works.
main_unsupported.go is a new file with all the unsupported commands
Fixes #9

Signed-off-by: Marianna <mtesselh@gmail.com>