### PR TITLE
Fixing container start when cgroup subsystem not found

### DIFF
--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -19,7 +19,10 @@ type BlkioGroup struct {
 
 func (s *BlkioGroup) Apply(d *data) error {
 	dir, err := d.join("blkio")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -19,7 +19,10 @@ func (s *CpuGroup) Apply(d *data) error {
 	// We always want to join the cpu group, to allow fair cpu scheduling
 	// on a container basis
 	dir, err := d.join("cpu")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -18,7 +18,10 @@ type CpusetGroup struct {
 
 func (s *CpusetGroup) Apply(d *data) error {
 	dir, err := d.path("cpuset")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	return s.ApplyDir(dir, d.c, d.pid)

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -16,7 +16,10 @@ type HugetlbGroup struct {
 
 func (s *HugetlbGroup) Apply(d *data) error {
 	dir, err := d.join("hugetlb")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -10,7 +10,10 @@ type NetClsGroup struct {
 
 func (s *NetClsGroup) Apply(d *data) error {
 	dir, err := d.join("net_cls")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -10,7 +10,10 @@ type NetPrioGroup struct {
 
 func (s *NetPrioGroup) Apply(d *data) error {
 	dir, err := d.join("net_prio")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
With current runc implementation, if the cgroup subsystem is not mounted in the host, subsequent directories are not created inside the container. But Set interface is called to write to respective subsystem attributes ( if the runtime.json had the right values). In that case container failed to start.

Example
In runtime.json, I've added the cpu shares and blkio related parameters
After unmounting the cpu and blkio subsystem from host, the container failed to start due to following errors
FATA[0000] Container start failed: [8] System error: no such directory for cpu.shares

As directories are not created if subsystem is not mounted, Let us try not to set the values for the respective subsystems ( if not mounted) and gracefully start the container instead of failing

Signed-off-by: Rajasekaran <rajasec79@gmail.com>