### PR TITLE
README.md: Update the config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ user with uid and gid of `0` defined within that file-system.
 `config.json`:
 ```json
 {
-	"version": "pre-draft",
+	"version": "0.1.0",
 	"platform": {
 		"os": "linux",
 		"arch": "amd64"
@@ -144,8 +144,7 @@ user with uid and gid of `0` defined within that file-system.
 			"CAP_AUDIT_WRITE",
 			"CAP_KILL",
 			"CAP_NET_BIND_SERVICE"
-		],
-		"rootfsPropagation": ""
+		]
 	}
 }
 ```
@@ -231,7 +230,7 @@ user with uid and gid of `0` defined within that file-system.
 		"gidMappings": null,
 		"rlimits": [
 			{
-				"type": 7,
+				"type": "RLIMIT_NOFILE",
 				"hard": 1024,
 				"soft": 1024
 			}
@@ -255,6 +254,9 @@ user with uid and gid of `0` defined within that file-system.
 				"cpus": "",
 				"mems": ""
 			},
+			"pids": {
+				"limit": 0
+			},
 			"blockIO": {
 				"blkioWeight": 0,
 				"blkioWeightDevice": "",
@@ -269,6 +271,7 @@ user with uid and gid of `0` defined within that file-system.
 				"priorities": null
 			}
 		},
+		"cgroupsPath": "",
 		"namespaces": [
 			{
 				"type": "pid",


### PR DESCRIPTION
* version in the config example is advanced to 0.1.0 as the current spec version
* rootfsPropagation in config.json is removed
    (The same one is already in runtime.json)
* rlimit time is changed from magic number to name(string)
* add pids cgroup
* add cgroup path

After this change applied, the example config in this README.md
is consistent with the result of `runc spec`.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>