### PR TITLE
libcontainer: configs: create cgroup_unsupported.go in order to build on darwin as well

### DIFF
--- a/libcontainer/configs/cgroup_unsupported.go
+++ b/libcontainer/configs/cgroup_unsupported.go
@@ -1,0 +1,6 @@
+// +build !windows,!linux,!freebsd
+
+package configs
+
+type Cgroup struct {
+}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>