### PR TITLE
pull version from specs.Version instead of hardcoding; and make versi…

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,8 +9,7 @@ import (
 )
 
 const (
-	version = "0.3"
-	usage   = `Open Container Initiative runtime
+	usage = `Open Container Initiative runtime
 
 runc is a command line client for running applications packaged according to
 the Open Container Format (OCF) and is a compliant implementation of the
@@ -35,7 +34,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "runc"
 	app.Usage = usage
-	app.Version = version
+	app.Version = specs.Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",

--- a/spec.go
+++ b/spec.go
@@ -321,11 +321,12 @@ func loadSpec(cPath, rPath string) (spec *specs.LinuxSpec, rspec *specs.LinuxRun
 	return spec, rspec, checkSpecVersion(spec)
 }
 
-// checkSpecVersion makes sure that the spec version matches runc's while we are in the initial
-// development period.  It is better to hard fail than have missing fields or options in the spec.
+// checkSpecVersion makes sure that the spec version specified in config.json is
+// not ahead of runc's version.  It is better to hard fail than have missing
+// fields or options in the spec.
 func checkSpecVersion(s *specs.LinuxSpec) error {
-	if s.Version != specs.Version {
-		return fmt.Errorf("spec version is not compatible with implemented version %q: spec %q", specs.Version, s.Version)
+	if s.Version > specs.Version {
+		return fmt.Errorf("spec required: %q is not compatible with implemented version: %q", s.Version, specs.Version)
 	}
 	return nil
 }


### PR DESCRIPTION
I believe the version tag should come from the specs package... `opencontainers/specs/version.go` Correct?  

Also modifying 'checkSpecVersion()' to be a min check vs. exact check. Otherwise we have to change versions in every container 'config.json' on every  minor revision.

Associated with issue #244

Signed-off-by: Mike Brown <brownwm@us.ibm.com>