### PR TITLE
bump docker pkgs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -24,23 +24,23 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/mount",
-			"Comment": "v1.4.1-4127-gb81f2ee",
-			"Rev": "b81f2ee5f20d094c13893f565ce716595c539d22"
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/symlink",
-			"Comment": "v1.4.1-4127-gb81f2ee",
-			"Rev": "b81f2ee5f20d094c13893f565ce716595c539d22"
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/term",
-			"Comment": "v1.4.1-4127-gb81f2ee",
-			"Rev": "b81f2ee5f20d094c13893f565ce716595c539d22"
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/units",
-			"Comment": "v1.4.1-4127-gb81f2ee",
-			"Rev": "b81f2ee5f20d094c13893f565ce716595c539d22"
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
 		},
 		{
 			"ImportPath": "github.com/godbus/dbus",

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mount.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mount.go
@@ -5,7 +5,7 @@ import (
 )
 
 // GetMounts retrieves a list of mounts for the current running process.
-func GetMounts() ([]*MountInfo, error) {
+func GetMounts() ([]*Info, error) {
 	return parseMountTable()
 }
 

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo.go
@@ -1,10 +1,10 @@
 package mount
 
-// MountInfo reveals information about a particular mounted filesystem. This
+// Info reveals information about a particular mounted filesystem. This
 // struct is populated from the content in the /proc/<pid>/mountinfo file.
-type MountInfo struct {
-	// Id is a unique identifier of the mount (may be reused after umount).
-	Id int
+type Info struct {
+	// ID is a unique identifier of the mount (may be reused after umount).
+	ID int
 
 	// Parent indicates the ID of the mount parent (or of self for the top of the
 	// mount tree).

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_freebsd.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_freebsd.go
@@ -15,7 +15,7 @@ import (
 
 // Parse /proc/self/mountinfo because comparing Dev and ino does not work from
 // bind mounts.
-func parseMountTable() ([]*MountInfo, error) {
+func parseMountTable() ([]*Info, error) {
 	var rawEntries *C.struct_statfs
 
 	count := int(C.getmntinfo(&rawEntries, C.MNT_WAIT))
@@ -29,9 +29,9 @@ func parseMountTable() ([]*MountInfo, error) {
 	header.Len = count
 	header.Data = uintptr(unsafe.Pointer(rawEntries))
 
-	var out []*MountInfo
+	var out []*Info
 	for _, entry := range entries {
-		var mountinfo MountInfo
+		var mountinfo Info
 		mountinfo.Mountpoint = C.GoString(&entry.f_mntonname[0])
 		mountinfo.Source = C.GoString(&entry.f_mntfromname[0])
 		mountinfo.Fstype = C.GoString(&entry.f_fstypename[0])

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_linux.go
@@ -30,7 +30,7 @@ const (
 
 // Parse /proc/self/mountinfo because comparing Dev and ino does not work from
 // bind mounts
-func parseMountTable() ([]*MountInfo, error) {
+func parseMountTable() ([]*Info, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return nil, err
@@ -40,10 +40,10 @@ func parseMountTable() ([]*MountInfo, error) {
 	return parseInfoFile(f)
 }
 
-func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
+func parseInfoFile(r io.Reader) ([]*Info, error) {
 	var (
 		s   = bufio.NewScanner(r)
-		out = []*MountInfo{}
+		out = []*Info{}
 	)
 
 	for s.Scan() {
@@ -52,13 +52,13 @@ func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
 		}
 
 		var (
-			p              = &MountInfo{}
+			p              = &Info{}
 			text           = s.Text()
 			optionalFields string
 		)
 
 		if _, err := fmt.Sscanf(text, mountinfoFormat,
-			&p.Id, &p.Parent, &p.Major, &p.Minor,
+			&p.ID, &p.Parent, &p.Major, &p.Minor,
 			&p.Root, &p.Mountpoint, &p.Opts, &optionalFields); err != nil {
 			return nil, fmt.Errorf("Scanning '%s' failed: %s", text, err)
 		}
@@ -84,7 +84,7 @@ func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
 // PidMountInfo collects the mounts for a specific process ID. If the process
 // ID is unknown, it is better to use `GetMounts` which will inspect
 // "/proc/self/mountinfo" instead.
-func PidMountInfo(pid int) ([]*MountInfo, error) {
+func PidMountInfo(pid int) ([]*Info, error) {
 	f, err := os.Open(fmt.Sprintf("/proc/%d/mountinfo", pid))
 	if err != nil {
 		return nil, err

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_linux_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_linux_test.go
@@ -457,8 +457,8 @@ func TestParseFedoraMountinfoFields(t *testing.T) {
 	if len(infos) != expectedLength {
 		t.Fatalf("Expected %d entries, got %d", expectedLength, len(infos))
 	}
-	mi := MountInfo{
-		Id:         15,
+	mi := Info{
+		ID:         15,
 		Parent:     35,
 		Major:      0,
 		Minor:      3,

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/mountinfo_unsupported.go
@@ -7,6 +7,6 @@ import (
 	"runtime"
 )
 
-func parseMountTable() ([]*MountInfo, error) {
+func parseMountTable() ([]*Info, error) {
 	return nil, fmt.Errorf("mount.parseMountTable is not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/sharedsubtree_linux_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/mount/sharedsubtree_linux_test.go
@@ -107,7 +107,7 @@ func TestSubtreePrivate(t *testing.T) {
 }
 
 // Testing that when a target is a shared mount,
-// then child mounts propogate to the source
+// then child mounts propagate to the source
 func TestSubtreeShared(t *testing.T) {
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+
 package term
 
 import (

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/units/size.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/units/size.go
@@ -51,7 +51,7 @@ func CustomSize(format string, size float64, base float64, _map []string) string
 // HumanSize returns a human-readable approximation of a size
 // using SI standard (eg. "44kB", "17MB")
 func HumanSize(size float64) string {
-	return CustomSize("%.4g %s", float64(size), 1000.0, decimapAbbrs)
+	return CustomSize("%.4g %s", size, 1000.0, decimapAbbrs)
 }
 
 func BytesSize(size float64) string {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -421,7 +421,7 @@ func mknodDevice(dest string, node *configs.Device) error {
 	return syscall.Chown(dest, int(node.Uid), int(node.Gid))
 }
 
-func getMountInfo(mountinfo []*mount.MountInfo, dir string) *mount.MountInfo {
+func getMountInfo(mountinfo []*mount.Info, dir string) *mount.Info {
 	for _, m := range mountinfo {
 		if m.Mountpoint == dir {
 			return m


### PR DESCRIPTION
Docker pkgs were updated while golinting the whole docker code base.
Now when trying to bump libcontainer/runc in docker, it fails compiling with the following error:
```
vendor/src/github.com/opencontainers/runc/libcontainer/rootfs_linux.go:424: undefined: mount.MountInfo
```
This is because, for instance, the mount pkg was updated here https://github.com/docker/docker/commit/0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d#diff-49294d05afa48e2f7c0d2f02c6f7614c and now that type is only `mount.Info`.
This patch bump docker pkgs commit and adapt code to it.

get -u github.com/opencontainers/runc fails as well while building
this is necessary to update libcontainer/runc in docker
ping @LK4D4 @crosbymichael @mrunalp 

Signed-off-by: Antonio Murdaca <amurdaca@redhat.com>