### PR TITLE
Validate process configuration for runc exec

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -23,6 +23,9 @@ var execCommand = cli.Command{
 		if os.Geteuid() != 0 {
 			logrus.Fatal("runc should be run as root")
 		}
+		if config.Args == nil {
+			logrus.Fatal("args missing in process configuration")
+		}
 		status, err := execProcess(context, config)
 		if err != nil {
 			logrus.Fatalf("exec failed: %v", err)


### PR DESCRIPTION
We make sure that the args are present. All other items are optional and default to sensible values.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>