### PR TITLE
Revert "Remount /sys/fs/cgroup as readonly always"

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -845,15 +845,6 @@ func TestMountCgroupRO(t *testing.T) {
 	mountInfo := buffers.Stdout.String()
 	lines := strings.Split(mountInfo, "\n")
 	for _, l := range lines {
-		if strings.HasPrefix(l, "tmpfs on /sys/fs/cgroup") {
-			if !strings.Contains(l, "ro,nosuid,nodev,noexec") {
-				t.Fatalf("Mode expected to contain 'ro,nosuid,nodev,noexec': %s", l)
-			}
-			if !strings.Contains(l, "mode=755") {
-				t.Fatalf("Mode expected to contain 'mode=755': %s", l)
-			}
-			continue
-		}
 		if !strings.HasPrefix(l, "cgroup") {
 			continue
 		}
@@ -889,15 +880,6 @@ func TestMountCgroupRW(t *testing.T) {
 	mountInfo := buffers.Stdout.String()
 	lines := strings.Split(mountInfo, "\n")
 	for _, l := range lines {
-		if strings.HasPrefix(l, "tmpfs on /sys/fs/cgroup") {
-			if !strings.Contains(l, "ro,nosuid,nodev,noexec") {
-				t.Fatalf("Mode expected to contain 'ro,nosuid,nodev,noexec': %s", l)
-			}
-			if !strings.Contains(l, "mode=755") {
-				t.Fatalf("Mode expected to contain 'mode=755': %s", l)
-			}
-			continue
-		}
 		if !strings.HasPrefix(l, "cgroup") {
 			continue
 		}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -196,7 +196,6 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			Device:      "tmpfs",
 			Destination: m.Destination,
 			Flags:       defaultMountFlags,
-			Data:        "mode=755",
 		}
 		if err := mountToRootfs(tmpfs, rootfs, mountLabel); err != nil {
 			return err
@@ -205,11 +204,6 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			if err := mountToRootfs(b, rootfs, mountLabel); err != nil {
 				return err
 			}
-		}
-		// remount cgroup root as readonly
-		rootfsCgroup := filepath.Join(rootfs, m.Destination)
-		if err := syscall.Mount("", rootfsCgroup, "", defaultMountFlags|syscall.MS_REMOUNT|syscall.MS_RDONLY, ""); err != nil {
-			return err
 		}
 	default:
 		return fmt.Errorf("unknown mount device %q to %q", m.Device, m.Destination)


### PR DESCRIPTION
This reverts commit 18de1a273e00fd87205e174e2bfe3c36837a6d37.

It caused failures in docker test suite.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>