### PR TITLE
Container kill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,8 @@ WantedBy=multi-user.target
 ```
 ##Usage:
 runc --id=runc kill <arguments>
-##Arguments can be signal number or signal name in string 
+####Arguments can be signal number or signal name in string 
 
 ##Example
 runc --id=runc kill TERM
 runc --id=runc kill 15
-##if the shell is interactive, few signals can not be forwarded. /bin/sh can not forward the signal

--- a/README.md
+++ b/README.md
@@ -237,3 +237,11 @@ WorkingDirectory=/containers/minecraftbuild
 [Install]
 WantedBy=multi-user.target
 ```
+##Usage:
+runc --id=runc kill <arguments>
+##Arguments can be signal number or signal name in string 
+
+##Example
+runc --id=runc kill TERM
+runc --id=runc kill 15
+##if the shell is interactive, few signals can not be forwarded. /bin/sh can not forward the signal

--- a/kill.go
+++ b/kill.go
@@ -1,0 +1,53 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"github.com/codegangsta/cli"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+var killCommand = cli.Command{
+	Name:  "kill",
+	Usage: "kill a container",
+	Action: func(context *cli.Context) {
+		container, err := getContainer(context)
+		if err != nil {
+			fatal(fmt.Errorf("%s", err))
+		}
+		sigStr := context.Args().First()
+		state, err := container.Status()
+		if err != nil {
+			fatal(fmt.Errorf("Container not running %d", state))
+			// return here
+		}
+		var sig uint64
+		sigN, err := strconv.ParseUint(sigStr, 10, 5)
+		if err != nil {
+			//The signal is not a number, treat it as a string (either like
+			//KILL" or like "SIGKILL")
+			syscallSig, ok := SignalMap[strings.TrimPrefix(sigStr, "SIG")]
+			if !ok {
+				fatal(fmt.Errorf("Invalid Signal: %s", sigStr))
+			}
+			sig = uint64(syscallSig)
+			errVal := container.Signal(syscall.Signal(sig))
+			if errVal != nil {
+				fatal(fmt.Errorf("%s", errVal))
+			}
+		} else {
+			sig = sigN
+			errVar := container.Signal(syscall.Signal(sig))
+			if errVar != nil {
+				fatal(fmt.Errorf("%s", errVar))
+			}
+
+		}
+		if sig == 0 {
+			fatal(fmt.Errorf("Invalid signal: %s", sigStr))
+		}
+	},
+}

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -5,6 +5,8 @@
 package libcontainer
 
 import (
+	"os"
+
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -159,4 +161,10 @@ type Container interface {
 	// errors:
 	// Systemerror - System error.
 	NotifyOOM() (<-chan struct{}, error)
+
+	// Signal sends the provided signal code to the container's initial process.
+	//
+	// errors:
+	// Systemerror - System error.
+	Signal(s os.Signal) error
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -118,6 +118,13 @@ func (c *linuxContainer) Start(process *Process) error {
 	return nil
 }
 
+func (c *linuxContainer) Signal(s os.Signal) error {
+	if err := c.initProcess.signal(s); err != nil {
+		return newSystemError(err)
+	}
+	return nil
+}
+
 func (c *linuxContainer) newParentProcess(p *Process, doInit bool) (parentProcess, error) {
 	parentPipe, childPipe, err := newPipe()
 	if err != nil {

--- a/libcontainer/restored_process.go
+++ b/libcontainer/restored_process.go
@@ -106,7 +106,11 @@ func (p *nonChildProcess) startTime() (string, error) {
 }
 
 func (p *nonChildProcess) signal(s os.Signal) error {
-	return newGenericError(fmt.Errorf("restored process cannot be signaled"), SystemError)
+	proc, err := os.FindProcess(p.processPid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(s)
 }
 
 func (p *nonChildProcess) externalDescriptors() []string {

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 		checkpointCommand,
 		eventsCommand,
 		restoreCommand,
+		killCommand,
 		specCommand,
 	}
 	app.Before = func(context *cli.Context) error {

--- a/signal_linux.go
+++ b/signal_linux.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"syscall"
+)
+
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":   syscall.SIGABRT,
+	"ALRM":   syscall.SIGALRM,
+	"BUS":    syscall.SIGBUS,
+	"CHLD":   syscall.SIGCHLD,
+	"CLD":    syscall.SIGCLD,
+	"CONT":   syscall.SIGCONT,
+	"FPE":    syscall.SIGFPE,
+	"HUP":    syscall.SIGHUP,
+	"ILL":    syscall.SIGILL,
+	"INT":    syscall.SIGINT,
+	"IO":     syscall.SIGIO,
+	"IOT":    syscall.SIGIOT,
+	"KILL":   syscall.SIGKILL,
+	"PIPE":   syscall.SIGPIPE,
+	"POLL":   syscall.SIGPOLL,
+	"PROF":   syscall.SIGPROF,
+	"PWR":    syscall.SIGPWR,
+	"QUIT":   syscall.SIGQUIT,
+	"SEGV":   syscall.SIGSEGV,
+	"STKFLT": syscall.SIGSTKFLT,
+	"STOP":   syscall.SIGSTOP,
+	"SYS":    syscall.SIGSYS,
+	"TERM":   syscall.SIGTERM,
+	"TRAP":   syscall.SIGTRAP,
+	"TSTP":   syscall.SIGTSTP,
+	"TTIN":   syscall.SIGTTIN,
+	"TTOU":   syscall.SIGTTOU,
+	"UNUSED": syscall.SIGUNUSED,
+	"URG":    syscall.SIGURG,
+	"USR1":   syscall.SIGUSR1,
+	"USR2":   syscall.SIGUSR2,
+	"VTALRM": syscall.SIGVTALRM,
+	"WINCH":  syscall.SIGWINCH,
+	"XCPU":   syscall.SIGXCPU,
+	"XFSZ":   syscall.SIGXFSZ,
+}


### PR DESCRIPTION
@crosbymichael 
I have rebased the changes from your branch and added the CLI code in runc ( took the change from #175 
Added the runc kill support, to kill the containers by passing the signals.
Usage:
After running the container
./runc --id=runc kill TERM
. or
./runc --id=runc kill 15
updated README.md for usage

Tested with multiple containers by giving bash as the first PID.
/bin/sh can not handle the signals, so it will be ignored by container

Rajasec