### PR TITLE
Change softlink name to /dev/core

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -341,7 +341,7 @@ func setupDevSymlinks(rootfs string) error {
 	// kcore support can be toggled with CONFIG_PROC_KCORE; only create a symlink
 	// in /dev if it exists in /proc.
 	if _, err := os.Stat("/proc/kcore"); err == nil {
-		links = append(links, [2]string{"/proc/kcore", "/dev/kcore"})
+		links = append(links, [2]string{"/proc/kcore", "/dev/core"})
 	}
 	for _, link := range links {
 		var (


### PR DESCRIPTION
Host is having /dev/core linked to /proc/kcore
To be consistent with host, changing the link name from /dev/kcore to /dev/core


Signed-off-by: rajasec <rajasec79@gmail.com>