### PR TITLE
Split start/create

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,125 @@
+// +build linux
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/coreos/go-systemd/activation"
+	"github.com/opencontainers/specs/specs-go"
+)
+
+var batchCommand = cli.Command{
+	Name:  "batch",
+	Usage: "create and run a container with a series of commands",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config-file, c",
+			Value: "config.json",
+			Usage: "path to spec config file",
+		},
+		cli.StringFlag{
+			Name:  "runtime-file, r",
+			Value: "runtime.json",
+			Usage: "path to runtime config file",
+		},
+	},
+	Action: func(context *cli.Context) {
+		spec, err := loadSpec(context.String("config-file"))
+		if err != nil {
+			fatal(err)
+		}
+
+		id := context.Args().First()
+		if id == "" {
+			fatal(errEmptyID)
+		}
+
+		batchFilename := context.Args().Get(1)
+		if batchFilename == "" {
+			fatal(fmt.Errorf("Missing batch-file-name"))
+		}
+
+		notifySocket := os.Getenv("NOTIFY_SOCKET")
+		if notifySocket != "" {
+			setupSdNotify(spec, notifySocket)
+		}
+
+		if os.Geteuid() != 0 {
+			logrus.Fatal("runc should be run as root")
+		}
+
+		status, err := batchContainer(context, id, spec, batchFilename)
+		if err != nil {
+			logrus.Fatalf("Container start failed: %v", err)
+		}
+		// exit with the container's exit status so any external supervisor is
+		// notified of the exit with the correct exit status.
+		os.Exit(status)
+	},
+}
+
+func batchContainer(context *cli.Context, id string, spec *specs.Spec, batchFilename string) (int, error) {
+	var file *os.File
+	var err error
+
+	if batchFilename == "-" {
+		file = os.Stdin
+	} else {
+		if file, err = os.Open(batchFilename); err != nil {
+			return -1, err
+		}
+		defer file.Close()
+	}
+
+	scanner := bufio.NewScanner(file)
+
+	container, err := createContainer(context, id, spec)
+	if err != nil {
+		return -1, err
+	}
+	defer deleteContainer(container)
+
+	// Support on-demand socket activation by passing file descriptors into the container init process.
+	listenFDs := []*os.File{}
+	if os.Getenv("LISTEN_FDS") != "" {
+		listenFDs = activation.Files(false)
+	}
+
+	// Loop over the list of processes that people want executed.
+	// Use the config Process as the template for now
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		proc := specs.Process{
+			Terminal: spec.Process.Terminal,
+			User:     spec.Process.User,
+			Args:     strings.Split(line, " "),
+			Env:      spec.Process.Env,
+			Cwd:      spec.Process.Cwd,
+		}
+
+		if batchFilename == "-" {
+			proc.Terminal = false
+		}
+
+		fmt.Printf("--> %q\n", proc.Args)
+
+		rc, err := runProcess(container, &proc, listenFDs, context.String("console"), context.String("pid-file"), false)
+		if rc != 0 || err != nil {
+			// For now just stop on first error
+			return rc, nil
+		}
+	}
+
+	// All is well
+	return 0, nil
+}

--- a/create.go
+++ b/create.go
@@ -1,0 +1,57 @@
+// +build linux
+
+package main
+
+import (
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
+
+var createCommand = cli.Command{
+	Name:  "create",
+	Usage: "create container",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "bundle, b",
+			Value: "",
+			Usage: "path to the root of the bundle directory",
+		},
+		cli.StringFlag{
+			Name:  "console",
+			Value: "",
+			Usage: "specify the pty slave path for use with the container",
+		},
+	},
+	Action: func(context *cli.Context) {
+		id := context.Args().First()
+		if id == "" {
+			fatal(errEmptyID)
+		}
+
+		bundle := context.String("bundle")
+		if bundle != "" {
+			if err := os.Chdir(bundle); err != nil {
+				fatal(err)
+			}
+		}
+		spec, err := loadSpec(specConfig)
+		if err != nil {
+			fatal(err)
+		}
+
+		notifySocket := os.Getenv("NOTIFY_SOCKET")
+		if notifySocket != "" {
+			setupSdNotify(spec, notifySocket)
+		}
+
+		if os.Geteuid() != 0 {
+			logrus.Fatal("runc should be run as root")
+		}
+		_, err = createContainer(context, id, spec)
+		if err != nil {
+			logrus.Fatalf("Container create failed: %v", err)
+		}
+	},
+}

--- a/delete.go
+++ b/delete.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/codegangsta/cli"
+import (
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
 
 var deleteCommand = cli.Command{
 	Name:  "delete",
@@ -14,11 +19,16 @@ status of "ubuntu01" as "destroyed" the following will delete resources held for
 "ubuntu01" removing "ubuntu01" from the runc list of containers:  
 	 
        # runc delete ubuntu01`,
+	Flags: []cli.Flag{},
 	Action: func(context *cli.Context) {
+		if os.Geteuid() != 0 {
+			logrus.Fatal("runc should be run as root")
+		}
 		container, err := getContainer(context)
 		if err != nil {
-			fatal(err)
+			logrus.Fatalf("Container delete failed: %v", err)
+			os.Exit(-1)
 		}
-		destroy(container)
+		deleteContainer(container)
 	},
 }

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -117,6 +117,9 @@ type BaseContainer interface {
 	// Systemerror - System error.
 	Set(config configs.Config) error
 
+	// Create will setup a new container but not actually run a user process
+	Create(process *Process) (err error)
+
 	// Start a process inside the container. Returns error if process fails to
 	// start. You can track process lifecycle with passed Process structure.
 	//

--- a/libcontainer/create_init_linux.go
+++ b/libcontainer/create_init_linux.go
@@ -16,13 +16,13 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 )
 
-type linuxStandardInit struct {
+type linuxCreateInit struct {
 	pipe      io.ReadWriter
 	parentPid int
 	config    *initConfig
 }
 
-func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
+func (l *linuxCreateInit) getSessionRingParams() (string, uint32, uint32) {
 	var newperms uint32
 
 	if l.config.Config.Namespaces.Contains(configs.NEWUSER) {
@@ -38,11 +38,7 @@ func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
 	return fmt.Sprintf("_ses.%s", l.config.ContainerId), 0xffffffff, newperms
 }
 
-// PR_SET_NO_NEW_PRIVS isn't exposed in Golang so we define it ourselves copying the value
-// the kernel
-const PR_SET_NO_NEW_PRIVS = 0x26
-
-func (l *linuxStandardInit) Init() error {
+func (l *linuxCreateInit) Init() error {
 	ringname, keepperms, newperms := l.getSessionRingParams()
 
 	// do not inherit the parent's session keyring
@@ -147,5 +143,6 @@ func (l *linuxStandardInit) Init() error {
 		return syscall.Kill(syscall.Getpid(), syscall.SIGKILL)
 	}
 
-	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
+	os.Exit(0)
+	return nil
 }

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -22,11 +22,13 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// initType is the reason we're being called - the action should we take
 type initType string
 
 const (
-	initSetns    initType = "setns"
-	initStandard initType = "standard"
+	initCreate   initType = "create"   // Just setting up the namespaces
+	initSetns    initType = "setns"    // Joining and existing container
+	initStandard initType = "standard" // Starting the main proces
 )
 
 type pid struct {
@@ -73,6 +75,12 @@ func newContainerInit(t initType, pipe *os.File) (initer, error) {
 		return nil, err
 	}
 	switch t {
+	case initCreate:
+		return &linuxCreateInit{
+			pipe:      pipe,
+			parentPid: syscall.Getppid(),
+			config:    config,
+		}, nil
 	case initSetns:
 		return &linuxSetnsInit{
 			config: config,

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -123,6 +123,11 @@ func runContainer(config *configs.Config, console string, args ...string) (buffe
 		Stderr: buffers.Stderr,
 	}
 
+	err = container.Create(process)
+	if err != nil {
+		return buffers, -1, err
+	}
+
 	err = container.Start(process)
 	if err != nil {
 		return buffers, -1, err

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -69,13 +69,13 @@ func runPoststopHooks(c *linuxContainer) error {
 	return nil
 }
 
-// stoppedState represents a container is a stopped/destroyed state.
+// stoppedState represents a container is a created/stopped/destroyed state.
 type stoppedState struct {
 	c *linuxContainer
 }
 
 func (b *stoppedState) status() Status {
-	return Destroyed
+	return Created
 }
 
 func (b *stoppedState) transition(s containerState) error {

--- a/libcontainer/state_linux_test.go
+++ b/libcontainer/state_linux_test.go
@@ -6,7 +6,7 @@ import "testing"
 
 func TestStateStatus(t *testing.T) {
 	states := map[containerState]Status{
-		&stoppedState{}:  Destroyed,
+		&stoppedState{}:  Created,
 		&runningState{}:  Running,
 		&restoredState{}: Running,
 		&pausedState{}:   Paused,

--- a/main.go
+++ b/main.go
@@ -81,7 +81,9 @@ func main() {
 		},
 	}
 	app.Commands = []cli.Command{
+		batchCommand,
 		checkpointCommand,
+		createCommand,
 		deleteCommand,
 		eventsCommand,
 		execCommand,
@@ -91,6 +93,7 @@ func main() {
 		pauseCommand,
 		restoreCommand,
 		resumeCommand,
+		runCommand,
 		specCommand,
 		startCommand,
 		stateCommand,

--- a/run.go
+++ b/run.go
@@ -1,0 +1,103 @@
+// +build linux
+
+package main
+
+import (
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/coreos/go-systemd/activation"
+	"github.com/opencontainers/specs/specs-go"
+)
+
+var runCommand = cli.Command{
+	Name:  "run",
+	Usage: "create and run a single command in a new container",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "bundle, b",
+			Value: "",
+			Usage: "path to the root of the bundle directory",
+		},
+		cli.StringFlag{
+			Name:  "console",
+			Value: "",
+			Usage: "specify the pty slave path for use with the container",
+		},
+		cli.BoolFlag{
+			Name:  "detach,d",
+			Usage: "detach from the container's process",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Value: "",
+			Usage: "specify the file to write the process id to",
+		},
+	},
+	Action: func(context *cli.Context) {
+		id := context.Args().First()
+		if id == "" {
+			fatal(errEmptyID)
+		}
+
+		bundle := context.String("bundle")
+		if bundle != "" {
+			if err := os.Chdir(bundle); err != nil {
+				fatal(err)
+			}
+		}
+
+		spec, err := loadSpec(specConfig)
+		if err != nil {
+			fatal(err)
+		}
+
+		notifySocket := os.Getenv("NOTIFY_SOCKET")
+		if notifySocket != "" {
+			setupSdNotify(spec, notifySocket)
+		}
+
+		if os.Geteuid() != 0 {
+			logrus.Fatal("runc should be run as root")
+		}
+
+		status, err := runContainer(context, id, spec, context.Args()[1:])
+		if err != nil {
+			logrus.Fatalf("Container start failed: %v", err)
+		}
+
+		// exit with the container's exit status so any external supervisor is
+		// notified of the exit with the correct exit status.
+		os.Exit(status)
+	},
+}
+
+func runContainer(context *cli.Context, id string, spec *specs.Spec, args []string) (int, error) {
+	container, err := createContainer(context, id, spec)
+	if err != nil {
+		return -1, err
+	}
+
+	detach := context.Bool("detach")
+	if !detach {
+		defer deleteContainer(container) // delete when process dies
+	}
+
+	// Support on-demand socket activation by passing file descriptors into the container init process.
+	listenFDs := []*os.File{}
+
+	if os.Getenv("LISTEN_FDS") != "" {
+		listenFDs = activation.Files(false)
+	}
+
+	proc := specs.Process{
+		Terminal: spec.Process.Terminal,
+		User:     spec.Process.User,
+		Args:     args,
+		Env:      spec.Process.Env,
+		Cwd:      spec.Process.Cwd,
+	}
+
+	return runProcess(container, &proc, listenFDs, context.String("console"), context.String("pid-file"), detach)
+}

--- a/utils.go
+++ b/utils.go
@@ -300,10 +300,29 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcont
 	if err != nil {
 		return nil, err
 	}
-	return factory.Create(id, config)
+	container, err := factory.Create(id, config)
+	if err != nil {
+		return nil, err
+	}
+
+	proc, err := newProcess(spec.Process)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := container.Create(proc); err != nil {
+		return nil, err
+	}
+	return container, nil
 }
 
-// runProcess will create a new process in the specified container
+func deleteContainer(container libcontainer.Container) {
+	if err := container.Destroy(); err != nil {
+		logrus.Error(err)
+	}
+}
+
+// runProcess will create a new process (PID ns) in the specified container
 // by executing the process specified in the 'config'.
 func runProcess(container libcontainer.Container, config *specs.Process, listenFDs []*os.File, console string, pidFile string, detach bool) (int, error) {
 	process, err := newProcess(*config)


### PR DESCRIPTION
First pass at splitting create and start.
`runc create` will create all of the namespaces, except PID.
`runc start` will then run the main proc.
There's `runc delete` too for when you're done.
Also added `runc batch <list of commands file>` to show how you could do create+a series of cmds.
And added `runc run <cmd>` which is like `runc exec` but uses a main proc - again just for demo purposes. Not sure if we want to add batch/run to runc proper but it was an interesting exercise.

Any way, I'm not convinced all of this is correct - i think the new 'mount' property probably needs to go away but I wanted to let people play with it to see how it felt to use create and start separately. 