### PR TITLE
Move setns within nsexec

### DIFF
--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -117,3 +117,11 @@ func (n *Namespaces) index(t NamespaceType) int {
 func (n *Namespaces) Contains(t NamespaceType) bool {
 	return n.index(t) != -1
 }
+
+func (n *Namespaces) PathOf(t NamespaceType) string {
+	i := n.index(t)
+	if i == -1 {
+		return ""
+	}
+	return (*n)[i].Path
+}

--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -2,7 +2,11 @@
 
 package configs
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"sync"
+)
 
 const (
 	NEWNET  NamespaceType = "NEWNET"
@@ -12,6 +16,51 @@ const (
 	NEWIPC  NamespaceType = "NEWIPC"
 	NEWUSER NamespaceType = "NEWUSER"
 )
+
+var (
+	nsLock              sync.Mutex
+	supportedNamespaces = make(map[NamespaceType]bool)
+)
+
+// nsToFile converts the namespace type to its filename
+func nsToFile(ns NamespaceType) string {
+	switch ns {
+	case NEWNET:
+		return "net"
+	case NEWNS:
+		return "mnt"
+	case NEWPID:
+		return "pid"
+	case NEWIPC:
+		return "ipc"
+	case NEWUSER:
+		return "user"
+	case NEWUTS:
+		return "uts"
+	}
+	return ""
+}
+
+// IsNamespaceSupported returns whether a namespace is available or
+// not
+func IsNamespaceSupported(ns NamespaceType) bool {
+	nsLock.Lock()
+	defer nsLock.Unlock()
+	supported, ok := supportedNamespaces[ns]
+	if ok {
+		return supported
+	}
+	nsFile := nsToFile(ns)
+	// if the namespace type is unknown, just return false
+	if nsFile == "" {
+		return false
+	}
+	_, err := os.Stat(fmt.Sprintf("/proc/self/ns/%s", nsFile))
+	// a namespace is supported if it exists and we have permissions to read it
+	supported = err == nil
+	supportedNamespaces[ns] = supported
+	return supported
+}
 
 func NamespaceTypes() []NamespaceType {
 	return []NamespaceType{
@@ -35,26 +84,7 @@ func (n *Namespace) GetPath(pid int) string {
 	if n.Path != "" {
 		return n.Path
 	}
-	return fmt.Sprintf("/proc/%d/ns/%s", pid, n.file())
-}
-
-func (n *Namespace) file() string {
-	file := ""
-	switch n.Type {
-	case NEWNET:
-		file = "net"
-	case NEWNS:
-		file = "mnt"
-	case NEWPID:
-		file = "pid"
-	case NEWIPC:
-		file = "ipc"
-	case NEWUSER:
-		file = "user"
-	case NEWUTS:
-		file = "uts"
-	}
-	return file
+	return fmt.Sprintf("/proc/%d/ns/%s", pid, nsToFile(n.Type))
 }
 
 func (n *Namespaces) Remove(t NamespaceType) bool {

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -185,25 +185,6 @@ func syncParentHooks(pipe io.ReadWriter) error {
 	return nil
 }
 
-// joinExistingNamespaces gets all the namespace paths specified for the container and
-// does a setns on the namespace fd so that the current process joins the namespace.
-func joinExistingNamespaces(namespaces []configs.Namespace) error {
-	for _, ns := range namespaces {
-		if ns.Path != "" {
-			f, err := os.OpenFile(ns.Path, os.O_RDONLY, 0)
-			if err != nil {
-				return err
-			}
-			err = system.Setns(f.Fd(), uintptr(ns.Syscall()))
-			f.Close()
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // setupUser changes the groups, gid, and uid for the user inside the container
 func setupUser(config *initConfig) error {
 	// Set up defaults.

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -92,13 +92,15 @@ func copyBusybox(dest string) error {
 }
 
 func newContainer(config *configs.Config) (libcontainer.Container, error) {
-	f := factory
+	return newContainerWithName("testCT", config)
+}
 
+func newContainerWithName(name string, config *configs.Config) (libcontainer.Container, error) {
+	f := factory
 	if config.Cgroups != nil && config.Cgroups.Parent == "system.slice" {
 		f = systemdFactory
 	}
-
-	return f.Create("testCT", config)
+	return f.Create(name, config)
 }
 
 // runContainer runs the container with the specific config and arguments

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -12,8 +12,12 @@ import (
 // The number is randomly chosen to not conflict with known netlink types
 const (
 	InitMsg         uint16 = 62000
-	PidAttr         uint16 = 27281
+	CloneFlagsAttr  uint16 = 27281
 	ConsolePathAttr uint16 = 27282
+	NsPathsAttr     uint16 = 27283
+	UidmapAttr      uint16 = 27284
+	GidmapAttr      uint16 = 27285
+	SetgroupAttr    uint16 = 27286
 	// When syscall.NLA_HDRLEN is in gccgo, take this out.
 	syscall_NLA_HDRLEN = (syscall.SizeofNlAttr + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)
 )
@@ -59,4 +63,26 @@ func (msg *Bytemsg) Serialize() []byte {
 
 func (msg *Bytemsg) Len() int {
 	return syscall_NLA_HDRLEN + len(msg.Value) + 1 // null-terminated
+}
+
+type Boolmsg struct {
+	Type  uint16
+	Value bool
+}
+
+func (msg *Boolmsg) Serialize() []byte {
+	buf := make([]byte, msg.Len())
+	native := nl.NativeEndian()
+	native.PutUint16(buf[0:2], uint16(msg.Len()))
+	native.PutUint16(buf[2:4], msg.Type)
+	if msg.Value {
+		buf[4] = 1
+	} else {
+		buf[4] = 0
+	}
+	return buf
+}
+
+func (msg *Boolmsg) Len() int {
+	return syscall_NLA_HDRLEN + 1
 }

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -3,7 +3,9 @@ package nsenter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -18,35 +20,51 @@ type pid struct {
 	Pid int `json:"Pid"`
 }
 
-func TestNsenterAlivePid(t *testing.T) {
+func TestNsenterValidPaths(t *testing.T) {
 	args := []string{"nsenter-exec"}
 	parent, child, err := newPipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe %v", err)
 	}
 
+	namespaces := []string{
+		// join pid ns of the current process
+		fmt.Sprintf("/proc/%d/ns/pid", os.Getpid()),
+	}
 	cmd := &exec.Cmd{
 		Path:       os.Args[0],
 		Args:       args,
 		ExtraFiles: []*os.File{child},
-		Env:        []string{"_LIBCONTAINER_INITTYPE=setns", "_LIBCONTAINER_INITPIPE=3"},
+		Env:        []string{"_LIBCONTAINER_INITPIPE=3"},
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
 	}
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("nsenter failed to start %v", err)
 	}
+	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
 	r.AddData(&libcontainer.Int32msg{
-		Type:  libcontainer.PidAttr,
-		Value: uint32(os.Getpid()),
+		Type:  libcontainer.CloneFlagsAttr,
+		Value: uint32(syscall.CLONE_NEWNET),
+	})
+	r.AddData(&libcontainer.Bytemsg{
+		Type:  libcontainer.NsPathsAttr,
+		Value: []byte(strings.Join(namespaces, ",")),
 	})
 	if _, err := io.Copy(parent, bytes.NewReader(r.Serialize())); err != nil {
 		t.Fatal(err)
 	}
+
 	decoder := json.NewDecoder(parent)
 	var pid *pid
 
 	if err := decoder.Decode(&pid); err != nil {
+		dir, _ := ioutil.ReadDir(fmt.Sprintf("/proc/%d/ns", os.Getpid()))
+		for _, d := range dir {
+			t.Log(d.Name())
+		}
 		t.Fatalf("%v", err)
 	}
 
@@ -60,70 +78,43 @@ func TestNsenterAlivePid(t *testing.T) {
 	p.Wait()
 }
 
-func TestNsenterInvalidPid(t *testing.T) {
+func TestNsenterInvalidPaths(t *testing.T) {
 	args := []string{"nsenter-exec"}
 	parent, child, err := newPipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe %v", err)
 	}
 
+	namespaces := []string{
+		// join pid ns of the current process
+		fmt.Sprintf("/proc/%d/ns/pid", -1),
+	}
 	cmd := &exec.Cmd{
 		Path:       os.Args[0],
 		Args:       args,
 		ExtraFiles: []*os.File{child},
-		Env:        []string{"_LIBCONTAINER_INITTYPE=setns", "_LIBCONTAINER_INITPIPE=3"},
+		Env:        []string{"_LIBCONTAINER_INITPIPE=3"},
 	}
 
 	if err := cmd.Start(); err != nil {
-		t.Fatal("nsenter exits with a zero exit status")
+		t.Fatal(err)
 	}
+	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
 	r.AddData(&libcontainer.Int32msg{
-		Type:  libcontainer.PidAttr,
-		Value: 0,
+		Type:  libcontainer.CloneFlagsAttr,
+		Value: uint32(syscall.CLONE_NEWNET),
+	})
+	r.AddData(&libcontainer.Bytemsg{
+		Type:  libcontainer.NsPathsAttr,
+		Value: []byte(strings.Join(namespaces, ",")),
 	})
 	if _, err := io.Copy(parent, bytes.NewReader(r.Serialize())); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := cmd.Wait(); err == nil {
-		t.Fatal("nsenter exits with a zero exit status")
-	}
-}
-
-func TestNsenterDeadPid(t *testing.T) {
-	deadCmd := exec.Command("true")
-	if err := deadCmd.Run(); err != nil {
-		t.Fatal(err)
-	}
-	args := []string{"nsenter-exec"}
-	parent, child, err := newPipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe %v", err)
-	}
-
-	cmd := &exec.Cmd{
-		Path:       os.Args[0],
-		Args:       args,
-		ExtraFiles: []*os.File{child},
-		Env:        []string{"_LIBCONTAINER_INITTYPE=setns", "_LIBCONTAINER_INITPIPE=3"},
-	}
-
-	if err := cmd.Start(); err != nil {
-		t.Fatal("nsenter exits with a zero exit status")
-	}
-
-	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
-	r.AddData(&libcontainer.Int32msg{
-		Type:  libcontainer.PidAttr,
-		Value: uint32(deadCmd.Process.Pid),
-	})
-	if _, err := io.Copy(parent, bytes.NewReader(r.Serialize())); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := cmd.Wait(); err == nil {
-		t.Fatal("nsenter exits with a zero exit status")
+		t.Fatalf("nsenter exits with a zero exit status")
 	}
 }
 

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-
 #include <linux/limits.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -16,6 +15,14 @@
 #include <setjmp.h>
 #include <sched.h>
 #include <signal.h>
+#include <endian.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+// netlink related
+#include <linux/types.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
 
 #include <bits/sockaddr.h>
 #include <linux/netlink.h>
@@ -57,16 +64,54 @@ int setns(int fd, int nstype)
 #endif
 #endif
 
-static int clone_parent(jmp_buf * env) __attribute__ ((noinline));
-static int clone_parent(jmp_buf * env)
+static int clone_parent(jmp_buf * env, int flags) __attribute__ ((noinline));
+static int clone_parent(jmp_buf * env, int flags)
 {
 	struct clone_arg ca;
 	int child;
 
 	ca.env = env;
-	child = clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD, &ca);
-
+	child =
+	    clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD | flags,
+		  &ca);
 	return child;
+}
+
+// get init pipe from the parent. It's used to read bootstrap data, and to
+// write pid to after nsexec finishes setting up the environment.
+static int get_init_pipe()
+{
+	char buf[PATH_MAX], *initpipe;
+	int pipenum = -1;
+
+	initpipe = getenv("_LIBCONTAINER_INITPIPE");
+	if (initpipe == NULL) {
+		return -1;
+	}
+
+	pipenum = atoi(initpipe);
+	snprintf(buf, sizeof(buf), "%d", pipenum);
+	if (strcmp(initpipe, buf)) {
+		pr_perror("Unable to parse _LIBCONTAINER_INITPIPE");
+		exit(1);
+	}
+
+	return pipenum;
+}
+
+// num_namespaces returns the number of additional namespaces to setns. The
+// argument is a comma-separated string of namespace paths.
+static int num_namespaces(char *nspaths)
+{
+	int size = 0, i = 0;
+
+	for (i = 0; nspaths[i]; i++) {
+		if (nspaths[i] == ',') {
+			size += 1;
+		}
+	}
+
+	return size + 1;
 }
 
 static uint32_t readint32(char *buf)
@@ -74,149 +119,191 @@ static uint32_t readint32(char *buf)
 	return *(uint32_t *) buf;
 }
 
+static uint8_t readint8(char *buf)
+{
+	return *(uint8_t *) buf;
+}
+
+static void writedata(int fd, char *data, int start, int len)
+{
+	int written = 0;
+	while (written < len) {
+		size_t nbyte, i;
+		if ((len - written) < 1024) {
+			nbyte = len - written;
+		} else {
+			nbyte = 1024;
+		}
+		i = write(fd, data + start + written, nbyte);
+		if (i == -1) {
+			pr_perror("failed to write data to %d", fd);
+			exit(1);
+		}
+		written += i;
+	}
+}
+
 // list of known message types we want to send to bootstrap program
 // These are defined in libcontainer/message_linux.go
-#define INIT_MSG 62000
-#define PID_ATTR 27281
-#define CONSOLE_PATH_ATTR 27282
+#define INIT_MSG            62000
+#define CLONE_FLAGS_ATTR    27281
+#define CONSOLE_PATH_ATTR   27282
+#define NS_PATHS_ATTR       27283
+#define UIDMAP_ATTR         27284
+#define GIDMAP_ATTR         27285
+#define SETGROUP_ATTR       27286
 
 void nsexec()
 {
-	char *namespaces[] = { "ipc", "uts", "net", "pid", "mnt", "user" };
-	const int num = sizeof(namespaces) / sizeof(char *);
 	jmp_buf env;
-	char buf[PATH_MAX], *val;
-	int i, tfd, self_tfd, child, n, len, pipenum, consolefd = -1;
-	pid_t pid = 0;
+	int pipenum;
 
-	// if we dont have INITTYPE or this is the init process, skip the bootstrap process
-	val = getenv("_LIBCONTAINER_INITTYPE");
-	if (val == NULL || strcmp(val, "standard") == 0) {
+	// if we dont have init pipe, then just return to the parent
+	pipenum = get_init_pipe();
+	if (pipenum == -1) {
 		return;
 	}
-	if (strcmp(val, "setns") != 0) {
-		pr_perror("Invalid inittype %s", val);
+	// Retrieve the netlink header
+	struct nlmsghdr nl_msg_hdr;
+	int len;
+
+	if ((len = read(pipenum, &nl_msg_hdr, NLMSG_HDRLEN)) != NLMSG_HDRLEN) {
+		pr_perror("Failed to read netlink header, got %d instead of %d",
+			  len, NLMSG_HDRLEN);
 		exit(1);
 	}
 
-	val = getenv("_LIBCONTAINER_INITPIPE");
-	if (val == NULL) {
-		pr_perror("Child pipe not found");
+	if (nl_msg_hdr.nlmsg_type == NLMSG_ERROR) {
+		pr_perror("failed to read netlink message");
 		exit(1);
 	}
-	pipenum = atoi(val);
-	snprintf(buf, sizeof(buf), "%d", pipenum);
-	if (strcmp(val, buf)) {
-		pr_perror("Unable to parse _LIBCONTAINER_INITPIPE");
+	if (nl_msg_hdr.nlmsg_type != INIT_MSG) {
+		pr_perror("unexpected msg type %d", nl_msg_hdr.nlmsg_type);
 		exit(1);
 	}
+	// Retrieve data
+	int nl_total_size = NLMSG_PAYLOAD(&nl_msg_hdr, 0);
+	char data[nl_total_size];
 
-	char nlbuf[NLMSG_HDRLEN];
-	struct nlmsghdr *nh;
-	if ((n = read(pipenum, nlbuf, NLMSG_HDRLEN)) != NLMSG_HDRLEN) {
-		pr_perror("Failed to read netlink header, got %d", n);
+	if ((len = read(pipenum, data, nl_total_size)) != nl_total_size) {
+		pr_perror
+		    ("Failed to read netlink payload, got %d instead of %d",
+		     len, nl_total_size);
 		exit(1);
 	}
-
-	nh = (struct nlmsghdr *)nlbuf;
-	if (nh->nlmsg_type == NLMSG_ERROR) {
-		pr_perror("Invalid netlink header message");
-		exit(1);
-	}
-	if (nh->nlmsg_type != INIT_MSG) {
-		pr_perror("Unexpected netlink message type %d", nh->nlmsg_type);
-		exit(1);
-	}
-	// read the netlink payload
-	len = NLMSG_PAYLOAD(nh, 0);
-	char data[len];
-	if ((n = read(pipenum, data, len)) != len) {
-		pr_perror("Failed to read netlink payload, got %d", n);
-		exit(1);
-	}
-
+	// Process the passed attributes
 	int start = 0;
-	struct nlattr *attr;
-	while (start < len) {
-		int payload_len;
-		attr = (struct nlattr *)((void *)data + start);
+	uint32_t cloneflags = -1;
+	uint8_t is_setgroup = 0;
+	int consolefd = -1;
+	int uidmap_start = -1, uidmap_len = -1;
+	int gidmap_start = -1, gidmap_len = -1;
+	int payload_len;
+	struct nlattr *nlattr;
+
+	while (start < nl_total_size) {
+		nlattr = (struct nlattr *)(data + start);
 		start += NLA_HDRLEN;
-		payload_len = attr->nla_len - NLA_HDRLEN;
-		switch (attr->nla_type) {
-		case PID_ATTR:
-			pid = (pid_t) readint32(data + start);
-			break;
-		case CONSOLE_PATH_ATTR:
-			consolefd = open((char *)data + start, O_RDWR);
+		payload_len = nlattr->nla_len - NLA_HDRLEN;
+
+		if (nlattr->nla_type == CLONE_FLAGS_ATTR) {
+			cloneflags = readint32(data + start);
+		} else if (nlattr->nla_type == CONSOLE_PATH_ATTR) {
+			// get the console path before setns because it may change mnt namespace
+			consolefd = open(data + start, O_RDWR);
 			if (consolefd < 0) {
-				pr_perror("Failed to open console %s", (char *)data + start);
+				pr_perror("Failed to open console %s",
+					  data + start);
 				exit(1);
 			}
-			break;
+		} else if (nlattr->nla_type == NS_PATHS_ATTR) {
+			char nspaths[payload_len + 1];
+
+			strncpy(nspaths, data + start, payload_len);
+			nspaths[payload_len] = '\0';
+
+			// if custom namespaces are required, open all descriptors and perform
+			// setns on them
+			int nslen = num_namespaces(nspaths);
+			int fds[nslen];
+			char *nslist[nslen];
+			int i;
+			char *ns, *saveptr;
+
+			for (i = 0; i < nslen; i++) {
+				char *str = NULL;
+
+				if (i == 0) {
+					str = nspaths;
+				}
+				ns = strtok_r(str, ",", &saveptr);
+				if (ns == NULL) {
+					break;
+				}
+				fds[i] = open(ns, O_RDONLY);
+				if (fds[i] == -1) {
+					pr_perror("Failed to open %s", ns);
+					exit(1);
+				}
+				nslist[i] = ns;
+			}
+
+			for (i = 0; i < nslen; i++) {
+				if (setns(fds[i], 0) != 0) {
+					pr_perror("Failed to setns to %s",
+						  nslist[i]);
+					exit(1);
+				}
+				close(fds[i]);
+			}
+		} else if (nlattr->nla_type == UIDMAP_ATTR) {
+			uidmap_len = payload_len;
+			uidmap_start = start;
+		} else if (nlattr->nla_type == GIDMAP_ATTR) {
+			gidmap_len = payload_len;
+			gidmap_start = start;
+		} else if (nlattr->nla_type == SETGROUP_ATTR) {
+			is_setgroup = readint8(data + start);
+		} else {
+			pr_perror("unknown netlink message type %d",
+				  nlattr->nla_type);
+			exit(1);
 		}
+
 		start += NLA_ALIGN(payload_len);
 	}
 
-	// required pid to be passed
-	if (pid == 0) {
-		pr_perror("missing pid");
+	// required clone_flags to be passed
+	if (cloneflags == -1) {
+		pr_perror("missing clone_flags");
 		exit(1);
 	}
-
-	/* Check that the specified process exists */
-	snprintf(buf, PATH_MAX - 1, "/proc/%d/ns", pid);
-	tfd = open(buf, O_DIRECTORY | O_RDONLY);
-	if (tfd == -1) {
-		pr_perror("Failed to open \"%s\"", buf);
+	// prepare sync pipe between parent and child. We need this to let the child
+	// know that the parent has finished setting up
+	int syncpipe[2] = { -1, -1 };
+	if (pipe(syncpipe) != 0) {
+		pr_perror("failed to setup sync pipe between parent and child");
 		exit(1);
-	}
-
-	self_tfd = open("/proc/self/ns", O_DIRECTORY | O_RDONLY);
-	if (self_tfd == -1) {
-		pr_perror("Failed to open /proc/self/ns");
-		exit(1);
-	}
-
-	for (i = 0; i < num; i++) {
-		struct stat st;
-		struct stat self_st;
-		int fd;
-
-		/* Symlinks on all namespaces exist for dead processes, but they can't be opened */
-		if (fstatat(tfd, namespaces[i], &st, 0) == -1) {
-			// Ignore nonexistent namespaces.
-			if (errno == ENOENT)
-				continue;
-		}
-
-		/* Skip namespaces we're already part of */
-		if (fstatat(self_tfd, namespaces[i], &self_st, 0) != -1 && st.st_ino == self_st.st_ino) {
-			continue;
-		}
-
-		fd = openat(tfd, namespaces[i], O_RDONLY);
-		if (fd == -1) {
-			pr_perror("Failed to open ns file %s for ns %s", buf, namespaces[i]);
-			exit(1);
-		}
-		// Set the namespace.
-		if (setns(fd, 0) == -1) {
-			pr_perror("Failed to setns for %s", namespaces[i]);
-			exit(1);
-		}
-		close(fd);
-	}
-
-	close(self_tfd);
-	close(tfd);
+	};
 
 	if (setjmp(env) == 1) {
 		// Child
+		uint8_t s;
+
+		// close the writing side of pipe
+		close(syncpipe[1]);
+
+		// sync with parent
+		if (read(syncpipe[0], &s, 1) != 1 || s != 1) {
+			pr_perror("failed to read sync byte from parent");
+			exit(1);
+		};
 
 		if (setsid() == -1) {
 			pr_perror("setsid failed");
 			exit(1);
 		}
+
 		if (consolefd != -1) {
 			if (ioctl(consolefd, TIOCSCTTY, 0) == -1) {
 				pr_perror("ioctl TIOCSCTTY failed");
@@ -243,19 +330,75 @@ void nsexec()
 	// We must fork to actually enter the PID namespace, use CLONE_PARENT
 	// so the child can have the right parent, and we don't need to forward
 	// the child's exit code or resend its death signal.
-	child = clone_parent(&env);
+	int child = clone_parent(&env, cloneflags);
 	if (child < 0) {
 		pr_perror("Unable to fork");
 		exit(1);
 	}
+	// if uid_map and gid_map were specified, writes the data to /proc files
+	if (uidmap_start > 0 && uidmap_len > 0) {
+		char buf[PATH_MAX];
+		if (snprintf(buf, sizeof(buf), "/proc/%d/uid_map", child) < 0) {
+			pr_perror("failed to construct uid_map file for %d",
+				  child);
+			exit(1);
+		}
 
-	len = snprintf(buf, sizeof(buf), "{ \"pid\" : %d }\n", child);
+		int fd = open(buf, O_RDWR);
+		writedata(fd, data, uidmap_start, uidmap_len);
+	}
 
-	if (write(pipenum, buf, len) != len) {
+	if (gidmap_start > 0 && gidmap_len > 0) {
+		if (is_setgroup == 1) {
+			char buf[PATH_MAX];
+			if (snprintf
+			    (buf, sizeof(buf), "/proc/%d/setgroups",
+			     child) < 0) {
+				pr_perror
+				    ("failed to construct setgroups file for %d",
+				     child);
+				exit(1);
+			}
+
+			int fd = open(buf, O_RDWR);
+			if (write(fd, "allow", 5) != 5) {
+				// If the kernel is too old to support /proc/PID/setgroups,
+				// write will return ENOENT; this is OK.
+				if (errno != ENOENT) {
+					pr_perror("failed to write allow to %s",
+						  buf);
+					exit(1);
+				}
+			}
+		}
+		// write gid mappings
+		char buf[PATH_MAX];
+		if (snprintf(buf, sizeof(buf), "/proc/%d/gid_map", child) < 0) {
+			pr_perror("failed to construct gid_map file for %d",
+				  child);
+			exit(1);
+		}
+
+		int fd = open(buf, O_RDWR);
+		writedata(fd, data, gidmap_start, gidmap_len);
+	}
+	// Send the sync signal to the child
+	close(syncpipe[0]);
+	uint8_t s = 1;
+	if (write(syncpipe[1], &s, 1) != 1) {
+		pr_perror("failed to write sync byte to child");
+		exit(1);
+	};
+
+	// parent to finish the bootstrap process
+	char child_data[PATH_MAX];
+	len =
+	    snprintf(child_data, sizeof(child_data), "{ \"pid\" : %d }\n",
+		     child);
+	if (write(pipenum, child_data, len) != len) {
 		pr_perror("Unable to send a child pid");
 		kill(child, SIGKILL);
 		exit(1);
 	}
-
 	exit(0);
 }

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -1,28 +1,19 @@
 #define _GNU_SOURCE
-#include <stdlib.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <linux/limits.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <setjmp.h>
-#include <sched.h>
-#include <signal.h>
 #include <endian.h>
-#include <stdint.h>
-#include <inttypes.h>
-
-// netlink related
-#include <linux/types.h>
-#include <sys/socket.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/limits.h>
 #include <linux/netlink.h>
+#include <sched.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include <bits/sockaddr.h>
 #include <linux/netlink.h>

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <bits/sockaddr.h>
@@ -21,50 +22,71 @@
 #include <stdint.h>
 #include <sys/socket.h>
 
-/* All arguments should be above stack, because it grows down */
+// All arguments should be above the stack because it grows down
 struct clone_arg {
 	/*
 	 * Reserve some space for clone() to locate arguments
 	 * and retcode in this place
 	 */
-	char stack[4096] __attribute__ ((aligned(16)));
-	char stack_ptr[0];
+	char     stack[4096] __attribute__((aligned(16)));
+	char     stack_ptr[0];
 	jmp_buf *env;
 };
 
-#define pr_perror(fmt, ...) fprintf(stderr, "nsenter: " fmt ": %m\n", ##__VA_ARGS__)
+struct nsenter_config {
+	uint32_t cloneflags;
+	char     *uidmap;
+	int      uidmap_len;
+	char     *gidmap;
+	int      gidmap_len;
+	uint8_t  is_setgroup;
+};
+
+// list of known message types we want to send to bootstrap program
+// These are defined in libcontainer/message_linux.go
+#define INIT_MSG	    62000
+#define CLONE_FLAGS_ATTR    27281
+#define CONSOLE_PATH_ATTR   27282
+#define NS_PATHS_ATTR	    27283
+#define UIDMAP_ATTR	    27284
+#define GIDMAP_ATTR	    27285
+#define SETGROUP_ATTR	    27286
+
+// Use raw setns syscall for versions of glibc that don't include it
+// (namely glibc-2.12)
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 14
+    #define _GNU_SOURCE
+    #include "syscall.h"
+    #if defined(__NR_setns) && !defined(SYS_setns)
+	#define SYS_setns __NR_setns
+    #endif
+
+    #ifdef SYS_setns
+	int setns(int fd, int nstype)
+	{
+	    return syscall(SYS_setns, fd, nstype);
+	}
+    #endif
+#endif
+
+#define pr_perror(fmt, ...)                                                    \
+	fprintf(stderr, "nsenter: " fmt ": %m\n", ##__VA_ARGS__)
 
 static int child_func(void *_arg)
 {
-	struct clone_arg *arg = (struct clone_arg *)_arg;
-	longjmp(*arg->env, 1);
+    struct clone_arg *arg = (struct clone_arg *)_arg;
+    longjmp(*arg->env, 1);
 }
 
-// Use raw setns syscall for versions of glibc that don't include it (namely glibc-2.12)
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 14
-#define _GNU_SOURCE
-#include "syscall.h"
-#if defined(__NR_setns) && !defined(SYS_setns)
-#define SYS_setns __NR_setns
-#endif
-#ifdef SYS_setns
-int setns(int fd, int nstype)
-{
-	return syscall(SYS_setns, fd, nstype);
-}
-#endif
-#endif
-
-static int clone_parent(jmp_buf * env, int flags) __attribute__ ((noinline));
-static int clone_parent(jmp_buf * env, int flags)
+static int clone_parent(jmp_buf *env, int flags) __attribute__((noinline));
+static int clone_parent(jmp_buf *env, int flags)
 {
 	struct clone_arg ca;
-	int child;
+	int		 child;
 
 	ca.env = env;
-	child =
-	    clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD | flags,
-		  &ca);
+	child  = clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD | flags,
+		      &ca);
 	return child;
 }
 
@@ -72,8 +94,9 @@ static int clone_parent(jmp_buf * env, int flags)
 // write pid to after nsexec finishes setting up the environment.
 static int get_init_pipe()
 {
-	char buf[PATH_MAX], *initpipe;
-	int pipenum = -1;
+	char	buf[PATH_MAX];
+	char	*initpipe;
+	int	pipenum = -1;
 
 	initpipe = getenv("_LIBCONTAINER_INITPIPE");
 	if (initpipe == NULL) {
@@ -94,7 +117,8 @@ static int get_init_pipe()
 // argument is a comma-separated string of namespace paths.
 static int num_namespaces(char *nspaths)
 {
-	int size = 0, i = 0;
+	int i;
+	int size = 0;
 
 	for (i = 0; nspaths[i]; i++) {
 		if (nspaths[i] == ',') {
@@ -107,100 +131,154 @@ static int num_namespaces(char *nspaths)
 
 static uint32_t readint32(char *buf)
 {
-	return *(uint32_t *) buf;
+    return *(uint32_t *)buf;
 }
 
 static uint8_t readint8(char *buf)
 {
-	return *(uint8_t *) buf;
+    return *(uint8_t *)buf;
 }
 
-static void writedata(int fd, char *data, int start, int len)
+static void update_process_idmap(char *pathfmt, int pid, char *map, int map_len)
 {
-	int written = 0;
-	while (written < len) {
-		size_t nbyte, i;
-		if ((len - written) < 1024) {
-			nbyte = len - written;
-		} else {
-			nbyte = 1024;
-		}
-		i = write(fd, data + start + written, nbyte);
-		if (i == -1) {
-			pr_perror("failed to write data to %d", fd);
-			exit(1);
-		}
-		written += i;
+	char    buf[PATH_MAX];
+	int	len;
+	int	fd;
+
+	len = snprintf(buf, sizeof(buf), pathfmt, pid);
+	if (len < 0) {
+		pr_perror("failed to construct '%s' for %d", pathfmt, pid);
+		exit(1);
 	}
+
+	fd = open(buf, O_RDWR);
+	if (fd == -1) {
+		pr_perror("failed to open %s", buf);
+		exit(1);
+	}
+
+	len = write(fd, map, map_len);
+	if (len == -1) {
+		pr_perror("failed to write to %s", buf);
+		exit(1);
+	} else if (len != map_len) {
+		fprintf(stderr, "Failed to write data to %s (%d/%d)",
+			buf, len, map_len);
+		exit(1);
+	}
+
+	close(fd);
 }
 
-// list of known message types we want to send to bootstrap program
-// These are defined in libcontainer/message_linux.go
-#define INIT_MSG            62000
-#define CLONE_FLAGS_ATTR    27281
-#define CONSOLE_PATH_ATTR   27282
-#define NS_PATHS_ATTR       27283
-#define UIDMAP_ATTR         27284
-#define GIDMAP_ATTR         27285
-#define SETGROUP_ATTR       27286
-
-void nsexec()
+static void update_process_uidmap(int pid, char *map, int map_len)
 {
-	jmp_buf env;
-	int pipenum;
-
-	// if we dont have init pipe, then just return to the parent
-	pipenum = get_init_pipe();
-	if (pipenum == -1) {
+	if ((map == NULL) || (map_len <= 0)) {
 		return;
 	}
-	// Retrieve the netlink header
-	struct nlmsghdr nl_msg_hdr;
-	int len;
 
-	if ((len = read(pipenum, &nl_msg_hdr, NLMSG_HDRLEN)) != NLMSG_HDRLEN) {
-		pr_perror("Failed to read netlink header, got %d instead of %d",
-			  len, NLMSG_HDRLEN);
+	update_process_idmap("/proc/%d/uid_map", pid, map, map_len);
+}
+
+static void update_process_gidmap(int pid, uint8_t is_setgroup, char *map, int map_len)
+{
+	if ((map == NULL) || (map_len <= 0)) {
+		return;
+	}
+
+	if (is_setgroup == 1) {
+		int	fd;
+		int	len;
+		char	buf[PATH_MAX];
+
+		len = snprintf(buf, sizeof(buf), "/proc/%d/setgroups", pid);
+		if (len < 0) {
+			pr_perror("failed to get setgroups path for %d", pid);
+			exit(1);
+		}
+
+		fd = open(buf, O_RDWR);
+		if (fd == -1) {
+			pr_perror("failed to open %s", buf);
+			exit(1);
+		}
+		if (write(fd, "allow", 5) != 5) {
+			// If the kernel is too old to support
+			// /proc/PID/setgroups, write will return
+			// ENOENT; this is OK.
+			if (errno != ENOENT) {
+				pr_perror("failed to write allow to %s", buf);
+				exit(1);
+			}
+		}
+		close(fd);
+	}
+
+	update_process_idmap("/proc/%d/gid_map", pid, map, map_len);
+}
+
+
+static void start_child(int pipenum, jmp_buf *env, int syncpipe[2],
+		 struct nsenter_config *config)
+{
+	int     len;
+	int     childpid;
+	char    buf[PATH_MAX];
+	uint8_t syncbyte = 1;
+
+	// We must fork to actually enter the PID namespace, use CLONE_PARENT
+	// so the child can have the right parent, and we don't need to forward
+	// the child's exit code or resend its death signal.
+	childpid = clone_parent(env, config->cloneflags);
+	if (childpid < 0) {
+		pr_perror("Unable to fork");
 		exit(1);
 	}
 
-	if (nl_msg_hdr.nlmsg_type == NLMSG_ERROR) {
-		pr_perror("failed to read netlink message");
-		exit(1);
-	}
-	if (nl_msg_hdr.nlmsg_type != INIT_MSG) {
-		pr_perror("unexpected msg type %d", nl_msg_hdr.nlmsg_type);
-		exit(1);
-	}
-	// Retrieve data
-	int nl_total_size = NLMSG_PAYLOAD(&nl_msg_hdr, 0);
-	char data[nl_total_size];
+	// update uid_map and gid_map for the child process if they
+	// were provided
+	update_process_uidmap(childpid, config->uidmap, config->uidmap_len);
 
-	if ((len = read(pipenum, data, nl_total_size)) != nl_total_size) {
-		pr_perror
-		    ("Failed to read netlink payload, got %d instead of %d",
-		     len, nl_total_size);
+	update_process_gidmap(childpid, config->is_setgroup, config->gidmap, config->gidmap_len);
+
+	// Send the sync signal to the child
+	close(syncpipe[0]);
+	syncbyte = 1;
+	if (write(syncpipe[1], &syncbyte, 1) != 1) {
+		pr_perror("failed to write sync byte to child");
 		exit(1);
 	}
-	// Process the passed attributes
-	int start = 0;
-	uint32_t cloneflags = -1;
-	uint8_t is_setgroup = 0;
-	int consolefd = -1;
-	int uidmap_start = -1, uidmap_len = -1;
-	int gidmap_start = -1, gidmap_len = -1;
-	int payload_len;
-	struct nlattr *nlattr;
 
-	while (start < nl_total_size) {
+	// Send the child pid back to our parent
+	len = snprintf(buf, sizeof(buf), "{ \"pid\" : %d }\n", childpid);
+	if ((len < 0) || (write(pipenum, buf, len) != len)) {
+		pr_perror("Unable to send a child pid");
+		kill(childpid, SIGKILL);
+		exit(1);
+	}
+
+	exit(0);
+}
+
+static void process_nl_attributes(int pipenum, char *data, int data_size)
+{
+	jmp_buf			env;
+	struct nsenter_config	config	    = {0};
+	struct nlattr		*nlattr;
+	int			payload_len;
+	int			start       = 0;
+	int			consolefd   = -1;
+	int			syncpipe[2] = {-1, -1};
+
+	while (start < data_size) {
 		nlattr = (struct nlattr *)(data + start);
 		start += NLA_HDRLEN;
 		payload_len = nlattr->nla_len - NLA_HDRLEN;
 
 		if (nlattr->nla_type == CLONE_FLAGS_ATTR) {
-			cloneflags = readint32(data + start);
+			config.cloneflags = readint32(data + start);
 		} else if (nlattr->nla_type == CONSOLE_PATH_ATTR) {
-			// get the console path before setns because it may change mnt namespace
+			// get the console path before setns because it may
+			// change mnt namespace
 			consolefd = open(data + start, O_RDWR);
 			if (consolefd < 0) {
 				pr_perror("Failed to open console %s",
@@ -208,24 +286,20 @@ void nsexec()
 				exit(1);
 			}
 		} else if (nlattr->nla_type == NS_PATHS_ATTR) {
-			char nspaths[payload_len + 1];
-
-			strncpy(nspaths, data + start, payload_len);
-			nspaths[payload_len] = '\0';
-
-			// if custom namespaces are required, open all descriptors and perform
-			// setns on them
-			int nslen = num_namespaces(nspaths);
-			int fds[nslen];
-			char *nslist[nslen];
-			int i;
-			char *ns, *saveptr;
+			// if custom namespaces are required, open all
+			// descriptors and perform setns on them
+			int	i;
+			int	nslen = num_namespaces(data + start);
+			int	fds[nslen];
+			char	*nslist[nslen];
+			char	*ns;
+			char	*saveptr;
 
 			for (i = 0; i < nslen; i++) {
 				char *str = NULL;
 
 				if (i == 0) {
-					str = nspaths;
+					str = data + start;
 				}
 				ns = strtok_r(str, ",", &saveptr);
 				if (ns == NULL) {
@@ -241,22 +315,21 @@ void nsexec()
 
 			for (i = 0; i < nslen; i++) {
 				if (setns(fds[i], 0) != 0) {
-					pr_perror("Failed to setns to %s",
-						  nslist[i]);
+					pr_perror("Failed to setns to %s", nslist[i]);
 					exit(1);
 				}
 				close(fds[i]);
 			}
 		} else if (nlattr->nla_type == UIDMAP_ATTR) {
-			uidmap_len = payload_len;
-			uidmap_start = start;
+			config.uidmap     = data + start;
+			config.uidmap_len = payload_len;
 		} else if (nlattr->nla_type == GIDMAP_ATTR) {
-			gidmap_len = payload_len;
-			gidmap_start = start;
+			config.gidmap     = data + start;
+			config.gidmap_len = payload_len;
 		} else if (nlattr->nla_type == SETGROUP_ATTR) {
-			is_setgroup = readint8(data + start);
+			config.is_setgroup = readint8(data + start);
 		} else {
-			pr_perror("unknown netlink message type %d",
+			pr_perror("Unknown netlink message type %d",
 				  nlattr->nla_type);
 			exit(1);
 		}
@@ -265,30 +338,30 @@ void nsexec()
 	}
 
 	// required clone_flags to be passed
-	if (cloneflags == -1) {
-		pr_perror("missing clone_flags");
+	if (config.cloneflags == -1) {
+		pr_perror("Missing clone_flags");
 		exit(1);
 	}
-	// prepare sync pipe between parent and child. We need this to let the child
+	// prepare sync pipe between parent and child. We need this to let the
+	// child
 	// know that the parent has finished setting up
-	int syncpipe[2] = { -1, -1 };
 	if (pipe(syncpipe) != 0) {
-		pr_perror("failed to setup sync pipe between parent and child");
+		pr_perror("Failed to setup sync pipe between parent and child");
 		exit(1);
-	};
+	}
 
 	if (setjmp(env) == 1) {
 		// Child
-		uint8_t s;
+		uint8_t s = 0;
 
 		// close the writing side of pipe
 		close(syncpipe[1]);
 
 		// sync with parent
-		if (read(syncpipe[0], &s, 1) != 1 || s != 1) {
-			pr_perror("failed to read sync byte from parent");
+		if ((read(syncpipe[0], &s, 1) != 1) || (s != 1)) {
+			pr_perror("Failed to read sync byte from parent");
 			exit(1);
-		};
+		}
 
 		if (setsid() == -1) {
 			pr_perror("setsid failed");
@@ -301,95 +374,65 @@ void nsexec()
 				exit(1);
 			}
 			if (dup3(consolefd, STDIN_FILENO, 0) != STDIN_FILENO) {
-				pr_perror("Failed to dup 0");
+				pr_perror("Failed to dup stdin");
 				exit(1);
 			}
 			if (dup3(consolefd, STDOUT_FILENO, 0) != STDOUT_FILENO) {
-				pr_perror("Failed to dup 1");
+				pr_perror("Failed to dup stdout");
 				exit(1);
 			}
 			if (dup3(consolefd, STDERR_FILENO, 0) != STDERR_FILENO) {
-				pr_perror("Failed to dup 2");
+				pr_perror("Failed to dup stderr");
 				exit(1);
 			}
 		}
+
 		// Finish executing, let the Go runtime take over.
 		return;
 	}
+
 	// Parent
+	start_child(pipenum, &env, syncpipe, &config);
+}
 
-	// We must fork to actually enter the PID namespace, use CLONE_PARENT
-	// so the child can have the right parent, and we don't need to forward
-	// the child's exit code or resend its death signal.
-	int child = clone_parent(&env, cloneflags);
-	if (child < 0) {
-		pr_perror("Unable to fork");
+void nsexec(void)
+{
+	int pipenum;
+
+	// if we dont have init pipe, then just return to the parent
+	pipenum = get_init_pipe();
+	if (pipenum == -1) {
+		return;
+	}
+
+	// Retrieve the netlink header
+	struct nlmsghdr nl_msg_hdr;
+	int		len;
+
+	if ((len = read(pipenum, &nl_msg_hdr, NLMSG_HDRLEN)) != NLMSG_HDRLEN) {
+		pr_perror("Invalid netlink header length %d", len);
 		exit(1);
 	}
-	// if uid_map and gid_map were specified, writes the data to /proc files
-	if (uidmap_start > 0 && uidmap_len > 0) {
-		char buf[PATH_MAX];
-		if (snprintf(buf, sizeof(buf), "/proc/%d/uid_map", child) < 0) {
-			pr_perror("failed to construct uid_map file for %d",
-				  child);
-			exit(1);
-		}
 
-		int fd = open(buf, O_RDWR);
-		writedata(fd, data, uidmap_start, uidmap_len);
-	}
-
-	if (gidmap_start > 0 && gidmap_len > 0) {
-		if (is_setgroup == 1) {
-			char buf[PATH_MAX];
-			if (snprintf
-			    (buf, sizeof(buf), "/proc/%d/setgroups",
-			     child) < 0) {
-				pr_perror
-				    ("failed to construct setgroups file for %d",
-				     child);
-				exit(1);
-			}
-
-			int fd = open(buf, O_RDWR);
-			if (write(fd, "allow", 5) != 5) {
-				// If the kernel is too old to support /proc/PID/setgroups,
-				// write will return ENOENT; this is OK.
-				if (errno != ENOENT) {
-					pr_perror("failed to write allow to %s",
-						  buf);
-					exit(1);
-				}
-			}
-		}
-		// write gid mappings
-		char buf[PATH_MAX];
-		if (snprintf(buf, sizeof(buf), "/proc/%d/gid_map", child) < 0) {
-			pr_perror("failed to construct gid_map file for %d",
-				  child);
-			exit(1);
-		}
-
-		int fd = open(buf, O_RDWR);
-		writedata(fd, data, gidmap_start, gidmap_len);
-	}
-	// Send the sync signal to the child
-	close(syncpipe[0]);
-	uint8_t s = 1;
-	if (write(syncpipe[1], &s, 1) != 1) {
-		pr_perror("failed to write sync byte to child");
-		exit(1);
-	};
-
-	// parent to finish the bootstrap process
-	char child_data[PATH_MAX];
-	len =
-	    snprintf(child_data, sizeof(child_data), "{ \"pid\" : %d }\n",
-		     child);
-	if (write(pipenum, child_data, len) != len) {
-		pr_perror("Unable to send a child pid");
-		kill(child, SIGKILL);
+	if (nl_msg_hdr.nlmsg_type == NLMSG_ERROR) {
+		pr_perror("Failed to read netlink message");
 		exit(1);
 	}
-	exit(0);
+
+	if (nl_msg_hdr.nlmsg_type != INIT_MSG) {
+		pr_perror("Unexpected msg type %d", nl_msg_hdr.nlmsg_type);
+		exit(1);
+	}
+
+	// Retrieve data
+	int  nl_total_size = NLMSG_PAYLOAD(&nl_msg_hdr, 0);
+	char data[nl_total_size];
+
+	if ((len = read(pipenum, data, nl_total_size)) != nl_total_size) {
+		pr_perror("Failed to read netlink payload, %d != %d", len,
+			  nl_total_size);
+		exit(1);
+	}
+
+	process_nl_attributes(pipenum, data, nl_total_size);
 }

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -55,19 +55,12 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	// join any namespaces via a path to the namespace fd if provided
-	if err := joinExistingNamespaces(l.config.Config.Namespaces); err != nil {
-		return err
-	}
 	var console *linuxConsole
 	if l.config.Console != "" {
 		console = newConsoleFromPath(l.config.Console)
 		if err := console.dupStdio(); err != nil {
 			return err
 		}
-	}
-	if _, err := syscall.Setsid(); err != nil {
-		return err
 	}
 	if console != nil {
 		if err := system.Setctty(); err != nil {

--- a/spec.go
+++ b/spec.go
@@ -590,7 +590,10 @@ func setupUserNamespace(spec *specs.LinuxSpec, config *configs.Config) error {
 	if len(spec.Linux.UIDMappings) == 0 {
 		return nil
 	}
-	config.Namespaces.Add(configs.NEWUSER, "")
+	// do not override the specified user namespace path
+	if config.Namespaces.PathOf(configs.NEWUSER) == "" {
+		config.Namespaces.Add(configs.NEWUSER, "")
+	}
 	create := func(m specs.IDMapping) configs.IDMap {
 		return configs.IDMap{
 			HostID:      int(m.HostID),


### PR DESCRIPTION
This is a rebase of https://github.com/opencontainers/runc/pull/105.

It move the `setns` calls within the init C code. This allows for namespaces that only affect future children (e.g. `NEWPID`) to correctly apply to created containers. 
