### PR TITLE
Only set cwd when not empty

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -134,8 +134,10 @@ func finalizeNamespace(config *initConfig) error {
 	if err := w.drop(); err != nil {
 		return err
 	}
-	if err := syscall.Chdir(config.Cwd); err != nil {
-		return err
+	if config.Cwd != "" {
+		if err := syscall.Chdir(config.Cwd); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
For existing consumers of libconatiner to not require cwd inside the
libcontainer code.  This can be done at the runc level and is already
evaluated there.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>