### PR TITLE
Windows: Refactor configs/cgroup.go

### DIFF
--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -1,3 +1,5 @@
+// +build linux freebsd
+
 package configs
 
 type FreezerState string
@@ -7,9 +9,6 @@ const (
 	Frozen    FreezerState = "FROZEN"
 	Thawed    FreezerState = "THAWED"
 )
-
-// TODO Windows: This can be factored out in the future as Cgroups are not
-// supported on the Windows platform.
 
 type Cgroup struct {
 	Name string `json:"name"`

--- a/libcontainer/configs/cgroup_windows.go
+++ b/libcontainer/configs/cgroup_windows.go
@@ -1,0 +1,6 @@
+package configs
+
+// TODO Windows: This can ultimately be entirely factored out on Windows as
+// cgroups are a Unix-specific construct.
+type Cgroup struct {
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Time to start refocusing on getting a "native" (libcontainer) exec driver on Windows. The first step to this is a bunch of refactoring of various structures and interfaces which have Unix-specific fields out of the Windows paths. For example the container state structure, the container interface, criu, cgroups and so on.

This is the fourth of a bunch of small PRs to move to that goal - refactoring of libcontainer\configs\cgroup.go as it's a Unix specific construct. More work can be done here ultimately to completely factor this out on Windows, but let's take a baby step first. 
