### PR TITLE
Remove unneeded cgroups path removal

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -129,11 +129,6 @@ func (m *Manager) Apply(pid int) (err error) {
 	}
 
 	paths := make(map[string]string)
-	defer func() {
-		if err != nil {
-			cgroups.RemovePaths(paths)
-		}
-	}()
 	for _, sys := range subsystems {
 		if err := sys.Apply(d); err != nil {
 			return err


### PR DESCRIPTION
It's handled in `destroy()`, no need to do this in
`Apply()`. I found this because systemd cgroup didn't
do this removal and it works well.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>