### PR TITLE
Adding selinux label

### DIFF
--- a/libcontainer/selinux/selinux_test.go
+++ b/libcontainer/selinux/selinux_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,selinux
 
 package selinux_test
 

--- a/libcontainer/selinux/selinux_test.go
+++ b/libcontainer/selinux/selinux_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/opencontainers/runc/libcontainer/selinux"
 )
 
-func testSetfilecon(t *testing.T) {
+func TestSetfilecon(t *testing.T) {
 	if selinux.SelinuxEnabled() {
 		tmp := "selinux_test"
-		out, _ := os.OpenFile(tmp, os.O_WRONLY, 0)
+		out, _ := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE, 0)
 		out.Close()
 		err := selinux.Setfilecon(tmp, "system_u:object_r:bin_t:s0")
 		if err != nil {


### PR DESCRIPTION
Currently selinux test programs runs even with seccomp and apparmor enabled. Added the selinux compile flag to test programs

testSetfilecon function is in lower case, not executed during localtest.
Modified to uppercase ( starting letter)

Post that file creation was problem
--- FAIL: TestSetfilecon (0.00s)
        selinux_test.go:19: Setfilecon failed
        selinux_test.go:20: no such file or directory

Added the O_CREAT flags for the file creation

Signed-off-by: rajasec <rajasec79@gmail.com>