### PR TITLE
panic during start of failed detached container

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -135,14 +135,18 @@ func restoreContainer(context *cli.Context, spec *specs.LinuxSpec, config *confi
 		return -1, err
 	}
 	if err := container.Restore(process, options); err != nil {
-		tty.Close()
+		if tty != nil {
+			tty.Close()
+		}
 		return -1, err
 	}
 	if pidFile := context.String("pid-file"); pidFile != "" {
 		if err := createPidFile(pidFile, process); err != nil {
 			process.Signal(syscall.SIGKILL)
 			process.Wait()
-			tty.Close()
+			if tty != nil {
+				tty.Close()
+			}
 			return -1, err
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -308,7 +308,9 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 	}
 
 	if err := container.Start(process); err != nil {
-		tty.Close()
+		if tty != nil {
+			tty.Close()
+		}
 		return -1, err
 	}
 
@@ -316,7 +318,9 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 		if err := createPidFile(pidFile, process); err != nil {
 			process.Signal(syscall.SIGKILL)
 			process.Wait()
-			tty.Close()
+			if tty != nil {
+				tty.Close()
+			}
 			return -1, err
 		}
 	}


### PR DESCRIPTION

Started container in detached mode, since the executable was not in right path, it could not start the container
Since the container started in detached mode, return value of setupIO function was nil.
The container failed to start of incorrect executable path, it tried to close the tty. Derefenced the nil pointer and thrown the below panic condition

Added the nil check before tty closure as part of fix

Below is the panic trace
WARN[0000] os: process already finished
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x410e5d]

goroutine 1 [running]:
main.(*tty).Close(0x0, 0x0, 0x0)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/tty.go:82 +0x12d
main.runProcess(0x7ff6aac62c18, 0xc20809a0c0, 0xc2080366f0, 0xc2080a11a0, 0x0, 0x0, 0xbde148, 0x0, 0xbde148, 0x0, ...)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/utils.go:311 +0x61b
main.startContainer(0xc208001b00, 0xc2080366c0, 0x0, 0x0, 0x0)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/start.go:107 +0x371
main.func·011(0xc208001b00)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/start.go:62 +0x243
github.com/codegangsta/cli.Command.Run(0x7eeb40, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x835690, 0x1a, 0x0, ...)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/codegangsta/cli/command.go:137 +0x1073
github.com/codegangsta/cli.(*App).Run(0xc2080018c0, 0xc20800a000, 0x4, 0x4, 0x0, 0x0)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/codegangsta/cli/app.go:176 +0x11a5
main.main()
        /home/raj/go/pkg/src/github.com/opencontainers/runc/main.go:100 +0x8b9

goroutine 5 [syscall]:
os/signal.loop()
        /usr/local/go/src/os/signal/signal_unix.go:21 +0x1f
created by os/signal.init·1
        /usr/local/go/src/os/signal/signal_unix.go:27 +0x35

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:2232 +0x1

Signed-off-by: rajasec <rajasec79@gmail.com>