### PR TITLE
Fix bug in Readme.md,change GOPATH to GOPATH/src

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on the specs repository and support the update spec.
 ### Building:
 
 ```bash
-# create a 'github.com/opencontainers' in your GOPATH
+# create a 'github.com/opencontainers' in your GOPATH/src
 cd github.com/opencontainers
 git clone https://github.com/opencontainers/runc
 cd runc


### PR DESCRIPTION
Fix bug in Readme.md,change GOPATH to GOPATH/src
 to avoid missunderstanding of how to build.

Signed-off-by: zenlin <linzhinan@huawei.com>