### PR TITLE
Read all data from pipe in StartInitialization

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -5,6 +5,7 @@ package libcontainer
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -251,6 +252,9 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	if err != nil {
 		return err
 	}
+	// Ensure that we've read everything from the pipe to ensure that the parent
+	// does not get an ECONNRESET after we close it.
+	ioutil.ReadAll(pipe)
 	return i.Init()
 }
 


### PR DESCRIPTION
This reads all data from the parent pipe before closing. Long story short is the Go JSON encoder adds a newline at the end of its generated JSON blob. If the length of the incoming JSON minus the newline is exactly 512, 512+1024, 512+1024+2048, 512+1024+2048+4096, ... bytes, the final newline will not be read and will remain in the pipe. This causes the parent `read` to fail with an `ECONNRESET` because there is still data to be read in the pipe.

IMO this is really just a workaround - the real fix would be to have the Go JSON decoder read the final newline.

See https://github.com/docker/docker/issues/14203#issuecomment-174177790 for more debugging details. 
