### PR TITLE
Fixing xattr test step issue

### DIFF
--- a/libcontainer/xattr/xattr_test.go
+++ b/libcontainer/xattr/xattr_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/opencontainers/runc/libcontainer/xattr"
 )
 
-func testXattr(t *testing.T) {
+func TestXattr(t *testing.T) {
 	tmp := "xattr_test"
-	out, err := os.OpenFile(tmp, os.O_WRONLY, 0)
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE, 0)
 	if err != nil {
 		t.Fatal("failed")
 	}
+	defer os.Remove(tmp)
 	attr := "user.test"
 	out.Close()
 


### PR DESCRIPTION

1)xattr Test case were not ran due to smaller case in function name
2) xattr-test file was not created in openFile

With this PR
Modified to upper case to pick up xattr test step
Added O_CREAT to create the file during localtest

Signed-off-by: Rajasekaran <rajasec79@gmail.com>