### PR TITLE
Use "net" and "mnt" namespace names to match spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ user with uid and gid of `0` defined within that file-system.
                 "path": ""
             },
             {
-                "type": "network",
+                "type": "net",
                 "path": ""
             },
             {
@@ -192,7 +192,7 @@ user with uid and gid of `0` defined within that file-system.
                 "path": ""
             },
             {
-                "type": "mount",
+                "type": "mnt",
                 "path": ""
             }
         ],

--- a/spec.go
+++ b/spec.go
@@ -97,7 +97,7 @@ var specCommand = cli.Command{
 						Type: "pid",
 					},
 					{
-						Type: "network",
+						Type: "net",
 					},
 					{
 						Type: "ipc",
@@ -106,7 +106,7 @@ var specCommand = cli.Command{
 						Type: "uts",
 					},
 					{
-						Type: "mount",
+						Type: "mnt",
 					},
 				},
 				Capabilities: []string{
@@ -204,12 +204,12 @@ var specCommand = cli.Command{
 }
 
 var namespaceMapping = map[string]configs.NamespaceType{
-	"pid":     configs.NEWPID,
-	"network": configs.NEWNET,
-	"mount":   configs.NEWNS,
-	"user":    configs.NEWUSER,
-	"ipc":     configs.NEWIPC,
-	"uts":     configs.NEWUTS,
+	"pid":  configs.NEWPID,
+	"net":  configs.NEWNET,
+	"mnt":  configs.NEWNS,
+	"user": configs.NEWUSER,
+	"ipc":  configs.NEWIPC,
+	"uts":  configs.NEWUTS,
 }
 
 // loadSpec loads the specification from the provided path.


### PR DESCRIPTION
The spec [uses "net" and "mnt" in the examples](https://github.com/opencontainers/specs/blob/master/runtime-config-linux.md#namespaces) , but runc currently uses "network" and "mount". "net" and "mnt" seem most consistent with the other names. This PR fixes the runtime to match the spec.

@julz & @glestaris