### PR TITLE
Change HugepageLimit.Limit type to uint64

### DIFF
--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -29,7 +29,7 @@ func (s *HugetlbGroup) Apply(d *data) error {
 
 func (s *HugetlbGroup) Set(path string, cgroup *configs.Cgroup) error {
 	for _, hugetlb := range cgroup.HugetlbLimit {
-		if err := writeFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.Itoa(hugetlb.Limit)); err != nil {
+		if err := writeFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -33,7 +33,7 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 	)
 
 	helper.writeFileContents(map[string]string{
-		limit: strconv.Itoa(hugetlbBefore),
+		limit: strconv.FormatUint(hugetlbBefore, 10),
 	})
 
 	helper.CgroupData.c.HugetlbLimit = []*configs.HugepageLimit{

--- a/libcontainer/configs/hugepage_limit.go
+++ b/libcontainer/configs/hugepage_limit.go
@@ -5,5 +5,5 @@ type HugepageLimit struct {
 	Pagesize string `json:"page_size"`
 
 	// usage limit for hugepage.
-	Limit int `json:"limit"`
+	Limit uint64 `json:"limit"`
 }


### PR DESCRIPTION
Minor change, just reflecting kernel value and not just `int`
depends on https://github.com/opencontainers/specs/pull/198 and require godep bump

Signed-off-by: Antonio Murdaca <runcom@linux.com>