### PR TITLE
Make runc buildable everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/pkg
-runc
+/runc
+Godeps/_workspace/src/github.com/opencontainers/runc

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BUILDTAGS=seccomp
 export GOPATH:=$(CURDIR)/Godeps/_workspace:$(GOPATH)
 
 all:
+	ln -sfn $(CURDIR) $(CURDIR)/Godeps/_workspace/src/github.com/opencontainers/runc
 	go build -tags "$(BUILDTAGS)" -o runc .
 
 vet:
@@ -29,6 +30,7 @@ install:
 
 clean:
 	rm runc
+	rm $(CURDIR)/Godeps/_workspace/src/github.com/opencontainers/runc
 
 validate: vet
 	script/validate-gofmt


### PR DESCRIPTION
Currently we need to clone github.com/opencontainers/runc to
GOPATH so we can make it, it's not friendly for developers.

We can resolve it by vendoring itself as a symlink in GOPATH.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>