### PR TITLE
Fixing removal of checkpointed directory after destroying container

### DIFF
--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -5,7 +5,6 @@ package libcontainer
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -194,11 +193,12 @@ func (r *restoredState) transition(s containerState) error {
 }
 
 func (r *restoredState) destroy() error {
-	if _, err := os.Stat(filepath.Join(r.c.root, "checkpoint")); err != nil {
+	if _, err := os.Stat(r.imageDir); err != nil {
 		if !os.IsNotExist(err) {
 			return err
 		}
 	}
+	defer os.RemoveAll(r.imageDir)
 	return destroy(r.c)
 }
 


### PR DESCRIPTION
@crosbymichael @LK4D4 @mrunalp @hqhq 

Currently terminating an restored container is not cleaning up the checkpoint directory. even though the container is destroyed. it is not cleaning up the checkpoint directory.

func (r *restoredState) destroy() error {
        if _, err := os.Stat(filepath.Join(r.c.root, "checkpoint")); err != nil {

Above code always expects the container to be in /run/opencontainers/containers/runc/checkpoint
Corrected to imageDir which is the place of checkpointed images.

Tested with image-path, where the directory creation is removed after container is destroyed.
Tested with default image path which is checkpoint directory of current working dir.

Note:
As this fix involves removal of checkpointed directory, user need to be little careful while giving the image-path option, if user gives /home, all the images will be stored during checkpoint, but during destroy of container, there is potential loss of /home too. 
I'm planning to address in different PR

Signed-off-by: rajasec <rajasec79@gmail.com>