### PR TITLE
skip non-existant volume host path

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -150,9 +151,8 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 	case "bind":
 		stat, err := os.Stat(m.Source)
 		if err != nil {
-			// error out if the source of a bind mount does not exist as we will be
-			// unable to bind anything to it.
-			return err
+			logrus.Warnf("Non-existant volume host path %s, skip!", m.Source)
+			return nil
 		}
 		// ensure that the destination of the bind mount is resolved of symlinks at mount time because
 		// any previous mounts can invalidate the next mount's destination.


### PR DESCRIPTION
currently, docker create non-existent volume host path automatically.see the code of docker
```
func (m *MountPoint) Setup() (string, error) {
	if m.Volume != nil {
		return m.Volume.Mount()
	}
	if len(m.Source) > 0 {
		if _, err := os.Stat(m.Source); err != nil {
			if !os.IsNotExist(err) {
				return "", err
			}
			if runtime.GOOS != "windows" { // Windows does not have deprecation issues here
				logrus.Warnf("Auto-creating non-existent volume host path %s, this is deprecated and will be removed soon", m.Source)
				if err := system.MkdirAll(m.Source, 0755); err != nil {
					return "", err
				}
			}
		}
		return m.Source, nil
	}
	return "", derr.ErrorCodeMountSetup
}

```
 e.g. 
```
docker run --rm -ti -v /hello:/hello ubuntu bash
```
if the /hello dir don't exist in host, docker will create it to avoid the fail of mount. 

But it is not reasonable.in fact,we can skip non-existant volume host path and remove "MkdirAll" from Setup.

Signed-off-by: yangshukui <yangshukui@huawei.com>