### PR TITLE
updating usage for runc, and all runc commands that now use <container id> as the first argument

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -14,6 +14,11 @@ import (
 var checkpointCommand = cli.Command{
 	Name:  "checkpoint",
 	Usage: "checkpoint a running container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+checkpointed.`,
+	Description: `The checkpoint command saves the state of the container instance.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "image-path", Value: "", Usage: "path for saving criu image files"},
 		cli.StringFlag{Name: "work-path", Value: "", Usage: "path for saving work files and logs"},

--- a/delete.go
+++ b/delete.go
@@ -5,6 +5,15 @@ import "github.com/codegangsta/cli"
 var deleteCommand = cli.Command{
 	Name:  "delete",
 	Usage: "delete any resources held by the container often used with detached containers",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container.
+	 
+For example, if the container id is "ubuntu01" and runc list currently shows the
+status of "ubuntu01" as "destroyed" the following will delete resources held for
+"ubuntu01" removing "ubuntu01" from the runc list of containers:  
+	 
+       # runc delete ubuntu01`,
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)
 		if err != nil {

--- a/events.go
+++ b/events.go
@@ -23,6 +23,11 @@ type event struct {
 var eventsCommand = cli.Command{
 	Name:  "events",
 	Usage: "display container events such as OOM notifications, cpu, memory, IO and network stats",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container.`,
+	Description: `The events command displays information about the container. By default the
+information is displayed once every 5 seconds.`,
 	Flags: []cli.Flag{
 		cli.DurationFlag{Name: "interval", Value: 5 * time.Second, Usage: "set the stats collection interval"},
 		cli.BoolFlag{Name: "stats", Usage: "display the container's stats then exit"},

--- a/exec.go
+++ b/exec.go
@@ -18,6 +18,15 @@ import (
 var execCommand = cli.Command{
 	Name:  "exec",
 	Usage: "execute new process inside the container",
+	ArgsUsage: `<container-id> <container command>
+
+Where "<container-id>" is the name for the instance of the container and
+"<container command>" is the command to be executed in the container.
+
+For example, if the container is configured to run the linux ps command the
+following will output a list of processes running in the container:
+	 
+       # runc exec <container-id> ps`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "console",

--- a/kill.go
+++ b/kill.go
@@ -52,6 +52,15 @@ var signalMap = map[string]syscall.Signal{
 var killCommand = cli.Command{
 	Name:  "kill",
 	Usage: "kill sends the specified signal (default: SIGTERM) to the container's init process",
+	ArgsUsage: `<container-id> <signal>
+
+Where "<container-id>" is the name for the instance of the container and
+"<signal>" is the signal to be sent to the init process.
+	 
+For example, if the container id is "ubuntu01" the following will send a "KILL"
+signal to the init process of the "ubuntu01" container:
+	 
+       # runc kill ubuntu01 KILL`,
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)
 		if err != nil {

--- a/list.go
+++ b/list.go
@@ -15,10 +15,37 @@ import (
 	"github.com/opencontainers/runc/libcontainer"
 )
 
+const formatOptions = `table, json, yaml, xml, or "go=<go-template text>"`
+
 var listCommand = cli.Command{
 	Name:  "list",
 	Usage: "lists containers started by runc with the given root",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "format, f",
+			Value: "",
+			Usage: `select one of: ` + formatOptions + `.
+
+The default format is table.  The following will output the list of containers
+in json format:
+
+    # runc list -f json`,
+		},
+	},
 	Action: func(context *cli.Context) {
+		format := context.String("format")
+		if format != "" {
+			switch format {
+			default:
+				logrus.Fatal("invalid format, valid formats are: " + formatOptions)
+			case "":
+				format = "table"
+			case "json", "yaml", "xml":
+			}
+		}
+		//quiet := context.Bool("quiet")
+		//noTrunc := context.Bool("no-trunc")
+
 		factory, err := loadFactory(context)
 		if err != nil {
 			logrus.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -23,14 +23,18 @@ container runtime environment for applications. It can be used with your
 existing process monitoring tools and the container will be spawned as a
 direct child of the process supervisor.
 
-After creating config files for your root filesystem with runc, you can execute 
-a container in your shell by running:
+Containers are configured using bundles. A bundle for a container is a directory
+that includes a specification file named "` + specConfig + `" and a root filesystem.
+The root filesystem contains the contents of the container. 
 
-    # cd /mycontainer
+To start a new instance of a container:
+
     # runc start [ -b bundle ] <container-id>
 
-If not specified, the default value for the 'bundle' is the current directory.
-'Bundle' is the directory where '` + specConfig + `' must be located.`
+Where "<container-id>" is your name for the instance of the container that you
+are starting. The name you provide for the container instance must be unique on
+your host. Providing the bundle directory using "-b" is optional. The default
+value for "bundle" is the current directory.`
 )
 
 func main() {

--- a/pause.go
+++ b/pause.go
@@ -7,6 +7,13 @@ import "github.com/codegangsta/cli"
 var pauseCommand = cli.Command{
 	Name:  "pause",
 	Usage: "pause suspends all processes inside the container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+paused. `,
+	Description: `The pause command suspends all processes in the instance of the container.
+
+Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)
 		if err != nil {
@@ -21,6 +28,13 @@ var pauseCommand = cli.Command{
 var resumeCommand = cli.Command{
 	Name:  "resume",
 	Usage: "resumes all processes that have been previously paused",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+resumed.`,
+	Description: `The resume command resumes all processes in the instance of the container.
+
+Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)
 		if err != nil {

--- a/restore.go
+++ b/restore.go
@@ -17,6 +17,12 @@ import (
 var restoreCommand = cli.Command{
 	Name:  "restore",
 	Usage: "restore a container from a previous checkpoint",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+restored.`,
+	Description: `Restores the saved state of the container instance that was previously saved
+using the runc checkpoint command.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "image-path",

--- a/spec.go
+++ b/spec.go
@@ -23,8 +23,10 @@ import (
 )
 
 var specCommand = cli.Command{
-	Name:  "spec",
-	Usage: "create a new specification file",
+	Name:        "spec",
+	Usage:       "create a new specification file",
+	ArgsUsage:   "",
+	Description: `The spec command creates the new specification file named "` + specConfig + `" for the bundle." `,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "bundle, b",

--- a/start.go
+++ b/start.go
@@ -17,11 +17,18 @@ import (
 var startCommand = cli.Command{
 	Name:  "start",
 	Usage: "create and run a container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is your name for the instance of the container that you
+are starting. The name you provide for the container instance must be unique on
+your host.`,
+	Description: `The start command creates an instance of a container for a bundle. The bundle
+is a directory with a specification file and a root filesystem.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "bundle, b",
 			Value: "",
-			Usage: "path to the root of the bundle directory",
+			Usage: `path to the root of the bundle directory, defaults to the current directory`,
 		},
 		cli.StringFlag{
 			Name:  "console",


### PR DESCRIPTION
Signed-off-by: Mike Brown <brownwm@us.ibm.com>