### PR TITLE
Only validate post-hyphen field length on cgroup mounts

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -84,10 +84,19 @@ func FindCgroupMountpointDir() (string, error) {
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
 		index := strings.Index(text, " - ")
 		postSeparatorFields := strings.Fields(text[index+3:])
-		if len(postSeparatorFields) < 3 {
-			return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
+		numPostFields := len(postSeparatorFields)
+
+		// This is an error as we can't detect if the mount is for "cgroup"
+		if numPostFields == 0 {
+			return "", fmt.Errorf("Found no fields post '-' in %q", text)
 		}
+
 		if postSeparatorFields[0] == "cgroup" {
+			// Check that the mount is properly formated.
+			if numPostFields < 3 {
+				return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
+			}
+
 			return filepath.Dir(fields[4]), nil
 		}
 	}


### PR DESCRIPTION
This PR solves an issue where the cgroup mount can't be found because another, non-cgroup, mount doesn't pass the validation. For example:

```
Error found less than 3 fields post '-' in "24 21 0:6 / /home/ec2-user/web/dev ro,relatime - devtmpfs  rw,size=500712k,nr_inodes=125178,mode=755"
```

The validation remains intact for cgroup mounts.