### PR TITLE
Adding error conditions when apparmor disabled

### DIFF
--- a/libcontainer/apparmor/apparmor_disabled.go
+++ b/libcontainer/apparmor/apparmor_disabled.go
@@ -2,10 +2,19 @@
 
 package apparmor
 
+import (
+	"errors"
+)
+
+var ErrApparmorNotEnabled = errors.New("apparmor: config provided but apparmor not supported")
+
 func IsEnabled() bool {
 	return false
 }
 
 func ApplyProfile(name string) error {
+	if name != "" {
+		return ErrApparmorNotEnabled
+	}
 	return nil
 }


### PR DESCRIPTION
When apparmor is disabled during runc compilation and runtime config had the appamor profile configured, added the error condition during container start to handle this case

Signed-off-by: rajasec <rajasec79@gmail.com>