### PR TITLE
container id is the cgroup name

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -32,7 +32,7 @@ var restoreCommand = cli.Command{
 		if err != nil {
 			fatal(err)
 		}
-		config, err := createLibcontainerConfig(spec)
+		config, err := createLibcontainerConfig(context.GlobalString("id"), spec)
 		if err != nil {
 			fatal(err)
 		}

--- a/run.go
+++ b/run.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func execContainer(context *cli.Context, spec *specs.LinuxSpec) (int, error) {
-	config, err := createLibcontainerConfig(spec)
+	config, err := createLibcontainerConfig(context.GlobalString("id"), spec)
 	if err != nil {
 		return -1, err
 	}

--- a/spec.go
+++ b/spec.go
@@ -176,7 +176,7 @@ func checkSpecVersion(s *specs.LinuxSpec) error {
 	return nil
 }
 
-func createLibcontainerConfig(spec *specs.LinuxSpec) (*configs.Config, error) {
+func createLibcontainerConfig(cgroupName string, spec *specs.LinuxSpec) (*configs.Config, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func createLibcontainerConfig(spec *specs.LinuxSpec) (*configs.Config, error) {
 	if err := setupUserNamespace(spec, config); err != nil {
 		return nil, err
 	}
-	c, err := createCgroupConfig(spec, config.Devices)
+	c, err := createCgroupConfig(cgroupName, spec, config.Devices)
 	if err != nil {
 		return nil, err
 	}
@@ -250,13 +250,13 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	}
 }
 
-func createCgroupConfig(spec *specs.LinuxSpec, devices []*configs.Device) (*configs.Cgroup, error) {
+func createCgroupConfig(name string, spec *specs.LinuxSpec, devices []*configs.Device) (*configs.Cgroup, error) {
 	myCgroupPath, err := cgroups.GetThisCgroupDir("devices")
 	if err != nil {
 		return nil, err
 	}
 	c := &configs.Cgroup{
-		Name:           getDefaultID(),
+		Name:           name,
 		Parent:         myCgroupPath,
 		AllowedDevices: append(devices, allowedDevices...),
 	}


### PR DESCRIPTION
Without this, multiple runc containers can accidentally share the same cgroup(s) (and change each other's limits), when runc is invoked from the same directory (i.e.: same `cwd` on multiple runc invocations).

After these changes, each runc container will run on its own cgroup(s). Before, the only workaround was to invoke runc from an unique (temporary?) cwd for each container (ugh).

Common cgroup configuration (and hierarchical limits) can be set by having multiple runc containers share the same cgroup parent, which is the cgroup of the process executing runc.

The behavior will be the same as before when an explicit `--id` option is not passed to `runc`: the container id will be inferred from `cwd`.

Related: #3 

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>