### PR TITLE
Remove double exec from command list

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,6 @@ func main() {
 		deleteCommand,
 		eventsCommand,
 		execCommand,
-		execCommand,
 		killCommand,
 		listCommand,
 		pauseCommand,


### PR DESCRIPTION
This happened from a bad rebase, sorry.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>