### PR TITLE
Add a 'start' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,27 @@ sudo make install
 
 ### Using:
 
-To run a container that you received just execute `runc` with the JSON format as the argument or have a
-`config.json` file in the current working directory.
-
+To run a container, execute `runc start` in the bundle's root directory:
 ```bash
-runc
+runc start
 / $ ps
 PID   USER     COMMAND
 1     daemon   sh
 5     daemon   sh
 / $
 ```
+
+Or you can specify the path to a JSON configuration file:
+```bash
+runc start config.json
+/ $ ps
+PID   USER     COMMAND
+1     daemon   sh
+5     daemon   sh
+/ $
+```
+Note: the use of the `start` command is required when specifying a 
+configuration file.
 
 ### OCF Container JSON Format:
 
@@ -210,9 +220,9 @@ tar -C rootfs -xf busybox.tar
 ```
 * Create a file called `config.json` using the example from above.  You can also
 generate a spec using `runc spec`, redirecting the output into `config.json`
-* Execute `runc` and you should be placed into a shell where you can run `ps`:
+* Execute `runc start` and you should be placed into a shell where you can run `ps`:
 ```
-$ runc
+$ runc start
 / # ps
 PID   USER     COMMAND
     1 root     sh

--- a/main.go
+++ b/main.go
@@ -24,7 +24,11 @@ After creating a spec for your root filesystem with runc, you can execute a
 container in your shell by running:
 
     cd /mycontainer
-    runc  [ spec-file ]
+    runc start
+
+or
+	cd /mycontainer
+	runc start [ spec-file ]
 
 If not specified, the default value for the 'spec-file' is 'config.json'. `
 )
@@ -56,6 +60,7 @@ func main() {
 		},
 	}
 	app.Commands = []cli.Command{
+		startCommand,
 		checkpointCommand,
 		eventsCommand,
 		restoreCommand,
@@ -69,7 +74,8 @@ func main() {
 		return nil
 	}
 
-	app.Action = runAction
+	// Default to 'start' is no command is specified
+	app.Action = startCommand.Action
 
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
When any non-global-flag parameter appears on the command line make sure
there's a "command" even in the 'start' (run) case to ensure its not
ambiguous as to what the arg is. For example, w/o this fix its not
clear if
```
   runc foo
```
means 'foo' is the name of a config file or an unknown command.  Or worse,
you can't name a config file the same as ANY command, even future (yet to
be created) commands.

We should fix this now before we ship 1.0 and are forced to support this
ambiguous case for a long time.

Signed-off-by: Doug Davis <dug@us.ibm.com>