### PR TITLE
Adding architecture to seccomp spec

### DIFF
--- a/Godeps/_workspace/src/github.com/opencontainers/specs/runtime_config_linux.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/specs/runtime_config_linux.go
@@ -207,6 +207,7 @@ type Device struct {
 // Seccomp represents syscall restrictions
 type Seccomp struct {
 	DefaultAction Action     `json:"defaultAction"`
+	Architectures []string   `json:"architectures"`
 	Syscalls      []*Syscall `json:"syscalls"`
 }
 

--- a/spec.go
+++ b/spec.go
@@ -618,6 +618,11 @@ func setupSeccomp(config *specs.Seccomp) (*configs.Seccomp, error) {
 	}
 	newConfig.DefaultAction = newDefaultAction
 
+	// Adding the architecures
+	for _, arch := range config.Architectures {
+		newConfig.Architectures = append(newConfig.Architectures, arch)
+	}
+
 	// Loop through all syscall blocks and convert them to libcontainer format
 	for _, call := range config.Syscalls {
 		newAction, err := seccomp.ConvertStringToAction(string(call.Action))


### PR DESCRIPTION
@mheon @crosbymichael 

While I have added the architecture, it did not reflect in state.json file later as architecture was missing in the spec, I have added the architecture to spec and configs for parsing.

Later When I referred your PR, you have also mentioned it needs an PR. Was an coincident. : )

If you have already worked on this effort. I'll close this PR right way.


Signed-off-by: Rajasekaran <rajasec79@gmail.com>