### PR TITLE
libcontainer: network_linux.go: fix go vet

### DIFF
--- a/libcontainer/network_linux.go
+++ b/libcontainer/network_linux.go
@@ -93,7 +93,7 @@ func (l *loopback) create(n *network, nspid int) error {
 }
 
 func (l *loopback) initialize(config *network) error {
-	return netlink.LinkSetUp(&netlink.Device{netlink.LinkAttrs{Name: "lo"}})
+	return netlink.LinkSetUp(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo"}})
 }
 
 func (l *loopback) attach(n *configs.Network) (err error) {
@@ -111,7 +111,7 @@ type veth struct {
 }
 
 func (v *veth) detach(n *configs.Network) (err error) {
-	return netlink.LinkSetMaster(&netlink.Device{netlink.LinkAttrs{Name: n.HostInterfaceName}}, nil)
+	return netlink.LinkSetMaster(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: n.HostInterfaceName}}, nil)
 }
 
 // attach a container network interface to an external network


### PR DESCRIPTION
This patch fixes the following go vet warnings (even if `LinkAttrs` is an embedded field):
```
libcontainer/network_linux.go:96: github.com/vishvananda/netlink.Device
composite literal uses unkeyed fields
libcontainer/network_linux.go:114: github.com/vishvananda/netlink.Device
composite literal uses unkeyed fields
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>