### PR TITLE
Revert "Remove sample configs from libcontainer"

### DIFF
--- a/libcontainer/sample_configs/README.md
+++ b/libcontainer/sample_configs/README.md
@@ -1,0 +1,5 @@
+These configuration files can be used with `nsinit` to quickly develop, test,
+and experiment with features of libcontainer.
+
+When consuming these configuration files, copy them into your rootfs and rename
+the file to `container.json` for use with `nsinit`.

--- a/libcontainer/sample_configs/apparmor.json
+++ b/libcontainer/sample_configs/apparmor.json
@@ -1,0 +1,340 @@
+{
+	"no_pivot_root": false,
+	"parent_death_signal": 0,
+	"pivot_dir": "",
+	"rootfs": "/rootfs/jessie",
+	"readonlyfs": false,
+	"mounts": [
+		{
+			"source": "shm",
+			"destination": "/dev/shm",
+			"device": "tmpfs",
+			"flags": 14,
+			"data": "mode=1777,size=65536k",
+			"relabel": ""
+		},
+		{
+			"source": "mqueue",
+			"destination": "/dev/mqueue",
+			"device": "mqueue",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
+			"source": "sysfs",
+			"destination": "/sys",
+			"device": "sysfs",
+			"flags": 15,
+			"data": "",
+			"relabel": ""
+		}
+	],
+	"devices": [
+		{
+			"type": 99,
+			"path": "/dev/fuse",
+			"major": 10,
+			"minor": 229,
+			"permissions": "rwm",
+			"file_mode": 0,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/null",
+			"major": 1,
+			"minor": 3,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/zero",
+			"major": 1,
+			"minor": 5,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/full",
+			"major": 1,
+			"minor": 7,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/tty",
+			"major": 5,
+			"minor": 0,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/urandom",
+			"major": 1,
+			"minor": 9,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/random",
+			"major": 1,
+			"minor": 8,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		}
+	],
+	"mount_label": "",
+	"hostname": "nsinit",
+	"namespaces": [
+		{
+			"type": "NEWNS",
+			"path": ""
+		},
+		{
+			"type": "NEWUTS",
+			"path": ""
+		},
+		{
+			"type": "NEWIPC",
+			"path": ""
+		},
+		{
+			"type": "NEWPID",
+			"path": ""
+		},
+		{
+			"type": "NEWNET",
+			"path": ""
+		}
+	],
+	"capabilities": [
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"MKNOD",
+		"NET_RAW",
+		"SETGID",
+		"SETUID",
+		"SETFCAP",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"SYS_CHROOT",
+		"KILL",
+		"AUDIT_WRITE"
+	],
+	"networks": [
+		{
+			"type": "loopback",
+			"name": "",
+			"bridge": "",
+			"mac_address": "",
+			"address": "127.0.0.1/0",
+			"gateway": "localhost",
+			"ipv6_address": "",
+			"ipv6_gateway": "",
+			"mtu": 0,
+			"txqueuelen": 0,
+			"host_interface_name": ""
+		}
+	],
+	"routes": null,
+	"cgroups": {
+		"name": "libcontainer",
+		"parent": "nsinit",
+		"allow_all_devices": false,
+		"allowed_devices": [
+			{
+				"type": 99,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 98,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/console",
+				"major": 5,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty0",
+				"major": 4,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty1",
+				"major": 4,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 136,
+				"minor": -1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 5,
+				"minor": 2,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 10,
+				"minor": 200,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/null",
+				"major": 1,
+				"minor": 3,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/zero",
+				"major": 1,
+				"minor": 5,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/full",
+				"major": 1,
+				"minor": 7,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty",
+				"major": 5,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/urandom",
+				"major": 1,
+				"minor": 9,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/random",
+				"major": 1,
+				"minor": 8,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			}
+		],
+		"memory": 0,
+		"memory_reservation": 0,
+		"memory_swap": 0,
+		"cpu_shares": 0,
+		"cpu_quota": 0,
+		"cpu_period": 0,
+		"cpuset_cpus": "",
+		"cpuset_mems": "",
+		"blkio_weight": 0,
+		"freezer": "",
+		"slice": ""
+	},
+	"apparmor_profile": "docker-default",
+	"process_label": "",
+	"rlimits": [
+		{
+			"type": 7,
+			"hard": 1024,
+			"soft": 1024
+		}
+	],
+	"additional_groups": null,
+	"uid_mappings": null,
+	"gid_mappings": null,
+	"mask_paths": [
+		"/proc/kcore"
+	],
+	"readonly_paths": [
+		"/proc/sys",
+		"/proc/sysrq-trigger",
+		"/proc/irq",
+		"/proc/bus"
+	]
+}

--- a/libcontainer/sample_configs/attach_to_bridge.json
+++ b/libcontainer/sample_configs/attach_to_bridge.json
@@ -1,0 +1,353 @@
+{
+	"no_pivot_root": false,
+	"parent_death_signal": 0,
+	"pivot_dir": "",
+	"rootfs": "/rootfs/jessie",
+	"readonlyfs": false,
+	"mounts": [
+		{
+			"source": "shm",
+			"destination": "/dev/shm",
+			"device": "tmpfs",
+			"flags": 14,
+			"data": "mode=1777,size=65536k",
+			"relabel": ""
+		},
+		{
+			"source": "mqueue",
+			"destination": "/dev/mqueue",
+			"device": "mqueue",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
+			"source": "sysfs",
+			"destination": "/sys",
+			"device": "sysfs",
+			"flags": 15,
+			"data": "",
+			"relabel": ""
+		}
+	],
+	"devices": [
+		{
+			"type": 99,
+			"path": "/dev/fuse",
+			"major": 10,
+			"minor": 229,
+			"permissions": "rwm",
+			"file_mode": 0,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/null",
+			"major": 1,
+			"minor": 3,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/zero",
+			"major": 1,
+			"minor": 5,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/full",
+			"major": 1,
+			"minor": 7,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/tty",
+			"major": 5,
+			"minor": 0,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/urandom",
+			"major": 1,
+			"minor": 9,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/random",
+			"major": 1,
+			"minor": 8,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		}
+	],
+	"mount_label": "",
+	"hostname": "koye",
+	"namespaces": [
+		{
+			"type": "NEWNS",
+			"path": ""
+		},
+		{
+			"type": "NEWUTS",
+			"path": ""
+		},
+		{
+			"type": "NEWIPC",
+			"path": ""
+		},
+		{
+			"type": "NEWPID",
+			"path": ""
+		},
+		{
+			"type": "NEWNET",
+			"path": ""
+		}
+	],
+	"capabilities": [
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"MKNOD",
+		"NET_RAW",
+		"SETGID",
+		"SETUID",
+		"SETFCAP",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"SYS_CHROOT",
+		"KILL",
+		"AUDIT_WRITE"
+	],
+	"networks": [
+		{
+			"type": "loopback",
+			"name": "",
+			"bridge": "",
+			"mac_address": "",
+			"address": "127.0.0.1/0",
+			"gateway": "localhost",
+			"ipv6_address": "",
+			"ipv6_gateway": "",
+			"mtu": 0,
+			"txqueuelen": 0,
+			"host_interface_name": ""
+		},
+        {
+			"type": "veth",
+			"name": "eth0",
+			"bridge": "docker0",
+			"mac_address": "",
+			"address": "172.17.0.101/16",
+			"gateway": "172.17.42.1",
+			"ipv6_address": "",
+			"ipv6_gateway": "",
+			"mtu": 1500,
+			"txqueuelen": 0,
+			"host_interface_name": "vethnsinit"
+		}
+	],
+	"routes": null,
+	"cgroups": {
+		"name": "libcontainer",
+		"parent": "nsinit",
+		"allow_all_devices": false,
+		"allowed_devices": [
+			{
+				"type": 99,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 98,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/console",
+				"major": 5,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty0",
+				"major": 4,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty1",
+				"major": 4,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 136,
+				"minor": -1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 5,
+				"minor": 2,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 10,
+				"minor": 200,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/null",
+				"major": 1,
+				"minor": 3,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/zero",
+				"major": 1,
+				"minor": 5,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/full",
+				"major": 1,
+				"minor": 7,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty",
+				"major": 5,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/urandom",
+				"major": 1,
+				"minor": 9,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/random",
+				"major": 1,
+				"minor": 8,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			}
+		],
+		"memory": 0,
+		"memory_reservation": 0,
+		"memory_swap": 0,
+		"cpu_shares": 0,
+		"cpu_quota": 0,
+		"cpu_period": 0,
+		"cpuset_cpus": "",
+		"cpuset_mems": "",
+		"blkio_weight": 0,
+		"freezer": "",
+		"slice": ""
+	},
+	"apparmor_profile": "",
+	"process_label": "",
+	"rlimits": [
+		{
+			"type": 7,
+			"hard": 1024,
+			"soft": 1024
+		}
+	],
+	"additional_groups": null,
+	"uid_mappings": null,
+	"gid_mappings": null,
+	"mask_paths": [
+		"/proc/kcore"
+	],
+	"readonly_paths": [
+		"/proc/sys",
+		"/proc/sysrq-trigger",
+		"/proc/irq",
+		"/proc/bus"
+	]
+}

--- a/libcontainer/sample_configs/host-pid.json
+++ b/libcontainer/sample_configs/host-pid.json
@@ -1,0 +1,336 @@
+{
+	"no_pivot_root": false,
+	"parent_death_signal": 0,
+	"pivot_dir": "",
+	"rootfs": "/rootfs/jessie",
+	"readonlyfs": false,
+	"mounts": [
+		{
+			"source": "shm",
+			"destination": "/dev/shm",
+			"device": "tmpfs",
+			"flags": 14,
+			"data": "mode=1777,size=65536k",
+			"relabel": ""
+		},
+		{
+			"source": "mqueue",
+			"destination": "/dev/mqueue",
+			"device": "mqueue",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
+			"source": "sysfs",
+			"destination": "/sys",
+			"device": "sysfs",
+			"flags": 15,
+			"data": "",
+			"relabel": ""
+		}
+	],
+	"devices": [
+		{
+			"type": 99,
+			"path": "/dev/fuse",
+			"major": 10,
+			"minor": 229,
+			"permissions": "rwm",
+			"file_mode": 0,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/null",
+			"major": 1,
+			"minor": 3,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/zero",
+			"major": 1,
+			"minor": 5,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/full",
+			"major": 1,
+			"minor": 7,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/tty",
+			"major": 5,
+			"minor": 0,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/urandom",
+			"major": 1,
+			"minor": 9,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/random",
+			"major": 1,
+			"minor": 8,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		}
+	],
+	"mount_label": "",
+	"hostname": "nsinit",
+	"namespaces": [
+		{
+			"type": "NEWNS",
+			"path": ""
+		},
+		{
+			"type": "NEWUTS",
+			"path": ""
+		},
+		{
+			"type": "NEWIPC",
+			"path": ""
+		},
+        {
+			"type": "NEWNET",
+			"path": ""
+		}
+	],
+	"capabilities": [
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"MKNOD",
+		"NET_RAW",
+		"SETGID",
+		"SETUID",
+		"SETFCAP",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"SYS_CHROOT",
+		"KILL",
+		"AUDIT_WRITE"
+	],
+	"networks": [
+		{
+			"type": "loopback",
+			"name": "",
+			"bridge": "",
+			"mac_address": "",
+			"address": "127.0.0.1/0",
+			"gateway": "localhost",
+			"ipv6_address": "",
+			"ipv6_gateway": "",
+			"mtu": 0,
+			"txqueuelen": 0,
+			"host_interface_name": ""
+		}
+	],
+	"routes": null,
+	"cgroups": {
+		"name": "libcontainer",
+		"parent": "nsinit",
+		"allow_all_devices": false,
+		"allowed_devices": [
+			{
+				"type": 99,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 98,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/console",
+				"major": 5,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty0",
+				"major": 4,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty1",
+				"major": 4,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 136,
+				"minor": -1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 5,
+				"minor": 2,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 10,
+				"minor": 200,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/null",
+				"major": 1,
+				"minor": 3,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/zero",
+				"major": 1,
+				"minor": 5,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/full",
+				"major": 1,
+				"minor": 7,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty",
+				"major": 5,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/urandom",
+				"major": 1,
+				"minor": 9,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/random",
+				"major": 1,
+				"minor": 8,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			}
+		],
+		"memory": 0,
+		"memory_reservation": 0,
+		"memory_swap": 0,
+		"cpu_shares": 0,
+		"cpu_quota": 0,
+		"cpu_period": 0,
+		"cpuset_cpus": "",
+		"cpuset_mems": "",
+		"blkio_weight": 0,
+		"freezer": "",
+		"slice": ""
+	},
+	"apparmor_profile": "",
+	"process_label": "",
+	"rlimits": [
+		{
+			"type": 7,
+			"hard": 1024,
+			"soft": 1024
+		}
+	],
+	"additional_groups": null,
+	"uid_mappings": null,
+	"gid_mappings": null,
+	"mask_paths": [
+		"/proc/kcore"
+	],
+	"readonly_paths": [
+		"/proc/sys",
+		"/proc/sysrq-trigger",
+		"/proc/irq",
+		"/proc/bus"
+	]
+}

--- a/libcontainer/sample_configs/minimal.json
+++ b/libcontainer/sample_configs/minimal.json
@@ -1,0 +1,340 @@
+{
+	"no_pivot_root": false,
+	"parent_death_signal": 0,
+	"pivot_dir": "",
+	"rootfs": "/home/michael/development/gocode/src/github.com/opencontainers/runc/libcontainer",
+	"readonlyfs": false,
+	"mounts": [
+		{
+			"source": "shm",
+			"destination": "/dev/shm",
+			"device": "tmpfs",
+			"flags": 14,
+			"data": "mode=1777,size=65536k",
+			"relabel": ""
+		},
+		{
+			"source": "mqueue",
+			"destination": "/dev/mqueue",
+			"device": "mqueue",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
+			"source": "sysfs",
+			"destination": "/sys",
+			"device": "sysfs",
+			"flags": 15,
+			"data": "",
+			"relabel": ""
+		}
+	],
+	"devices": [
+		{
+			"type": 99,
+			"path": "/dev/fuse",
+			"major": 10,
+			"minor": 229,
+			"permissions": "rwm",
+			"file_mode": 0,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/null",
+			"major": 1,
+			"minor": 3,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/zero",
+			"major": 1,
+			"minor": 5,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/full",
+			"major": 1,
+			"minor": 7,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/tty",
+			"major": 5,
+			"minor": 0,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/urandom",
+			"major": 1,
+			"minor": 9,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/random",
+			"major": 1,
+			"minor": 8,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		}
+	],
+	"mount_label": "",
+	"hostname": "nsinit",
+	"namespaces": [
+		{
+			"type": "NEWNS",
+			"path": ""
+		},
+		{
+			"type": "NEWUTS",
+			"path": ""
+		},
+		{
+			"type": "NEWIPC",
+			"path": ""
+		},
+		{
+			"type": "NEWPID",
+			"path": ""
+		},
+		{
+			"type": "NEWNET",
+			"path": ""
+		}
+	],
+	"capabilities": [
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"MKNOD",
+		"NET_RAW",
+		"SETGID",
+		"SETUID",
+		"SETFCAP",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"SYS_CHROOT",
+		"KILL",
+		"AUDIT_WRITE"
+	],
+	"networks": [
+		{
+			"type": "loopback",
+			"name": "",
+			"bridge": "",
+			"mac_address": "",
+			"address": "127.0.0.1/0",
+			"gateway": "localhost",
+			"ipv6_address": "",
+			"ipv6_gateway": "",
+			"mtu": 0,
+			"txqueuelen": 0,
+			"host_interface_name": ""
+		}
+	],
+	"routes": null,
+	"cgroups": {
+		"name": "libcontainer",
+		"parent": "nsinit",
+		"allow_all_devices": false,
+		"allowed_devices": [
+			{
+				"type": 99,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 98,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/console",
+				"major": 5,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty0",
+				"major": 4,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty1",
+				"major": 4,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 136,
+				"minor": -1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 5,
+				"minor": 2,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 10,
+				"minor": 200,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/null",
+				"major": 1,
+				"minor": 3,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/zero",
+				"major": 1,
+				"minor": 5,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/full",
+				"major": 1,
+				"minor": 7,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty",
+				"major": 5,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/urandom",
+				"major": 1,
+				"minor": 9,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/random",
+				"major": 1,
+				"minor": 8,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			}
+		],
+		"memory": 0,
+		"memory_reservation": 0,
+		"memory_swap": 0,
+		"cpu_shares": 0,
+		"cpu_quota": 0,
+		"cpu_period": 0,
+		"cpuset_cpus": "",
+		"cpuset_mems": "",
+		"blkio_weight": 0,
+		"freezer": "",
+		"slice": ""
+	},
+	"apparmor_profile": "",
+	"process_label": "",
+	"rlimits": [
+		{
+			"type": 7,
+			"hard": 1024,
+			"soft": 1024
+		}
+	],
+	"additional_groups": null,
+	"uid_mappings": null,
+	"gid_mappings": null,
+	"mask_paths": [
+		"/proc/kcore"
+	],
+	"readonly_paths": [
+		"/proc/sys",
+		"/proc/sysrq-trigger",
+		"/proc/irq",
+		"/proc/bus"
+	]
+}

--- a/libcontainer/sample_configs/selinux.json
+++ b/libcontainer/sample_configs/selinux.json
@@ -1,0 +1,340 @@
+{
+	"no_pivot_root": false,
+	"parent_death_signal": 0,
+	"pivot_dir": "",
+	"rootfs": "/rootfs/jessie",
+	"readonlyfs": false,
+	"mounts": [
+		{
+			"source": "shm",
+			"destination": "/dev/shm",
+			"device": "tmpfs",
+			"flags": 14,
+			"data": "mode=1777,size=65536k",
+			"relabel": ""
+		},
+		{
+			"source": "mqueue",
+			"destination": "/dev/mqueue",
+			"device": "mqueue",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
+			"source": "sysfs",
+			"destination": "/sys",
+			"device": "sysfs",
+			"flags": 15,
+			"data": "",
+			"relabel": ""
+		}
+	],
+	"devices": [
+		{
+			"type": 99,
+			"path": "/dev/fuse",
+			"major": 10,
+			"minor": 229,
+			"permissions": "rwm",
+			"file_mode": 0,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/null",
+			"major": 1,
+			"minor": 3,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/zero",
+			"major": 1,
+			"minor": 5,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/full",
+			"major": 1,
+			"minor": 7,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/tty",
+			"major": 5,
+			"minor": 0,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/urandom",
+			"major": 1,
+			"minor": 9,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/random",
+			"major": 1,
+			"minor": 8,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		}
+	],
+	"mount_label": "system_u:system_r:svirt_lxc_net_t:s0:c164,c475",
+	"hostname": "nsinit",
+	"namespaces": [
+		{
+			"type": "NEWNS",
+			"path": ""
+		},
+		{
+			"type": "NEWUTS",
+			"path": ""
+		},
+		{
+			"type": "NEWIPC",
+			"path": ""
+		},
+		{
+			"type": "NEWPID",
+			"path": ""
+		},
+		{
+			"type": "NEWNET",
+			"path": ""
+		}
+	],
+	"capabilities": [
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"MKNOD",
+		"NET_RAW",
+		"SETGID",
+		"SETUID",
+		"SETFCAP",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"SYS_CHROOT",
+		"KILL",
+		"AUDIT_WRITE"
+	],
+	"networks": [
+		{
+			"type": "loopback",
+			"name": "",
+			"bridge": "",
+			"mac_address": "",
+			"address": "127.0.0.1/0",
+			"gateway": "localhost",
+			"ipv6_address": "",
+			"ipv6_gateway": "",
+			"mtu": 0,
+			"txqueuelen": 0,
+			"host_interface_name": ""
+		}
+	],
+	"routes": null,
+	"cgroups": {
+		"name": "libcontainer",
+		"parent": "nsinit",
+		"allow_all_devices": false,
+		"allowed_devices": [
+			{
+				"type": 99,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 98,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/console",
+				"major": 5,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty0",
+				"major": 4,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty1",
+				"major": 4,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 136,
+				"minor": -1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 5,
+				"minor": 2,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 10,
+				"minor": 200,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/null",
+				"major": 1,
+				"minor": 3,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/zero",
+				"major": 1,
+				"minor": 5,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/full",
+				"major": 1,
+				"minor": 7,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty",
+				"major": 5,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/urandom",
+				"major": 1,
+				"minor": 9,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/random",
+				"major": 1,
+				"minor": 8,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			}
+		],
+		"memory": 0,
+		"memory_reservation": 0,
+		"memory_swap": 0,
+		"cpu_shares": 0,
+		"cpu_quota": 0,
+		"cpu_period": 0,
+		"cpuset_cpus": "",
+		"cpuset_mems": "",
+		"blkio_weight": 0,
+		"freezer": "",
+		"slice": ""
+	},
+	"apparmor_profile": "",
+	"process_label": "system_u:system_r:svirt_lxc_net_t:s0:c164,c475",
+	"rlimits": [
+		{
+			"type": 7,
+			"hard": 1024,
+			"soft": 1024
+		}
+	],
+	"additional_groups": null,
+	"uid_mappings": null,
+	"gid_mappings": null,
+	"mask_paths": [
+		"/proc/kcore"
+	],
+	"readonly_paths": [
+		"/proc/sys",
+		"/proc/sysrq-trigger",
+		"/proc/irq",
+		"/proc/bus"
+	]
+}

--- a/libcontainer/sample_configs/userns.json
+++ b/libcontainer/sample_configs/userns.json
@@ -1,0 +1,376 @@
+{
+	"no_pivot_root": false,
+	"parent_death_signal": 0,
+	"pivot_dir": "",
+	"rootfs": "/rootfs/jessie",
+	"readonlyfs": false,
+	"mounts": [
+		{
+			"source": "shm",
+			"destination": "/dev/shm",
+			"device": "tmpfs",
+			"flags": 14,
+			"data": "mode=1777,size=65536k",
+			"relabel": ""
+		},
+		{
+			"source": "mqueue",
+			"destination": "/dev/mqueue",
+			"device": "mqueue",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
+			"source": "sysfs",
+			"destination": "/sys",
+			"device": "sysfs",
+			"flags": 15,
+			"data": "",
+			"relabel": ""
+		}
+	],
+	"devices": [
+		{
+			"type": 99,
+			"path": "/dev/fuse",
+			"major": 10,
+			"minor": 229,
+			"permissions": "rwm",
+			"file_mode": 0,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/null",
+			"major": 1,
+			"minor": 3,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/zero",
+			"major": 1,
+			"minor": 5,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/full",
+			"major": 1,
+			"minor": 7,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/tty",
+			"major": 5,
+			"minor": 0,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/urandom",
+			"major": 1,
+			"minor": 9,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		},
+		{
+			"type": 99,
+			"path": "/dev/random",
+			"major": 1,
+			"minor": 8,
+			"permissions": "rwm",
+			"file_mode": 438,
+			"uid": 0,
+			"gid": 0
+		}
+	],
+	"mount_label": "",
+	"hostname": "nsinit",
+	"namespaces": [
+		{
+			"type": "NEWNS",
+			"path": ""
+		},
+		{
+			"type": "NEWUTS",
+			"path": ""
+		},
+		{
+			"type": "NEWIPC",
+			"path": ""
+		},
+		{
+			"type": "NEWPID",
+			"path": ""
+		},
+		{
+			"type": "NEWNET",
+			"path": ""
+		},
+		{
+			"type": "NEWUSER",
+			"path": ""
+		}
+	],
+	"capabilities": [
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"MKNOD",
+		"NET_RAW",
+		"SETGID",
+		"SETUID",
+		"SETFCAP",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"SYS_CHROOT",
+		"KILL",
+		"AUDIT_WRITE"
+	],
+	"networks": [
+		{
+			"type": "loopback",
+			"name": "",
+			"bridge": "",
+			"mac_address": "",
+			"address": "127.0.0.1/0",
+			"gateway": "localhost",
+			"ipv6_address": "",
+			"ipv6_gateway": "",
+			"mtu": 0,
+			"txqueuelen": 0,
+			"host_interface_name": ""
+		}
+	],
+	"routes": null,
+	"cgroups": {
+		"name": "libcontainer",
+		"parent": "nsinit",
+		"allow_all_devices": false,
+		"allowed_devices": [
+			{
+				"type": 99,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 98,
+				"path": "",
+				"major": -1,
+				"minor": -1,
+				"permissions": "m",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/console",
+				"major": 5,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty0",
+				"major": 4,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty1",
+				"major": 4,
+				"minor": 1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 136,
+				"minor": -1,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 5,
+				"minor": 2,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "",
+				"major": 10,
+				"minor": 200,
+				"permissions": "rwm",
+				"file_mode": 0,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/null",
+				"major": 1,
+				"minor": 3,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/zero",
+				"major": 1,
+				"minor": 5,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/full",
+				"major": 1,
+				"minor": 7,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/tty",
+				"major": 5,
+				"minor": 0,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/urandom",
+				"major": 1,
+				"minor": 9,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"type": 99,
+				"path": "/dev/random",
+				"major": 1,
+				"minor": 8,
+				"permissions": "rwm",
+				"file_mode": 438,
+				"uid": 0,
+				"gid": 0
+			}
+		],
+		"memory": 0,
+		"memory_reservation": 0,
+		"memory_swap": 0,
+		"cpu_shares": 0,
+		"cpu_quota": 0,
+		"cpu_period": 0,
+		"cpuset_cpus": "",
+		"cpuset_mems": "",
+		"blkio_weight": 0,
+		"freezer": "",
+		"slice": ""
+	},
+	"apparmor_profile": "",
+	"process_label": "",
+	"rlimits": [
+		{
+			"type": 7,
+			"hard": 1024,
+			"soft": 1024
+		}
+	],
+	"additional_groups": null,
+	"uid_mappings": [
+		{
+			"container_id": 0,
+			"host_id": 1000,
+			"size": 1
+		},
+		{
+			"container_id": 1,
+			"host_id": 1,
+			"size": 999
+		},
+		{
+			"container_id": 1001,
+			"host_id": 1001,
+			"size": 2147482647
+		}
+	],
+	"gid_mappings": [
+		{
+			"container_id": 0,
+			"host_id": 1000,
+			"size": 1
+		},
+		{
+			"container_id": 1,
+			"host_id": 1,
+			"size": 999
+		},
+		{
+			"container_id": 1001,
+			"host_id": 1001,
+			"size": 2147482647
+		}
+	],
+	"mask_paths": [
+		"/proc/kcore"
+	],
+	"readonly_paths": [
+		"/proc/sys",
+		"/proc/sysrq-trigger",
+		"/proc/irq",
+		"/proc/bus"
+	]
+}


### PR DESCRIPTION
This is breaking runc builds as libcontainer tests depend on some of these configs.