### PR TITLE
Ensure the cleanup jobs in the deferrer are executed on error

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -83,7 +83,7 @@ type data struct {
 	pid    int
 }
 
-func (m *Manager) Apply(pid int) error {
+func (m *Manager) Apply(pid int) (err error) {
 	if m.Cgroups == nil {
 		return nil
 	}

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -173,9 +173,9 @@ func (p *initProcess) externalDescriptors() []string {
 	return p.fds
 }
 
-func (p *initProcess) start() error {
+func (p *initProcess) start() (err error) {
 	defer p.parentPipe.Close()
-	err := p.cmd.Start()
+	err = p.cmd.Start()
 	p.childPipe.Close()
 	if err != nil {
 		return newSystemError(err)


### PR DESCRIPTION
Some of the cleanup jobs in the deferrer depend on an 'err' variable that would be assigned later on. 
But this is a bit fragile because it's quite usual to use
```go
if err := func(); err != nil {
    return err
}
```
to handle errors in go.
In such cases a new local 'err' variable will be created and the outer 'err' that the deferrer depends on won't be assigned so this will prevent the cleanup jobs from executing.

Signed-off-by: Shijiang Wei <mountkin@gmail.com>