### PR TITLE
script: test_Dockerfile: update criu version

### DIFF
--- a/script/test_Dockerfile
+++ b/script/test_Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.4
 
 RUN echo "deb http://ftp.us.debian.org/debian testing main contrib" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -y iptables criu=1.6-2 libseccomp2 libseccomp-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y iptables criu/testing libseccomp2 libseccomp-dev && rm -rf /var/lib/apt/lists/*
 
 # setup a playground for us to spawn containers in
 RUN mkdir /busybox && \


### PR DESCRIPTION
debian testing doesn't contain criu `1.6-2` anymore, `1.7-2` is available
this fixes CI failures and `make test` locally

Signed-off-by: Antonio Murdaca <runcom@linux.com>