### PR TITLE
Add SCMP_ACT_TRACE as a valid Seccomp action

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -33,9 +33,10 @@ type Seccomp struct {
 type Action int
 
 const (
-	Kill Action = iota - 4
+	Kill Action = iota - 5
 	Errno
 	Trap
+	Trace
 	Allow
 )
 

--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -47,6 +47,8 @@ func ConvertStringToAction(in string) (configs.Action, error) {
 		return configs.Trap, nil
 	case "SCMP_ACT_ALLOW":
 		return configs.Allow, nil
+	case "SCMP_ACT_TRACE":
+		return configs.Trace, nil
 	default:
 		return 0, fmt.Errorf("string %s is not a valid action for seccomp", in)
 	}

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -15,6 +15,7 @@ var (
 	actAllow = libseccomp.ActAllow
 	actTrap  = libseccomp.ActTrap
 	actKill  = libseccomp.ActKill
+	actTrace = libseccomp.ActTrace.SetReturnCode(int16(syscall.EPERM))
 	actErrno = libseccomp.ActErrno.SetReturnCode(int16(syscall.EPERM))
 )
 
@@ -81,6 +82,8 @@ func getAction(act configs.Action) (libseccomp.ScmpAction, error) {
 		return actErrno, nil
 	case configs.Trap:
 		return actTrap, nil
+	case configs.Trace:
+		return actTrace, nil
 	case configs.Allow:
 		return actAllow, nil
 	default:


### PR DESCRIPTION
This enables tracing of blocked system calls in a container. This could be useful for debugging, and is the only Seccomp action runc doesn't support at present.