### PR TITLE
Fixes build tags on cgroups\fs\*.go

### DIFF
--- a/libcontainer/cgroups/fs/freezer_test.go
+++ b/libcontainer/cgroups/fs/freezer_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package fs
 
 import (

--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package fs
 
 import (

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package fs
 
 import (

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package fs
 
 import (

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package fs
 
 import (

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package fs
 
 import (

--- a/libcontainer/cgroups/fs/net_prio_test.go
+++ b/libcontainer/cgroups/fs/net_prio_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package fs
 
 import (


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Time to start refocusing on getting a "native" (libcontainer) exec driver on Windows. The first step to this is a bunch of refactoring of various structures and interfaces which have Unix-specific fields out of the Windows paths. For example the container state structure, the container interface, criu, cgroups and so on.

This is the sixth of a bunch of small PRs to move to that goal - this fixes a bunch of build tags under libcontainer\cgroups\fs which were missing the Linux build tag. This allows a clean build and test on Windows (even though it's not actually imported).
