### PR TITLE
Change mount dest after resolving symlinks

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -158,6 +158,8 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 		if err := checkMountDestination(rootfs, dest); err != nil {
 			return err
 		}
+		// update the mount with the correct dest after symlinks are resolved.
+		m.Destination = dest
 		if err := createIfNotExists(dest, stat.IsDir()); err != nil {
 			return err
 		}


### PR DESCRIPTION
We need to update the mount's destination after we resolve symlinks so
that it properly creates and mounts the correct location.

This fixes a regression from the mount propagation merge. 
Signed-off-by: Michael Crosby <crosbymichael@gmail.com>