### PR TITLE
runc: remove call to libcontainer.Cgroupfs()

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -104,7 +104,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	if err != nil {
 		return nil, err
 	}
-	return libcontainer.New(abs, libcontainer.Cgroupfs, func(l *libcontainer.LinuxFactory) error {
+	return libcontainer.New(abs, func(l *libcontainer.LinuxFactory) error {
 		l.CriuPath = context.GlobalString("criu")
 		return nil
 	})


### PR DESCRIPTION
libcontainer.New() by default will call Cgroupfs() for enforcing a native
cgroup manager. Runc don't have to do that again.

Signed-off-by: WANG Chao <wcwxyz@gmail.com>