### PR TITLE
Add support for several new CRIU options to libcontainer

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -20,10 +20,13 @@ var checkpointCommand = cli.Command{
 		cli.BoolFlag{Name: "leave-running", Usage: "leave the process running after checkpointing"},
 		cli.BoolFlag{Name: "tcp-established", Usage: "allow open tcp connections"},
 		cli.BoolFlag{Name: "ext-unix-sk", Usage: "allow external unix sockets"},
-		cli.BoolFlag{Name: "shell-job", Usage: "allow shell jobs"},
+		cli.BoolFlag{Name: "file-locks", Usage: "allow file locks, for safety"},
+		cli.IntFlag{Name: "log-level", Value: 4, Usage: "set criu log level (1-4, least to most verbose)"},
 		cli.StringFlag{Name: "page-server", Value: "", Usage: "ADDRESS:PORT of the page server"},
-		cli.BoolFlag{Name: "file-locks", Usage: "handle file locks, for safety"},
 		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'."},
+		cli.StringFlag{Name: "parent-path", Value: "", Usage: "path to parent image, relative to image-path"},
+		cli.BoolFlag{Name: "track-mem", Usage: "enable tracking changed memory pages in kernel"},
+		cli.BoolFlag{Name: "auto-dedup", Usage: "reduce space required for secondary checpoints"},
 	},
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -397,10 +397,19 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 	}
 	defer imageDir.Close()
 
+	if criuOpts.LogLevel == 0 {
+		criuOpts.LogLevel = 4
+	}
+
+	var parentImg *string
+	if criuOpts.ParentImagesDirectory != "" {
+		parentImg = proto.String(criuOpts.ParentImagesDirectory)
+	}
+
 	rpcOpts := criurpc.CriuOpts{
 		ImagesDirFd:    proto.Int32(int32(imageDir.Fd())),
 		WorkDirFd:      proto.Int32(int32(workDir.Fd())),
-		LogLevel:       proto.Int32(4),
+		LogLevel:       proto.Int32(int32(criuOpts.LogLevel)),
 		LogFile:        proto.String("dump.log"),
 		Root:           proto.String(c.config.Rootfs),
 		ManageCgroups:  proto.Bool(true),
@@ -411,6 +420,9 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 		TcpEstablished: proto.Bool(criuOpts.TcpEstablished),
 		ExtUnixSk:      proto.Bool(criuOpts.ExternalUnixConnections),
 		FileLocks:      proto.Bool(criuOpts.FileLocks),
+		AutoDedup:      proto.Bool(criuOpts.AutoDedup),
+		TrackMem:       proto.Bool(criuOpts.TrackMemory),
+		ParentImg:      parentImg,
 	}
 
 	// append optional criu opts, e.g., page-server and port
@@ -516,6 +528,15 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 	}
 	defer imageDir.Close()
 
+	if criuOpts.LogLevel == 0 {
+		criuOpts.LogLevel = 4
+	}
+
+	var parentImg *string
+	if criuOpts.ParentImagesDirectory != "" {
+		parentImg = proto.String(criuOpts.ParentImagesDirectory)
+	}
+
 	// CRIU has a few requirements for a root directory:
 	// * it must be a mount point
 	// * its parent must not be overmounted
@@ -545,7 +566,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 			ImagesDirFd:    proto.Int32(int32(imageDir.Fd())),
 			WorkDirFd:      proto.Int32(int32(workDir.Fd())),
 			EvasiveDevices: proto.Bool(true),
-			LogLevel:       proto.Int32(4),
+			LogLevel:       proto.Int32(int32(criuOpts.LogLevel)),
 			LogFile:        proto.String("restore.log"),
 			RstSibling:     proto.Bool(true),
 			Root:           proto.String(root),
@@ -555,6 +576,8 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 			ExtUnixSk:      proto.Bool(criuOpts.ExternalUnixConnections),
 			TcpEstablished: proto.Bool(criuOpts.TcpEstablished),
 			FileLocks:      proto.Bool(criuOpts.FileLocks),
+			AutoDedup:      proto.Bool(criuOpts.AutoDedup),
+			ParentImg:      parentImg,
 		},
 	}
 

--- a/libcontainer/criu_opts.go
+++ b/libcontainer/criu_opts.go
@@ -22,12 +22,16 @@ type VethPairName struct {
 
 type CriuOpts struct {
 	ImagesDirectory         string             // directory for storing image files
+	ParentImagesDirectory   string             // path to images from previous dump (relative to ImagesDirectory)
 	WorkDirectory           string             // directory to cd and write logs/pidfiles/stats to
+	LogLevel                int                // logging level (1 to 4, from least to most verbose)
 	LeaveRunning            bool               // leave container in running state after checkpoint
 	TcpEstablished          bool               // checkpoint/restore established TCP connections
 	ExternalUnixConnections bool               // allow external unix connections
 	ShellJob                bool               // allow to dump and restore shell jobs
 	FileLocks               bool               // handle file locks, for safety
+	TrackMemory             bool               // turn on memory changes tracker in the kernel
+	AutoDedup               bool               // dump: dedupes data in previous dumps, restore: punch data from image as restored
 	PageServer              CriuPageServerInfo // allow to dump to criu page server
 	VethPairs               []VethPairName     // pass the veth to criu when restore
 	ManageCgroupsMode       cg_mode            // dump or restore cgroup mode

--- a/restore.go
+++ b/restore.go
@@ -24,6 +24,11 @@ var restoreCommand = cli.Command{
 			Usage: "path to criu image files for restoring",
 		},
 		cli.StringFlag{
+			Name:  "parent-path",
+			Value: "",
+			Usage: "path to parent image, relative to image-path",
+		},
+		cli.StringFlag{
 			Name:  "work-path",
 			Value: "",
 			Usage: "path for saving work files and logs",
@@ -37,10 +42,6 @@ var restoreCommand = cli.Command{
 			Usage: "allow external unix sockets",
 		},
 		cli.BoolFlag{
-			Name:  "shell-job",
-			Usage: "allow shell jobs",
-		},
-		cli.BoolFlag{
 			Name:  "file-locks",
 			Usage: "handle file locks, for safety",
 		},
@@ -48,6 +49,15 @@ var restoreCommand = cli.Command{
 			Name:  "manage-cgroups-mode",
 			Value: "",
 			Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'.",
+		},
+		cli.IntFlag{
+			Name: "log-level",
+			Value: 4,
+			Usage: "set criu log level (1-4, least to most verbose)",
+		},
+		cli.BoolFlag{
+			Name: "auto-dedup",
+			Usage: "reduce space required for restore",
 		},
 		cli.StringFlag{
 			Name:  "config-file, c",
@@ -160,10 +170,14 @@ func criuOptions(context *cli.Context) *libcontainer.CriuOpts {
 	return &libcontainer.CriuOpts{
 		ImagesDirectory:         imagePath,
 		WorkDirectory:           context.String("work-path"),
+		ParentImagesDirectory:   context.String("parent-image-path"),
+		LogLevel:                context.Int("log-level"),
+		AutoDedup:               context.Bool("auto-dedup"),
+		TrackMemory:             context.Bool("track-mem"),
 		LeaveRunning:            context.Bool("leave-running"),
 		TcpEstablished:          context.Bool("tcp-established"),
 		ExternalUnixConnections: context.Bool("ext-unix-sk"),
-		ShellJob:                context.Bool("shell-job"),
 		FileLocks:               context.Bool("file-locks"),
+		ShellJob:                false,
 	}
 }


### PR DESCRIPTION
These options are primarily useful for the case where you want to do a multi-step checkpoint (you checkpoint once with mem tracking and leave running enabled, then you checkpoint a second time with a parent image, which theoretically means you need less total time with the process stopped).

It also changes the various "protection" flags in CRIU to be enabled by default with the option to disable them.
