### PR TITLE
Use /proc/self/exe as default for InitPath

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -46,7 +46,7 @@ func InitArgs(args ...string) func(*LinuxFactory) error {
 			}
 			name = abs
 		}
-		l.InitPath = name
+		l.InitPath = "/proc/self/exe"
 		l.InitArgs = append([]string{name}, args[1:]...)
 		return nil
 	}


### PR DESCRIPTION
This is more secure and simpler than using os.Args[0].