### PR TITLE
/proc and /sys do not support labeling

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -106,7 +106,8 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 		if err := os.MkdirAll(dest, 0755); err != nil {
 			return err
 		}
-		return mountPropagate(m, rootfs, mountLabel)
+		// Selinux kernels do not support labeling of /proc or /sys
+		return mountPropagate(m, rootfs, "")
 	case "mqueue":
 		if err := os.MkdirAll(dest, 0755); err != nil {
 			return err

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -113,7 +113,10 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			return err
 		}
 		if err := mountPropagate(m, rootfs, mountLabel); err != nil {
-			return err
+			// older kernels do not support labeling of /dev/mqueue
+			if err := mountPropagate(m, rootfs, ""); err != nil {
+				return err
+			}
 		}
 		return label.SetFileLabel(dest, mountLabel)
 	case "tmpfs":


### PR DESCRIPTION
This is causing docker to crash when --selinux-enforcing mode is set.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>