### PR TITLE
Make label.Relabel safer.

### DIFF
--- a/libcontainer/label/label.go
+++ b/libcontainer/label/label.go
@@ -29,7 +29,7 @@ func SetFileCreateLabel(fileLabel string) error {
 	return nil
 }
 
-func Relabel(path string, fileLabel string, relabel string) error {
+func Relabel(path string, fileLabel string, shared bool) error {
 	return nil
 }
 
@@ -58,4 +58,14 @@ func DupSecOpt(src string) []string {
 // support for future container processes
 func DisableSecOpt() []string {
 	return nil
+}
+
+// Validate checks that the label does not include unexpected options
+func Validate(label string) error {
+	return nil
+}
+
+// IsShared checks that the label includes a "shared" mark
+func IsShared(label string) bool {
+	return false
 }

--- a/libcontainer/label/label_selinux.go
+++ b/libcontainer/label/label_selinux.go
@@ -9,6 +9,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer/selinux"
 )
 
+var ErrIncompatibleLabel = fmt.Errorf("Bad SELinux option z and Z can not be used together")
+
 // InitLabels returns the process label and file labels to be used within
 // the container.  A list of options can be passed into this function to alter
 // the labels.  The labels returned will include a random MCS String, that is
@@ -95,28 +97,24 @@ func SetFileCreateLabel(fileLabel string) error {
 	return nil
 }
 
-// Change the label of path to the filelabel string.  If the relabel string
-// is "z", relabel will change the MCS label to s0.  This will allow all
-// containers to share the content.  If the relabel string is a "Z" then
-// the MCS label should continue to be used.  SELinux will use this field
-// to make sure the content can not be shared by other containes.
-func Relabel(path string, fileLabel string, relabel string) error {
-	exclude_path := []string{"/", "/usr", "/etc"}
+// Change the label of path to the filelabel string.
+// It changes the MCS label to s0 if shared is true.
+// This will allow all containers to share the content.
+func Relabel(path string, fileLabel string, shared bool) error {
+	if !selinux.SelinuxEnabled() {
+		return nil
+	}
+
 	if fileLabel == "" {
 		return nil
 	}
-	if !strings.ContainsAny(relabel, "zZ") {
-		return nil
+
+	exclude_paths := map[string]bool{"/": true, "/usr": true, "/etc": true}
+	if exclude_paths[path] {
+		return fmt.Errorf("Relabeling of %s is not allowed", path)
 	}
-	for _, p := range exclude_path {
-		if path == p {
-			return fmt.Errorf("Relabeling of %s is not allowed", path)
-		}
-	}
-	if strings.Contains(relabel, "z") && strings.Contains(relabel, "Z") {
-		return fmt.Errorf("Bad SELinux option z and Z can not be used together")
-	}
-	if strings.Contains(relabel, "z") {
+
+	if shared {
 		c := selinux.NewContext(fileLabel)
 		c["level"] = "s0"
 		fileLabel = c.Get()
@@ -160,4 +158,17 @@ func DupSecOpt(src string) []string {
 // support for future container processes
 func DisableSecOpt() []string {
 	return selinux.DisableSecOpt()
+}
+
+// Validate checks that the label does not include unexpected options
+func Validate(label string) error {
+	if strings.Contains(label, "z") && strings.Contains(label, "Z") {
+		return ErrIncompatibleLabel
+	}
+	return nil
+}
+
+// IsShared checks that the label includes a "shared" mark
+func IsShared(label string) bool {
+	return strings.Contains(label, "z")
 }

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -160,7 +160,11 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			}
 		}
 		if m.Relabel != "" {
-			if err := label.Relabel(m.Source, mountLabel, m.Relabel); err != nil {
+			if err := label.Validate(m.Relabel); err != nil {
+				return err
+			}
+			shared := label.IsShared(m.Relabel)
+			if err := label.Relabel(m.Source, mountLabel, shared); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
- Check if Selinux is enabled before relabeling. This is a bug.
- Make exclusion detection constant time. Kinda buggy too, imo.
- Do not depend on a magic string to create a new Selinux context.

/cc @lk4d4

Signed-off-by: David Calavera <david.calavera@gmail.com>