### PR TITLE
A container can join namespaces of another container

### DIFF
--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -2,7 +2,11 @@
 
 package configs
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"sync"
+)
 
 const (
 	NEWNET  NamespaceType = "NEWNET"
@@ -12,6 +16,52 @@ const (
 	NEWIPC  NamespaceType = "NEWIPC"
 	NEWUSER NamespaceType = "NEWUSER"
 )
+
+var (
+	nsLock              sync.Mutex
+	supportedNamespaces = make(map[NamespaceType]bool)
+)
+
+// nsToFile converts the namespace type to its filename
+func nsToFile(ns NamespaceType) string {
+	switch ns {
+	case NEWNET:
+		return "net"
+	case NEWNS:
+		return "mnt"
+	case NEWPID:
+		return "pid"
+	case NEWIPC:
+		return "ipc"
+	case NEWUSER:
+		return "user"
+	case NEWUTS:
+		return "uts"
+	}
+	return ""
+}
+
+// IsNamespaceSupported returns the list of current kernel's supported
+// namespaces. The namespaces will be sorted in order that we can safely setns
+// to (i.e., mount namespace is at the bottom of the list)
+func IsNamespaceSupported(ns NamespaceType) bool {
+	nsLock.Lock()
+	defer nsLock.Unlock()
+	supported, ok := supportedNamespaces[ns]
+	if ok {
+		return supported
+	}
+	nsFile := nsToFile(ns)
+	// if the namespace type is unknown, just return false
+	if nsFile == "" {
+		return false
+	}
+	_, err := os.Stat(fmt.Sprintf("/proc/self/ns/%s", nsFile))
+	// a namespace is supported if it exists and we have permissions to read it
+	supported = err == nil
+	supportedNamespaces[ns] = supported
+	return supported
+}
 
 func NamespaceTypes() []NamespaceType {
 	return []NamespaceType{
@@ -35,26 +85,7 @@ func (n *Namespace) GetPath(pid int) string {
 	if n.Path != "" {
 		return n.Path
 	}
-	return fmt.Sprintf("/proc/%d/ns/%s", pid, n.file())
-}
-
-func (n *Namespace) file() string {
-	file := ""
-	switch n.Type {
-	case NEWNET:
-		file = "net"
-	case NEWNS:
-		file = "mnt"
-	case NEWPID:
-		file = "pid"
-	case NEWIPC:
-		file = "ipc"
-	case NEWUSER:
-		file = "user"
-	case NEWUTS:
-		file = "uts"
-	}
-	return file
+	return fmt.Sprintf("/proc/%d/ns/%s", pid, nsToFile(n.Type))
 }
 
 func (n *Namespaces) Remove(t NamespaceType) bool {

--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -118,3 +118,11 @@ func (n *Namespaces) index(t NamespaceType) int {
 func (n *Namespaces) Contains(t NamespaceType) bool {
 	return n.index(t) != -1
 }
+
+func (n *Namespaces) PathOf(t NamespaceType) string {
+	i := n.index(t)
+	if i == -1 {
+		return ""
+	}
+	return (*n)[i].Path
+}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -869,3 +869,40 @@ func (c *linuxContainer) currentState() (*State, error) {
 	}
 	return state, nil
 }
+
+// orderNamespacePaths sorts namespace paths into a list of paths that we
+// can setns in order.
+func (c *linuxContainer) orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
+	paths := []string{}
+	nsTypes := []configs.NamespaceType{
+		configs.NEWIPC,
+		configs.NEWUTS,
+		configs.NEWNET,
+		configs.NEWPID,
+		configs.NEWNS,
+	}
+	// join userns if the init process explicitly requires NEWUSER
+	if c.config.Namespaces.Contains(configs.NEWUSER) {
+		nsTypes = append(nsTypes, configs.NEWUSER)
+	}
+	for _, nsType := range nsTypes {
+		if p, ok := namespaces[nsType]; ok && p != "" {
+			// check if the requested namespace is supported
+			if !configs.IsNamespaceSupported(nsType) {
+				return nil, newSystemError(fmt.Errorf("namespace %s is not supported", nsType))
+			}
+			// only set to join this namespace if it exists
+			if _, err := os.Lstat(p); err != nil {
+				return nil, newSystemError(err)
+			}
+			// do not allow namespace path with comma as we use it to separate
+			// the namespace paths
+			if strings.ContainsRune(p, ',') {
+				return nil, newSystemError(fmt.Errorf("invalid path %s", p))
+			}
+			paths = append(paths, p)
+		}
+	}
+	return paths, nil
+}
+}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -140,25 +140,6 @@ func finalizeNamespace(config *initConfig) error {
 	return nil
 }
 
-// joinExistingNamespaces gets all the namespace paths specified for the container and
-// does a setns on the namespace fd so that the current process joins the namespace.
-func joinExistingNamespaces(namespaces []configs.Namespace) error {
-	for _, ns := range namespaces {
-		if ns.Path != "" {
-			f, err := os.OpenFile(ns.Path, os.O_RDONLY, 0)
-			if err != nil {
-				return err
-			}
-			err = system.Setns(f.Fd(), uintptr(ns.Syscall()))
-			f.Close()
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // setupUser changes the groups, gid, and uid for the user inside the container
 func setupUser(config *initConfig) error {
 	// Set up defaults.

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -2,9 +2,11 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -993,4 +995,191 @@ func TestHook(t *testing.T) {
 	if err == nil || !os.IsNotExist(err) {
 		t.Fatalf("expected file to not exist, got %s", fi.Name())
 	}
+}
+
+func TestInitJoinPID(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	rootfs, err := newRootfs()
+	ok(t, err)
+	defer remove(rootfs)
+
+	// Execute a long-running container
+	container1, err := newContainer(newTemplateConfig(rootfs))
+	ok(t, err)
+	defer container1.Destroy()
+
+	stdinR1, stdinW1, err := os.Pipe()
+	ok(t, err)
+	init1 := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR1,
+	}
+	err = container1.Start(init1)
+	stdinR1.Close()
+	defer stdinW1.Close()
+	ok(t, err)
+
+	// get the state of the first container
+	state1, err := container1.State()
+	ok(t, err)
+	pidns1 := state1.NamespacePaths[configs.NEWPID]
+
+	// Start a container inside the existing pidns but with different cgroups
+	config2 := newTemplateConfig(rootfs)
+	config2.Namespaces.Add(configs.NEWPID, pidns1)
+	config2.Cgroups.Name = "test2"
+	container2, err := newContainerWithName("testCT2", config2)
+	ok(t, err)
+	defer container2.Destroy()
+
+	stdinR2, stdinW2, err := os.Pipe()
+	ok(t, err)
+	init2 := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR2,
+	}
+	err = container2.Start(init2)
+	stdinR2.Close()
+	defer stdinW2.Close()
+	ok(t, err)
+	// get the state of the second container
+	state2, err := container2.State()
+	ok(t, err)
+
+	ns1, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", state1.InitProcessPid))
+	ok(t, err)
+	ns2, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", state2.InitProcessPid))
+	ok(t, err)
+	if ns1 != ns2 {
+		t.Errorf("pidns(%s), wanted %s", ns2, ns1)
+	}
+
+	// check that namespaces are not the same
+	if reflect.DeepEqual(state2.NamespacePaths, state1.NamespacePaths) {
+		t.Errorf("Namespaces(%v), original %v", state2.NamespacePaths,
+			state1.NamespacePaths)
+	}
+	// check that pidns is joined correctly. The initial container process list
+	// should contain the second container's init process
+	buffers := newStdBuffers()
+	ps := &libcontainer.Process{
+		Args:   []string{"ps"},
+		Env:    standardEnvironment,
+		Stdout: buffers.Stdout,
+	}
+	err = container1.Start(ps)
+	ok(t, err)
+	waitProcess(ps, t)
+
+	// Stop init processes one by one. Stop the second container should
+	// not stop the first.
+	stdinW2.Close()
+	waitProcess(init2, t)
+	stdinW1.Close()
+	waitProcess(init1, t)
+
+	out := strings.TrimSpace(buffers.Stdout.String())
+	// output of ps inside the initial PID namespace should have
+	// 1 line of header,
+	// 2 lines of init processes,
+	// 1 line of ps process
+	if len(strings.Split(out, "\n")) != 4 {
+		t.Errorf("unexpected running process, output %q", out)
+	}
+}
+
+func TestInitJoinNetworkAndUser(t *testing.T) {
+	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
+		t.Skip("userns is unsupported")
+	}
+	if testing.Short() {
+		return
+	}
+	rootfs, err := newRootfs()
+	ok(t, err)
+	defer remove(rootfs)
+
+	// Execute a long-running container
+	config1 := newTemplateConfig(rootfs)
+	config1.UidMappings = []configs.IDMap{{0, 0, 1000}}
+	config1.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config1.Namespaces = append(config1.Namespaces, configs.Namespace{Type: configs.NEWUSER})
+	container1, err := newContainer(config1)
+	ok(t, err)
+	defer container1.Destroy()
+
+	stdinR1, stdinW1, err := os.Pipe()
+	ok(t, err)
+	init1 := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR1,
+	}
+	err = container1.Start(init1)
+	stdinR1.Close()
+	defer stdinW1.Close()
+	ok(t, err)
+
+	// get the state of the first container
+	state1, err := container1.State()
+	ok(t, err)
+	netns1 := state1.NamespacePaths[configs.NEWNET]
+	userns1 := state1.NamespacePaths[configs.NEWUSER]
+
+	// Start a container inside the existing pidns but with different cgroups
+	rootfs2, err := newRootfs()
+	ok(t, err)
+	defer remove(rootfs2)
+
+	config2 := newTemplateConfig(rootfs2)
+	config2.UidMappings = []configs.IDMap{{0, 0, 1000}}
+	config2.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config2.Namespaces.Add(configs.NEWNET, netns1)
+	config2.Namespaces.Add(configs.NEWUSER, userns1)
+	config2.Cgroups.Name = "test2"
+	container2, err := newContainerWithName("testCT2", config2)
+	ok(t, err)
+	defer container2.Destroy()
+
+	stdinR2, stdinW2, err := os.Pipe()
+	ok(t, err)
+	init2 := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR2,
+	}
+	err = container2.Start(init2)
+	stdinR2.Close()
+	defer stdinW2.Close()
+	ok(t, err)
+
+	// get the state of the second container
+	state2, err := container2.State()
+	ok(t, err)
+
+	for _, ns := range []string{"net", "user"} {
+		ns1, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/%s", state1.InitProcessPid, ns))
+		ok(t, err)
+		ns2, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/%s", state2.InitProcessPid, ns))
+		ok(t, err)
+		if ns1 != ns2 {
+			t.Errorf("%s(%s), wanted %s", ns, ns2, ns1)
+		}
+	}
+
+	// check that namespaces are not the same
+	if reflect.DeepEqual(state2.NamespacePaths, state1.NamespacePaths) {
+		t.Errorf("Namespaces(%v), original %v", state2.NamespacePaths,
+			state1.NamespacePaths)
+	}
+	// Stop init processes one by one. Stop the second container should
+	// not stop the first.
+	stdinW2.Close()
+	waitProcess(init2, t)
+	stdinW1.Close()
+	waitProcess(init1, t)
 }

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func TestExecIn(t *testing.T) {
@@ -377,5 +379,61 @@ func TestExecInOomScoreAdj(t *testing.T) {
 	out := buffers.Stdout.String()
 	if oomScoreAdj := strings.TrimSpace(out); oomScoreAdj != strconv.Itoa(config.OomScoreAdj) {
 		t.Fatalf("expected oomScoreAdj to be %d, got %s", config.OomScoreAdj, oomScoreAdj)
+	}
+}
+
+func TestExecInUserns(t *testing.T) {
+	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
+		t.Skip("userns is unsupported")
+	}
+	if testing.Short() {
+		return
+	}
+	rootfs, err := newRootfs()
+	ok(t, err)
+	defer remove(rootfs)
+	config := newTemplateConfig(rootfs)
+	config.UidMappings = []configs.IDMap{{0, 0, 1000}}
+	config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
+	container, err := newContainer(config)
+	ok(t, err)
+	defer container.Destroy()
+
+	// Execute a first process in the container
+	stdinR, stdinW, err := os.Pipe()
+	ok(t, err)
+	process := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR,
+	}
+	err = container.Start(process)
+	stdinR.Close()
+	defer stdinW.Close()
+	ok(t, err)
+
+	initPID, err := process.Pid()
+	ok(t, err)
+	initUserns, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/user", initPID))
+	ok(t, err)
+
+	buffers := newStdBuffers()
+	process2 := &libcontainer.Process{
+		Args: []string{"readlink", "/proc/self/ns/user"},
+		Env: []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		},
+		Stdout: buffers.Stdout,
+		Stderr: os.Stderr,
+	}
+	err = container.Start(process2)
+	ok(t, err)
+	waitProcess(process2, t)
+	stdinW.Close()
+	waitProcess(process, t)
+
+	if out := strings.TrimSpace(buffers.Stdout.String()); out != initUserns {
+		t.Errorf("execin userns(%s), wanted %s", out, initUserns)
 	}
 }

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -92,13 +92,15 @@ func copyBusybox(dest string) error {
 }
 
 func newContainer(config *configs.Config) (libcontainer.Container, error) {
-	f := factory
+	return newContainerWithName("testCT", config)
+}
 
+func newContainerWithName(name string, config *configs.Config) (libcontainer.Container, error) {
+	f := factory
 	if config.Cgroups != nil && config.Cgroups.Slice == "system.slice" {
 		f = systemdFactory
 	}
-
-	return f.Create("testCT", config)
+	return f.Create(name, config)
 }
 
 // runContainer runs the container with the specific config and arguments

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -1,41 +1,70 @@
 package nsenter
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/vishvananda/netlink/nl"
 )
 
 type pid struct {
 	Pid int `json:"Pid"`
 }
 
-func TestNsenterAlivePid(t *testing.T) {
+func TestNsenterValidPaths(t *testing.T) {
 	args := []string{"nsenter-exec"}
-	r, w, err := os.Pipe()
+	parent, child, err := newPipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe %v", err)
 	}
 
+	namespaces := []string{
+		// join pid ns of the current process
+		fmt.Sprintf("/proc/%d/ns/pid", os.Getpid()),
+	}
 	cmd := &exec.Cmd{
 		Path:       os.Args[0],
 		Args:       args,
-		ExtraFiles: []*os.File{w},
-		Env:        []string{fmt.Sprintf("_LIBCONTAINER_INITPID=%d", os.Getpid()), "_LIBCONTAINER_INITPIPE=3"},
+		ExtraFiles: []*os.File{child},
+		Env:        []string{"_LIBCONTAINER_INITPIPE=3"},
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
 	}
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("nsenter failed to start %v", err)
 	}
-	w.Close()
+	// write cloneFlags
+	r := nl.NewNetlinkRequest(int(libcontainer.RuncInit), 0)
+	r.AddData(&libcontainer.Int32msg{
+		Type:  libcontainer.RuncInitCloneFlags,
+		Value: uint32(syscall.CLONE_NEWNET),
+	})
+	r.AddData(&libcontainer.Bytemsg{
+		Type:  libcontainer.RuncInitNsPaths,
+		Value: []byte(strings.Join(namespaces, ",")),
+	})
+	if _, err := io.Copy(parent, bytes.NewReader(r.Serialize())); err != nil {
+		t.Fatal(err)
+	}
 
-	decoder := json.NewDecoder(r)
+	decoder := json.NewDecoder(parent)
 	var pid *pid
 
 	if err := decoder.Decode(&pid); err != nil {
+		dir, _ := ioutil.ReadDir(fmt.Sprintf("/proc/%d/ns", os.Getpid()))
+		for _, d := range dir {
+			t.Log(d.Name())
+		}
 		t.Fatalf("%v", err)
 	}
 
@@ -49,37 +78,43 @@ func TestNsenterAlivePid(t *testing.T) {
 	p.Wait()
 }
 
-func TestNsenterInvalidPid(t *testing.T) {
+func TestNsenterInvalidPaths(t *testing.T) {
 	args := []string{"nsenter-exec"}
+	parent, child, err := newPipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe %v", err)
+	}
 
+	namespaces := []string{
+		// join pid ns of the current process
+		fmt.Sprintf("/proc/%d/ns/pid", -1),
+	}
 	cmd := &exec.Cmd{
-		Path: os.Args[0],
-		Args: args,
-		Env:  []string{"_LIBCONTAINER_INITPID=-1"},
+		Path:       os.Args[0],
+		Args:       args,
+		ExtraFiles: []*os.File{child},
+		Env:        []string{"_LIBCONTAINER_INITPIPE=3"},
 	}
 
-	err := cmd.Run()
-	if err == nil {
-		t.Fatal("nsenter exits with a zero exit status")
-	}
-}
-
-func TestNsenterDeadPid(t *testing.T) {
-	dead_cmd := exec.Command("true")
-	if err := dead_cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	args := []string{"nsenter-exec"}
-
-	cmd := &exec.Cmd{
-		Path: os.Args[0],
-		Args: args,
-		Env:  []string{fmt.Sprintf("_LIBCONTAINER_INITPID=%d", dead_cmd.Process.Pid)},
+	// write cloneFlags
+	r := nl.NewNetlinkRequest(int(libcontainer.RuncInit), 0)
+	r.AddData(&libcontainer.Int32msg{
+		Type:  libcontainer.RuncInitCloneFlags,
+		Value: uint32(syscall.CLONE_NEWNET),
+	})
+	r.AddData(&libcontainer.Bytemsg{
+		Type:  libcontainer.RuncInitNsPaths,
+		Value: []byte(strings.Join(namespaces, ",")),
+	})
+	if _, err := io.Copy(parent, bytes.NewReader(r.Serialize())); err != nil {
+		t.Fatal(err)
 	}
 
-	err := cmd.Run()
-	if err == nil {
-		t.Fatal("nsenter exits with a zero exit status")
+	if err := cmd.Wait(); err == nil {
+		t.Fatalf("nsenter exits with a zero exit status")
 	}
 }
 
@@ -88,4 +123,12 @@ func init() {
 		os.Exit(0)
 	}
 	return
+}
+
+func newPipe() (parent *os.File, child *os.File, err error) {
+	fds, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return os.NewFile(uintptr(fds[1]), "parent"), os.NewFile(uintptr(fds[0]), "child"), nil
 }

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -1,28 +1,19 @@
 #define _GNU_SOURCE
-#include <stdlib.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <linux/limits.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <setjmp.h>
-#include <sched.h>
-#include <signal.h>
 #include <endian.h>
-#include <stdint.h>
-#include <inttypes.h>
-
-// netlink related
-#include <linux/types.h>
-#include <sys/socket.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/limits.h>
 #include <linux/netlink.h>
+#include <sched.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 /* All arguments should be above stack, because it grows down */
 struct clone_arg {

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-
 #include <linux/limits.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -16,6 +15,14 @@
 #include <setjmp.h>
 #include <sched.h>
 #include <signal.h>
+#include <endian.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+// netlink related
+#include <linux/types.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
 
 /* All arguments should be above stack, because it grows down */
 struct clone_arg {
@@ -51,101 +58,284 @@ int setns(int fd, int nstype)
 #endif
 #endif
 
-static int clone_parent(jmp_buf * env) __attribute__ ((noinline));
-static int clone_parent(jmp_buf * env)
+static int clone_parent(jmp_buf * env, int flags) __attribute__ ((noinline));
+static int clone_parent(jmp_buf * env, int flags)
 {
 	struct clone_arg ca;
 	int child;
 
 	ca.env = env;
-	child = clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD, &ca);
-
+	child = clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD | flags, &ca);
 	return child;
 }
 
-void nsexec()
+// get init pipe from the parent. It's used to read bootstrap data, and to
+// write pid to after nsexec finishes setting up the environment.
+static int get_init_pipe()
 {
-	char *namespaces[] = { "ipc", "uts", "net", "pid", "mnt" };
-	const int num = sizeof(namespaces) / sizeof(char *);
-	jmp_buf env;
-	char buf[PATH_MAX], *val;
-	int i, tfd, child, len, pipenum, consolefd = -1;
-	pid_t pid;
-	char *console;
-
-	val = getenv("_LIBCONTAINER_INITPID");
-	if (val == NULL)
-		return;
-
-	pid = atoi(val);
-	snprintf(buf, sizeof(buf), "%d", pid);
-	if (strcmp(val, buf)) {
-		pr_perror("Unable to parse _LIBCONTAINER_INITPID");
-		exit(1);
+	char buf[PATH_MAX], *initpipe;
+	int pipenum = -1;
+	initpipe = getenv("_LIBCONTAINER_INITPIPE");
+	if (initpipe == NULL) {
+		return -1;
 	}
-
-	val = getenv("_LIBCONTAINER_INITPIPE");
-	if (val == NULL) {
-		pr_perror("Child pipe not found");
-		exit(1);
-	}
-
-	pipenum = atoi(val);
+	pipenum = atoi(initpipe);
 	snprintf(buf, sizeof(buf), "%d", pipenum);
-	if (strcmp(val, buf)) {
+	if (strcmp(initpipe, buf)) {
 		pr_perror("Unable to parse _LIBCONTAINER_INITPIPE");
 		exit(1);
 	}
 
-	console = getenv("_LIBCONTAINER_CONSOLE_PATH");
-	if (console != NULL) {
-		consolefd = open(console, O_RDWR);
-		if (consolefd < 0) {
-			pr_perror("Failed to open console %s", console);
-			exit(1);
+	return pipenum;
+}
+
+// return 0 for big endian, 1 for little endian.
+static int is_little_endian()
+{
+	int i = 0x01234567;
+	return (*((uint8_t *) (&i))) == 0x67;
+}
+
+// num_namespaces returns the number of additional namespaces to setns. The
+// argument is a comma-separated string of namespace paths.
+static int num_namespaces(char *nspaths)
+{
+	int size = 0, i = 0;
+	for (i = 0; nspaths[i]; i++) {
+		if (nspaths[i] == ',') {
+			size += 1;
 		}
 	}
+	return size + 1;
+}
 
-	/* Check that the specified process exists */
-	snprintf(buf, PATH_MAX - 1, "/proc/%d/ns", pid);
-	tfd = open(buf, O_DIRECTORY | O_RDONLY);
-	if (tfd == -1) {
-		pr_perror("Failed to open \"%s\"", buf);
+static uint32_t readint32(char *buf, int *start)
+{
+	union {
+		uint32_t n;
+		char arr[4];
+	} num;
+	int i = 0;
+	for (i = 0; i < 4; i++) {
+		num.arr[i] = buf[*start + i];
+	}
+	*start += 4;
+	if (is_little_endian() == 1) {
+		return le32toh(num.n);
+	}
+	return be32toh(num.n);
+}
+
+static uint16_t readint16(char *buf, int *start)
+{
+	union {
+		uint16_t n;
+		char arr[2];
+	} num;
+	int i = 0;
+	for (i = 0; i < 2; i++) {
+		num.arr[i] = buf[*start + i];
+	}
+	*start += 2;
+	if (is_little_endian() == 1) {
+		return le16toh(num.n);
+	}
+	return be16toh(num.n);
+}
+
+static uint8_t readint8(char *buf, int *start)
+{
+	union {
+		uint8_t n;
+		char arr[1];
+	} num;
+	num.arr[0] = buf[*start];
+	*start += 1;
+	return num.n;
+}
+
+static void writedata(int fd, char *data, int start, int len)
+{
+	int written = 0;
+	while (written < len) {
+		size_t nbyte, i;
+		if ((len - written) < 1024) {
+			nbyte = len - written;
+		} else {
+			nbyte = 1024;
+		}
+		i = write(fd, data + start + written, nbyte);
+		if (i == -1) {
+			pr_perror("failed to write data to %d", fd);
+			exit(1);
+		}
+		written += i;
+	}
+}
+
+const uint16_t RUNC_INIT = 62000;
+// list of known message types we want to send to bootstrap program
+const uint16_t RUNC_INIT_CLONEFLAGS = 27281;
+const uint16_t RUNC_INIT_CONSOLEPATH = 27282;
+const uint16_t RUNC_INIT_NSPATHS = 27283;
+const uint16_t RUNC_INIT_UIDMAP = 27284;
+const uint16_t RUNC_INIT_GIDMAP = 27285;
+const uint16_t RUNC_INIT_SETGROUP = 27286;
+
+void nsexec()
+{
+	jmp_buf env;
+
+	// if we dont have init pipe, then just return to the parent
+	int pipenum = get_init_pipe();
+	if (pipenum == -1) {
+		return;
+	}
+
+	int len;
+	static char buf[16384];
+	struct iovec iov = { buf, sizeof(buf) };
+	struct msghdr msg;
+	struct nlmsghdr *nh;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_name = &nh;
+	msg.msg_namelen = sizeof(nh);
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	while (1) {
+		len = recvmsg(pipenum, &msg, 0);
+		if (len <= 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			pr_perror("invalid netlink init message size %d", len);
+			exit(1);
+		}
+		break;
+	}
+
+	nh = (struct nlmsghdr *)buf;
+	if (NLMSG_OK(nh, len) != 1) {
+		pr_perror("malformed message");
+		exit(1);
+	};
+	if (nh->nlmsg_type == NLMSG_ERROR) {
+		pr_perror("failed to read netlink message");
+		exit(1);
+	}
+	if (nh->nlmsg_type != RUNC_INIT) {
+		pr_perror("unexpected msg type %d", nh->nlmsg_type);
 		exit(1);
 	}
 
-	for (i = 0; i < num; i++) {
-		struct stat st;
-		int fd;
+	int total = NLMSG_PAYLOAD(nh, 0);
+	char data[total];
+	memcpy(data, NLMSG_DATA(nh), total);
 
-		/* Symlinks on all namespaces exist for dead processes, but they can't be opened */
-		if (fstatat(tfd, namespaces[i], &st, AT_SYMLINK_NOFOLLOW) == -1) {
-			// Ignore nonexistent namespaces.
-			if (errno == ENOENT)
-				continue;
-		}
-
-		fd = openat(tfd, namespaces[i], O_RDONLY);
-		if (fd == -1) {
-			pr_perror("Failed to open ns file %s for ns %s", buf,
-				  namespaces[i]);
+	// processing message
+	int start = 0;
+	uint32_t cloneflags = -1;
+	uint8_t is_setgroup = 0;
+	int consolefd = -1;
+	int uidmap_start = -1, uidmap_len = -1;
+	int gidmap_start = -1, gidmap_len = -1;
+	while (start < total) {
+		uint16_t msgtype = readint16(data, &start);
+		if (msgtype == RUNC_INIT_CLONEFLAGS) {
+			cloneflags = readint32(data, &start);
+		} else if (msgtype == RUNC_INIT_CONSOLEPATH) {
+			uint32_t consolelen = readint32(data, &start);
+			// get the console path before setns because it may change mnt namespace
+			char console[consolelen + 1];
+			strncpy(console, data + start, consolelen);
+			console[consolelen] = '\0';
+			consolefd = open(console, O_RDWR);
+			if (consolefd < 0) {
+				pr_perror("Failed to open console %s", console);
+				exit(1);
+			}
+			start = start + consolelen;
+		} else if (msgtype == RUNC_INIT_NSPATHS) {
+			uint32_t nspaths_len = readint32(data, &start);
+			char nspaths[nspaths_len + 1];
+			strncpy(nspaths, data + start, nspaths_len);
+			nspaths[nspaths_len] = '\0';
+			// if custom namespaces are required, open all descriptors and perform
+			// setns on them
+			int nslen = num_namespaces(nspaths);
+			int fds[nslen];
+			char *nslist[nslen];
+			int i = -1;
+			char *ns, *saveptr;
+			for (i = 0; i < nslen; i++) {
+				char *str = NULL;
+				if (i == 0) {
+					str = nspaths;
+				}
+				ns = strtok_r(str, ",", &saveptr);
+				if (ns == NULL) {
+					break;
+				}
+				fds[i] = open(ns, O_RDONLY);
+				if (fds[i] == -1) {
+					pr_perror("Failed to open %s", ns);
+					exit(1);
+				}
+				nslist[i] = ns;
+			}
+			for (i = 0; i < nslen; i++) {
+				if (setns(fds[i], 0) != 0) {
+					pr_perror("Failed to setns to %s", nslist[i]);
+					exit(1);
+				}
+				close(fds[i]);
+			}
+			start = start + nspaths_len;
+		} else if (msgtype == RUNC_INIT_UIDMAP) {
+			uidmap_len = readint32(data, &start);
+			uidmap_start = start;
+			start = start + uidmap_len;
+		} else if (msgtype == RUNC_INIT_GIDMAP) {
+			gidmap_len = readint32(data, &start);
+			gidmap_start = start;
+			start = start + gidmap_len;
+		} else if (msgtype == RUNC_INIT_SETGROUP) {
+			is_setgroup = readint8(data, &start);
+		} else {
+			pr_perror("unknown msgtype %d", msgtype);
 			exit(1);
 		}
-		// Set the namespace.
-		if (setns(fd, 0) == -1) {
-			pr_perror("Failed to setns for %s", namespaces[i]);
-			exit(1);
-		}
-		close(fd);
 	}
 
-	if (setjmp(env) == 1) {
-		// Child
+	// required clone_flags to be passed
+	if (cloneflags == -1) {
+		pr_perror("missing clone_flags");
+		exit(1);
+	}
+	// prepare sync pipe between parent and child. We need this to let the child
+	// know that the parent has finished setting up 
+	int syncpipe[2];
+	syncpipe[0] = -1;
+	syncpipe[1] = -1;
+	if (pipe(syncpipe) != 0) {
+		pr_perror("failed to setup sync pipe between parent and child");
+		exit(1);
+	};
 
+	if (setjmp(env) == 1) {
+		// close the writing side of pipe
+		close(syncpipe[1]);
+		uint8_t s;
+		if (read(syncpipe[0], &s, 1) != 1 || s != 1) {
+			pr_perror("failed to read sync byte from parent");
+			exit(1);
+		};
 		if (setsid() == -1) {
 			pr_perror("setsid failed");
 			exit(1);
 		}
+		// Child
 		if (consolefd != -1) {
 			if (ioctl(consolefd, TIOCSCTTY, 0) == -1) {
 				pr_perror("ioctl TIOCSCTTY failed");
@@ -168,23 +358,63 @@ void nsexec()
 		return;
 	}
 	// Parent
-
 	// We must fork to actually enter the PID namespace, use CLONE_PARENT
 	// so the child can have the right parent, and we don't need to forward
 	// the child's exit code or resend its death signal.
-	child = clone_parent(&env);
+	int child = clone_parent(&env, cloneflags);
 	if (child < 0) {
 		pr_perror("Unable to fork");
 		exit(1);
 	}
-
-	len = snprintf(buf, sizeof(buf), "{ \"pid\" : %d }\n", child);
-
-	if (write(pipenum, buf, len) != len) {
+	// if we specifies uid_map and gid_map, writes the data to /proc files
+	if (uidmap_start > 0 && uidmap_len > 0) {
+		char buf[PATH_MAX];
+		if (snprintf(buf, sizeof(buf), "/proc/%d/uid_map", child) < 0) {
+			pr_perror("failed to construct uid_map file for %d", child);
+			exit(1);
+		}
+		int fd = open(buf, O_RDWR);
+		writedata(fd, data, uidmap_start, uidmap_len);
+	}
+	if (gidmap_start > 0 && gidmap_len > 0) {
+		if (is_setgroup == 1) {
+			char buf[PATH_MAX];
+			if (snprintf(buf, sizeof(buf), "/proc/%d/setgroups", child) < 0) {
+				pr_perror("failed to construct setgroups file for %d", child);
+				exit(1);
+			}
+			int fd = open(buf, O_RDWR);
+			if (write(fd, "allow", 5) != 5) {
+				// If the kernel is too old to support /proc/PID/setgroups,
+				// write will return ENOENT; this is OK.
+				if (errno != ENOENT) {
+					pr_perror("failed to write allow to %s", buf);
+					exit(1);
+				}
+			}
+		}
+		// write gid mappings
+		char buf[PATH_MAX];
+		if (snprintf(buf, sizeof(buf), "/proc/%d/gid_map", child) < 0) {
+			pr_perror("failed to construct gid_map file for %d", child);
+			exit(1);
+		}
+		int fd = open(buf, O_RDWR);
+		writedata(fd, data, gidmap_start, gidmap_len);
+	}
+	close(syncpipe[0]);
+	uint8_t s = 1;
+	if (write(syncpipe[1], &s, 1) != 1) {
+		pr_perror("failed to write sync byte to child");
+		exit(1);
+	};
+	// parent to finish the bootstrap process
+	char child_data[PATH_MAX];
+	len = snprintf(child_data, sizeof(child_data), "{ \"pid\" : %d }\n", child);
+	if (write(pipenum, child_data, len) != len) {
 		pr_perror("Unable to send a child pid");
 		kill(child, SIGKILL);
 		exit(1);
 	}
-
 	exit(0);
 }

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -41,12 +41,13 @@ type parentProcess interface {
 }
 
 type setnsProcess struct {
-	cmd         *exec.Cmd
-	parentPipe  *os.File
-	childPipe   *os.File
-	cgroupPaths map[string]string
-	config      *initConfig
-	fds         []string
+	cmd           *exec.Cmd
+	parentPipe    *os.File
+	childPipe     *os.File
+	cgroupPaths   map[string]string
+	config        *initConfig
+	fds           []string
+	bootstrapData io.Reader
 }
 
 func (p *setnsProcess) startTime() (string, error) {
@@ -63,6 +64,14 @@ func (p *setnsProcess) signal(sig os.Signal) error {
 
 func (p *setnsProcess) start() (err error) {
 	defer p.parentPipe.Close()
+	err = p.cmd.Start()
+	p.childPipe.Close()
+	if err != nil {
+		return newSystemError(err)
+	}
+	if _, err := io.Copy(p.parentPipe, p.bootstrapData); err != nil {
+		return err
+	}
 	if err = p.execSetns(); err != nil {
 		return newSystemError(err)
 	}
@@ -71,6 +80,7 @@ func (p *setnsProcess) start() (err error) {
 			return newSystemError(err)
 		}
 	}
+
 	if err := json.NewEncoder(p.parentPipe).Encode(p.config); err != nil {
 		return newSystemError(err)
 	}
@@ -95,11 +105,6 @@ func (p *setnsProcess) start() (err error) {
 // before the go runtime boots, we wait on the process to die and receive the child's pid
 // over the provided pipe.
 func (p *setnsProcess) execSetns() error {
-	err := p.cmd.Start()
-	p.childPipe.Close()
-	if err != nil {
-		return newSystemError(err)
-	}
 	status, err := p.cmd.Process.Wait()
 	if err != nil {
 		p.cmd.Wait()
@@ -157,13 +162,15 @@ func (p *setnsProcess) setExternalDescriptors(newFds []string) {
 }
 
 type initProcess struct {
-	cmd        *exec.Cmd
-	parentPipe *os.File
-	childPipe  *os.File
-	config     *initConfig
-	manager    cgroups.Manager
-	container  *linuxContainer
-	fds        []string
+	cmd           *exec.Cmd
+	parentPipe    *os.File
+	childPipe     *os.File
+	config        *initConfig
+	manager       cgroups.Manager
+	container     *linuxContainer
+	fds           []string
+	bootstrapData io.Reader
+	sharePidns    bool
 }
 
 func (p *initProcess) pid() int {
@@ -174,11 +181,45 @@ func (p *initProcess) externalDescriptors() []string {
 	return p.fds
 }
 
-func (p *initProcess) start() (err error) {
+// execSetns runs the process that executes C code to perform the setns calls
+// because setns support requires the C process to fork off a child and perform the setns
+// before the go runtime boots, we wait on the process to die and receive the child's pid
+// over the provided pipe.
+// This is called by initProcess.start function
+func (p *initProcess) execSetns() error {
+	status, err := p.cmd.Process.Wait()
+	if err != nil {
+		p.cmd.Wait()
+		return err
+	}
+	if !status.Success() {
+		p.cmd.Wait()
+		return &exec.ExitError{ProcessState: status}
+	}
+	var pid *pid
+	if err := json.NewDecoder(p.parentPipe).Decode(&pid); err != nil {
+		p.cmd.Wait()
+		return err
+	}
+	process, err := os.FindProcess(pid.Pid)
+	if err != nil {
+		return err
+	}
+	p.cmd.Process = process
+	return nil
+}
+
+func (p *initProcess) start() error {
 	defer p.parentPipe.Close()
-	err = p.cmd.Start()
+	err := p.cmd.Start()
 	p.childPipe.Close()
 	if err != nil {
+		return newSystemError(err)
+	}
+	if _, err := io.Copy(p.parentPipe, p.bootstrapData); err != nil {
+		return err
+	}
+	if err := p.execSetns(); err != nil {
 		return newSystemError(err)
 	}
 	// Save the standard descriptor names before the container process
@@ -237,7 +278,7 @@ func (p *initProcess) wait() (*os.ProcessState, error) {
 		return p.cmd.ProcessState, err
 	}
 	// we should kill all processes in cgroup when init is died if we use host PID namespace
-	if p.cmd.SysProcAttr.Cloneflags&syscall.CLONE_NEWPID == 0 {
+	if p.sharePidns {
 		killCgroupProcesses(p.manager)
 	}
 	return p.cmd.ProcessState, nil

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -19,10 +19,6 @@ type linuxStandardInit struct {
 }
 
 func (l *linuxStandardInit) Init() error {
-	// join any namespaces via a path to the namespace fd if provided
-	if err := joinExistingNamespaces(l.config.Config.Namespaces); err != nil {
-		return err
-	}
 	var console *linuxConsole
 	if l.config.Console != "" {
 		console = newConsoleFromPath(l.config.Console)

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -26,9 +26,6 @@ func (l *linuxStandardInit) Init() error {
 			return err
 		}
 	}
-	if _, err := syscall.Setsid(); err != nil {
-		return err
-	}
 	if console != nil {
 		if err := system.Setctty(); err != nil {
 			return err

--- a/spec.go
+++ b/spec.go
@@ -401,7 +401,10 @@ func setupUserNamespace(spec *specs.LinuxSpec, config *configs.Config) error {
 	if len(spec.Linux.UIDMappings) == 0 {
 		return nil
 	}
-	config.Namespaces.Add(configs.NEWUSER, "")
+	// do not override the specified user namespace path
+	if config.Namespaces.PathOf(configs.NEWUSER) == "" {
+		config.Namespaces.Add(configs.NEWUSER, "")
+	}
 	create := func(m specs.IDMapping) configs.IDMap {
 		return configs.IDMap{
 			HostID:      int(m.HostID),


### PR DESCRIPTION
Original PR and discussion: https://github.com/docker/libcontainer/pull/609

Enable https://github.com/docker/docker/pull/13453 and https://github.com/docker/docker/issues/10163

This supports setting existing namespaces for a container's init process. It leverages the same C code infrastructure for execin to clone a new init process with the wanted namespaces and cloneflags. Now all namespaces related operation is performed in nsenter C layer, with data sent from Go layer using a simple binary format.