### PR TITLE
Setting cgroup resources

### DIFF
--- a/libcontainer/README.md
+++ b/libcontainer/README.md
@@ -130,6 +130,9 @@ container.Pause()
 
 // resume all paused processes.
 container.Resume()
+
+// set cgroup resources inside the running container.
+container.Set()
 ```
 
 

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 		pauseCommand,
 		resumeCommand,
 		execCommand,
+		setCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {

--- a/set.go
+++ b/set.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/codegangsta/cli"
+	"os"
+)
+
+var setCommand = cli.Command{
+	Name:  "set",
+	Usage: "set cgroup resources",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "bundle, b",
+			Value: "",
+			Usage: "path to the root of the bundle directory",
+		},
+		cli.StringFlag{
+			Name:  "config-file, c",
+			Value: "config.json",
+			Usage: "path to spec file for writing",
+		},
+		cli.StringFlag{
+			Name:  "runtime-file, r",
+			Value: "runtime.json",
+			Usage: "path for runtime file for writing",
+		},
+	},
+	Action: func(context *cli.Context) {
+		container, err := getContainer(context)
+		if err != nil {
+			fatal(err)
+		}
+		bundle := context.String("bundle")
+		if bundle != "" {
+			if err := os.Chdir(bundle); err != nil {
+				fatal(err)
+			}
+		}
+		spec, rspec, err := loadSpec(context.String("config-file"), context.String("runtime-file"))
+		if err != nil {
+			fatal(err)
+		}
+		config, err := createLibcontainerConfig(context.GlobalString("id"), spec, rspec)
+		if err != nil {
+			fatal(err)
+		}
+		if err := container.Set(*config); err != nil {
+			fatal(err)
+		}
+	},
+}


### PR DESCRIPTION
Using the container interface set to set the cgroup resources when container is running
Usage:
runc set
This will apply the new values to running container as per the runtime.json

Signed-off-by: rajasec <rajasec79@gmail.com>