### PR TITLE
make localtest fills up /tmp with /tmp/libcontainer

### DIFF
--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/docker/docker/pkg/mount"
@@ -97,6 +98,7 @@ func TestFactoryNewTmpfs(t *testing.T) {
 	if !found {
 		t.Fatalf("Factory Root is not listed in mounts list")
 	}
+	defer syscall.Unmount(root, syscall.MNT_DETACH)
 }
 
 func TestFactoryLoadNotExists(t *testing.T) {


### PR DESCRIPTION
@LK4D4 @mrunalp 
While running make localtest /tmp is filled with /tmp/libcontainer<ID>
Function TestFactoryNewTmpfs is created using
factory, err := New(root, Cgroupfs, TmpfsRoot), since tmpfs is mounted on /tmp/libcontainer<ID>, unless we unmount the tmpfs, /tmp/libcontainer<ID> directory is not removed

Added the umount call, so that it unmount the file system and cleans up the /tmp/libcontainer<ID> correctly


Signed-off-by: rajasec <rajasec79@gmail.com>