### PR TITLE
Only add network info if NEWNET is set

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -191,11 +191,6 @@ func createLibcontainerConfig(spec *specs.LinuxSpec) (*configs.Config, error) {
 		Readonlyfs:   spec.Root.Readonly,
 		Hostname:     spec.Hostname,
 		Privatefs:    true,
-		Networks: []*configs.Network{
-			{
-				Type: "loopback",
-			},
-		},
 	}
 	for _, ns := range spec.Linux.Namespaces {
 		t, exists := namespaceMapping[ns.Type]
@@ -203,6 +198,13 @@ func createLibcontainerConfig(spec *specs.LinuxSpec) (*configs.Config, error) {
 			return nil, fmt.Errorf("namespace %q does not exist", ns)
 		}
 		config.Namespaces.Add(t, ns.Path)
+	}
+	if config.Namespaces.Contains(configs.NEWNET) {
+		config.Networks = []*configs.Network{
+			{
+				Type: "loopback",
+			},
+		}
 	}
 	for _, m := range spec.Mounts {
 		config.Mounts = append(config.Mounts, createLibcontainerMount(cwd, m))


### PR DESCRIPTION
Only add the localhost interface information to the config if the NEWNET
flag is passed on the namespaces.

This fixes an issue running the container in the host's network namespace.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>