### PR TITLE
update the command usage for `runc start`

### DIFF
--- a/start.go
+++ b/start.go
@@ -24,12 +24,12 @@ var startCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "config-file, c",
 			Value: "config.json",
-			Usage: "path to spec file for writing",
+			Usage: "path to spec config file",
 		},
 		cli.StringFlag{
 			Name:  "runtime-file, r",
 			Value: "runtime.json",
-			Usage: "path for runtime file for writing",
+			Usage: "path to runtime config file",
 		},
 	},
 	Action: func(context *cli.Context) {


### PR DESCRIPTION
The patch mainly removes the wrong "for writing".
The config files are readonly when `runc start`.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>