### PR TITLE
libcontainer: cgroups: add intel_rdt support in runc

### DIFF
--- a/Godeps/_workspace/src/github.com/opencontainers/specs/config-linux.md
+++ b/Godeps/_workspace/src/github.com/opencontainers/specs/config-linux.md
@@ -163,7 +163,7 @@ In addition to any devices configured with this setting, the runtime MUST also s
 ## Control groups
 
 Also known as cgroups, they are used to restrict resource usage for a container and handle device access.
-cgroups provide controls to restrict cpu, memory, IO, pids and network for the container.
+cgroups provide controls to restrict cpu, memory, IO, pids, network and intel_rdt for the container.
 For more information, see the [kernel cgroups documentation][cgroup-v1].
 
 The path to the cgroups can be specified in the Spec via `cgroupsPath`.
@@ -451,6 +451,23 @@ The following paramters can be specified to setup the controller:
 ```json
    "pids": {
         "limit": 32771
+   }
+```
+
+#### Intel rdt 
+
+`intelRdt` represents the cgroup subsystem `intel_rdt`.
+For more information, see [the intel_rdt cgroup man page](https://lkml.org/lkml/2015/12/17/574).
+
+The following paramters can be specified to setup the controller:
+
+* **`l3Cbm`** *(uint64, optional)* - specifies L3 cache capacity bitmask (CBM) in the cgroup
+
+###### Example
+
+```json
+   "intelRdt": {
+        "l3Cbm": 4080 
    }
 ```
 

--- a/Godeps/_workspace/src/github.com/opencontainers/specs/config_linux.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/specs/config_linux.go
@@ -211,6 +211,12 @@ type Network struct {
 	Priorities []InterfacePriority `json:"priorities,omitempty"`
 }
 
+// IntelRdt for Linux cgroup 'intel_rdt' resource management
+type IntelRdt struct {
+	// L3 cache capacity bitmask (CBM) for container
+	L3Cbm *uint64 `json:"l3Cbm,omitempty"`
+}
+
 // Resources has container runtime resource constraints
 type Resources struct {
 	// Devices are a list of device rules for the whitelist controller
@@ -231,6 +237,8 @@ type Resources struct {
 	HugepageLimits []HugepageLimit `json:"hugepageLimits,omitempty"`
 	// Network restriction configuration
 	Network *Network `json:"network,omitempty"`
+	// IntelRdt restriction configuration
+	IntelRdt *IntelRdt `json:"intelRdt,omitempty"`
 }
 
 // Device represents the mknod information for a Linux special device file

--- a/libcontainer/SPEC.md
+++ b/libcontainer/SPEC.md
@@ -143,6 +143,7 @@ system resources like cpu, memory, and device access.
 | freezer    | 1       |
 | hugetlb    | 1       |
 | pids       | 1       |
+| intel_rdt  | 1       |
 
 
 All cgroup subsystem are joined so that statistics can be collected from

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -30,6 +30,7 @@ var (
 		&NetPrioGroup{},
 		&PerfEventGroup{},
 		&FreezerGroup{},
+		&IntelRdtGroup{},
 	}
 	CgroupProcesses  = "cgroup.procs"
 	HugePageSizes, _ = cgroups.GetHugePageSize()

--- a/libcontainer/cgroups/fs/intel_rdt.go
+++ b/libcontainer/cgroups/fs/intel_rdt.go
@@ -1,0 +1,75 @@
+// +build linux
+
+package fs
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+type IntelRdtGroup struct {
+}
+
+func (s *IntelRdtGroup) Name() string {
+	return "intel_rdt"
+}
+
+func (s *IntelRdtGroup) Apply(d *cgroupData) error {
+	dir, err := d.join("intel_rdt")
+	if err != nil {
+		if !cgroups.IsNotFound(err) {
+			return err
+		}
+		// We will not return err here when:
+		// 1. The h/w platform doesn't support Intel RDT/CAT feature,
+		//    intel_rdt cgroup is not enabled in kernel.
+		// 2. intel_rdt cgroup is not mounted
+		return nil
+	}
+
+	if err := s.Set(dir, d.config); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *IntelRdtGroup) Set(path string, cgroup *configs.Cgroup) error {
+	// The valid CBM (capacity bitmask) is a *contiguous bits set* and
+	// number of bits that can be set is less than the max bit. The max
+	// bits in the CBM is varied among supported Intel platforms.
+	//
+	// By default the child cgroups inherit the CBM from parent. The CBM
+	// in a child cgroup should be a subset of the CBM in parent. Kernel
+	// will check if it is valid when writing.
+	//
+	// e.g., 0xfffff in root cgroup indicates the max bits of CBM is 20
+	// bits, which mapping to entire L3 cache capacity. Some valid CBM
+	// values to Set in children cgroup: 0xf, 0xf0, 0x3ff, 0x1f00 and etc.
+	if cgroup.Resources.IntelRdtL3Cbm != 0 {
+		l3CbmStr := fmt.Sprintf("0x%s", strconv.FormatUint(cgroup.Resources.IntelRdtL3Cbm, 16))
+		if err := writeFile(path, "intel_rdt.l3_cbm", l3CbmStr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *IntelRdtGroup) Remove(d *cgroupData) error {
+	return removePath(d.path("intel_rdt"))
+}
+
+func (s *IntelRdtGroup) GetStats(path string, stats *cgroups.Stats) error {
+	value, err := getCgroupParamUintHex(path, "intel_rdt.l3_cbm")
+	if err != nil {
+		return fmt.Errorf("failed to parse intel_rdt.l3_cbm - %s", err)
+	}
+
+	stats.IntelRdtStats.L3Cbm = value
+
+	return nil
+}

--- a/libcontainer/cgroups/fs/intel_rdt_test.go
+++ b/libcontainer/cgroups/fs/intel_rdt_test.go
@@ -1,0 +1,62 @@
+// +build linux
+
+package fs
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+func TestIntelRdtSetL3Cbm(t *testing.T) {
+	helper := NewCgroupTestUtil("intel_rdt", t)
+	defer helper.cleanup()
+
+	const (
+		l3CbmBefore = 0xf
+		l3CbmAfter  = 0xf0
+	)
+
+	helper.writeFileContents(map[string]string{
+		"intel_rdt.l3_cbm": strconv.FormatUint(l3CbmBefore, 16),
+	})
+
+	helper.CgroupData.config.Resources.IntelRdtL3Cbm = l3CbmAfter
+	intelrdt := &IntelRdtGroup{}
+	if err := intelrdt.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
+		t.Fatal(err)
+	}
+
+	value, err := getCgroupParamUintHex(helper.CgroupPath, "intel_rdt.l3_cbm")
+	if err != nil {
+		t.Fatalf("Failed to parse intel_rdt.l3_cbm - %s", err)
+	}
+
+	if value != l3CbmAfter {
+		t.Fatal("Got the wrong value, set intel_rdt.l3_cbm failed.")
+	}
+}
+
+func TestIntelRdtStats(t *testing.T) {
+	helper := NewCgroupTestUtil("intel_rdt", t)
+	defer helper.cleanup()
+
+	const (
+		l3CbmContents = 0x1f00
+	)
+
+	helper.writeFileContents(map[string]string{
+		"intel_rdt.l3_cbm": strconv.FormatUint(l3CbmContents, 16),
+	})
+
+	intelrdt := &IntelRdtGroup{}
+	stats := *cgroups.NewStats()
+	if err := intelrdt.GetStats(helper.CgroupPath, &stats); err != nil {
+		t.Fatal(err)
+	}
+
+	if stats.IntelRdtStats.L3Cbm != l3CbmContents {
+		t.Fatalf("Expected '0x%x', got '0x%x' for intel_rdt.l3_cbm", l3CbmContents, stats.IntelRdtStats.L3Cbm)
+	}
+}

--- a/libcontainer/cgroups/fs/utils.go
+++ b/libcontainer/cgroups/fs/utils.go
@@ -68,6 +68,22 @@ func getCgroupParamUint(cgroupPath, cgroupFile string) (uint64, error) {
 	return res, nil
 }
 
+// Gets a single hex uint64 value from the specified cgroup file.
+func getCgroupParamUintHex(cgroupPath, cgroupFile string) (uint64, error) {
+	fileName := filepath.Join(cgroupPath, cgroupFile)
+	contents, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return 0, err
+	}
+
+	hexStr := strings.TrimSpace(strings.TrimPrefix(string(contents), "0x"))
+	res, err := parseUint(hexStr, 16, 64)
+	if err != nil {
+		return res, fmt.Errorf("unable to parse %q as a uint from Cgroup file %q", string(contents), fileName)
+	}
+	return res, nil
+}
+
 // Gets a string value from the specified cgroup file
 func getCgroupParamString(cgroupPath, cgroupFile string) (string, error) {
 	contents, err := ioutil.ReadFile(filepath.Join(cgroupPath, cgroupFile))

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -84,13 +84,18 @@ type HugetlbStats struct {
 	Failcnt uint64 `json:"failcnt"`
 }
 
+type IntelRdtStats struct {
+	L3Cbm uint64 `json:"l3_cbm,omitempty"`
+}
+
 type Stats struct {
 	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 	PidsStats   PidsStats   `json:"pids_stats,omitempty"`
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
 	// the map is in the format "size of hugepage: stats of the hugepage"
-	HugetlbStats map[string]HugetlbStats `json:"hugetlb_stats,omitempty"`
+	HugetlbStats  map[string]HugetlbStats `json:"hugetlb_stats,omitempty"`
+	IntelRdtStats IntelRdtStats           `json:"intel_rdt_stats,omitempty"`
 }
 
 func NewStats() *Stats {

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -118,4 +118,7 @@ type Resources struct {
 
 	// Set class identifier for container's network packets
 	NetClsClassid string `json:"net_cls_classid"`
+
+	// L3 cache capacity bitmask (CBM) for container
+	IntelRdtL3Cbm uint64 `json:"intel_rdt_l3_cbm"`
 }

--- a/spec.go
+++ b/spec.go
@@ -480,6 +480,10 @@ func createCgroupConfig(name string, spec *specs.LinuxSpec) (*configs.Cgroup, er
 			})
 		}
 	}
+	if r.IntelRdt != nil {
+		c.Resources.IntelRdtL3Cbm = *r.IntelRdt.L3Cbm
+	}
+
 	return c, nil
 }
 


### PR DESCRIPTION
This PR fixes issue #433 (Proposal: Intel RDT/CAT cgroup support in runc/libcontainer)

**Patch v2:**
Rebased the code for "unified config file" according to #284.
Commit 273cbbbd083d6cfb4b73568bd1232f2e7d7a7043: is to update specs for compiling, it is **_NOT_** necessary for this pull request
when https://github.com/opencontainers/specs/pull/267 is merged.

Commit 9808367f2473687c5210c196226c3e3a712bd3d9:
This PR fixes issue #433

**Patch v1:**
This version is for **code review only** because kernel patch is not upstream yet and the
specs change is under discussion in https://github.com/opencontainers/specs/pull/267

Commit b3282581e7252b2b08cb0305bbdd7e03b936f40b: is to update specs for compiling, it is **_NOT_** necessary for this pull request
when https://github.com/opencontainers/specs/pull/267 is merged. I am not sure if this will break Jenkins building.

Commit febaf8225b49019248c849bb0a16b07bd31cd478:
This PR fixes issue #433 

**About Intel RDT/CAT feature:**
Intel platforms with new Xeon CPU support Resource Director Technology (RDT).
Intel Cache Allocation Technology (CAT) is a sub-feature of RDT. Currently L3
Cache is the only resource that is supported in RDT.

This feature provides a way for the software to restrict cache allocation to a
defined 'subset' of L3 cache which may be overlapping with other 'subsets'.
The different subsets are identified by class of service (CLOS) and each CLOS
has a capacity bitmask (CBM).

More information can be found in the section 17.16 of Intel Software Developer
Manual.

**About intel_rdt cgroup:**
Linux kernel 4.6 (or later) will introduce new cgroup subsystem 'intel_rdt'
with kernel config CONFIG_INTEL_RDT.

The 'intel_rdt' cgroup manages L3 cache allocation. It has a file 'l3_cbm'
which represents the L3 cache capacity bitmask (CBM). The CBM needs to have
only _contiguous bits set_ and number of bits that can be set is less than the
max bits. The max bits in the CBM is varied among supported Intel platforms.
The tasks belonging to a cgroup get to fill in the L3 cache represented by
the CBM. For example, if the max bits in the CBM is 10 and the L3 cache size
is 10MB, each bit represents 1MB of the L3 cache capacity.

Root cgroup always has all the bits set in the l3_cbm. User can create more
cgroups with mkdir syscall. By default the child cgroups inherit the CBM from
parent. User can change the CBM specified in hex for each cgroup.

For more information about intel_rdt cgroup:
https://lkml.org/lkml/2015/12/17/574

An example:
    Root cgroup: intel_rdt.l3_cbm == 0xfffff, the max bits of CBM is 20
    L3 cache size: 55 MB
This assigns 11 MB (1/5) of L3 cache to the child group:
    $ /bin/echo 0xf > intel_rdt.l3_cbm

Signed-off-by: Xiaochen Shen xiaochen.shen@intel.com
