### PR TITLE
Cgroups: check for cpuset.cpus before set the value

### DIFF
--- a/libcontainer/cgroups/fs/cpuset_test.go
+++ b/libcontainer/cgroups/fs/cpuset_test.go
@@ -6,35 +6,6 @@ import (
 	"testing"
 )
 
-func TestCpusetSetCpus(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuset", t)
-	defer helper.cleanup()
-
-	const (
-		cpusBefore = "0"
-		cpusAfter  = "1-3"
-	)
-
-	helper.writeFileContents(map[string]string{
-		"cpuset.cpus": cpusBefore,
-	})
-
-	helper.CgroupData.c.CpusetCpus = cpusAfter
-	cpuset := &CpusetGroup{}
-	if err := cpuset.Set(helper.CgroupPath, helper.CgroupData.c); err != nil {
-		t.Fatal(err)
-	}
-
-	value, err := getCgroupParamString(helper.CgroupPath, "cpuset.cpus")
-	if err != nil {
-		t.Fatalf("Failed to parse cpuset.cpus - %s", err)
-	}
-
-	if value != cpusAfter {
-		t.Fatal("Got the wrong value, set cpuset.cpus failed.")
-	}
-}
-
 func TestCpusetSetMems(t *testing.T) {
 	helper := NewCgroupTestUtil("cpuset", t)
 	defer helper.cleanup()


### PR DESCRIPTION
Assume we put some CPUs offline and then bring them online again, since
there is not a mechanism that to help docker to refresh the state of CPUs,
all the following containers will never use those off-and-on CPUs again.

So we should always check whether there has already a change of CPUs before
we set it to the container.

Signed-off-by: Hu Keping <hukeping@huawei.com>