### PR TITLE
test: propagate the error to the caller

### DIFF
--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -72,7 +72,7 @@ func newRootfs() (string, error) {
 		return "", err
 	}
 	if err := copyBusybox(dir); err != nil {
-		return "", nil
+		return "", err
 	}
 	return dir, nil
 }


### PR DESCRIPTION
When the copyBusybox() fails, the error message should be
propagated to the caller of newRootfs().

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>