### PR TITLE
Fix error when memory cgroup not mounted

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -19,7 +19,10 @@ type MemoryGroup struct {
 
 func (s *MemoryGroup) Apply(d *data) error {
 	path, err := d.path("memory")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
Fixes: #57

Normally all cgroup subsystems are optional except device cgroup,
but memory cgroup optional was broken by:
https://github.com/docker/libcontainer/pull/637

This patch fixes this.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>