### PR TITLE
Fixing checkpoint issue

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -30,6 +30,13 @@ var checkpointCommand = cli.Command{
 			fatal(err)
 		}
 		options := criuOptions(context)
+		status, err := container.Status()
+		if err != nil {
+			fatal(err)
+		}
+		if status == libcontainer.Checkpointed {
+			fatal(fmt.Errorf("Container with id %s already checkpointed", context.GlobalString("id")))
+		}
 		// these are the mandatory criu options for a container
 		setPageServer(context, options)
 		if err := container.Checkpoint(options); err != nil {


### PR DESCRIPTION
@crosbymichael @mrunalp 
I've done the checkpoint of my container, In another terminal ( by mistake) I have done the checkpoint again. It failed as expected. But the problem is, I could not restore my container back.
First terminal ( with terminal as false)
./runc checkpoint

Second terminal
./runc checkpoint ( this failed the checkpoint as it is already checkpointed)
Post that I could not restore my container back.

I have added condition if the container is already checkpointed, have the message to user saying Container already checkpointed, 
This will prevent checkpoint on checkpointed container.

Signed-off-by: Rajasekaran <rajasec79@gmail.com>