### PR TITLE
Update list command and created methods

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -65,8 +65,8 @@ type BaseState struct {
 	// InitProcessStartTime is the init process start time in clock cycles since boot time.
 	InitProcessStartTime string `json:"init_process_start"`
 
-	// CreatedTime is the unix timestamp for the creation time of the container in UTC
-	CreatedTime time.Time `json:"created_time"`
+	// Created is the unix timestamp for the creation time of the container in UTC
+	Created time.Time `json:"created"`
 
 	// Config is the container's configuration.
 	Config configs.Config `json:"config"`

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -40,7 +40,7 @@ type linuxContainer struct {
 	m             sync.Mutex
 	criuVersion   int
 	state         containerState
-	createdTime   time.Time
+	created       time.Time
 }
 
 // State represents a running container's state
@@ -120,11 +120,6 @@ func (c *linuxContainer) ID() string {
 	return c.id
 }
 
-// CreatedTime returns the timestamp from when the container was CREATED
-func (c *linuxContainer) CreatedTime() time.Time {
-	return c.createdTime
-}
-
 // Config returns the container's configuration
 func (c *linuxContainer) Config() configs.Config {
 	return *c.config
@@ -198,7 +193,7 @@ func (c *linuxContainer) Start(process *Process) error {
 		return newSystemError(err)
 	}
 	// generate a timestamp indicating when the container was started
-	c.createdTime = time.Now().UTC()
+	c.created = time.Now().UTC()
 
 	c.state = &runningState{
 		c: c,
@@ -1053,7 +1048,7 @@ func (c *linuxContainer) currentState() (*State, error) {
 			Config:               *c.config,
 			InitProcessPid:       pid,
 			InitProcessStartTime: startTime,
-			CreatedTime:          c.createdTime,
+			Created:              c.created,
 		},
 		CgroupPaths:         c.cgroupManager.GetPaths(),
 		NamespacePaths:      make(map[configs.NamespaceType]string),

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -202,7 +202,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		criuPath:      l.CriuPath,
 		cgroupManager: l.NewCgroupsManager(state.Config.Cgroups, state.CgroupPaths),
 		root:          containerRoot,
-		createdTime:   state.CreatedTime,
+		created:       state.Created,
 	}
 	c.state = &createdState{c: c, s: Created}
 	if err := c.refreshState(); err != nil {

--- a/utils.go
+++ b/utils.go
@@ -86,17 +86,6 @@ func containerPreload(context *cli.Context) error {
 	return nil
 }
 
-var factory libcontainer.Factory
-
-func factoryPreload(context *cli.Context) error {
-	f, err := loadFactory(context)
-	if err != nil {
-		return err
-	}
-	factory = f
-	return nil
-}
-
 // loadFactory returns the configured factory instance for execing containers.
 func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	root := context.GlobalString("root")


### PR DESCRIPTION
We don't need a CreatedTime method on the container because it's not
part of the interface and can be received via the state.  We also do not
need to call it CreateTime because the type of this field is time.Time
so we know its time.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>