### PR TITLE
Move mount methods out of configs pkg

### DIFF
--- a/libcontainer/configs/mount.go
+++ b/libcontainer/configs/mount.go
@@ -1,13 +1,5 @@
 package configs
 
-import (
-	"path/filepath"
-	"strings"
-	"syscall"
-
-	"github.com/opencontainers/runc/libcontainer/label"
-)
-
 type Mount struct {
 	// Source path for the mount.
 	Source string `json:"source"`
@@ -35,41 +27,4 @@ type Mount struct {
 
 	// Optional Command to be run after Source is mounted.
 	PostmountCmds []Command `json:"postmount_cmds"`
-}
-
-func (m *Mount) Remount(rootfs string) error {
-	var (
-		dest = m.Destination
-	)
-	if !strings.HasPrefix(dest, rootfs) {
-		dest = filepath.Join(rootfs, dest)
-	}
-
-	if err := syscall.Mount(m.Source, dest, m.Device, uintptr(m.Flags|syscall.MS_REMOUNT), ""); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Do the mount operation followed by additional mounts required to take care
-// of propagation flags.
-func (m *Mount) MountPropagate(rootfs string, mountLabel string) error {
-	var (
-		dest = m.Destination
-		data = label.FormatMountLabel(m.Data, mountLabel)
-	)
-	if !strings.HasPrefix(dest, rootfs) {
-		dest = filepath.Join(rootfs, dest)
-	}
-
-	if err := syscall.Mount(m.Source, dest, m.Device, uintptr(m.Flags), data); err != nil {
-		return err
-	}
-
-	for _, pflag := range m.PropagationFlags {
-		if err := syscall.Mount("", dest, "", uintptr(pflag), ""); err != nil {
-			return err
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Do not have methods and actions that require syscalls in the configs
package because it breaks cross compile.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>