### PR TITLE
Add spec version to runC version cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Sirupsen/logrus"
@@ -37,7 +38,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "runc"
 	app.Usage = usage
-	app.Version = version
+	app.Version = fmt.Sprintf("%s\nspec version %s", version, specs.Version)
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",


### PR DESCRIPTION
This PR prints specs versions when `runc --version` is used.

Sample:
```
marcos@XPS:~$ ./runc --version
runc version 0.3
spec version 0.2.0
```


Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>