### PR TITLE
Fix cgroups mount points

### DIFF
--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -56,7 +56,7 @@ func (s *CpusetGroup) ApplyDir(dir string, cgroup *configs.Cgroup, pid int) erro
 	if dir == "" {
 		return nil
 	}
-	root, err := getCgroupRoot()
+	root, err := getCgroupRoot("cpuset")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The cgroups module currently assumes that all cgroups are mounted under
a single root directory. Unfortunately, this isn't always true. On
systems where this assumption does not hold, the directory holding the
first cgroup will be chosen arbitrarily, resulting in a failure to
utilize cgroups mounted elsewhere.

To fix this, always resolve the absolute path based on the subsystem in
question.

Signed-off-by: Ido Yariv <ido@wizery.com>