### PR TITLE
When creating systemd unit sanitize the unit name

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -450,7 +450,14 @@ func (m *Manager) Set(container *configs.Config) error {
 }
 
 func getUnitName(c *configs.Cgroup) string {
-	return fmt.Sprintf("%s-%s.scope", c.Parent, c.Name)
+	allowed := "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ:-_.\\"
+	sanitizeFunc := func(r rune) rune {
+		if strings.ContainsRune(allowed, r) {
+			return r
+		}
+		return '.'
+	}
+	return fmt.Sprintf("%s-%s.scope", strings.Map(sanitizeFunc, c.Parent), strings.Map(sanitizeFunc, c.Name))
 }
 
 // Atm we can't use the systemd device support because of two missing things:


### PR DESCRIPTION
Systemd requires that unit names consist of only alphabetical characters
as well as some symbols. apply_systemd constructs unit time directly from
parent cgroup name, but because cgroup name may contain forward slash "/"
resulting unit name may not be valid and will be rejected by systemd.

This change will replace all characters prohibited by systemd
with a period ".".

This change fixes docker/docker#17126
