### PR TITLE
change spec test from exact match to greater than

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -320,11 +320,12 @@ func loadSpec(cPath, rPath string) (spec *specs.LinuxSpec, rspec *specs.LinuxRun
 	return spec, rspec, checkSpecVersion(spec)
 }
 
-// checkSpecVersion makes sure that the spec version matches runc's while we are in the initial
-// development period.  It is better to hard fail than have missing fields or options in the spec.
+// checkSpecVersion makes sure that the spec version specified in config.json is
+// not ahead of runc's version.  It is better to hard fail than have missing
+// fields or options in the spec.
 func checkSpecVersion(s *specs.LinuxSpec) error {
-	if s.Version != specs.Version {
-		return fmt.Errorf("spec version is not compatible with implemented version %q: spec %q", specs.Version, s.Version)
+	if s.Version > specs.Version {
+		return fmt.Errorf("spec requires a container implementation of %q or higher, current version is %q", s.Version, specs.Version)
 	}
 	return nil
 }


### PR DESCRIPTION
Current version test checks for an exact match.  Changing test to a greater than test instead of forcing folks to edit their config.json version tag each time the container spec version changes.  To easy to just change the version.. without editing the broken fields.  Might as well just tell folks to gen a new spec and merge than have them manually changing the version in the config.json file without knowing what changed.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>