### PR TITLE
Remove dind

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -864,7 +864,6 @@ func TestMountCgroupRO(t *testing.T) {
 }
 
 func TestMountCgroupRW(t *testing.T) {
-	t.Skip("This test is screwed because of dind")
 	if testing.Short() {
 		return
 	}

--- a/script/test_Dockerfile
+++ b/script/test_Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && apt-get install -y iptables criu=1.6-2 && rm -rf /var/lib/
 RUN mkdir /busybox && \
     curl -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.11/rootfs.tar' | tar -xC /busybox
 
-RUN curl -sSL https://raw.githubusercontent.com/docker/docker/master/hack/dind -o /dind && \
-    chmod +x /dind
-
+COPY script/tmpmount /
 WORKDIR /go/src/github.com/opencontainers/runc
-ENTRYPOINT ["/dind"]
+ENTRYPOINT ["/tmpmount"]

--- a/script/tmpmount
+++ b/script/tmpmount
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mount -t tmpfs none /tmp
+exec "$@"


### PR DESCRIPTION
Also unskip test that was screwed by it.
We don't need dind anymore, because docker mounting cgroups in container
itself.