### PR TITLE
Add a new command to list the checkpointed images of a container

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -54,6 +54,9 @@ type State struct {
 
 	// Container's standard descriptors (std{in,out,err}), needed for checkpoint and restore
 	ExternalDescriptors []string `json:"external_descriptors,omitempty"`
+
+	// Criu image paths
+	CriuimagePaths map[string]string `json:"criu_image_paths"`
 }
 
 // A libcontainer container object.
@@ -127,6 +130,12 @@ type Container interface {
 	// errors:
 	// Systemerror - System error.
 	Restore(process *Process, criuOpts *CriuOpts) error
+
+	// List the checkpointed images of a container
+	//
+	// errors:
+	// Systemerror - System error.
+	Listimages() error
 
 	// Destroys the container after killing all running processes.
 	//

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -468,6 +468,55 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 	if err != nil {
 		return err
 	}
+
+	// checkpoint succeeds; update the state file
+	r, err := os.Open(filepath.Join(c.root, stateFilename))
+	if err != nil {
+		fmt.Println("Can not open state file")
+		return err
+	}
+	decoder := json.NewDecoder(r)
+	var old_state *State
+	if err := decoder.Decode(&old_state); err != nil {
+		return err
+	}
+	r.Close()
+
+	// Append new criu images
+	state, err := c.currentState()
+	for k, v := range old_state.CriuimagePaths {
+		state.CriuimagePaths[k] = v
+	}
+	state.CriuimagePaths[criuOpts.ImagesDirectory] = criuOpts.ImagesDirectory
+
+	f, err := os.Create(filepath.Join(c.root, stateFilename))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	json.NewEncoder(f).Encode(state)
+
+	return nil
+}
+
+func (c *linuxContainer) Listimages() error {
+	f, err := os.Open(filepath.Join(c.root, stateFilename))
+	defer f.Close()
+	if err != nil {
+		fmt.Println("Can not open state file")
+		return err
+	}
+
+	decoder := json.NewDecoder(f)
+	var state *State
+	if err := decoder.Decode(&state); err != nil {
+		return err
+	}
+
+	for _, v := range state.CriuimagePaths {
+		fmt.Println(v)
+	}
+
 	return nil
 }
 
@@ -906,6 +955,7 @@ func (c *linuxContainer) currentState() (*State, error) {
 		CgroupPaths:          c.cgroupManager.GetPaths(),
 		NamespacePaths:       make(map[configs.NamespaceType]string),
 		ExternalDescriptors:  c.initProcess.externalDescriptors(),
+		CriuimagePaths:       make(map[string]string),
 	}
 	for _, ns := range c.config.Namespaces {
 		state.NamespacePaths[ns.Type] = ns.GetPath(c.initProcess.pid())

--- a/listimages.go
+++ b/listimages.go
@@ -1,0 +1,22 @@
+// +build linux
+
+package main
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+var listimagesCommand = cli.Command{
+	Name:  "listimages",
+	Usage: "list the checkpointed images of a container",
+	Action: func(context *cli.Context) {
+		container, err := getContainer(context)
+		if err != nil {
+			fatal(err)
+		}
+
+		if err := container.Listimages(); err != nil {
+			fatal(err)
+		}
+	},
+}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 		pauseCommand,
 		resumeCommand,
 		execCommand,
+		listimagesCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {


### PR DESCRIPTION
A container could be checkpointed many times. We need to track the locations
of the checkpointed images. The locations are added to the runtime metadata
on disk, e.g., state.json.

List checkpointed images of a container by "runc listimages"

Signed-off-by: Hui Kang <hkang.sunysb@gmail.com>