### PR TITLE
Libcontainer: Add support for multiple architectures in Seccomp

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -20,8 +20,12 @@ type IDMap struct {
 }
 
 // Seccomp represents syscall restrictions
+// By default, only the native architecture of the kernel is allowed to be used
+// for syscalls. Additional architectures can be added by specifying them in
+// Architectures.
 type Seccomp struct {
 	DefaultAction Action     `json:"default_action"`
+	Architectures []string   `json:"architectures"`
 	Syscalls      []*Syscall `json:"syscalls"`
 }
 

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -37,6 +37,18 @@ func InitSeccomp(config *configs.Seccomp) error {
 		return fmt.Errorf("error creating filter: %s", err)
 	}
 
+	// Add extra architectures
+	for _, arch := range config.Architectures {
+		scmpArch, err := libseccomp.GetArchFromString(arch)
+		if err != nil {
+			return err
+		}
+
+		if err := filter.AddArch(scmpArch); err != nil {
+			return err
+		}
+	}
+
 	// Unset no new privs bit
 	if err := filter.SetNoNewPrivsBit(false); err != nil {
 		return fmt.Errorf("error setting no new privileges: %s", err)


### PR DESCRIPTION
This commit allows additional architectures to be added to Seccomp filters
created by containers. This allows containers to make syscalls using these
architectures. For example, in a container on an AMD64 system, only AMD64
syscalls would be usable unless x86 was added to the filter using this patch,
which would allow both 32-bit and 64-bit syscalls to be used.

This only adds support to the Libcontainer config - going to need an additional PR to the spec to get the field included there.