### PR TITLE
Only remount if requested flags differ from current

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -167,9 +167,14 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			return err
 		}
 		// bind mount won't change mount options, we need remount to make mount options effective.
-		if err := remount(m, rootfs); err != nil {
-			return err
+		// first check that we have non-default options required before attempting a remount
+		if m.Flags&^(syscall.MS_REC|syscall.MS_REMOUNT|syscall.MS_BIND) != 0 {
+			// only remount if unique mount options are set
+			if err := remount(m, rootfs); err != nil {
+				return err
+			}
 		}
+
 		if m.Relabel != "" {
 			if err := label.Validate(m.Relabel); err != nil {
 				return err


### PR DESCRIPTION
Do not remount a bind mount to enable flags if the current filesystem
mount already sufficiently provides the requested flags. MS_REC is not a
flag represented in statfs_t, so is cleaned from the comparison
operation.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)