### PR TITLE
Fix race setting process opts

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -179,7 +179,6 @@ func (c *linuxContainer) Start(process *Process) error {
 		}
 		return newSystemError(err)
 	}
-	process.ops = parent
 	if doInit {
 		c.updateState(parent)
 	}
@@ -254,6 +253,7 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, c
 		manager:    c.cgroupManager,
 		config:     c.newInitConfig(p),
 		container:  c,
+		process:    p,
 	}, nil
 }
 
@@ -272,6 +272,7 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 		childPipe:   childPipe,
 		parentPipe:  parentPipe,
 		config:      c.newInitConfig(p),
+		process:     p,
 	}
 }
 


### PR DESCRIPTION
When starting and quering for pids a container can start and exit before
this is set.  So set the opts after the process is started and while
libcontainer still has the container's process blocking on the pipe.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>