### PR TITLE
Windows: Factor down criu_opts

### DIFF
--- a/libcontainer/criu_opts_unix.go
+++ b/libcontainer/criu_opts_unix.go
@@ -1,3 +1,5 @@
+// +build linux freebsd
+
 package libcontainer
 
 // cgroup restoring strategy provided by criu

--- a/libcontainer/criu_opts_windows.go
+++ b/libcontainer/criu_opts_windows.go
@@ -1,0 +1,6 @@
+package libcontainer
+
+// TODO Windows: This can ultimately be entirely factored out as criu is
+// a Unix concept not relevant on Windows.
+type CriuOpts struct {
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Time to start refocusing on getting a "native" (libcontainer) exec driver on Windows. The first step to this is a bunch of refactoring of various structures and interfaces which have Unix-specific fields out of the Windows paths. For example the container state structure, the container interface, criu, cgroups and so on.

This is the third of a bunch of small PRs to move to that goal - refactoring of criu_opts as it's a Unix specific construct. More work can be done here ultimately to completely factor this out on Windows, but let's take a baby step first. 
