### PR TITLE
Systemd name

### DIFF
--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -1,0 +1,25 @@
+package fs
+
+import (
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+type NameGroup struct {
+}
+
+func (s *NameGroup) Apply(d *data) error {
+	return nil
+}
+
+func (s *NameGroup) Set(path string, cgroup *configs.Cgroup) error {
+	return nil
+}
+
+func (s *NameGroup) Remove(d *data) error {
+	return nil
+}
+
+func (s *NameGroup) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -34,17 +34,18 @@ type subsystem interface {
 }
 
 var subsystems = map[string]subsystem{
-	"devices":    &fs.DevicesGroup{},
-	"memory":     &fs.MemoryGroup{},
-	"cpu":        &fs.CpuGroup{},
-	"cpuset":     &fs.CpusetGroup{},
-	"cpuacct":    &fs.CpuacctGroup{},
-	"blkio":      &fs.BlkioGroup{},
-	"hugetlb":    &fs.HugetlbGroup{},
-	"perf_event": &fs.PerfEventGroup{},
-	"freezer":    &fs.FreezerGroup{},
-	"net_prio":   &fs.NetPrioGroup{},
-	"net_cls":    &fs.NetClsGroup{},
+	"devices":      &fs.DevicesGroup{},
+	"memory":       &fs.MemoryGroup{},
+	"cpu":          &fs.CpuGroup{},
+	"cpuset":       &fs.CpusetGroup{},
+	"cpuacct":      &fs.CpuacctGroup{},
+	"blkio":        &fs.BlkioGroup{},
+	"hugetlb":      &fs.HugetlbGroup{},
+	"perf_event":   &fs.PerfEventGroup{},
+	"freezer":      &fs.FreezerGroup{},
+	"net_prio":     &fs.NetPrioGroup{},
+	"net_cls":      &fs.NetClsGroup{},
+	"name=systemd": &fs.NameGroup{},
 }
 
 const (


### PR DESCRIPTION
This fixes https://github.com/docker/docker/issues/16775

docker exec doesn't set the name cgroup for systemd correctly. This PR introduces a name cgroup that is used only in GetPaths so docker exec gets all the paths that are passed down to EnterPid.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>