### PR TITLE
no need to use p.cmd.Process.Pid in function, use p.pid() instead.

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -58,7 +58,7 @@ func (p *setnsProcess) signal(sig os.Signal) error {
 	if !ok {
 		return errors.New("os: unsupported signal type")
 	}
-	return syscall.Kill(p.cmd.Process.Pid, s)
+	return syscall.Kill(p.pid(), s)
 }
 
 func (p *setnsProcess) start() (err error) {
@@ -67,7 +67,7 @@ func (p *setnsProcess) start() (err error) {
 		return newSystemError(err)
 	}
 	if len(p.cgroupPaths) > 0 {
-		if err := cgroups.EnterPid(p.cgroupPaths, p.cmd.Process.Pid); err != nil {
+		if err := cgroups.EnterPid(p.cgroupPaths, p.pid()); err != nil {
 			return newSystemError(err)
 		}
 	}
@@ -289,7 +289,7 @@ func (p *initProcess) signal(sig os.Signal) error {
 	if !ok {
 		return errors.New("os: unsupported signal type")
 	}
-	return syscall.Kill(p.cmd.Process.Pid, s)
+	return syscall.Kill(p.pid(), s)
 }
 
 func (p *initProcess) setExternalDescriptors(newFds []string) {


### PR DESCRIPTION
Signed-off-by: keloyang <yangshukui@huawei.com>