### PR TITLE
Adding tty closure for restore operation

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -135,12 +135,14 @@ func restoreContainer(context *cli.Context, spec *specs.LinuxSpec, config *confi
 		return -1, err
 	}
 	if err := container.Restore(process, options); err != nil {
+		tty.Close()
 		return -1, err
 	}
 	if pidFile := context.String("pid-file"); pidFile != "" {
 		if err := createPidFile(pidFile, process); err != nil {
 			process.Signal(syscall.SIGKILL)
 			process.Wait()
+			tty.Close()
 			return -1, err
 		}
 	}


### PR DESCRIPTION
@crosbymichael 
Though there is no direct terminal associated with for C/R, added the closure for pipes during failure of container restore
Please let me know your comments.

Signed-off-by: rajasec <rajasec79@gmail.com>