### PR TITLE
Cgroups mount fix

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -57,6 +57,7 @@ func FindCgroupMountpointDir() (string, error) {
 
 type Mount struct {
 	Mountpoint string
+	Root       string
 	Subsystems []string
 }
 
@@ -87,7 +88,7 @@ func GetCgroupMounts() ([]Mount, error) {
 	res := []Mount{}
 	for _, mount := range mounts {
 		if mount.Fstype == "cgroup" {
-			m := Mount{Mountpoint: mount.Mountpoint}
+			m := Mount{Mountpoint: mount.Mountpoint, Root: mount.Root}
 
 			for _, opt := range strings.Split(mount.VfsOpts, ",") {
 				if strings.HasPrefix(opt, "name=") {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -180,18 +180,22 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			if err != nil {
 				return err
 			}
+			relDir, err := filepath.Rel(mm.Root, dir)
+			if err != nil {
+				return err
+			}
 			binds = append(binds, &configs.Mount{
 				Device:      "bind",
-				Source:      filepath.Join(mm.Mountpoint, dir),
+				Source:      filepath.Join(mm.Mountpoint, relDir),
 				Destination: filepath.Join(m.Destination, strings.Join(mm.Subsystems, ",")),
 				Flags:       syscall.MS_BIND | syscall.MS_REC | m.Flags,
 			})
 		}
 		tmpfs := &configs.Mount{
-			Device:      "tmpfs",
 			Source:      "tmpfs",
+			Device:      "tmpfs",
 			Destination: m.Destination,
-			Flags:       syscall.MS_NOEXEC | syscall.MS_NOSUID | syscall.MS_NODEV,
+			Flags:       defaultMountFlags,
 		}
 		if err := mountToRootfs(tmpfs, rootfs, mountLabel); err != nil {
 			return err


### PR DESCRIPTION
Because of this there was problems with mounting cgroups in children containers. It tried to mount whole path, which exists on host, but not in container.
ping @mrunalp @hqhq @avagin