### PR TITLE
Use bash instead of sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ user named `daemon` defined within that file-system.
             "additionalGids": null
         },
         "args": [
-            "sh"
+            "bash"
         ],
         "env": [
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",


### PR DESCRIPTION
Using sh is really inconvenient, why not using bash by default?

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>