### PR TITLE
Adding the state transition for pause

### DIFF
--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -206,6 +206,10 @@ func (n *nullState) transition(s containerState) error {
 	switch s.(type) {
 	case *restoredState:
 		n.c.state = s
+	case *runningState:
+		n.c.state = s
+	case *pausedState:
+		n.c.state = s
 	default:
 		// do nothing for null states
 	}


### PR DESCRIPTION
While pausing the container, container context is loaded with null state in the factory using Load API
When try to get the status of paused container it always returned as undefined instead of pausedd
Added the paused states for nullTransition. so that when container pause is called paused state is set to the container
Signed-off-by: rajasec <rajasec79@gmail.com>