### PR TITLE
runc: accomodate the specs golint

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -316,7 +316,7 @@ func setReadonly(config *configs.Config) {
 }
 
 func setupUserNamespace(spec *specs.LinuxSpec, config *configs.Config) error {
-	if len(spec.Linux.UidMappings) == 0 {
+	if len(spec.Linux.UIDMappings) == 0 {
 		return nil
 	}
 	config.Namespaces.Add(configs.NEWUSER, "")
@@ -327,10 +327,10 @@ func setupUserNamespace(spec *specs.LinuxSpec, config *configs.Config) error {
 			Size:        int(m.Size),
 		}
 	}
-	for _, m := range spec.Linux.UidMappings {
+	for _, m := range spec.Linux.UIDMappings {
 		config.UidMappings = append(config.UidMappings, create(m))
 	}
-	for _, m := range spec.Linux.GidMappings {
+	for _, m := range spec.Linux.GIDMappings {
 		config.GidMappings = append(config.GidMappings, create(m))
 	}
 	rootUid, err := config.HostUID()

--- a/utils.go
+++ b/utils.go
@@ -168,7 +168,7 @@ func newProcess(p specs.Process) *libcontainer.Process {
 		Args: p.Args,
 		Env:  p.Env,
 		// TODO: fix libcontainer's API to better support uid/gid in a typesafe way.
-		User:   fmt.Sprintf("%d:%d", p.User.Uid, p.User.Gid),
+		User:   fmt.Sprintf("%d:%d", p.User.UID, p.User.GID),
 		Cwd:    p.Cwd,
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,


### PR DESCRIPTION
for https://github.com/opencontainers/specs/pull/91

There are other configs that live in libcontainer that could change for `golint`, but we can address them separately. This is just to accommodate the specs changes.

Signed-off-by: Vincent Batts <vbatts@redhat.com>