### PR TITLE
Build runC binary via a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM runc_test
+ADD . /go/src/github.com/opencontainers/runc
+RUN make

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+RUNC_IMAGE=runc_dev
 RUNC_TEST_IMAGE=runc_test
 PROJECT=github.com/opencontainers/runc
 TEST_DOCKERFILE=script/test_Dockerfile
 BUILDTAGS=seccomp
+RUNC_BUILD_PATH=/go/src/github.com/opencontainers/runc/runc
+RUNC_INSTANCE=runc_dev
 export GOPATH:=$(CURDIR)/Godeps/_workspace:$(GOPATH)
+
+.PHONY=dbuild
 
 all:
 	go build -tags "$(BUILDTAGS)" -o runc .
@@ -26,6 +31,11 @@ test: runctestimage
 localtest:
 	go test -tags "$(BUILDTAGS)" ${TESTFLAGS} -v ./...
 
+dbuild: runctestimage 
+	docker build -t $(RUNC_IMAGE) .
+	docker create --name=$(RUNC_INSTANCE) $(RUNC_IMAGE)
+	docker cp $(RUNC_INSTANCE):$(RUNC_BUILD_PATH) .
+	docker rm $(RUNC_INSTANCE)
 
 install:
 	cp runc /usr/local/bin/runc


### PR DESCRIPTION
This creates a runC binary using a Docker container. This means you are no longer dependent on having Golang installed on the host. The base image is the existing runctestimage. If this does not already exist it will be built as part of the build.

Usage: `make dbuild`
Result: A runC binary in the root directory. 

Signed-off-by: Ben Hall <ben@benhall.me.uk>