### PR TITLE
Do not allow access to /dev/tty{0,1}

### DIFF
--- a/libcontainer/configs/device_defaults.go
+++ b/libcontainer/configs/device_defaults.go
@@ -82,20 +82,6 @@ var (
 			Minor:       1,
 			Permissions: "rwm",
 		},
-		{
-			Path:        "/dev/tty0",
-			Type:        'c',
-			Major:       4,
-			Minor:       0,
-			Permissions: "rwm",
-		},
-		{
-			Path:        "/dev/tty1",
-			Type:        'c',
-			Major:       4,
-			Minor:       1,
-			Permissions: "rwm",
-		},
 		// /dev/pts/ - pts namespaces are "coming soon"
 		{
 			Path:        "",


### PR DESCRIPTION
These are the real host devices, container should not generally
have or need them.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>