### PR TITLE
Set cpuset.cpus and cpuset.mems before join the cgroup

### DIFF
--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -59,15 +59,14 @@ func (s *CpusetGroup) ApplyDir(dir string, cgroup *configs.Cgroup, pid int) erro
 	if err := s.ensureParent(dir, root); err != nil {
 		return err
 	}
-	// because we are not using d.join we need to place the pid into the procs file
-	// unlike the other subsystems
-	if err := writeFile(dir, "cgroup.procs", strconv.Itoa(pid)); err != nil {
-		return err
-	}
-
 	// the default values inherit from parent cgroup are already set in
 	// s.ensureParent, cover these if we have our own
 	if err := s.Set(dir, cgroup); err != nil {
+		return err
+	}
+	// because we are not using d.join we need to place the pid into the procs file
+	// unlike the other subsystems
+	if err := writeFile(dir, "cgroup.procs", strconv.Itoa(pid)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
It can avoid unnecessary task migrataion, see this scenario:
 - container init task is on cpu 1, and we assigned it to cpu 1,
   but parent cgroup's cpuset.cpus=2
 - we created the cgroup dir and inherited cpuset.cpus from parent as 2
 - write container init task's pid to cgroup.procs
 - [it's possibile the container init task migrated to cpu 2 here]
 - set cpuset.cpus as assigned to cpu 1
 - [the container init task has to be migrated back to cpu 1]

So we should set cpuset.cpus and cpuset.mems before writing pids
to cgroup.procs to aviod such problem.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>