### PR TITLE
Fix bug in find cgroup mount point dir

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -80,9 +80,15 @@ func FindCgroupMountpointDir() (string, error) {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		txt := scanner.Text()
-		fields := strings.Split(txt, " ")
-		if fields[7] == "cgroup" {
+		text := scanner.Text()
+		fields := strings.Split(text, " ")
+		// Safe as mountinfo encodes mountpoints with spaces as \040.
+		index := strings.Index(text, " - ")
+		postSeparatorFields := strings.Fields(text[index+3:])
+		if len(postSeparatorFields) < 3 {
+			return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
+		}
+		if postSeparatorFields[0] == "cgroup" {
 			return filepath.Dir(fields[4]), nil
 		}
 	}


### PR DESCRIPTION
Bug was introduced in #250

According to: http://man7.org/linux/man-pages/man5/proc.5.html

36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
(1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
...
(7)  optional fields: zero or more fields of the form
       "tag[:value]".
The 7th field is optional. We should skip it when parsing mount info.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>