### PR TITLE
bring the loopback interface up inside containers

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -191,6 +191,11 @@ func createLibcontainerConfig(spec *specs.LinuxSpec) (*configs.Config, error) {
 		Readonlyfs:   spec.Root.Readonly,
 		Hostname:     spec.Hostname,
 		Privatefs:    true,
+		Networks: []*configs.Network{
+			{
+				Type: "loopback",
+			},
+		},
 	}
 	for _, ns := range spec.Linux.Namespaces {
 		t, exists := namespaceMapping[ns.Type]


### PR DESCRIPTION
... unless there's any good reason to leave `lo` down inside private namespaces by default?

Without this, unnecessary privileges and capabilities would need to be given to the container so it can bring the interface up itself.