### PR TITLE
c/r: create cgroups to restore a container

### DIFF
--- a/libcontainer/cgroups/cgroups_test.go
+++ b/libcontainer/cgroups/cgroups_test.go
@@ -3,27 +3,16 @@
 package cgroups
 
 import (
-	"bytes"
 	"testing"
 )
 
-const (
-	cgroupsContents = `11:hugetlb:/
-10:perf_event:/
-9:blkio:/
-8:net_cls:/
-7:freezer:/
-6:devices:/
-5:memory:/
-4:cpuacct,cpu:/
-3:cpuset:/
-2:name=systemd:/user.slice/user-1000.slice/session-16.scope`
-)
-
 func TestParseCgroups(t *testing.T) {
-	r := bytes.NewBuffer([]byte(cgroupsContents))
-	_, err := ParseCgroupFile("blkio", r)
+	cgroups, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if _, ok := cgroups["cpu"]; !ok {
+		t.Fail()
 	}
 }

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -5,7 +5,6 @@ package cgroups
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -170,23 +169,22 @@ func GetAllSubsystems() ([]string, error) {
 
 // Returns the relative path to the cgroup docker is running in.
 func GetThisCgroupDir(subsystem string) (string, error) {
-	f, err := os.Open("/proc/self/cgroup")
+	cgroups, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
 
-	return ParseCgroupFile(subsystem, f)
+	return getControllerPath(subsystem, cgroups)
 }
 
 func GetInitCgroupDir(subsystem string) (string, error) {
-	f, err := os.Open("/proc/1/cgroup")
+
+	cgroups, err := ParseCgroupFile("/proc/1/cgroup")
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
 
-	return ParseCgroupFile(subsystem, f)
+	return getControllerPath(subsystem, cgroups)
 }
 
 func ReadProcsFile(dir string) ([]int, error) {
@@ -213,22 +211,39 @@ func ReadProcsFile(dir string) ([]int, error) {
 	return out, nil
 }
 
-func ParseCgroupFile(subsystem string, r io.Reader) (string, error) {
-	s := bufio.NewScanner(r)
+func ParseCgroupFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	cgroups := make(map[string]string)
 
 	for s.Scan() {
 		if err := s.Err(); err != nil {
-			return "", err
+			return nil, err
 		}
 
 		text := s.Text()
 		parts := strings.Split(text, ":")
 
 		for _, subs := range strings.Split(parts[1], ",") {
-			if subs == subsystem || subs == cgroupNamePrefix+subsystem {
-				return parts[2], nil
-			}
+			cgroups[subs] = parts[2]
 		}
+	}
+	return cgroups, nil
+}
+
+func getControllerPath(subsystem string, cgroups map[string]string) (string, error) {
+
+	if p, ok := cgroups[subsystem]; ok {
+		return p, nil
+	}
+
+	if p, ok := cgroups[cgroupNamePrefix+subsystem]; ok {
+		return p, nil
 	}
 
 	return "", NewNotFoundError(subsystem)

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -98,12 +98,12 @@ type Mount struct {
 	Subsystems []string
 }
 
-func (m Mount) GetThisCgroupDir() (string, error) {
+func (m Mount) GetThisCgroupDir(cgroups map[string]string) (string, error) {
 	if len(m.Subsystems) == 0 {
 		return "", fmt.Errorf("no subsystem for mount")
 	}
 
-	return GetThisCgroupDir(m.Subsystems[0])
+	return getControllerPath(m.Subsystems[0], cgroups)
 }
 
 func GetCgroupMounts() ([]Mount, error) {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -253,10 +253,15 @@ func getCgroupMounts(m *configs.Mount) ([]*configs.Mount, error) {
 		return nil, err
 	}
 
+	cgroupPaths, err := cgroups.ParseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		return nil, err
+	}
+
 	var binds []*configs.Mount
 
 	for _, mm := range mounts {
-		dir, err := mm.GetThisCgroupDir()
+		dir, err := mm.GetThisCgroupDir(cgroupPaths)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Here are two reasons:
* If we use systemd, we need to ask it to create cgroups
* If a container is restored with another ID, we need to
  change paths to cgroups.

Cc: @boucher 
Signed-off-by: Andrey Vagin <avagin@openvz.org>