### PR TITLE
Add ability to use json structured logging format.

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,11 @@ func main() {
 			Usage: "set the log file path where internal debug information is written",
 		},
 		cli.StringFlag{
+			Name:  "log-format",
+			Value: "text",
+			Usage: "set the format used by logs ('text' (default), or 'json')",
+		},
+		cli.StringFlag{
 			Name:  "root",
 			Value: specs.LinuxStateDirectory,
 			Usage: "root directory for storage of container state (this should be located in tmpfs)",
@@ -82,6 +87,14 @@ func main() {
 				return err
 			}
 			logrus.SetOutput(f)
+		}
+		switch context.GlobalString("log-format") {
+		case "text":
+			// retain logrus's default.
+		case "json":
+			logrus.SetFormatter(new(logrus.JSONFormatter))
+		default:
+			logrus.Fatalf("unknown log-format %q", context.GlobalString("log-format"))
 		}
 		return nil
 	}


### PR DESCRIPTION
Add a flag which allows the user to switch logging formats when execing `runc`.

Invoking `runc --logfmt json` will cause runc to emit lines of json which can be easily hoovered/parsed/collected/filtered by log handling tools.

The default value (or, invoking `runc --logfmt text` explicitly) continues to use the textual format (with tty autodetection, etc) that logrus used previously.  