### PR TITLE
Add support for CgroupsPath

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -270,6 +270,9 @@ func (raw *cgroupData) path(subsystem string) (string, error) {
 	}
 
 	cgPath := filepath.Join(raw.parent, raw.name)
+	if raw.config.CgroupsPath != "" {
+		cgPath = raw.config.CgroupsPath
+	}
 	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
 	if filepath.IsAbs(cgPath) {
 		// Sometimes subsystems can be mounted togethger as 'cpu,cpuacct'.

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -16,6 +16,9 @@ type Cgroup struct {
 	// name of parent cgroup or slice
 	Parent string `json:"parent"`
 
+	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
+	CgroupsPath string `json:"cgroupsPath"`
+
 	// If this is true allow access to any kind of device within the container.  If false, allow access only to devices explicitly listed in the allowed_devices list.
 	AllowAllDevices bool `json:"allow_all_devices"`
 

--- a/spec.go
+++ b/spec.go
@@ -441,6 +441,7 @@ func createCgroupConfig(name string, spec *specs.LinuxRuntimeSpec, devices []*co
 	c := &configs.Cgroup{
 		Name:           name,
 		Parent:         myCgroupPath,
+		CgroupsPath:    spec.Linux.CgroupsPath,
 		AllowedDevices: append(devices, allowedDevices...),
 	}
 	r := spec.Linux.Resources


### PR DESCRIPTION
It's defined in specs, add the support to runC.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>