### PR TITLE
Add NLA_HDRLEN workaround for gccgo

### DIFF
--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -14,6 +14,8 @@ const (
 	InitMsg         uint16 = 62000
 	PidAttr         uint16 = 27281
 	ConsolePathAttr uint16 = 27282
+	// When syscall.NLA_HDRLEN is in gccgo, take this out.
+	syscall_NLA_HDRLEN = (syscall.SizeofNlAttr + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)
 )
 
 type Int32msg struct {
@@ -34,7 +36,7 @@ func (msg *Int32msg) Serialize() []byte {
 }
 
 func (msg *Int32msg) Len() int {
-	return syscall.NLA_HDRLEN + 4
+	return syscall_NLA_HDRLEN + 4
 }
 
 // bytemsg has the following representation
@@ -56,5 +58,5 @@ func (msg *Bytemsg) Serialize() []byte {
 }
 
 func (msg *Bytemsg) Len() int {
-	return syscall.NLA_HDRLEN + len(msg.Value) + 1 // null-terminated
+	return syscall_NLA_HDRLEN + len(msg.Value) + 1 // null-terminated
 }


### PR DESCRIPTION
Caclulate NLA_HDRLEN as gccgo workaround
    
syscall.NLA_HDRLEN is not in gccgo (as of 5.3), so in the meantime
use the #defines taken from linux/netlink.h.
    
See https://github.com/golang/go/issues/13629

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>