### PR TITLE
Add detach to runc

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -1,0 +1,15 @@
+package main
+
+import "github.com/codegangsta/cli"
+
+var deleteCommand = cli.Command{
+	Name:  "delete",
+	Usage: "delete any resources held by the container often used with detached containers",
+	Action: func(context *cli.Context) {
+		container, err := getContainer(context)
+		if err != nil {
+			fatal(err)
+		}
+		destroy(container)
+	},
+}

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -219,5 +219,8 @@ func (n *createdState) transition(s containerState) error {
 }
 
 func (n *createdState) destroy() error {
-	return nil
+	if err := n.c.refreshState(); err != nil {
+		return err
+	}
+	return n.c.state.destroy()
 }

--- a/main.go
+++ b/main.go
@@ -70,16 +70,18 @@ func main() {
 		},
 	}
 	app.Commands = []cli.Command{
-		startCommand,
 		checkpointCommand,
+		deleteCommand,
 		eventsCommand,
-		restoreCommand,
-		killCommand,
-		specCommand,
-		pauseCommand,
-		resumeCommand,
 		execCommand,
+		execCommand,
+		killCommand,
 		listCommand,
+		pauseCommand,
+		restoreCommand,
+		resumeCommand,
+		specCommand,
+		startCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {


### PR DESCRIPTION
By adding detach to runc the container process is the only thing running
on the system is the containers process.
This allows better usage of memeory and no runc process being long
lived.  With this addition you also need a delete command because the
detached container will not be able to remove state and the left over
cgroups directories.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>