### PR TITLE
Go1.5 compatibility fix

### DIFF
--- a/libcontainer/compat_1.5_linux.go
+++ b/libcontainer/compat_1.5_linux.go
@@ -1,0 +1,10 @@
+// +build linux,!go1.5
+
+package libcontainer
+
+import "syscall"
+
+// GidMappingsEnableSetgroups was added in Go 1.5, so do nothing when building
+// with earlier versions
+func enableSetgroups(sys *syscall.SysProcAttr) {
+}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -164,6 +164,7 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, c
 			// user mappings are not supported
 			return nil, err
 		}
+		enableSetgroups(cmd.SysProcAttr)
 		// Default to root user when user namespaces are enabled.
 		if cmd.SysProcAttr.Credential == nil {
 			cmd.SysProcAttr.Credential = &syscall.Credential{}

--- a/libcontainer/setgroups_linux.go
+++ b/libcontainer/setgroups_linux.go
@@ -1,0 +1,11 @@
+// +build linux,go1.5
+
+package libcontainer
+
+import "syscall"
+
+// Set the GidMappingsEnableSetgroups member to true, so the process's
+// setgroups proc entry wont be set to 'deny' if GidMappings are set
+func enableSetgroups(sys *syscall.SysProcAttr) {
+	sys.GidMappingsEnableSetgroups = true
+}


### PR DESCRIPTION
This fixes an issue with Go 1.5, introduced by:
https://github.com/golang/go/commit/f5c60ff2da4851f9056120a423ce6b48624fb97e