### PR TITLE
Cause containers to be SIGKILLed when runc exits

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -53,6 +53,10 @@ var restoreCommand = cli.Command{
 			Value: "",
 			Usage: "path to the root of the bundle directory",
 		},
+		cli.IntFlag{
+			Name:  "parent-death-signal",
+			Usage: "signal to send to the container when runc terminates",
+		},
 	},
 	Action: func(context *cli.Context) {
 		imagePath := context.String("image-path")
@@ -69,7 +73,10 @@ var restoreCommand = cli.Command{
 		if err != nil {
 			fatal(err)
 		}
-		config, err := createLibcontainerConfig(context.GlobalString("id"), spec, rspec)
+		config, err := createLibcontainerConfig(
+			context.GlobalString("id"), context.Int("parent-death-signal"),
+			spec, rspec,
+		)
 		if err != nil {
 			fatal(err)
 		}

--- a/spec.go
+++ b/spec.go
@@ -345,7 +345,7 @@ func checkSpecVersion(s *specs.LinuxSpec) error {
 	return nil
 }
 
-func createLibcontainerConfig(cgroupName string, spec *specs.LinuxSpec, rspec *specs.LinuxRuntimeSpec) (*configs.Config, error) {
+func createLibcontainerConfig(cgroupName string, parentDeathSignal int, spec *specs.LinuxSpec, rspec *specs.LinuxRuntimeSpec) (*configs.Config, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -355,10 +355,11 @@ func createLibcontainerConfig(cgroupName string, spec *specs.LinuxSpec, rspec *s
 		rootfsPath = filepath.Join(cwd, rootfsPath)
 	}
 	config := &configs.Config{
-		Rootfs:       rootfsPath,
-		Capabilities: spec.Linux.Capabilities,
-		Readonlyfs:   spec.Root.Readonly,
-		Hostname:     spec.Hostname,
+		ParentDeathSignal: parentDeathSignal,
+		Rootfs:            rootfsPath,
+		Capabilities:      spec.Linux.Capabilities,
+		Readonlyfs:        spec.Root.Readonly,
+		Hostname:          spec.Hostname,
 	}
 
 	exists := false

--- a/start.go
+++ b/start.go
@@ -31,6 +31,10 @@ var startCommand = cli.Command{
 			Value: "",
 			Usage: "specify the pty slave path for use with the container",
 		},
+		cli.IntFlag{
+			Name:  "parent-death-signal",
+			Usage: "signal to send to the container when runc terminates",
+		},
 	},
 	Action: func(context *cli.Context) {
 		bundle := context.String("bundle")
@@ -83,7 +87,10 @@ func init() {
 }
 
 func startContainer(context *cli.Context, spec *specs.LinuxSpec, rspec *specs.LinuxRuntimeSpec) (int, error) {
-	config, err := createLibcontainerConfig(context.GlobalString("id"), spec, rspec)
+	config, err := createLibcontainerConfig(
+		context.GlobalString("id"), context.Int("parent-death-signal"),
+		spec, rspec,
+	)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
And avoid orphaned containers.

Thoughts? Should the signal to be sent configurable? I don't see a good reason to keep containers around after the parent runc process has been killed, or are there good reasons?