### PR TITLE
make localtest failure with selinux enabled

### DIFF
--- a/libcontainer/label/label_selinux_test.go
+++ b/libcontainer/label/label_selinux_test.go
@@ -3,6 +3,7 @@
 package label
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -89,6 +90,10 @@ func TestDuplicateLabel(t *testing.T) {
 }
 func TestRelabel(t *testing.T) {
 	testdir := "/tmp/test"
+	if err := os.Mkdir(testdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testdir)
 	label := "system_u:system_r:svirt_sandbox_file_t:s0:c1,c2"
 	if err := Relabel(testdir, "", true); err != nil {
 		t.Fatal("Relabel with no label failed: %v", err)


### PR DESCRIPTION
Upon enabling selinux in Makefile, make localtest fails with following error

--- FAIL: TestRelabel (0.00s)
        label_selinux_test.go:97: Relabel shared failed: %v no such file or directory

This PR handles to creation/removal of the required directory by the Relabel test step

Signed-off-by: rajasec <rajasec79@gmail.com>