### PR TITLE
Userns container in containers

### DIFF
--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -26,6 +26,9 @@ func (s *DevicesGroup) Apply(d *data) error {
 }
 
 func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
+	if cgroup.IsHostUnprivileged {
+		return nil
+	}
 	if !cgroup.AllowAllDevices {
 		if err := writeFile(path, "devices.deny", "a"); err != nil {
 			return err

--- a/libcontainer/configs/cgroup.go
+++ b/libcontainer/configs/cgroup.go
@@ -24,6 +24,7 @@ type Cgroup struct {
 
 	DeniedDevices []*Device `json:"denied_devices"`
 
+	IsHostUnprivileged bool `json:"isHostUnprivileged"`
 	// Memory limit (in bytes)
 	Memory int64 `json:"memory"`
 

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -72,6 +72,9 @@ type Syscall struct {
 
 // Config defines configuration options for executing a process inside a contained environment.
 type Config struct {
+	// Indicates if the host is unprivileged
+	// Used by libcontainer to check whether to mknod and write to devices cgroup
+	IsHostUnprivileged bool `json:"isHostUnprivileged"`
 	// NoPivotRoot will use MS_MOVE and a chroot to jail the process into the container's rootfs
 	// This is a common option when the container is running in ramdisk
 	NoPivotRoot bool `json:"no_pivot_root"`

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -370,7 +370,13 @@ func createDevices(config *configs.Config) error {
 	for _, node := range config.Devices {
 		// containers running in a user namespace are not allowed to mknod
 		// devices so we can just bind mount it from the host.
-		if err := createDeviceNode(config.Rootfs, node, config.Namespaces.Contains(configs.NEWUSER)); err != nil {
+		isHostUserns := config.IsHostUnprivileged
+
+		isContainerUserns := config.Namespaces.Contains(configs.NEWUSER)
+		if err := createDeviceNode(
+			config.Rootfs,
+			node,
+			isContainerUserns || isHostUserns); err != nil {
 			syscall.Umask(oldMask)
 			return err
 		}

--- a/spec.go
+++ b/spec.go
@@ -340,12 +340,12 @@ func createLibcontainerConfig(cgroupName string, spec *specs.LinuxSpec, rspec *s
 		rootfsPath = filepath.Join(cwd, rootfsPath)
 	}
 	config := &configs.Config{
-		Rootfs:       rootfsPath,
-		Capabilities: spec.Linux.Capabilities,
-		Readonlyfs:   spec.Root.Readonly,
-		Hostname:     spec.Hostname,
+		Rootfs:             rootfsPath,
+		Capabilities:       spec.Linux.Capabilities,
+		Readonlyfs:         spec.Root.Readonly,
+		Hostname:           spec.Hostname,
+		IsHostUnprivileged: rspec.Linux.IsHostUnprivileged,
 	}
-
 	exists := false
 	if config.RootPropagation, exists = mountPropagationMapping[rspec.Linux.RootfsPropagation]; !exists {
 		return nil, fmt.Errorf("rootfsPropagation=%v is not supported", rspec.Linux.RootfsPropagation)
@@ -444,6 +444,7 @@ func createCgroupConfig(name string, spec *specs.LinuxRuntimeSpec, devices []*co
 		AllowedDevices: append(devices, allowedDevices...),
 	}
 	r := spec.Linux.Resources
+	c.IsHostUnprivileged = spec.Linux.IsHostUnprivileged
 	c.Memory = r.Memory.Limit
 	c.MemoryReservation = r.Memory.Reservation
 	c.MemorySwap = r.Memory.Swap


### PR DESCRIPTION
Added a check on devices for hosts that are themselves usernamespaced
containers. It is not possible for a non-root host process to set the
devices.allow and devices.deny, and therefore this patch skips that for
host processes which have a non-root uid_map.
Signed-off-by: Abin Shahab <ashahab@altiscale.com>