### PR TITLE
Fixing seccomp convert string operator return type

### DIFF
--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -21,9 +21,9 @@ func ConvertStringToOperator(in string) (configs.Operator, error) {
 	case "SCMP_CMP_EQ":
 		return configs.EqualTo, nil
 	case "SCMP_CMP_GE":
-		return configs.GreaterThan, nil
-	case "SCMP_CMP_GT":
 		return configs.GreaterThanOrEqualTo, nil
+	case "SCMP_CMP_GT":
+		return configs.GreaterThan, nil
 	case "SCMP_CMP_MASKED_EQ":
 		return configs.MaskEqualTo, nil
 	default:


### PR DESCRIPTION
Seccomp ConvertStringTOOperator had incorrect return types for the following switch case

GE, it returns GreaterThan
GT it returns GreatherThanOrEqualTo

case "SCMP_CMP_GE":
                return configs.GreaterThan, nil  
        case "SCMP_CMP_GT":
                return configs.GreaterThanOrEqualTo, nil
 
Signed-off-by: rajasec <rajasec79@gmail.com>