### PR TITLE
Fix various state bugs for pause and destroy

### DIFF
--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -16,6 +16,7 @@ const (
 	ContainerPaused
 	ContainerNotStopped
 	ContainerNotRunning
+	ContainerNotPaused
 
 	// Process errors
 	ProcessNotExecuted
@@ -46,6 +47,8 @@ func (c ErrorCode) String() string {
 		return "Container is not running"
 	case ConsoleExists:
 		return "Console exists for process"
+	case ContainerNotPaused:
+		return "Container is not paused"
 	default:
 		return "Unknown error"
 	}

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -203,6 +203,9 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		root:          containerRoot,
 	}
 	c.state = &nullState{c: c}
+	if err := c.refreshState(); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -214,12 +214,7 @@ func (n *nullState) status() Status {
 }
 
 func (n *nullState) transition(s containerState) error {
-	switch s.(type) {
-	case *restoredState:
-		n.c.state = s
-	default:
-		// do nothing for null states
-	}
+	n.c.state = s
 	return nil
 }
 

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -49,6 +49,7 @@ func destroy(c *linuxContainer) error {
 	if herr := runPoststopHooks(c); err == nil {
 		err = herr
 	}
+	c.state = &stoppedState{c: c}
 	return err
 }
 
@@ -116,10 +117,10 @@ func (r *runningState) transition(s containerState) error {
 		}
 		r.c.state = s
 		return nil
-	case *pausedState:
+	case *pausedState, *nullState:
 		r.c.state = s
 		return nil
-	case *runningState, *nullState:
+	case *runningState:
 		return nil
 	}
 	return newStateTransitionError(r, s)
@@ -148,7 +149,7 @@ func (p *pausedState) status() Status {
 
 func (p *pausedState) transition(s containerState) error {
 	switch s.(type) {
-	case *runningState:
+	case *runningState, *stoppedState:
 		p.c.state = s
 		return nil
 	case *pausedState:
@@ -158,6 +159,16 @@ func (p *pausedState) transition(s containerState) error {
 }
 
 func (p *pausedState) destroy() error {
+	isRunning, err := p.c.isRunning()
+	if err != nil {
+		return err
+	}
+	if !isRunning {
+		if err := p.c.cgroupManager.Freeze(configs.Thawed); err != nil {
+			return err
+		}
+		return destroy(p.c)
+	}
 	return newGenericError(fmt.Errorf("container is paused"), ContainerPaused)
 }
 

--- a/libcontainer/state_linux_test.go
+++ b/libcontainer/state_linux_test.go
@@ -49,18 +49,12 @@ func TestPausedStateTransition(t *testing.T) {
 	valid := []containerState{
 		&pausedState{},
 		&runningState{},
+		&stoppedState{},
 	}
 	for _, v := range valid {
 		if err := s.transition(v); err != nil {
 			t.Fatal(err)
 		}
-	}
-	err := s.transition(&stoppedState{})
-	if err == nil {
-		t.Fatal("transition to stopped state should fail")
-	}
-	if !isStateTransitionError(err) {
-		t.Fatal("expected stateTransitionError")
 	}
 }
 


### PR DESCRIPTION
There were issues where a process could die before pausing completed
leaving the container in an inconsistent state and unable to be
destoryed.  This makes sure that if the container is paused and the
process is dead it will unfreeze the cgroup before removing them.

Closes #484 
Closes #470

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>