### PR TITLE
Simplify the return on process wait

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -138,11 +138,9 @@ func (p *setnsProcess) terminate() error {
 
 func (p *setnsProcess) wait() (*os.ProcessState, error) {
 	err := p.cmd.Wait()
-	if err != nil {
-		return p.cmd.ProcessState, err
-	}
 
-	return p.cmd.ProcessState, nil
+	// Return actual ProcessState even on Wait error
+	return p.cmd.ProcessState, err
 }
 
 func (p *setnsProcess) pid() int {


### PR DESCRIPTION
Simplify the code introduced by the commit d1f0d5705deb:
    Return actual ProcessState on Wait error

Cc: Alexander Morozov <lk4d4@docker.com>
Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>