### PR TITLE
Add a compatibility header for CentOS/RHEL 6

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -17,6 +17,7 @@
 #include <sched.h>
 #include <signal.h>
 
+#include <bits/sockaddr.h>
 #include <linux/netlink.h>
 #include <linux/types.h>
 #include <stdint.h>


### PR DESCRIPTION

Under CentOS/RHEL 6, the `linux/netlink.h` header is missing definition for `sa_family_t`. That definition is provided by including `bits/sockaddr.h`.

Under the applied patch, `runc` builds cleanly under the CentOS 6 kernel (`2.6.32-573.12.1.el6.x86_64`) and the CentOS 7 kernel (`3.10.0-327.4.5.el7.x86_64`).

With this patch `runc` works on a stock CentOS/RHEL 6 system (subject to proper `config.json` and `runtime.json` configuration).