### PR TITLE
Memory swap fix for non supporting kernels

### DIFF
--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -22,6 +22,7 @@ func (s *CpuGroup) Apply(d *data) error {
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err
 	}
+	cgroups.CheckSubsystem(dir, d.c, "cpu")
 
 	if err := s.Set(dir, d.c); err != nil {
 		return err

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -28,6 +28,7 @@ func (s *MemoryGroup) Apply(d *data) (err error) {
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return err
 	}
+	cgroups.CheckSubsystem(path, d.c, "memory")
 
 	defer func() {
 		if err != nil {

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -313,6 +313,7 @@ func joinCpu(c *configs.Cgroup, pid int) error {
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err
 	}
+	cgroups.CheckSubsystem(path, c, "cpu")
 	if c.CpuQuota != 0 {
 		if err = writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(c.CpuQuota, 10)); err != nil {
 			return err
@@ -497,7 +498,7 @@ func joinMemory(c *configs.Cgroup, pid int) error {
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err
 	}
-
+	cgroups.CheckSubsystem(path, c, "memory")
 	// -1 disables memoryswap
 	if c.MemorySwap > 0 {
 		err = writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(c.MemorySwap, 10))

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -13,8 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/units"
+	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const cgroupNamePrefix = "name="
@@ -290,4 +292,37 @@ func GetHugePageSize() ([]string, error) {
 	}
 
 	return pageSizes, nil
+}
+
+func CheckSubsystem(path string, cgroup *configs.Cgroup, subsystem string) {
+	switch subsystem {
+	case "memory":
+		if cgroup.MemorySwap > 0 {
+			if !PathExists(filepath.Join(path, "memory.memsw.limit_in_bytes")) {
+				logrus.Warn("Your kernel does not support swap memory limit.Limitation discarded.")
+				cgroup.MemorySwap = 0
+			}
+		}
+		if cgroup.OomKillDisable {
+			if !PathExists(filepath.Join(path, "memory.oom_control")) {
+				logrus.Warn("Your kernel does not support oom killer.Limitation discarded.")
+				cgroup.OomKillDisable = false
+			}
+		}
+		break
+	case "cpu":
+		if cgroup.CpuPeriod != 0 {
+			if !PathExists(filepath.Join(path, "cpu.cfs_period_us")) {
+				logrus.Warn("Your kernel does not support CPU Period.Limitation discarded.")
+				cgroup.CpuPeriod = 0
+			}
+		}
+		if cgroup.CpuQuota != 0 {
+			if !PathExists(filepath.Join(path, "cpu.cfs_quota_us")) {
+				logrus.Warn("Your kernel does not support CPU Quota.Limitation discarded.")
+				cgroup.CpuQuota = 0
+			}
+		}
+		break
+	}
 }


### PR DESCRIPTION
@LK4D4 @crosbymichael @mrunalp 
While I was modifying the swap value in config.json under memory section, it failed to write the value as the current kernel ( 3.19 : Ubuntu 15.04) and failed to start the container. Post that I have to update the grub to include cgroup_enable=memory swapaccount=1 which had "memory.memsw" values. So for the kernel which is not having "memory.memsw" by default,  I have added the condition to check whether memory.memsw.limit_in_bytes is available before writing to the cgroup file.

Signed-off-by: Rajasekaran <rajasec79@gmail.com>