### PR TITLE
Add memory swappiness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ user named `daemon` defined within that file-system.
                 "limit": 0,
                 "reservation": 0,
                 "swap": 0,
-                "kernel": 0
+                "kernel": 0,
+                "swappiness": -1
             },
             "cpu": {
                 "shares": 0,

--- a/spec.go
+++ b/spec.go
@@ -116,6 +116,11 @@ var specCommand = cli.Command{
 					"zero",
 					"urandom",
 				},
+				Resources: specs.Resources{
+					Memory: specs.Memory{
+						Swappiness: -1,
+					},
+				},
 			},
 		}
 		data, err := json.MarshalIndent(&spec, "", "\t")
@@ -247,6 +252,7 @@ func createCgroupConfig(spec *specs.LinuxSpec, devices []*configs.Device) (*conf
 	c.MemoryReservation = r.Memory.Reservation
 	c.MemorySwap = r.Memory.Swap
 	c.KernelMemory = r.Memory.Kernel
+	c.MemorySwappiness = r.Memory.Swappiness
 	c.CpuShares = r.CPU.Shares
 	c.CpuQuota = r.CPU.Quota
 	c.CpuPeriod = r.CPU.Period


### PR DESCRIPTION
(I made a mistake and causing the old PR to be closed, so I have to open a new PR)

Without this patch, I won't be able to start containers with runc, because it tries to write to the cgroup's swappiness and fails.