### PR TITLE
Use random ID as runc container ID

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -28,6 +28,11 @@
 			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
 		},
 		{
+			"ImportPath": "github.com/docker/docker/pkg/stringid",
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
+		},
+		{
 			"ImportPath": "github.com/docker/docker/pkg/symlink",
 			"Comment": "v1.4.1-4831-g0f5c9d3",
 			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/stringid/README.md
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/stringid/README.md
@@ -1,0 +1,1 @@
+This package provides helper functions for dealing with string identifiers

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/stringid/stringid.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/stringid/stringid.go
@@ -1,0 +1,48 @@
+package stringid
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"regexp"
+	"strconv"
+)
+
+const shortLen = 12
+
+var validShortID = regexp.MustCompile("^[a-z0-9]{12}$")
+
+// Determine if an arbitrary string *looks like* a short ID.
+func IsShortID(id string) bool {
+	return validShortID.MatchString(id)
+}
+
+// TruncateID returns a shorthand version of a string identifier for convenience.
+// A collision with other shorthands is very unlikely, but possible.
+// In case of a collision a lookup with TruncIndex.Get() will fail, and the caller
+// will need to use a langer prefix, or the full-length Id.
+func TruncateID(id string) string {
+	trimTo := shortLen
+	if len(id) < shortLen {
+		trimTo = len(id)
+	}
+	return id[:trimTo]
+}
+
+// GenerateRandomID returns an unique id
+func GenerateRandomID() string {
+	for {
+		id := make([]byte, 32)
+		if _, err := io.ReadFull(rand.Reader, id); err != nil {
+			panic(err) // This shouldn't happen
+		}
+		value := hex.EncodeToString(id)
+		// if we try to parse the truncated for as an int and we don't have
+		// an error then the value is all numberic and causes issues when
+		// used as a hostname. ref #3869
+		if _, err := strconv.ParseInt(TruncateID(value), 10, 64); err == nil {
+			continue
+		}
+		return value
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/stringid/stringid_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/stringid/stringid_test.go
@@ -1,0 +1,56 @@
+package stringid
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateRandomID(t *testing.T) {
+	id := GenerateRandomID()
+
+	if len(id) != 64 {
+		t.Fatalf("Id returned is incorrect: %s", id)
+	}
+}
+
+func TestShortenId(t *testing.T) {
+	id := GenerateRandomID()
+	truncID := TruncateID(id)
+	if len(truncID) != 12 {
+		t.Fatalf("Id returned is incorrect: truncate on %s returned %s", id, truncID)
+	}
+}
+
+func TestShortenIdEmpty(t *testing.T) {
+	id := ""
+	truncID := TruncateID(id)
+	if len(truncID) > len(id) {
+		t.Fatalf("Id returned is incorrect: truncate on %s returned %s", id, truncID)
+	}
+}
+
+func TestShortenIdInvalid(t *testing.T) {
+	id := "1234"
+	truncID := TruncateID(id)
+	if len(truncID) != len(id) {
+		t.Fatalf("Id returned is incorrect: truncate on %s returned %s", id, truncID)
+	}
+}
+
+func TestIsShortIDNonHex(t *testing.T) {
+	id := "some non-hex value"
+	if IsShortID(id) {
+		t.Fatalf("%s is not a short ID", id)
+	}
+}
+
+func TestIsShortIDNotCorrectSize(t *testing.T) {
+	id := strings.Repeat("a", shortLen+1)
+	if IsShortID(id) {
+		t.Fatalf("%s is not a short ID", id)
+	}
+	id = strings.Repeat("a", shortLen-1)
+	if IsShortID(id) {
+		t.Fatalf("%s is not a short ID", id)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
-			Value: getDefaultID(),
+			Value: generateID(),
 			Usage: "specify the ID to be used for the container",
 		},
 		cli.BoolFlag{

--- a/main_unsupported.go
+++ b/main_unsupported.go
@@ -7,10 +7,6 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-func getDefaultID() string {
-	return ""
-}
-
 func generateID() string {
 	return ""
 }

--- a/main_unsupported.go
+++ b/main_unsupported.go
@@ -11,6 +11,10 @@ func getDefaultID() string {
 	return ""
 }
 
+func generateID() string {
+	return ""
+}
+
 var (
 	checkpointCommand cli.Command
 	eventsCommand     cli.Command

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/codegangsta/cli"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/specs"
@@ -144,6 +145,11 @@ func getDefaultID() string {
 		panic(err)
 	}
 	return filepath.Base(cwd)
+}
+
+// generateID returns a random string to be used as the container id.
+func generateID() string {
+	return stringid.GenerateRandomID()
 }
 
 func getDefaultImagePath(context *cli.Context) string {

--- a/utils.go
+++ b/utils.go
@@ -136,17 +136,6 @@ func fatal(err error) {
 	os.Exit(1)
 }
 
-// getDefaultID returns a string to be used as the container id based on the
-// current working directory of the runc process.  This function panics
-// if the cwd is unable to be found based on a system error.
-func getDefaultID() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	return filepath.Base(cwd)
-}
-
 // generateID returns a random string to be used as the container id.
 func generateID() string {
 	return stringid.GenerateRandomID()


### PR DESCRIPTION
Currently we're using the working directory of the runc process as the container ID, that's not good to identify, and you can't start two container in the same directory, or different path with the same directory name. 

Use a random ID as the container ID like Docker does, I think that makes more sense.