### PR TITLE
Check IsTerminal before SetRawTerminal

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -55,9 +55,12 @@ func createTty(p *libcontainer.Process, rootuid int, consolePath string) (*tty, 
 	go io.Copy(console, os.Stdin)
 	go io.Copy(os.Stdout, console)
 
-	state, err := term.SetRawTerminal(os.Stdin.Fd())
-	if err != nil {
-		return nil, fmt.Errorf("failed to set the terminal from the stdin: %v", err)
+	var state *term.State
+	if term.IsTerminal(os.Stdin.Fd()) {
+		state, err = term.SetRawTerminal(os.Stdin.Fd())
+		if err != nil {
+			return nil, fmt.Errorf("failed to set the terminal from the stdin: %v", err)
+		}
 	}
 	t := &tty{
 		console: console,


### PR DESCRIPTION
Do not set raw terminal if stdin is not a terminal.
or else it will show this error `Container start failed: failed to set the terminal from the stdin: inappropriate ioctl for device` and failed to start if we call `runc` not via a terminal 

Signed-off-by: Lei Jitang <leijitang@huawei.com>