### PR TITLE
Add cgroup mount in the recommended config

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ user named `daemon` defined within that file-system.
             "source": "sysfs",
             "destination": "/sys",
             "options": "nosuid,noexec,nodev"
+        },
+        {
+            "type": "cgroup",
+            "source": "cgroup",
+            "destination": "/sys/fs/cgroup",
+            "options": "nosuid,noexec,nodev,relatime,ro"
         }
     ],
     "linux": {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -184,7 +184,7 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 				Device:      "bind",
 				Source:      filepath.Join(mm.Mountpoint, dir),
 				Destination: filepath.Join(m.Destination, strings.Join(mm.Subsystems, ",")),
-				Flags:       syscall.MS_BIND | syscall.MS_REC | syscall.MS_RDONLY,
+				Flags:       syscall.MS_BIND | syscall.MS_REC | m.Flags,
 			})
 		}
 		tmpfs := &configs.Mount{

--- a/spec.go
+++ b/spec.go
@@ -83,6 +83,12 @@ var specCommand = cli.Command{
 						Destination: "/sys",
 						Options:     "nosuid,noexec,nodev",
 					},
+					{
+						Type:        "cgroup",
+						Source:      "cgroup",
+						Destination: "/sys/fs/cgroup",
+						Options:     "nosuid,noexec,nodev,relatime,ro",
+					},
 				},
 			},
 			Linux: specs.Linux{


### PR DESCRIPTION
Otherwise we have no way to know our resource limit in the runtime.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>