### PR TITLE
Makefile: use test instead of localtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ validate: vet
 	script/validate-gofmt
 	go vet ./...
 
-ci: validate localtest
+ci: validate test


### PR DESCRIPTION
The target "localtest" can be only used in the RUNC_TEST_IMAGE
which has all the required dependency.  It can not be used in the host,
so we use the "test" instead.

Cc: Alexander Morozov <lk4d4@docker.com>
Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>