### PR TITLE
It's /proc/stat, not /proc/stats

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -308,7 +308,8 @@ func checkMountDestination(rootfs, dest string) error {
 		"/proc/cpuinfo",
 		"/proc/diskstats",
 		"/proc/meminfo",
-		"/proc/stats",
+		"/proc/stat",
+		"/proc/net/dev",
 	}
 	for _, valid := range validDestinations {
 		path, err := filepath.Rel(filepath.Join(rootfs, valid), dest)


### PR DESCRIPTION
Also adds /proc/net/dev to the valid mount destination white list

Signed-off-by: Chun Chen <ramichen@tencent.com>