### PR TITLE
Wrap Linux 4.3 pids cgroup

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -29,6 +29,7 @@ var (
 		&NetPrioGroup{},
 		&PerfEventGroup{},
 		&FreezerGroup{},
+		&PidsGroup{},
 	}
 	CgroupProcesses  = "cgroup.procs"
 	HugePageSizes, _ = cgroups.GetHugePageSize()

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -1,0 +1,86 @@
+// +build linux
+
+package fs
+
+import (
+	"fmt"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"strconv"
+)
+
+type PidsGroup struct {
+}
+
+func (s *PidsGroup) Name() string {
+	return "pids"
+}
+
+func (s *PidsGroup) Apply(d *data) error {
+	dir, err := d.join("pids")
+	if err != nil {
+		// since Linux 4.3
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if err := s.Set(dir, d.c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *PidsGroup) Set(path string, cgroup *configs.Cgroup) error {
+
+	if cgroup.PidsMax > 0 {
+		if err := writeFile(path, "pids.max", fmt.Sprint(cgroup.PidsMax)); err != nil {
+			return err
+		}
+	} else if cgroup.PidsMax < 0 {
+		if err := writeFile(path, "pids.max", "max"); err != nil {
+			return err
+		}
+	}
+
+	for pid := range cgroup.Pids {
+		if err := writeFile(path, "cgroup.procs", strconv.Itoa(pid)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *PidsGroup) Remove(d *data) error {
+	return removePath(d.path("pids"))
+}
+
+func (s *PidsGroup) GetStats(path string, stats *cgroups.Stats) error {
+
+	values, err := getCgroupParamUintArray(path, "pids.current")
+	if err != nil {
+		return fmt.Errorf("failed to parse pids.current - %v", err)
+	}
+
+	stats.PidsStats.Current = values
+
+	value, err := getCgroupParamString(path, "pids.max")
+	if err != nil {
+		return fmt.Errorf("failed to parse pids.max - %v", err)
+	}
+
+	if "max" == value {
+		stats.PidsStats.Max = configs.MaxPids
+	} else {
+		max, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("failed to parse pids.max content %s as int", value)
+		}
+		stats.PidsStats.Max = max
+	}
+
+	return nil
+}

--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -1,0 +1,55 @@
+// +build linux
+
+package fs
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func TestSetPids(t *testing.T) {
+	helper := NewCgroupTestUtil("pids", t)
+	defer helper.cleanup()
+
+	pidsArray := make([]uint32, 1)
+	pidsArray[0] = uint32(os.Getpid())
+
+	helper.CgroupData.c.Pids = pidsArray
+	pids := &PidsGroup{}
+	if err := pids.Set(helper.CgroupPath, helper.CgroupData.c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetPidsStats(t *testing.T) {
+	helper := NewCgroupTestUtil("pids", t)
+	defer helper.cleanup()
+
+	helper.writeFileContents(map[string]string{
+		"pids.current": strconv.Itoa(os.Getpid()),
+		"pids.max":     "max",
+	})
+
+	actualStats := *cgroups.NewStats()
+	pids := &PidsGroup{}
+	err := pids.GetStats(helper.CgroupPath, &actualStats)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actualStats.PidsStats.Current == nil {
+		t.Fatal("Expected PidsStats to be set")
+	}
+
+	if len(actualStats.PidsStats.Current) != 1 {
+		t.Fatal("Expected PidsStats.Current to have at least one element")
+	}
+
+	if actualStats.PidsStats.Max != configs.MaxPids {
+		t.Fatal("Expected PidsStats.Max to return -1")
+	}
+}

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -77,12 +77,21 @@ type HugetlbStats struct {
 	Failcnt uint64 `json:"failcnt"`
 }
 
+type PidsStats struct {
+	// current pids in cgroup; the set of processes can change at any time
+	Current []uint64 `json:"current,omitempty"`
+
+	// maximum number of processes allowed in this cgroup (fork limit)
+	Max int `json:"max,omitempty"`
+}
+
 type Stats struct {
 	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
 	// the map is in the format "size of hugepage: stats of the hugepage"
 	HugetlbStats map[string]HugetlbStats `json:"hugetlb_stats,omitempty"`
+	PidsStats    PidsStats               `json:"pids_stats,omitempty"`
 }
 
 func NewStats() *Stats {

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -8,6 +8,8 @@ const (
 	Undefined FreezerState = ""
 	Frozen    FreezerState = "FROZEN"
 	Thawed    FreezerState = "THAWED"
+
+	MaxPids = -1
 )
 
 type Cgroup struct {
@@ -97,4 +99,10 @@ type Cgroup struct {
 
 	// Set class identifier for container's network packets
 	NetClsClassid string `json:"net_cls_classid"`
+
+	// max. number of processes in this cgroup
+	PidsMax uint32 `json:"pids_max"`
+
+	// a set of processes to add to this cgroup
+	Pids []uint32 `json:"pids"`
 }


### PR DESCRIPTION
With Linux 4.3 the new 'pids' cgroup becomes available. It allows to set
fork limits on a group of processes. Once a process's PID has been added to
the cgroup, all its children will automatically be added to this cgroup.

The new cgroup has the following files:

cgroups.proc: To set the processes on which to impose a fork limit;
              The entry also shows the processes that are under the fork limit

pids.max: The maximum number of processes that can be spawned;
          The file may either container the string 'max' or an unsigned
          integer value

pids.current: The number of processes in this cgroup

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>