### PR TITLE
Change validation in expandSlice

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -405,11 +405,6 @@ func expandSlice(slice string) (string, error) {
 	var path, prefix string
 	sliceName := strings.TrimSuffix(slice, suffix)
 	for _, component := range strings.Split(sliceName, "-") {
-		// test--a.slice isn't permitted, nor is -test.slice.
-		if component == "" {
-			return "", fmt.Errorf("invalid slice name: %s", slice)
-		}
-
 		// Append the component to the path and to the prefix.
 		path += prefix + component + suffix + "/"
 		prefix += component + "-"


### PR DESCRIPTION
According to https://github.com/systemd/systemd/blob/fdb4ee00f022863ceee923b196f9c6dd536db9e2/src/basic/unit-name.c#L55
unit names like `test--a.slice` and `-test.slice` are valid
for systemd, we have no reason invalid them in runc.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>