### PR TITLE
fix a Hook Args Usage

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -242,9 +242,10 @@ func (c Command) Run(s HookState) error {
 	if err != nil {
 		return err
 	}
+	hArgs := append([]string{""}, c.Args...)
 	cmd := exec.Cmd{
 		Path:  c.Path,
-		Args:  c.Args,
+		Args:  hArgs,
 		Env:   c.Env,
 		Stdin: bytes.NewReader(b),
 	}


### PR DESCRIPTION
When I try to use prestart hooks , I found a bug about hook args
If  I add folllowing contents in `runtime.json`
``` json
"prestart":[ {
                "path": "/bin/bash",
                "args": ["-c","\"ls\""]
            }
            ],
```
runc terminated and return an error , but if I change the  args to 
``` json 
"prestart":[ {
                "path": "/bin/bash",
                "args": ["test","-c","\"ls\""]
            }
            ],
```
I can get the list of files from standouput, even I change `test` to  any other string such as `adfafadsf`, it also works, that means the first argument is useless

I think this problem is caused by the `Cmd` struct of golang , in Godocs, it says [1]
`Args holds command line arguments, including the command as Args[0].`
so I make a new string slice and insert a `""` string in front of current `Args` before `cmd.Run`to slove that

[1] [https://golang.org/pkg/os/exec/#Cmd](https://golang.org/pkg/os/exec/#Cmd)
Signed-off-by: Wang Qilin <wangqilin2@huawei.com>