### PR TITLE
Output container ID when create container

### DIFF
--- a/start.go
+++ b/start.go
@@ -76,7 +76,8 @@ func init() {
 }
 
 func startContainer(context *cli.Context, spec *specs.LinuxSpec, rspec *specs.LinuxRuntimeSpec) (int, error) {
-	config, err := createLibcontainerConfig(context.GlobalString("id"), spec, rspec)
+	containerID := context.GlobalString("id")
+	config, err := createLibcontainerConfig(containerID, spec, rspec)
 	if err != nil {
 		return -1, err
 	}
@@ -94,7 +95,7 @@ func startContainer(context *cli.Context, spec *specs.LinuxSpec, rspec *specs.Li
 	if err != nil {
 		return -1, err
 	}
-	container, err := factory.Create(context.GlobalString("id"), config)
+	container, err := factory.Create(containerID, config)
 	if err != nil {
 		return -1, err
 	}
@@ -124,6 +125,7 @@ func startContainer(context *cli.Context, spec *specs.LinuxSpec, rspec *specs.Li
 	if err := container.Start(process); err != nil {
 		return -1, err
 	}
+	output(containerID)
 	return handler.forward(process)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -135,6 +135,11 @@ func fatal(err error) {
 	os.Exit(1)
 }
 
+// output prints string to stdout.
+func output(str string) {
+	fmt.Fprintln(os.Stdout, str)
+}
+
 // getDefaultID returns a string to be used as the container id based on the
 // current working directory of the runc process.  This function panics
 // if the cwd is unable to be found based on a system error.


### PR DESCRIPTION
So users will always know the ID of the container.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>