### PR TITLE
Fixing memory swappiness as -1 in template file for older kernels

### DIFF
--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -46,10 +46,11 @@ func newTemplateConfig(rootfs string) *configs.Config {
 			{Type: configs.NEWNET},
 		}),
 		Cgroups: &configs.Cgroup{
-			Name:            "test",
-			Parent:          "integration",
-			AllowAllDevices: false,
-			AllowedDevices:  configs.DefaultAllowedDevices,
+			Name:             "test",
+			Parent:           "integration",
+			MemorySwappiness: -1,
+			AllowAllDevices:  false,
+			AllowedDevices:   configs.DefaultAllowedDevices,
 		},
 		MaskPaths: []string{
 			"/proc/kcore",


### PR DESCRIPTION

For older kernels, upon running make localtest, it fails to setting the swapiness value due to which the tests are failing
Kernel used for identifying this issue: 3.13 ( based on Ubuntu 14.04 LTS)
This change is made in template file for cgroups to have memory swappiness as -1.
post that tests were passed by not setting the value for the test containers

Signed-off-by: Rajasekaran <rajasec79@gmail.com>