### PR TITLE
golang compiler adds "src" in the end of GOPATH, so README.md file mu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ on the specs repository and support the update spec.
 ### Building:
 
 ```bash
-# create a 'github.com/opencontainers' in your GOPATH
-cd github.com/opencontainers
+# create a 'src/github.com/opencontainers' in your GOPATH
+cd src/github.com/opencontainers
 git clone https://github.com/opencontainers/runc
 cd runc
 make

--- a/events.go
+++ b/events.go
@@ -58,7 +58,7 @@ var eventsCommand = cli.Command{
 			return
 		}
 		go func() {
-			for range time.Tick(context.Duration("interval")) {
+			for _ = range time.Tick(context.Duration("interval")) {
 				s, err := container.Stats()
 				if err != nil {
 					logrus.Error(err)


### PR DESCRIPTION
…st be impoved as followings

      github.com/opencontainers -> src/github.com/opencontainers
Also, "Introduction page" of runc github need to be updated(seems to be done automatically).

Signed-off-by: Jin-Hwan Jeong <jhjeong.kr@gmail.com>