### PR TITLE
Adding status command to container

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -30,6 +30,23 @@ const (
 	Destroyed
 )
 
+//Custom type method for returning status as strings
+func (s Status) String() string {
+	switch s {
+	case Running:
+		return "Running"
+	case Pausing:
+		return "Pausing"
+	case Paused:
+		return "Paused"
+	case Checkpointed:
+		return "Checkpointed"
+	case Destroyed:
+		return "Destroyed"
+	}
+	return ""
+}
+
 // State represents a running container's state
 type State struct {
 	// ID is the container ID.

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 		pauseCommand,
 		resumeCommand,
 		execCommand,
+		statusCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {

--- a/status.go
+++ b/status.go
@@ -1,0 +1,25 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
+
+var statusCommand = cli.Command{
+	Name:  "status",
+	Usage: "Current status of container",
+	Action: func(context *cli.Context) {
+		container, err := getContainer(context)
+		if err != nil {
+			fatal(err)
+		}
+		status, err := container.Status()
+		if err != nil {
+			logrus.Error(err)
+		}
+		fmt.Printf("Container ID %s %s\n", context.GlobalString("id"), status)
+	},
+}


### PR DESCRIPTION
@crosbymichael @mrunalp 
Quick way to check the container status from CLI, It provides the message to the user whether container is running checkpointed destroyed or paused ( frozen)
I've checked with Running,Checkpointed container, but frozen container, currently it will give the status as Running ( will give the right status once after #218 closure)

Usage:
runc status

Signed-off-by: Rajasekaran <rajasec79@gmail.com>