### PR TITLE
richer information error message for terminal

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -56,7 +57,7 @@ func createTty(p *libcontainer.Process, rootuid int) (*tty, error) {
 	go io.Copy(os.Stdout, console)
 	state, err := term.SetRawTerminal(os.Stdin.Fd())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to set the terminal from the stdin: %v", err)
 	}
 	t := &tty{
 		console: console,


### PR DESCRIPTION
When we use ```cat | runc``` or ```runc /dev/stdin < config.json```,
it will fail and output ```FATA[0000] Container start failed: inappropriate ioctl for device```.
It is hard for the users to find out the reason from the message:
the config.json enables the terminal but the user redirect the stdin
to an non-terminal file.

After this patch, the output will be
```FATA[0000] Container start failed: Failed to set the terminal from the stdin: inappropriate ioctl for device```
So the user can disable the terminal in the config.json.

See the #202

Cc: W. Trevor King <wking@tremily.us> (@wking)
Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>