### PR TITLE
Add seccomp build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 RUNC_TEST_IMAGE=runc_test
 PROJECT=github.com/opencontainers/runc
 TEST_DOCKERFILE=script/test_Dockerfile
+BUILDTAGS=seccomp
 export GOPATH:=$(CURDIR)/Godeps/_workspace:$(GOPATH)
 
 all:
-	go build -o runc .
+	go build -tags "$(BUILDTAGS)" -o runc .
 
 vet:
 	go get golang.org/x/tools/cmd/vet
@@ -20,7 +21,8 @@ test: runctestimage
 	docker run -e TESTFLAGS --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_TEST_IMAGE) make localtest
 
 localtest:
-	go test ${TESTFLAGS} -v ./...
+	go test -tags "$(BUILDTAGS)" ${TESTFLAGS} -v ./...
+
 
 install:
 	cp runc /usr/local/bin/runc

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ make
 sudo make install
 ```
 
+In order to enable seccomp support you will need to install libseccomp on your platform.
+If you do not with to build `runc` with seccomp support you can add `BUILDTAGS=""` when running make.
+
 ### Using:
 
 To run a container, execute `runc start` in the bundle's root directory:

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -1,4 +1,4 @@
-// +build linux,cgo
+// +build linux,cgo,seccomp
 
 package seccomp
 

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -1,12 +1,19 @@
-// +build !linux !cgo
+// +build !linux !cgo !seccomp
 
 package seccomp
 
 import (
+	"errors"
+
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
+var ErrSeccompNotEnabled = errors.New("seccomp: config provided but seccomp not supported")
+
 // Seccomp not supported, do nothing
 func InitSeccomp(config *configs.Seccomp) error {
+	if config != nil {
+		return ErrSeccompNotEnabled
+	}
 	return nil
 }


### PR DESCRIPTION
Add a seccomp build tag and also support in the Makefile to add or
remove build tags.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>