### PR TITLE
Warn instead of error on Seccomp config if disabled

### DIFF
--- a/libcontainer/seccomp/common.go
+++ b/libcontainer/seccomp/common.go
@@ -1,10 +1,13 @@
 package seccomp
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
+
+var ErrSeccompNotEnabled = errors.New("seccomp: config provided but seccomp not supported")
 
 // ConvertStringToOperator converts a string into a Seccomp comparison operator.
 // Comparison operators use the names they are assigned by Libseccomp's header.

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -3,12 +3,8 @@
 package seccomp
 
 import (
-	"errors"
-
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
-
-var ErrSeccompNotEnabled = errors.New("seccomp: config provided but seccomp not supported")
 
 // Seccomp not supported, do nothing
 func InitSeccomp(config *configs.Seccomp) error {

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -5,6 +5,7 @@ package libcontainer
 import (
 	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/label"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
@@ -26,7 +27,11 @@ func (l *linuxSetnsInit) Init() error {
 	}
 	if l.config.Config.Seccomp != nil {
 		if err := seccomp.InitSeccomp(l.config.Config.Seccomp); err != nil {
-			return err
+			if err == seccomp.ErrSeccompNotEnabled {
+				logrus.Warn("Seccomp support not enabled, rules will be ignored!")
+			} else {
+				return err
+			}
 		}
 	}
 	if err := finalizeNamespace(l.config); err != nil {

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/label"
@@ -92,7 +93,11 @@ func (l *linuxStandardInit) Init() error {
 	}
 	if l.config.Config.Seccomp != nil {
 		if err := seccomp.InitSeccomp(l.config.Config.Seccomp); err != nil {
-			return err
+			if err == seccomp.ErrSeccompNotEnabled {
+				logrus.Warn("Seccomp support not enabled, rules will be ignored!")
+			} else {
+				return err
+			}
 		}
 	}
 	if err := finalizeNamespace(l.config); err != nil {


### PR DESCRIPTION
Fixes #273 

At present, runc without Seccomp support enabled will error if a Seccomp configuration is passed as part of the Runc configuration. Since we generate a Seccomp configuration as part of the output of `runc spec`, this means you need to manually remove this if you are using a binary without Seccomp compiled in. This demotes the error to a warning, which isn't a showstopper but still makes it clear that you're not getting the protection of any Seccomp rules that may be in the config.