### PR TITLE
Remove the timeframe for v1 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 ## State of the project
 
 Currently `runc` is an implementation of the OCI specification.  We are currently sprinting
-to have a v1 of the spec out within a quick timeframe of a few weeks, ~July 2015,
-so the `runc` config format will be constantly changing until
-the spec is finalized.  However, we encourage you to try out the tool and give feedback.
+to have a v1 of the spec out. So the `runc` config format will be constantly changing until
+the spec is finalized. However, we encourage you to try out the tool and give feedback.
 
 ### OCF
 


### PR DESCRIPTION
Fixes: #429

We missed the former one and haven't got a new one, remove
it from README to avoid confusing.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>