### PR TITLE
Require container id as arg1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ You can also run specific test cases by:
 
 ### Using:
 
-To run a container, execute `runc start` in the bundle's root directory:
+To run a container with the id "test", execute `runc start` with the containers id as arg one 
+in the bundle's root directory:
+
 ```bash
-runc start
+runc start test
 / $ ps
 PID   USER     COMMAND
 1     daemon   sh
@@ -98,7 +100,7 @@ tar -C rootfs -xf busybox.tar
 * Create `config.json` by using `runc spec`.
 * Execute `runc start` and you should be placed into a shell where you can run `ps`:
 ```
-$ runc start
+$ runc start test
 / # ps
 PID   USER     COMMAND
     1 root     sh
@@ -120,7 +122,7 @@ After=network.target
 [Service]
 CPUQuota=200%
 MemoryLimit=1536M
-ExecStart=/usr/local/bin/runc start
+ExecStart=/usr/local/bin/runc start minecraft
 Restart=on-failure
 WorkingDirectory=/containers/minecraftbuild
 

--- a/exec.go
+++ b/exec.go
@@ -128,7 +128,7 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 		return nil, err
 	}
 	p := spec.Process
-	p.Args = context.Args()
+	p.Args = context.Args()[1:]
 	// override the cwd, if passed
 	if context.String("cwd") != "" {
 		p.Cwd = context.String("cwd")

--- a/kill.go
+++ b/kill.go
@@ -58,7 +58,7 @@ var killCommand = cli.Command{
 			fatal(err)
 		}
 
-		sigstr := context.Args().First()
+		sigstr := context.Args().Get(1)
 		if sigstr == "" {
 			sigstr = "SIGTERM"
 		}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	version    = "0.0.7"
+	version    = "0.0.8"
 	specConfig = "config.json"
 	usage      = `Open Container Initiative runtime
 	

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ After creating config files for your root filesystem with runc, you can execute
 a container in your shell by running:
 
     # cd /mycontainer
-    # runc start [ -b bundle ] 
+    # runc start [ -b bundle ] <container-id>
 
 If not specified, the default value for the 'bundle' is the current directory.
 'Bundle' is the directory where '` + specConfig + `' must be located.`
@@ -39,11 +39,6 @@ func main() {
 	app.Usage = usage
 	app.Version = fmt.Sprintf("%s\nspec version %s", version, specs.Version)
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "id",
-			Value: getDefaultID(),
-			Usage: "specify the ID to be used for the container",
-		},
 		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "enable debug output for logging",

--- a/main_unsupported.go
+++ b/main_unsupported.go
@@ -7,10 +7,6 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-func getDefaultID() string {
-	return ""
-}
-
 var (
 	checkpointCommand cli.Command
 	eventsCommand     cli.Command

--- a/start.go
+++ b/start.go
@@ -93,13 +93,17 @@ func init() {
 }
 
 func startContainer(context *cli.Context, spec *specs.LinuxSpec) (int, error) {
-	config, err := createLibcontainerConfig(context.GlobalString("id"), spec)
+	id := context.Args().First()
+	if id == "" {
+		return -1, errEmptyID
+	}
+	config, err := createLibcontainerConfig(id, spec)
 	if err != nil {
 		return -1, err
 	}
 	if _, err := os.Stat(config.Rootfs); err != nil {
 		if os.IsNotExist(err) {
-			return -1, fmt.Errorf("Rootfs (%q) does not exist", config.Rootfs)
+			return -1, fmt.Errorf("rootfs (%q) does not exist", config.Rootfs)
 		}
 		return -1, err
 	}
@@ -111,7 +115,7 @@ func startContainer(context *cli.Context, spec *specs.LinuxSpec) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	container, err := factory.Create(context.GlobalString("id"), config)
+	container, err := factory.Create(id, config)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Closes #532

This requires the container id to always be passed to all runc commands
as arg one on the cli.  This was the result of the last OCI meeting and
how operations work with the spec.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>