### PR TITLE
Windows: Refactor state struct

### DIFF
--- a/libcontainer/configs/config_unix_test.go
+++ b/libcontainer/configs/config_unix_test.go
@@ -1,3 +1,5 @@
+// +build linux freebsd
+
 package configs
 
 import (

--- a/libcontainer/configs/config_windows_test.go
+++ b/libcontainer/configs/config_windows_test.go
@@ -1,0 +1,3 @@
+package configs
+
+// All current tests are for Unix-specific functionality

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -30,8 +30,9 @@ const (
 	Destroyed
 )
 
-// State represents a running container's state
-type State struct {
+// BaseState represents the platform agnostic pieces relating to a
+// running container's state
+type BaseState struct {
 	// ID is the container ID.
 	ID string `json:"id"`
 
@@ -41,19 +42,8 @@ type State struct {
 	// InitProcessStartTime is the init process start time.
 	InitProcessStartTime string `json:"init_process_start"`
 
-	// Path to all the cgroups setup for a container. Key is cgroup subsystem name
-	// with the value as the path.
-	CgroupPaths map[string]string `json:"cgroup_paths"`
-
-	// NamespacePaths are filepaths to the container's namespaces. Key is the namespace type
-	// with the value as the path.
-	NamespacePaths map[configs.NamespaceType]string `json:"namespace_paths"`
-
 	// Config is the container's configuration.
 	Config configs.Config `json:"config"`
-
-	// Container's standard descriptors (std{in,out,err}), needed for checkpoint and restore
-	ExternalDescriptors []string `json:"external_descriptors,omitempty"`
 }
 
 // A libcontainer container object.

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -34,6 +34,24 @@ type linuxContainer struct {
 	m             sync.Mutex
 }
 
+// State represents a running container's state
+type State struct {
+	BaseState
+
+	// Platform specific fields below here
+
+	// Path to all the cgroups setup for a container. Key is cgroup subsystem name
+	// with the value as the path.
+	CgroupPaths map[string]string `json:"cgroup_paths"`
+
+	// NamespacePaths are filepaths to the container's namespaces. Key is the namespace type
+	// with the value as the path.
+	NamespacePaths map[configs.NamespaceType]string `json:"namespace_paths"`
+
+	// Container's standard descriptors (std{in,out,err}), needed for checkpoint and restore
+	ExternalDescriptors []string `json:"external_descriptors,omitempty"`
+}
+
 // ID returns the container's unique ID
 func (c *linuxContainer) ID() string {
 	return c.id
@@ -899,13 +917,15 @@ func (c *linuxContainer) currentState() (*State, error) {
 		return nil, newSystemError(err)
 	}
 	state := &State{
-		ID:                   c.ID(),
-		Config:               *c.config,
-		InitProcessPid:       c.initProcess.pid(),
-		InitProcessStartTime: startTime,
-		CgroupPaths:          c.cgroupManager.GetPaths(),
-		NamespacePaths:       make(map[configs.NamespaceType]string),
-		ExternalDescriptors:  c.initProcess.externalDescriptors(),
+		BaseState: BaseState{
+			ID:                   c.ID(),
+			Config:               *c.config,
+			InitProcessPid:       c.initProcess.pid(),
+			InitProcessStartTime: startTime,
+		},
+		CgroupPaths:         c.cgroupManager.GetPaths(),
+		NamespacePaths:      make(map[configs.NamespaceType]string),
+		ExternalDescriptors: c.initProcess.externalDescriptors(),
 	}
 	for _, ns := range c.config.Namespaces {
 		state.NamespacePaths[ns.Type] = ns.GetPath(c.initProcess.pid())

--- a/libcontainer/container_windows.go
+++ b/libcontainer/container_windows.go
@@ -1,0 +1,8 @@
+package libcontainer
+
+// State represents a running container's state
+type State struct {
+	BaseState
+
+	// Platform specific fields below here
+}

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -137,8 +137,10 @@ func TestFactoryLoadContainer(t *testing.T) {
 			Rootfs: "/mycontainer/root",
 		}
 		expectedState = &State{
-			InitProcessPid: 1024,
-			Config:         *expectedConfig,
+			BaseState: BaseState{
+				InitProcessPid: 1024,
+				Config:         *expectedConfig,
+			},
 		}
 	)
 	if err := os.Mkdir(filepath.Join(root, id), 0700); err != nil {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Time to start refocusing on getting a "native" (libcontainer) exec driver on Windows. The first step to this is a bunch of refactoring of various structures and interfaces which have Unix-specific fields out of the Windows paths. For example the container state structure, the container interface, criu, cgroups and so on.

This is the first of a bunch of small PRs to move to that goal - refactoring of the state structure into platform agnostic (common) pieces, and platform specific pieces.