### PR TITLE
typo: kB -> KB

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -248,7 +248,7 @@ func RemovePaths(paths map[string]string) (err error) {
 
 func GetHugePageSize() ([]string, error) {
 	var pageSizes []string
-	sizeList := []string{"B", "kB", "MB", "GB", "TB", "PB"}
+	sizeList := []string{"B", "KB", "MB", "GB", "TB", "PB"}
 	files, err := ioutil.ReadDir("/sys/kernel/mm/hugepages")
 	if err != nil {
 		return pageSizes, err


### PR DESCRIPTION
in SI standard, kB means 1000B
in case of binary, use "KB" or "KiB" (IEC standard)
for consistency (docker/pkg/utils/size.go), "KB" is right
I recommend KB instead of KiB because of the consistency with other unit(MB, GB, etc)

Signed-off-by: Jin-Hwan Jeong <jhjeong.kr@gmail.com>