### PR TITLE
Add signal API to Container interface

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -5,6 +5,8 @@
 package libcontainer
 
 import (
+	"os"
+
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -159,4 +161,10 @@ type Container interface {
 	// errors:
 	// Systemerror - System error.
 	NotifyOOM() (<-chan struct{}, error)
+
+	// Signal sends the provided signal code to the container's initial process.
+	//
+	// errors:
+	// Systemerror - System error.
+	Signal(s os.Signal) error
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -118,6 +118,13 @@ func (c *linuxContainer) Start(process *Process) error {
 	return nil
 }
 
+func (c *linuxContainer) Signal(s os.Signal) error {
+	if err := c.initProcess.signal(s); err != nil {
+		return newSystemError(err)
+	}
+	return nil
+}
+
 func (c *linuxContainer) newParentProcess(p *Process, doInit bool) (parentProcess, error) {
 	parentPipe, childPipe, err := newPipe()
 	if err != nil {

--- a/libcontainer/restored_process.go
+++ b/libcontainer/restored_process.go
@@ -106,7 +106,11 @@ func (p *nonChildProcess) startTime() (string, error) {
 }
 
 func (p *nonChildProcess) signal(s os.Signal) error {
-	return newGenericError(fmt.Errorf("restored process cannot be signaled"), SystemError)
+	proc, err := os.FindProcess(p.processPid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(s)
 }
 
 func (p *nonChildProcess) externalDescriptors() []string {


### PR DESCRIPTION
This adds a `Signal()` method to the container interface so that the
initial process can be signaled after a Load or operation.  It also
implements signaling the init process from a nonChildProcess.

This implements the Signal API in the libcontainer so that #124 can be implemented.  

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>