### PR TITLE
Remove procStart

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -232,22 +232,18 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	os.Clearenv()
 	var i initer
 	defer func() {
-		// if we have an error during the initialization of the container's init then send it back to the
-		// parent process in the form of an initError.
-		if err != nil {
-			if _, ok := i.(*linuxStandardInit); ok {
-				//  Synchronisation only necessary for standard init.
-				if err := utils.WriteJSON(pipe, syncT{procError}); err != nil {
-					panic(err)
-				}
-			}
-			if err := utils.WriteJSON(pipe, newSystemError(err)); err != nil {
+		// We have an error during the initialization of the container's init,
+		// send it back to the parent process in the form of an initError.
+		// If container's init successed, syscall.Exec will not return, hence
+		// this defer function will never be called.
+		if _, ok := i.(*linuxStandardInit); ok {
+			//  Synchronisation only necessary for standard init.
+			if err := utils.WriteJSON(pipe, syncT{procError}); err != nil {
 				panic(err)
 			}
-		} else {
-			if err := utils.WriteJSON(pipe, syncT{procStart}); err != nil {
-				panic(err)
-			}
+		}
+		if err := utils.WriteJSON(pipe, newSystemError(err)); err != nil {
+			panic(err)
 		}
 		// ensure that this pipe is always closed
 		pipe.Close()

--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -14,7 +14,6 @@ type syncType uint8
 const (
 	procReady syncType = iota
 	procError
-	procStart
 	procRun
 )
 

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -247,8 +247,6 @@ loop:
 			return newSystemError(err)
 		}
 		switch procSync.Type {
-		case procStart:
-			break loop
 		case procReady:
 			if err := p.manager.Set(p.config.Config); err != nil {
 				return newSystemError(err)


### PR DESCRIPTION
It's never used and not needed. Our pipe is created with
syscall.SOCK_CLOEXEC, so pipe will be closed once container
process executed successfully, parent process will read EOF
and continue. If container process got error before executed,
we'll write procError to sync with parent.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>