### PR TITLE
Some fixes about memory stats

### DIFF
--- a/events.go
+++ b/events.go
@@ -22,7 +22,7 @@ type event struct {
 
 var eventsCommand = cli.Command{
 	Name:  "events",
-	Usage: "display container events such as OOM notifications, cpu, memory, IO and network stats",
+	Usage: "display container events such as OOM, cpu, memory, IO and network stats",
 	Flags: []cli.Flag{
 		cli.DurationFlag{Name: "interval", Value: 5 * time.Second, Usage: "set the stats collection interval"},
 		cli.BoolFlag{Name: "stats", Usage: "display the container's stats then exit"},

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -44,9 +44,12 @@ type MemoryStats struct {
 	Usage MemoryData `json:"usage,omitempty"`
 	// usage of memory + swap
 	SwapUsage MemoryData `json:"swap_usage,omitempty"`
-	// usafe of kernel memory
-	KernelUsage MemoryData        `json:"kernel_usage,omitempty"`
-	Stats       map[string]uint64 `json:"stats,omitempty"`
+	// usage of kernel memory
+	KernelUsage MemoryData `json:"kernel_usage,omitempty"`
+	// status of memory usage
+	Stats map[string]uint64 `json:"stats,omitempty"`
+	// status of oom
+	OomStat map[string]uint64 `json:"oom_stat,omitempry"`
 }
 
 type BlkioStatEntry struct {

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -35,7 +35,7 @@ type CpuStats struct {
 type MemoryData struct {
 	Usage    uint64 `json:"usage,omitempty"`
 	MaxUsage uint64 `json:"max_usage,omitempty"`
-	Failcnt  uint64 `json:"failcnt"`
+	Failcnt  uint64 `json:"failcnt,omitempty"`
 }
 type MemoryStats struct {
 	// memory used for cache
@@ -77,7 +77,7 @@ type HugetlbStats struct {
 	// maximum usage ever recorded.
 	MaxUsage uint64 `json:"max_usage,omitempty"`
 	// number of times htgetlb usage allocation failure.
-	Failcnt uint64 `json:"failcnt"`
+	Failcnt uint64 `json:"failcnt,omitempty"`
 }
 
 type Stats struct {


### PR DESCRIPTION
- Refactor GetStats for memory
- Add oom stat to MemoryStats
- Fix description about runc events
- Omit Failcnt in json

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
