### PR TITLE
Fix reOpenDevNull

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -332,7 +332,7 @@ func setupDevSymlinks(rootfs string) error {
 // symlinks are resolved locally.
 func reOpenDevNull() error {
 	var stat, devNullStat syscall.Stat_t
-	file, err := os.Open("/dev/null")
+	file, err := os.OpenFile("/dev/null", os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("Failed to open /dev/null - %s", err)
 	}


### PR DESCRIPTION
We should open /dev/null with os.O_RDWR, otherwise it won't be
possible written to it

Signed-off-by: Chun Chen <ramichen@tencent.com>

Found this bug when I tried to set docker containers' stdout/stderr to null if launching with --log-drive=none. 
See the following simple program. It won't work without `os.O_RDWR`.
```
func main() {
	if err := reOpenDevNull(); err != nil {
		fmt.Println("Error reOpenDevNull ", err, "\n")
	}
	fmt.Println(syscall.Exec("/bin/echo", []string{"echo"}, os.Environ()))
}

func reOpenDevNull() error {
	file, err := os.Open("/dev/null")
//	file, err := os.OpenFile("/dev/null", os.O_RDWR, 0) // should open it with os.O_RDWR
	if err != nil {
		return fmt.Errorf("Failed to open /dev/null - %s", err)
	}
	defer file.Close()
	for fd := 1; fd < 3; fd++ {
		if err := syscall.Dup3(int(file.Fd()), fd, 0); err != nil {
			return err
		}
	}
	return nil
}
```