### PR TITLE
Fetch the environments for the default global options

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "root",
-			Value: "/run/oci",
+			Value: getDefaultRoot(),
 			Usage: "root directory for storage of container state (this should be located in tmpfs)",
 		},
 		cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "criu",
-			Value: "criu",
+			Value: getDefaultCriu(),
 			Usage: "path to the criu binary used for checkpoint and restore",
 		},
 	}

--- a/utils.go
+++ b/utils.go
@@ -153,6 +153,15 @@ func getDefaultID() string {
 	return filepath.Base(cwd)
 }
 
+// getDefaultRoot returns a directory path for storage of container state.
+func getDefaultRoot() string {
+	root := os.Getenv("OCI_ROOT")
+	if root == "" {
+		root = "/run/oci"
+	}
+	return root
+}
+
 func getDefaultImagePath(context *cli.Context) string {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -162,6 +162,15 @@ func getDefaultRoot() string {
 	return root
 }
 
+// getDefaultCriu returns a path to the criu binary.
+func getDefaultCriu() string {
+	criu := os.Getenv("RUNC_CRIU")
+	if criu == "" {
+		criu = "criu"
+	}
+	return criu
+}
+
 func getDefaultImagePath(context *cli.Context) string {
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
So thus the user doesn't need to specific the global option on every execution.

get the default root path based on the environment OCI_ROOT
get the default criu path based on the environment RUNC_CRIU