### PR TITLE
Move the cgroups setting into a Resources struct

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -137,7 +137,7 @@ func (m *Manager) Apply(pid int) (err error) {
 	m.Paths = paths
 
 	if paths["cpu"] != "" {
-		if err := CheckCpushares(paths["cpu"], c.CpuShares); err != nil {
+		if err := CheckCpushares(paths["cpu"], c.Resources.CpuShares); err != nil {
 			return err
 		}
 	}
@@ -202,15 +202,15 @@ func (m *Manager) Freeze(state configs.FreezerState) error {
 	if err != nil {
 		return err
 	}
-	prevState := m.Cgroups.Freezer
-	m.Cgroups.Freezer = state
+	prevState := m.Cgroups.Resources.Freezer
+	m.Cgroups.Resources.Freezer = state
 	freezer, err := subsystems.Get("freezer")
 	if err != nil {
 		return err
 	}
 	err = freezer.Set(dir, m.Cgroups)
 	if err != nil {
-		m.Cgroups.Freezer = prevState
+		m.Cgroups.Resources.Freezer = prevState
 		return err
 	}
 	return nil

--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -35,18 +35,18 @@ func (s *BlkioGroup) Apply(d *cgroupData) error {
 }
 
 func (s *BlkioGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if cgroup.BlkioWeight != 0 {
-		if err := writeFile(path, "blkio.weight", strconv.FormatUint(uint64(cgroup.BlkioWeight), 10)); err != nil {
+	if cgroup.Resources.BlkioWeight != 0 {
+		if err := writeFile(path, "blkio.weight", strconv.FormatUint(uint64(cgroup.Resources.BlkioWeight), 10)); err != nil {
 			return err
 		}
 	}
 
-	if cgroup.BlkioLeafWeight != 0 {
-		if err := writeFile(path, "blkio.leaf_weight", strconv.FormatUint(uint64(cgroup.BlkioLeafWeight), 10)); err != nil {
+	if cgroup.Resources.BlkioLeafWeight != 0 {
+		if err := writeFile(path, "blkio.leaf_weight", strconv.FormatUint(uint64(cgroup.Resources.BlkioLeafWeight), 10)); err != nil {
 			return err
 		}
 	}
-	for _, wd := range cgroup.BlkioWeightDevice {
+	for _, wd := range cgroup.Resources.BlkioWeightDevice {
 		if err := writeFile(path, "blkio.weight_device", wd.WeightString()); err != nil {
 			return err
 		}
@@ -54,22 +54,22 @@ func (s *BlkioGroup) Set(path string, cgroup *configs.Cgroup) error {
 			return err
 		}
 	}
-	for _, td := range cgroup.BlkioThrottleReadBpsDevice {
+	for _, td := range cgroup.Resources.BlkioThrottleReadBpsDevice {
 		if err := writeFile(path, "blkio.throttle.read_bps_device", td.String()); err != nil {
 			return err
 		}
 	}
-	for _, td := range cgroup.BlkioThrottleWriteBpsDevice {
+	for _, td := range cgroup.Resources.BlkioThrottleWriteBpsDevice {
 		if err := writeFile(path, "blkio.throttle.write_bps_device", td.String()); err != nil {
 			return err
 		}
 	}
-	for _, td := range cgroup.BlkioThrottleReadIOPSDevice {
+	for _, td := range cgroup.Resources.BlkioThrottleReadIOPSDevice {
 		if err := writeFile(path, "blkio.throttle.read_iops_device", td.String()); err != nil {
 			return err
 		}
 	}
-	for _, td := range cgroup.BlkioThrottleWriteIOPSDevice {
+	for _, td := range cgroup.Resources.BlkioThrottleWriteIOPSDevice {
 		if err := writeFile(path, "blkio.throttle.write_iops_device", td.String()); err != nil {
 			return err
 		}

--- a/libcontainer/cgroups/fs/blkio_test.go
+++ b/libcontainer/cgroups/fs/blkio_test.go
@@ -89,7 +89,7 @@ func TestBlkioSetWeight(t *testing.T) {
 		"blkio.weight": strconv.Itoa(weightBefore),
 	})
 
-	helper.CgroupData.config.BlkioWeight = weightAfter
+	helper.CgroupData.config.Resources.BlkioWeight = weightAfter
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -120,7 +120,7 @@ func TestBlkioSetWeightDevice(t *testing.T) {
 		"blkio.weight_device": weightDeviceBefore,
 	})
 
-	helper.CgroupData.config.BlkioWeightDevice = []*configs.WeightDevice{wd}
+	helper.CgroupData.config.Resources.BlkioWeightDevice = []*configs.WeightDevice{wd}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -157,7 +157,7 @@ func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 		"blkio.weight_device": weightDeviceBefore,
 	})
 
-	helper.CgroupData.config.BlkioWeightDevice = []*configs.WeightDevice{wd1, wd2}
+	helper.CgroupData.config.Resources.BlkioWeightDevice = []*configs.WeightDevice{wd1, wd2}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -529,7 +529,7 @@ func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
 		"blkio.throttle.read_bps_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.BlkioThrottleReadBpsDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.config.Resources.BlkioThrottleReadBpsDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -559,7 +559,7 @@ func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
 		"blkio.throttle.write_bps_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.BlkioThrottleWriteBpsDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.config.Resources.BlkioThrottleWriteBpsDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -589,7 +589,7 @@ func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
 		"blkio.throttle.read_iops_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.BlkioThrottleReadIOPSDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.config.Resources.BlkioThrottleReadIOPSDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -619,7 +619,7 @@ func TestBlkioSetThrottleWriteIOpsDevice(t *testing.T) {
 		"blkio.throttle.write_iops_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.BlkioThrottleWriteIOPSDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.config.Resources.BlkioThrottleWriteIOPSDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -35,28 +35,28 @@ func (s *CpuGroup) Apply(d *cgroupData) error {
 }
 
 func (s *CpuGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if cgroup.CpuShares != 0 {
-		if err := writeFile(path, "cpu.shares", strconv.FormatInt(cgroup.CpuShares, 10)); err != nil {
+	if cgroup.Resources.CpuShares != 0 {
+		if err := writeFile(path, "cpu.shares", strconv.FormatInt(cgroup.Resources.CpuShares, 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.CpuPeriod != 0 {
-		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(cgroup.CpuPeriod, 10)); err != nil {
+	if cgroup.Resources.CpuPeriod != 0 {
+		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(cgroup.Resources.CpuPeriod, 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.CpuQuota != 0 {
-		if err := writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(cgroup.CpuQuota, 10)); err != nil {
+	if cgroup.Resources.CpuQuota != 0 {
+		if err := writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(cgroup.Resources.CpuQuota, 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.CpuRtPeriod != 0 {
-		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatInt(cgroup.CpuRtPeriod, 10)); err != nil {
+	if cgroup.Resources.CpuRtPeriod != 0 {
+		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatInt(cgroup.Resources.CpuRtPeriod, 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.CpuRtRuntime != 0 {
-		if err := writeFile(path, "cpu.rt_runtime_us", strconv.FormatInt(cgroup.CpuRtRuntime, 10)); err != nil {
+	if cgroup.Resources.CpuRtRuntime != 0 {
+		if err := writeFile(path, "cpu.rt_runtime_us", strconv.FormatInt(cgroup.Resources.CpuRtRuntime, 10)); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -23,7 +23,7 @@ func TestCpuSetShares(t *testing.T) {
 		"cpu.shares": strconv.Itoa(sharesBefore),
 	})
 
-	helper.CgroupData.config.CpuShares = sharesAfter
+	helper.CgroupData.config.Resources.CpuShares = sharesAfter
 	cpu := &CpuGroup{}
 	if err := cpu.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -61,10 +61,10 @@ func TestCpuSetBandWidth(t *testing.T) {
 		"cpu.rt_period_us":  strconv.Itoa(rtPeriodBefore),
 	})
 
-	helper.CgroupData.config.CpuQuota = quotaAfter
-	helper.CgroupData.config.CpuPeriod = periodAfter
-	helper.CgroupData.config.CpuRtRuntime = rtRuntimeAfter
-	helper.CgroupData.config.CpuRtPeriod = rtPeriodAfter
+	helper.CgroupData.config.Resources.CpuQuota = quotaAfter
+	helper.CgroupData.config.Resources.CpuPeriod = periodAfter
+	helper.CgroupData.config.Resources.CpuRtRuntime = rtRuntimeAfter
+	helper.CgroupData.config.Resources.CpuRtPeriod = rtPeriodAfter
 	cpu := &CpuGroup{}
 	if err := cpu.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -29,13 +29,13 @@ func (s *CpusetGroup) Apply(d *cgroupData) error {
 }
 
 func (s *CpusetGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if cgroup.CpusetCpus != "" {
-		if err := writeFile(path, "cpuset.cpus", cgroup.CpusetCpus); err != nil {
+	if cgroup.Resources.CpusetCpus != "" {
+		if err := writeFile(path, "cpuset.cpus", cgroup.Resources.CpusetCpus); err != nil {
 			return err
 		}
 	}
-	if cgroup.CpusetMems != "" {
-		if err := writeFile(path, "cpuset.mems", cgroup.CpusetMems); err != nil {
+	if cgroup.Resources.CpusetMems != "" {
+		if err := writeFile(path, "cpuset.mems", cgroup.Resources.CpusetMems); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fs/cpuset_test.go
+++ b/libcontainer/cgroups/fs/cpuset_test.go
@@ -19,7 +19,7 @@ func TestCpusetSetCpus(t *testing.T) {
 		"cpuset.cpus": cpusBefore,
 	})
 
-	helper.CgroupData.config.CpusetCpus = cpusAfter
+	helper.CgroupData.config.Resources.CpusetCpus = cpusAfter
 	cpuset := &CpusetGroup{}
 	if err := cpuset.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -48,7 +48,7 @@ func TestCpusetSetMems(t *testing.T) {
 		"cpuset.mems": memsBefore,
 	})
 
-	helper.CgroupData.config.CpusetMems = memsAfter
+	helper.CgroupData.config.Resources.CpusetMems = memsAfter
 	cpuset := &CpusetGroup{}
 	if err := cpuset.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -30,12 +30,12 @@ func (s *DevicesGroup) Apply(d *cgroupData) error {
 }
 
 func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if !cgroup.AllowAllDevices {
+	if !cgroup.Resources.AllowAllDevices {
 		if err := writeFile(path, "devices.deny", "a"); err != nil {
 			return err
 		}
 
-		for _, dev := range cgroup.AllowedDevices {
+		for _, dev := range cgroup.Resources.AllowedDevices {
 			if err := writeFile(path, "devices.allow", dev.CgroupString()); err != nil {
 				return err
 			}
@@ -47,7 +47,7 @@ func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
 		return err
 	}
 
-	for _, dev := range cgroup.DeniedDevices {
+	for _, dev := range cgroup.Resources.DeniedDevices {
 		if err := writeFile(path, "devices.deny", dev.CgroupString()); err != nil {
 			return err
 		}

--- a/libcontainer/cgroups/fs/devices_test.go
+++ b/libcontainer/cgroups/fs/devices_test.go
@@ -41,8 +41,8 @@ func TestDevicesSetAllow(t *testing.T) {
 		"devices.deny": "a",
 	})
 
-	helper.CgroupData.config.AllowAllDevices = false
-	helper.CgroupData.config.AllowedDevices = allowedDevices
+	helper.CgroupData.config.Resources.AllowAllDevices = false
+	helper.CgroupData.config.Resources.AllowedDevices = allowedDevices
 	devices := &DevicesGroup{}
 	if err := devices.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -66,8 +66,8 @@ func TestDevicesSetDeny(t *testing.T) {
 		"devices.allow": "a",
 	})
 
-	helper.CgroupData.config.AllowAllDevices = true
-	helper.CgroupData.config.DeniedDevices = deniedDevices
+	helper.CgroupData.config.Resources.AllowAllDevices = true
+	helper.CgroupData.config.Resources.DeniedDevices = deniedDevices
 	devices := &DevicesGroup{}
 	if err := devices.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -32,9 +32,9 @@ func (s *FreezerGroup) Apply(d *cgroupData) error {
 }
 
 func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {
-	switch cgroup.Freezer {
+	switch cgroup.Resources.Freezer {
 	case configs.Frozen, configs.Thawed:
-		if err := writeFile(path, "freezer.state", string(cgroup.Freezer)); err != nil {
+		if err := writeFile(path, "freezer.state", string(cgroup.Resources.Freezer)); err != nil {
 			return err
 		}
 
@@ -43,7 +43,7 @@ func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {
 			if err != nil {
 				return err
 			}
-			if strings.TrimSpace(state) == string(cgroup.Freezer) {
+			if strings.TrimSpace(state) == string(cgroup.Resources.Freezer) {
 				break
 			}
 			time.Sleep(1 * time.Millisecond)
@@ -51,7 +51,7 @@ func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {
 	case configs.Undefined:
 		return nil
 	default:
-		return fmt.Errorf("Invalid argument '%s' to freezer.state", string(cgroup.Freezer))
+		return fmt.Errorf("Invalid argument '%s' to freezer.state", string(cgroup.Resources.Freezer))
 	}
 
 	return nil

--- a/libcontainer/cgroups/fs/freezer_test.go
+++ b/libcontainer/cgroups/fs/freezer_test.go
@@ -16,7 +16,7 @@ func TestFreezerSetState(t *testing.T) {
 		"freezer.state": string(configs.Frozen),
 	})
 
-	helper.CgroupData.config.Freezer = configs.Thawed
+	helper.CgroupData.config.Resources.Freezer = configs.Thawed
 	freezer := &FreezerGroup{}
 	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -39,7 +39,7 @@ func TestFreezerSetInvalidState(t *testing.T) {
 		invalidArg configs.FreezerState = "Invalid"
 	)
 
-	helper.CgroupData.config.Freezer = invalidArg
+	helper.CgroupData.config.Resources.Freezer = invalidArg
 	freezer := &FreezerGroup{}
 	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.config); err == nil {
 		t.Fatal("Failed to return invalid argument error")

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -32,7 +32,7 @@ func (s *HugetlbGroup) Apply(d *cgroupData) error {
 }
 
 func (s *HugetlbGroup) Set(path string, cgroup *configs.Cgroup) error {
-	for _, hugetlb := range cgroup.HugetlbLimit {
+	for _, hugetlb := range cgroup.Resources.HugetlbLimit {
 		if err := writeFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
 			return err
 		}

--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -40,7 +40,7 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 	}
 
 	for _, pageSize := range HugePageSizes {
-		helper.CgroupData.config.HugetlbLimit = []*configs.HugepageLimit{
+		helper.CgroupData.config.Resources.HugetlbLimit = []*configs.HugepageLimit{
 			{
 				Pagesize: pageSize,
 				Limit:    hugetlbAfter,

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -55,40 +55,40 @@ func (s *MemoryGroup) Apply(d *cgroupData) (err error) {
 }
 
 func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if cgroup.Memory != 0 {
-		if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatInt(cgroup.Memory, 10)); err != nil {
+	if cgroup.Resources.Memory != 0 {
+		if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.MemoryReservation != 0 {
-		if err := writeFile(path, "memory.soft_limit_in_bytes", strconv.FormatInt(cgroup.MemoryReservation, 10)); err != nil {
+	if cgroup.Resources.MemoryReservation != 0 {
+		if err := writeFile(path, "memory.soft_limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemoryReservation, 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.MemorySwap > 0 {
-		if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.MemorySwap, 10)); err != nil {
+	if cgroup.Resources.MemorySwap > 0 {
+		if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.KernelMemory > 0 {
-		if err := writeFile(path, "memory.kmem.limit_in_bytes", strconv.FormatInt(cgroup.KernelMemory, 10)); err != nil {
+	if cgroup.Resources.KernelMemory > 0 {
+		if err := writeFile(path, "memory.kmem.limit_in_bytes", strconv.FormatInt(cgroup.Resources.KernelMemory, 10)); err != nil {
 			return err
 		}
 	}
 
-	if cgroup.OomKillDisable {
+	if cgroup.Resources.OomKillDisable {
 		if err := writeFile(path, "memory.oom_control", "1"); err != nil {
 			return err
 		}
 	}
-	if cgroup.MemorySwappiness >= 0 && cgroup.MemorySwappiness <= 100 {
-		if err := writeFile(path, "memory.swappiness", strconv.FormatInt(cgroup.MemorySwappiness, 10)); err != nil {
+	if cgroup.Resources.MemorySwappiness >= 0 && cgroup.Resources.MemorySwappiness <= 100 {
+		if err := writeFile(path, "memory.swappiness", strconv.FormatInt(cgroup.Resources.MemorySwappiness, 10)); err != nil {
 			return err
 		}
-	} else if cgroup.MemorySwappiness == -1 {
+	} else if cgroup.Resources.MemorySwappiness == -1 {
 		return nil
 	} else {
-		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", cgroup.MemorySwappiness)
+		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", cgroup.Resources.MemorySwappiness)
 	}
 
 	return nil
@@ -139,12 +139,12 @@ func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
 }
 
 func memoryAssigned(cgroup *configs.Cgroup) bool {
-	return cgroup.Memory != 0 ||
-		cgroup.MemoryReservation != 0 ||
-		cgroup.MemorySwap > 0 ||
-		cgroup.KernelMemory > 0 ||
-		cgroup.OomKillDisable ||
-		cgroup.MemorySwappiness != -1
+	return cgroup.Resources.Memory != 0 ||
+		cgroup.Resources.MemoryReservation != 0 ||
+		cgroup.Resources.MemorySwap > 0 ||
+		cgroup.Resources.KernelMemory > 0 ||
+		cgroup.Resources.OomKillDisable ||
+		cgroup.Resources.MemorySwappiness != -1
 }
 
 func getMemoryData(path, name string) (cgroups.MemoryData, error) {

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -33,8 +33,8 @@ func TestMemorySetMemory(t *testing.T) {
 		"memory.soft_limit_in_bytes": strconv.Itoa(reservationBefore),
 	})
 
-	helper.CgroupData.config.Memory = memoryAfter
-	helper.CgroupData.config.MemoryReservation = reservationAfter
+	helper.CgroupData.config.Resources.Memory = memoryAfter
+	helper.CgroupData.config.Resources.MemoryReservation = reservationAfter
 	memory := &MemoryGroup{}
 	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -70,7 +70,7 @@ func TestMemorySetMemoryswap(t *testing.T) {
 		"memory.memsw.limit_in_bytes": strconv.Itoa(memoryswapBefore),
 	})
 
-	helper.CgroupData.config.MemorySwap = memoryswapAfter
+	helper.CgroupData.config.Resources.MemorySwap = memoryswapAfter
 	memory := &MemoryGroup{}
 	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -98,7 +98,7 @@ func TestMemorySetKernelMemory(t *testing.T) {
 		"memory.kmem.limit_in_bytes": strconv.Itoa(kernelMemoryBefore),
 	})
 
-	helper.CgroupData.config.KernelMemory = kernelMemoryAfter
+	helper.CgroupData.config.Resources.KernelMemory = kernelMemoryAfter
 	memory := &MemoryGroup{}
 	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)
@@ -126,7 +126,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 		"memory.swappiness": strconv.Itoa(swappinessBefore),
 	})
 
-	helper.CgroupData.config.Memory = swappinessAfter
+	helper.CgroupData.config.Resources.Memory = swappinessAfter
 	memory := &MemoryGroup{}
 	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -28,8 +28,8 @@ func (s *NetClsGroup) Apply(d *cgroupData) error {
 }
 
 func (s *NetClsGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if cgroup.NetClsClassid != "" {
-		if err := writeFile(path, "net_cls.classid", cgroup.NetClsClassid); err != nil {
+	if cgroup.Resources.NetClsClassid != "" {
+		if err := writeFile(path, "net_cls.classid", cgroup.Resources.NetClsClassid); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -19,7 +19,7 @@ func TestNetClsSetClassid(t *testing.T) {
 		"net_cls.classid": classidBefore,
 	})
 
-	helper.CgroupData.config.NetClsClassid = classidAfter
+	helper.CgroupData.config.Resources.NetClsClassid = classidAfter
 	netcls := &NetClsGroup{}
 	if err := netcls.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -28,7 +28,7 @@ func (s *NetPrioGroup) Apply(d *cgroupData) error {
 }
 
 func (s *NetPrioGroup) Set(path string, cgroup *configs.Cgroup) error {
-	for _, prioMap := range cgroup.NetPrioIfpriomap {
+	for _, prioMap := range cgroup.Resources.NetPrioIfpriomap {
 		if err := writeFile(path, "net_prio.ifpriomap", prioMap.CgroupString()); err != nil {
 			return err
 		}

--- a/libcontainer/cgroups/fs/net_prio_test.go
+++ b/libcontainer/cgroups/fs/net_prio_test.go
@@ -22,7 +22,7 @@ func TestNetPrioSetIfPrio(t *testing.T) {
 	helper := NewCgroupTestUtil("net_prio", t)
 	defer helper.cleanup()
 
-	helper.CgroupData.config.NetPrioIfpriomap = prioMap
+	helper.CgroupData.config.Resources.NetPrioIfpriomap = prioMap
 	netPrio := &NetPrioGroup{}
 	if err := netPrio.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
 		t.Fatal(err)

--- a/libcontainer/cgroups/fs/util_test.go
+++ b/libcontainer/cgroups/fs/util_test.go
@@ -33,6 +33,7 @@ func NewCgroupTestUtil(subsystem string, t *testing.T) *cgroupTestUtil {
 	d := &cgroupData{
 		config: &configs.Cgroup{},
 	}
+	d.config.Resources = &configs.Resources{}
 	tempDir, err := ioutil.TempDir("", "cgroup_test")
 	if err != nil {
 		t.Fatal(err)

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -16,6 +16,14 @@ type Cgroup struct {
 	// name of parent cgroup or slice
 	Parent string `json:"parent"`
 
+	// ScopePrefix decribes prefix for the scope name
+	ScopePrefix string `json:"scope_prefix"`
+
+	// Resources contains various cgroups settings to apply
+	Resources *Resources `json:"resources"`
+}
+
+type Resources struct {
 	// If this is true allow access to any kind of device within the container.  If false, allow access only to devices explicitly listed in the allowed_devices list.
 	AllowAllDevices bool `json:"allow_all_devices"`
 
@@ -82,9 +90,6 @@ type Cgroup struct {
 
 	// Hugetlb limit (in bytes)
 	HugetlbLimit []*HugepageLimit `json:"hugetlb_limit"`
-
-	// ScopePrefix decribes prefix for the scope name
-	ScopePrefix string `json:"scope_prefix"`
 
 	// Whether to disable OOM Killer
 	OomKillDisable bool `json:"oom_kill_disable"`

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -985,7 +985,7 @@ func (c *linuxContainer) currentStatus() (Status, error) {
 		}
 		return 0, newSystemError(err)
 	}
-	if c.config.Cgroups != nil && c.config.Cgroups.Freezer == configs.Frozen {
+	if c.config.Cgroups != nil && c.config.Cgroups.Resources != nil && c.config.Cgroups.Resources.Freezer == configs.Frozen {
 		return Paused, nil
 	}
 	return Running, nil

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -517,7 +517,7 @@ func testCpuShares(t *testing.T, systemd bool) {
 	if systemd {
 		config.Cgroups.Parent = "system.slice"
 	}
-	config.Cgroups.CpuShares = 1
+	config.Cgroups.Resources.CpuShares = 1
 
 	_, _, err = runContainer(config, "", "ps")
 	if err == nil {
@@ -548,7 +548,7 @@ func testRunWithKernelMemory(t *testing.T, systemd bool) {
 	if systemd {
 		config.Cgroups.Parent = "system.slice"
 	}
-	config.Cgroups.KernelMemory = 52428800
+	config.Cgroups.Resources.KernelMemory = 52428800
 
 	_, _, err = runContainer(config, "", "ps")
 	if err != nil {

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -46,11 +46,13 @@ func newTemplateConfig(rootfs string) *configs.Config {
 			{Type: configs.NEWNET},
 		}),
 		Cgroups: &configs.Cgroup{
-			Name:             "test",
-			Parent:           "integration",
-			MemorySwappiness: -1,
-			AllowAllDevices:  false,
-			AllowedDevices:   configs.DefaultAllowedDevices,
+			Name:   "test",
+			Parent: "integration",
+			Resources: &configs.Resources{
+				MemorySwappiness: -1,
+				AllowAllDevices:  false,
+				AllowedDevices:   configs.DefaultAllowedDevices,
+			},
 		},
 		MaskPaths: []string{
 			"/proc/kcore",

--- a/spec.go
+++ b/spec.go
@@ -438,55 +438,56 @@ func createCgroupConfig(name string, spec *specs.LinuxRuntimeSpec, devices []*co
 		return nil, err
 	}
 	c := &configs.Cgroup{
-		Name:           name,
-		Parent:         myCgroupPath,
-		AllowedDevices: append(devices, allowedDevices...),
+		Name:      name,
+		Parent:    myCgroupPath,
+		Resources: &configs.Resources{},
 	}
+	c.Resources.AllowedDevices = append(devices, allowedDevices...)
 	r := spec.Linux.Resources
-	c.Memory = r.Memory.Limit
-	c.MemoryReservation = r.Memory.Reservation
-	c.MemorySwap = r.Memory.Swap
-	c.KernelMemory = r.Memory.Kernel
-	c.MemorySwappiness = r.Memory.Swappiness
-	c.CpuShares = r.CPU.Shares
-	c.CpuQuota = r.CPU.Quota
-	c.CpuPeriod = r.CPU.Period
-	c.CpuRtRuntime = r.CPU.RealtimeRuntime
-	c.CpuRtPeriod = r.CPU.RealtimePeriod
-	c.CpusetCpus = r.CPU.Cpus
-	c.CpusetMems = r.CPU.Mems
-	c.BlkioWeight = r.BlockIO.Weight
-	c.BlkioLeafWeight = r.BlockIO.LeafWeight
+	c.Resources.Memory = r.Memory.Limit
+	c.Resources.MemoryReservation = r.Memory.Reservation
+	c.Resources.MemorySwap = r.Memory.Swap
+	c.Resources.KernelMemory = r.Memory.Kernel
+	c.Resources.MemorySwappiness = r.Memory.Swappiness
+	c.Resources.CpuShares = r.CPU.Shares
+	c.Resources.CpuQuota = r.CPU.Quota
+	c.Resources.CpuPeriod = r.CPU.Period
+	c.Resources.CpuRtRuntime = r.CPU.RealtimeRuntime
+	c.Resources.CpuRtPeriod = r.CPU.RealtimePeriod
+	c.Resources.CpusetCpus = r.CPU.Cpus
+	c.Resources.CpusetMems = r.CPU.Mems
+	c.Resources.BlkioWeight = r.BlockIO.Weight
+	c.Resources.BlkioLeafWeight = r.BlockIO.LeafWeight
 	for _, wd := range r.BlockIO.WeightDevice {
 		weightDevice := configs.NewWeightDevice(wd.Major, wd.Minor, wd.Weight, wd.LeafWeight)
-		c.BlkioWeightDevice = append(c.BlkioWeightDevice, weightDevice)
+		c.Resources.BlkioWeightDevice = append(c.Resources.BlkioWeightDevice, weightDevice)
 	}
 	for _, td := range r.BlockIO.ThrottleReadBpsDevice {
 		throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, td.Rate)
-		c.BlkioThrottleReadBpsDevice = append(c.BlkioThrottleReadBpsDevice, throttleDevice)
+		c.Resources.BlkioThrottleReadBpsDevice = append(c.Resources.BlkioThrottleReadBpsDevice, throttleDevice)
 	}
 	for _, td := range r.BlockIO.ThrottleWriteBpsDevice {
 		throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, td.Rate)
-		c.BlkioThrottleWriteBpsDevice = append(c.BlkioThrottleWriteBpsDevice, throttleDevice)
+		c.Resources.BlkioThrottleWriteBpsDevice = append(c.Resources.BlkioThrottleWriteBpsDevice, throttleDevice)
 	}
 	for _, td := range r.BlockIO.ThrottleReadIOPSDevice {
 		throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, td.Rate)
-		c.BlkioThrottleReadIOPSDevice = append(c.BlkioThrottleReadIOPSDevice, throttleDevice)
+		c.Resources.BlkioThrottleReadIOPSDevice = append(c.Resources.BlkioThrottleReadIOPSDevice, throttleDevice)
 	}
 	for _, td := range r.BlockIO.ThrottleWriteIOPSDevice {
 		throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, td.Rate)
-		c.BlkioThrottleWriteIOPSDevice = append(c.BlkioThrottleWriteIOPSDevice, throttleDevice)
+		c.Resources.BlkioThrottleWriteIOPSDevice = append(c.Resources.BlkioThrottleWriteIOPSDevice, throttleDevice)
 	}
 	for _, l := range r.HugepageLimits {
-		c.HugetlbLimit = append(c.HugetlbLimit, &configs.HugepageLimit{
+		c.Resources.HugetlbLimit = append(c.Resources.HugetlbLimit, &configs.HugepageLimit{
 			Pagesize: l.Pagesize,
 			Limit:    l.Limit,
 		})
 	}
-	c.OomKillDisable = r.DisableOOMKiller
-	c.NetClsClassid = r.Network.ClassID
+	c.Resources.OomKillDisable = r.DisableOOMKiller
+	c.Resources.NetClsClassid = r.Network.ClassID
 	for _, m := range r.Network.Priorities {
-		c.NetPrioIfpriomap = append(c.NetPrioIfpriomap, &configs.IfPrioMap{
+		c.Resources.NetPrioIfpriomap = append(c.Resources.NetPrioIfpriomap, &configs.IfPrioMap{
 			Interface: m.Name,
 			Priority:  m.Priority,
 		})


### PR DESCRIPTION
This allows us to distinguish cases where a container
needs to just join the paths or also additionally
set cgroups settings. This will help in implementing
cgroupsPath support in the spec.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>