### PR TITLE
Allow for main process to just be sleep() - aka: no cmd

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -75,6 +75,7 @@ func newContainerInit(t initType, pipe *os.File) (initer, error) {
 		return &linuxStandardInit{
 			parentPid: syscall.Getppid(),
 			config:    config,
+			pipe:      pipe,
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown init type %q", t)


### PR DESCRIPTION
This adds support for starting a container w/o a cmd - which will mean that
it creates the container and then holds on to it forever so the namespaces
and cgroups don't go away. Then the user can then do things like
`runc exec ...` to run whatever other cmds they need to run.
This allows for cases where the container needs to be setup in advance of
knowing what cmds will be run.

Instead of calling system.Execv to run the cmd we just `select {}`, which
sleeps forever.

This assumes that we don't need to have the apparmor stuff kick-in because
there's no risk of this process doing anything bad from this point on.
Is this a safe assumption?  If not, we'll need another way to fork/exec+sleep.

Signed-off-by: Doug Davis <dug@us.ibm.com>