### PR TITLE
Fixing tty reset after container start failure

### DIFF
--- a/start.go
+++ b/start.go
@@ -129,6 +129,8 @@ func startContainer(context *cli.Context, spec *specs.LinuxSpec) (int, error) {
 	if err != nil {
 		return -1, err
 	}
+	handler := newSignalHandler(tty)
+	defer handler.Close()
 	if err := container.Start(process); err != nil {
 		return -1, err
 	}
@@ -142,7 +144,5 @@ func startContainer(context *cli.Context, spec *specs.LinuxSpec) (int, error) {
 	if detach {
 		return 0, nil
 	}
-	handler := newSignalHandler(tty)
-	defer handler.Close()
 	return handler.forward(process)
 }


### PR DESCRIPTION
When I was testing with pid group subsystem, container failed to start due to following errors
The error is expected which is right behavior

WARN[0000] signal: killed
FATA[0000] Container start failed: [10] System error: no such directory for pids.max.

But post container failure, I could not view what I'm typing in that terminal ( though it takes input)

This problem was observed for all container start failure. 

As part of this fix moved the signal handler and tty closure after setupIO. so that even container failed to start tty closures will be proper.

Signed-off-by: rajasec <rajasec79@gmail.com>