### PR TITLE
Fix IDMapping host / container field confusion

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/opencontainers/runc",
-	"GoVersion": "go1.4.1",
+	"GoVersion": "go1.4.2",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -48,7 +48,7 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/specs",
-			"Rev": "8fa5eb040abe89f09767c1b249b10757bb431cc2"
+			"Rev": "08873003592da169f89ec7c671ed34e1a2333ef8"
 		},
 		{
 			"ImportPath": "github.com/syndtr/gocapability/capability",

--- a/Godeps/_workspace/src/github.com/opencontainers/specs/config-linux.md
+++ b/Godeps/_workspace/src/github.com/opencontainers/specs/config-linux.md
@@ -1,8 +1,8 @@
-# Linux
+# Linux-specific configuration
 
 The Linux container specification uses various kernel features like namespaces,
-cgroups, capabilities, LSM, and file system jails to fulfill the spec.  
-Additional information is needed for Linux over the default spec configuration
+cgroups, capabilities, LSM, and file system jails to fulfill the spec.
+Additional information is needed for Linux over the [default spec configuration](config.md)
 in order to configure these various kernel features.
 
 ## Linux namespaces
@@ -117,6 +117,27 @@ For more information, see [the man page](http://man7.org/linux/man-pages/man8/sy
 ```
 
 rlimits allow setting resource limits. The type is from the values defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html). The kernel enforces the soft limit for a resource while the hard limit acts as a ceiling for that value that could be set by an unprivileged process.
+
+## Linux user namespace mappings
+
+```
+    "uidMappings": [
+        {
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
+        }
+    ],
+    "gidMappings": [
+        {
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
+        }
+    ]
+```
+
+uid/gid mappings describe the user namespace mappings from the host to the container. *from* is the starting uid/gid on the host to be mapped to *to* which is the starting uid/gid in the container and *count* refers to the number of ids to be mapped. The Linux kernel has a limit of 5 such mappings that can be specified.
 
 ## Security
 

--- a/Godeps/_workspace/src/github.com/opencontainers/specs/config.md
+++ b/Godeps/_workspace/src/github.com/opencontainers/specs/config.md
@@ -10,7 +10,7 @@ Below is a detailed description of each field defined in the configuration forma
 
 ## Manifest version
 
-* **version** (string, required) must be in SemVer v2.0.0 format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
+* **version** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
 
 *Example*
 
@@ -93,7 +93,7 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
 
 * **terminal** (bool, optional) specifies whether you want a terminal attached to that process. Defaults to false.
 * **cwd** (string, optional) is the working directory that will be set for the executable.
-* **env** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores '_' as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
+* **env** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
 * **args** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
 
 The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
@@ -137,8 +137,8 @@ For Linux-based systems the user structure has the following fields:
 
 ## Platform-specific configuration
 
-* **os** (string, required) specifies the operating system family this image must run on. Values for arch must be in the list specified by the Go Language document for [$GOOS](https://golang.org/doc/install/source#environment).
-* **arch** (string, required) specifies the instruction set for which the binaries in the image have been compiled. Values for arch must be in the list specified by the Go Language document for [$GOARCH](https://golang.org/doc/install/source#environment).
+* **os** (string, required) specifies the operating system family this image must run on. Values for os must be in the list specified by the Go Language document for [`$GOOS`](https://golang.org/doc/install/source#environment).
+* **arch** (string, required) specifies the instruction set for which the binaries in the image have been compiled. Values for arch must be in the list specified by the Go Language document for [`$GOARCH`](https://golang.org/doc/install/source#environment).
 
 ```json
 "platform": {
@@ -147,6 +147,4 @@ For Linux-based systems the user structure has the following fields:
 }
 ```
 
-Interpretation of the platform section of the JSON file is used to find which platform specific section may be available in the document. For example if `os` is set to `linux` then the `linux` JSON object SHOULD be found in the `config.json`.
-
-
+Interpretation of the platform section of the JSON file is used to find which platform-specific sections may be available in the document. For example, if `os` is set to `linux`, then a JSON object conforming to the [Linux-specific schema](config-linux.md) SHOULD be found at the key `linux` in the `config.json`.

--- a/Godeps/_workspace/src/github.com/opencontainers/specs/spec_linux.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/specs/spec_linux.go
@@ -52,12 +52,12 @@ type Namespace struct {
 
 // IDMapping specifies uid/gid mappings.
 type IDMapping struct {
-	// From is the uid/gid of the host user or group.
-	From int32 `json:"from"`
-	// To is the uid/gid of the container's user or group.
-	To int32 `json:"to"`
-	// Count is how many uid/gids to map after To.
-	Count int32 `json:"count"`
+	// HostID is the uid/gid of the host user or group.
+	HostID int32 `json:"hostID"`
+	// ContainerID is the uid/gid of the container's user or group.
+	ContainerID int32 `json:"containerID"`
+	// Size is the length of the range of IDs mapped between the two namespaces.
+	Size int32 `json:"size"`
 }
 
 // Rlimit type and restrictions.

--- a/spec.go
+++ b/spec.go
@@ -303,9 +303,9 @@ func setupUserNamespace(spec *specs.LinuxSpec, config *configs.Config) error {
 	config.Namespaces.Add(configs.NEWUSER, "")
 	create := func(m specs.IDMapping) configs.IDMap {
 		return configs.IDMap{
-			ContainerID: int(m.From),
-			HostID:      int(m.To),
-			Size:        int(m.Count),
+			HostID:      int(m.HostID),
+			ContainerID: int(m.ContainerID),
+			Size:        int(m.Size),
 		}
 	}
 	for _, m := range spec.Linux.UidMappings {


### PR DESCRIPTION
Pull in opencontainers/specs#63 to get clearer field names and fix the
swapped assignment when parsing JSON specs.

I've split this pull request into two commits, so the Godeps bump is
independent of the local change.  I think that will make it easier to
review the change.  It may cause trouble for folks bisecting bugs
though (because the Godeps-bump commit won't compile without the
local-change commit), so feel free to squash the two commits together
if that's a concern.