### PR TITLE
Adding securityfs mount

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -137,6 +137,11 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			return err
 		}
 		return syscall.Mount(m.Source, dest, m.Device, uintptr(m.Flags), data)
+	case "securityfs":
+		if err := os.MkdirAll(dest, 0755); err != nil {
+			return err
+		}
+		return syscall.Mount(m.Source, dest, m.Device, uintptr(m.Flags), data)
 	case "bind":
 		stat, err := os.Stat(m.Source)
 		if err != nil {


### PR DESCRIPTION
Adding the securityfs mount point during start of the container for apparmor profiles to be loaded at run time

~Rajasec

Signed-off-by: rajasec <rajasec79@gmail.com>