### PR TITLE
Restorefixforrunningcontainer

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -59,6 +60,13 @@ func restoreContainer(context *cli.Context, spec *specs.LinuxSpec, config *confi
 		}
 	}
 	options := criuOptions(context)
+	status, err := container.Status()
+	if err != nil {
+		logrus.Error(err)
+	}
+	if status == libcontainer.Running {
+		fatal(fmt.Errorf("Container with id %s already running", context.GlobalString("id")))
+	}
 	// ensure that the container is always removed if we were the process
 	// that created it.
 	defer func() {


### PR DESCRIPTION
With the runc, I've started the container by setting the terminal as false for checkpointing. In second terminal gave the command runc checkpoint --leave-running, 
Checkpoint happened successfully and at the same time container running in first terminal is not stopped which is expected behavior.
In the second terminal I typed runc restore, this also started the container.
with single ID runc, two instances of runc were running.

Upon killing  ./runc restore, it failed to remove the cgroup paths.

So I've added the check in restore, if the container with specific ID is already running, give an message saying " Container with ID already running".




Signed-off-by: Rajasekaran <rajasec79@gmail.com>