### PR TITLE
Update README.md to correct comment about spec and user

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ To test using Docker's `busybox` image follow these steps:
 mkdir rootfs
 tar -C rootfs -xf busybox.tar
 ```
-* Create a file called `config.json` using the example from above.
-Modify the `user` property to be `root`.
+* Create a file called `config.json` using the example from above.  You can also
+generate a spec using `runc spec`, redirecting the output into `config.json`
 * Execute `runc` and you should be placed into a shell where you can run `ps`:
 ```
 $ runc


### PR DESCRIPTION
Now that the generated spec (and the example above in the README) use
uid/gid and don't have the hardcoded `daemon` entry, the statement about
changing `daemon` to `root` no longer applies.  Also added a comment
about using the `runc spec` command to generate `config.json`.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)