### PR TITLE
Modifying cpu attribute data type as per specs

### DIFF
--- a/Godeps/_workspace/src/github.com/opencontainers/specs/runtime_config_linux.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/specs/runtime_config_linux.go
@@ -165,15 +165,15 @@ type Memory struct {
 // CPU for Linux cgroup 'cpu' resource management
 type CPU struct {
 	// CPU shares (relative weight vs. other cgroups with cpu shares)
-	Shares int64 `json:"shares"`
+	Shares uint64 `json:"shares"`
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period
-	Quota int64 `json:"quota"`
+	Quota uint64 `json:"quota"`
 	// CPU period to be used for hardcapping (in usecs). 0 to use system default
-	Period int64 `json:"period"`
+	Period uint64 `json:"period"`
 	// How many time CPU will use in realtime scheduling (in usecs)
-	RealtimeRuntime int64 `json:"realtimeRuntime"`
+	RealtimeRuntime uint64 `json:"realtimeRuntime"`
 	// CPU period to be used for realtime scheduling (in usecs)
-	RealtimePeriod int64 `json:"realtimePeriod"`
+	RealtimePeriod uint64 `json:"realtimePeriod"`
 	// CPU to use within the cpuset
 	Cpus string `json:"cpus"`
 	// MEM to use within the cpuset

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -318,8 +318,8 @@ func removePath(p string, err error) error {
 	return nil
 }
 
-func CheckCpushares(path string, c int64) error {
-	var cpuShares int64
+func CheckCpushares(path string, c uint64) error {
+	var cpuShares uint64
 
 	if c == 0 {
 		return nil

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -36,27 +36,27 @@ func (s *CpuGroup) Apply(d *data) error {
 
 func (s *CpuGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.CpuShares != 0 {
-		if err := writeFile(path, "cpu.shares", strconv.FormatInt(cgroup.CpuShares, 10)); err != nil {
+		if err := writeFile(path, "cpu.shares", strconv.FormatUint(uint64(cgroup.CpuShares), 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuPeriod != 0 {
-		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(cgroup.CpuPeriod, 10)); err != nil {
+		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatUint(uint64(cgroup.CpuPeriod), 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuQuota != 0 {
-		if err := writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(cgroup.CpuQuota, 10)); err != nil {
+		if err := writeFile(path, "cpu.cfs_quota_us", strconv.FormatUint(uint64(cgroup.CpuQuota), 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuRtPeriod != 0 {
-		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatInt(cgroup.CpuRtPeriod, 10)); err != nil {
+		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatUint(uint64(cgroup.CpuRtPeriod), 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuRtRuntime != 0 {
-		if err := writeFile(path, "cpu.rt_runtime_us", strconv.FormatInt(cgroup.CpuRtRuntime, 10)); err != nil {
+		if err := writeFile(path, "cpu.rt_runtime_us", strconv.FormatUint(uint64(cgroup.CpuRtRuntime), 10)); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -335,22 +335,22 @@ func joinCpu(c *configs.Cgroup, pid int) error {
 		return err
 	}
 	if c.CpuQuota != 0 {
-		if err = writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(c.CpuQuota, 10)); err != nil {
+		if err = writeFile(path, "cpu.cfs_quota_us", strconv.FormatUint(uint64(c.CpuQuota), 10)); err != nil {
 			return err
 		}
 	}
 	if c.CpuPeriod != 0 {
-		if err = writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(c.CpuPeriod, 10)); err != nil {
+		if err = writeFile(path, "cpu.cfs_period_us", strconv.FormatUint(uint64(c.CpuPeriod), 10)); err != nil {
 			return err
 		}
 	}
 	if c.CpuRtPeriod != 0 {
-		if err = writeFile(path, "cpu.rt_period_us", strconv.FormatInt(c.CpuRtPeriod, 10)); err != nil {
+		if err = writeFile(path, "cpu.rt_period_us", strconv.FormatUint(uint64(c.CpuRtPeriod), 10)); err != nil {
 			return err
 		}
 	}
 	if c.CpuRtRuntime != 0 {
-		if err = writeFile(path, "cpu.rt_runtime_us", strconv.FormatInt(c.CpuRtRuntime, 10)); err != nil {
+		if err = writeFile(path, "cpu.rt_runtime_us", strconv.FormatUint(uint64(c.CpuRtRuntime), 10)); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -36,19 +36,19 @@ type Cgroup struct {
 	KernelMemory int64 `json:"kernel_memory"`
 
 	// CPU shares (relative weight vs. other containers)
-	CpuShares int64 `json:"cpu_shares"`
+	CpuShares uint64 `json:"cpu_shares"`
 
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
-	CpuQuota int64 `json:"cpu_quota"`
+	CpuQuota uint64 `json:"cpu_quota"`
 
 	// CPU period to be used for hardcapping (in usecs). 0 to use system default.
-	CpuPeriod int64 `json:"cpu_period"`
+	CpuPeriod uint64 `json:"cpu_period"`
 
 	// How many time CPU will use in realtime scheduling (in usecs).
-	CpuRtRuntime int64 `json:"cpu_quota"`
+	CpuRtRuntime uint64 `json:"cpu_quota"`
 
 	// CPU period to be used for realtime scheduling (in usecs).
-	CpuRtPeriod int64 `json:"cpu_period"`
+	CpuRtPeriod uint64 `json:"cpu_period"`
 
 	// CPU to use
 	CpusetCpus string `json:"cpuset_cpus"`

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -523,6 +523,12 @@ func testCpuShares(t *testing.T, systemd bool) {
 	if err == nil {
 		t.Fatalf("runContainer should failed with invalid CpuShares")
 	}
+	config.Cgroups.CpuShares = 262145
+
+	_, _, err = runContainer(config, "", "ps")
+	if err == nil {
+		t.Fatalf("runContainer should failed with invalid CpuShares")
+	}
 }
 
 func TestRunWithKernelMemory(t *testing.T) {


### PR DESCRIPTION
As per specs, modified cpu subsystem attributes to uint64 instead of int64

Signed-off-by: rajasec <rajasec79@gmail.com>