### PR TITLE
Change example JSON to refer to "pid" namespace rather than "process."

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ user named `daemon` defined within that file-system.
         },
         "namespaces": [
             {
-                "type": "process",
+                "type": "pid",
                 "path": ""
             },
             {


### PR DESCRIPTION
#180 changed `spec.go` but not the example configuration in the README file. To use "pid" rather than "process" in the namespaces.

Signed-off-by: William Temple <wtemple@redhat.com>