### PR TITLE
make localtest failure on removing seccomp flag in Makefile

### DIFF
--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -1,4 +1,4 @@
-// +build linux,cgo
+// +build linux,cgo,seccomp
 
 package integration
 


### PR DESCRIPTION
@crosbymichael @mrunalp @LK4D4 

With the latest runc, I've compiled by eliminating seccomp build tag in Makefile.

When I ran make localtest, following errors occured.
--- FAIL: TestSeccompDenyGetcwd (0.37s)
        seccomp_test.go:54: [8] System error: seccomp: config provided but seccomp not supported
=== RUN TestSeccompPermitWriteConditional
time="2015-09-12T14:32:13+05:30" level=warning msg="exit status 1"
--- FAIL: TestSeccompPermitWriteConditional (0.41s)
        seccomp_test.go:128: [8] System error: seccomp: config provided but seccomp not supported
=== RUN TestSeccompDenyWriteConditional

Added the seccomp tag in seccomp_test.go to compile only if seccomp build tag is enabled in Makefile

Signed-off-by: Rajasekaran <rajasec79@gmail.com>