### PR TITLE
runc kill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ user named `daemon` defined within that file-system.
 }
 ```
 
+
+
 ### Examples:
 
 #### Using a Docker image (requires version 1.3 or later)
@@ -230,3 +232,12 @@ WorkingDirectory=/containers/minecraftbuild
 [Install]
 WantedBy=multi-user.target
 ```
+
+#####Kill Support for runc
+Usage:
+runc --id=runc kill <arguments>
+Arguments can be signal number or signal name in string 
+
+Example
+runc --id=runc kill TERM
+runc --id=runc kill 15

--- a/kill.go
+++ b/kill.go
@@ -79,7 +79,7 @@ var killCommand = cli.Command{
 
 		state, err := container.Status()
 		if err != nil {
-			fmt.Println("Container not running %d", state)
+			fatal(fmt.Errorf("Container not running %d",state))
 			// return here
 		}
 		if sig == 0 || syscall.Signal(sig) == syscall.SIGKILL {

--- a/kill.go
+++ b/kill.go
@@ -1,0 +1,119 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/codegangsta/cli"
+	"github.com/opencontainers/runc/libcontainer"
+)
+
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":   syscall.SIGABRT,
+	"ALRM":   syscall.SIGALRM,
+	"BUS":    syscall.SIGBUS,
+	"CHLD":   syscall.SIGCHLD,
+	"CLD":    syscall.SIGCLD,
+	"CONT":   syscall.SIGCONT,
+	"FPE":    syscall.SIGFPE,
+	"HUP":    syscall.SIGHUP,
+	"ILL":    syscall.SIGILL,
+	"INT":    syscall.SIGINT,
+	"IO":     syscall.SIGIO,
+	"IOT":    syscall.SIGIOT,
+	"KILL":   syscall.SIGKILL,
+	"PIPE":   syscall.SIGPIPE,
+	"POLL":   syscall.SIGPOLL,
+	"PROF":   syscall.SIGPROF,
+	"PWR":    syscall.SIGPWR,
+	"QUIT":   syscall.SIGQUIT,
+	"SEGV":   syscall.SIGSEGV,
+	"STKFLT": syscall.SIGSTKFLT,
+	"STOP":   syscall.SIGSTOP,
+	"SYS":    syscall.SIGSYS,
+	"TERM":   syscall.SIGTERM,
+	"TRAP":   syscall.SIGTRAP,
+	"TSTP":   syscall.SIGTSTP,
+	"TTIN":   syscall.SIGTTIN,
+	"TTOU":   syscall.SIGTTOU,
+	"UNUSED": syscall.SIGUNUSED,
+	"URG":    syscall.SIGURG,
+	"USR1":   syscall.SIGUSR1,
+	"USR2":   syscall.SIGUSR2,
+	"VTALRM": syscall.SIGVTALRM,
+	"WINCH":  syscall.SIGWINCH,
+	"XCPU":   syscall.SIGXCPU,
+	"XFSZ":   syscall.SIGXFSZ,
+}
+
+var killCommand = cli.Command{
+	Name:  "kill",
+	Usage: "kill a container",
+	Action: func(context *cli.Context) {
+		container, err := getContainer(context)
+		if err != nil {
+			fatal(fmt.Errorf("%s", err))
+		}
+		sigStr := context.Args().First()
+		var sig uint64
+		sigN, err := strconv.ParseUint(sigStr, 10, 5)
+		if err != nil {
+			//The signal is not a number, treat it as a string (either like
+			//KILL" or like "SIGKILL")
+			syscallSig, ok := SignalMap[strings.TrimPrefix(sigStr, "SIG")]
+			if !ok {
+				fatal(fmt.Errorf("Invalid signal: %s", sigStr))
+			}
+			sig = uint64(syscallSig)
+		} else {
+			sig = sigN
+		}
+
+		if sig == 0 {
+			fatal(fmt.Errorf("Invalid signal: %s", sigStr))
+		}
+
+		state, err := container.Status()
+		if err != nil {
+			fmt.Println("Container not running %d", state)
+			// return here
+		}
+		if sig == 0 || syscall.Signal(sig) == syscall.SIGKILL {
+			if err := Kill(container); err != nil {
+				fatal(fmt.Errorf("Can not kill the container"))
+			}
+		} else {
+			// Otherwise, just send the requested signal
+			if err := KillSig(container, int(sig)); err != nil {
+				fatal(fmt.Errorf("Can not kill the container"))
+			}
+		}
+
+	},
+}
+
+func Kill(container libcontainer.Container) error {
+
+	processes, err := container.Processes()
+	if err != nil {
+		fatal(fmt.Errorf("Can not kill the container %d", err))
+		return err
+	}
+	syscall.Kill(processes[0], 9)
+	return nil
+
+}
+
+func KillSig(container libcontainer.Container, sig int) error {
+	processes, err := container.Processes()
+	if err != nil {
+		fatal(fmt.Errorf("Can not kill the container %d", err))
+		return err
+	}
+	syscall.Kill(processes[0], syscall.Signal(sig))
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 		checkpointCommand,
 		eventsCommand,
 		restoreCommand,
+		killCommand,
 		specCommand,
 	}
 	app.Before = func(context *cli.Context) error {


### PR DESCRIPTION
Hi

Added the runc kill support, to kill the containers by passing the signals.
Updated the file to support Linux signals.

Usage:
After running the container
./runc --id=runc kill TERM
. or
./runc --id=runc kill 15
updated README.md for usage

Tested with multiple containers by giving bash as the first PID.
/bin/sh can not handle the signals, so it will be ignored by container

Added test program to trap signals and ran as part of container. Upon running runc kill, it is able to terminate the container.

yet to add the test program in integration folder for supporting kill.

Signed-off-by: Rajasekaran <rajasec79@gmail.com>