### PR TITLE
avoid infinite loop with GCCGO

### DIFF
--- a/libcontainer/stacktrace/capture.go
+++ b/libcontainer/stacktrace/capture.go
@@ -9,13 +9,17 @@ func Capture(userSkip int) Stacktrace {
 	var (
 		skip   = userSkip + 1 // add one for our own function
 		frames []Frame
+		prevPc uintptr = 0
 	)
 	for i := skip; ; i++ {
 		pc, file, line, ok := runtime.Caller(i)
-		if !ok {
+		//detect if caller is repeated to avoid loop, gccgo
+		//currently runs  into a loop without this check
+		if !ok || pc == prevPc {
 			break
 		}
 		frames = append(frames, NewFrame(pc, file, line))
+		prevPc = pc
 	}
 	return Stacktrace{
 		Frames: frames,


### PR DESCRIPTION
The stack trace call goes into a infinite loop with GCCGO 5.1 branch. This is required for Docker integrations tests to run well.

Signed-off-by: Srini Brahmaroutu <srbrahma@us.ibm.com>