### PR TITLE
Register signal handlers earlier to avoid zombies

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -134,6 +134,8 @@ func restoreContainer(context *cli.Context, spec *specs.LinuxSpec, config *confi
 	if err != nil {
 		return -1, err
 	}
+	handler := newSignalHandler(tty)
+	defer handler.Close()
 	if err := container.Restore(process, options); err != nil {
 		tty.Close()
 		return -1, err
@@ -149,8 +151,6 @@ func restoreContainer(context *cli.Context, spec *specs.LinuxSpec, config *confi
 	if detach {
 		return 0, nil
 	}
-	handler := newSignalHandler(tty)
-	defer handler.Close()
 	return handler.forward(process)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -307,6 +307,9 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 		return -1, err
 	}
 
+	handler := newSignalHandler(tty)
+	defer handler.Close()
+
 	if err := container.Start(process); err != nil {
 		tty.Close()
 		return -1, err
@@ -323,8 +326,6 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 	if detach {
 		return 0, nil
 	}
-	handler := newSignalHandler(tty)
-	defer handler.Close()
 
 	return handler.forward(process)
 }


### PR DESCRIPTION
`newSignalHandler` needs to be called before the process is started, otherwise if
the process exits quickly the SIGCHLD can be recieved (and ignored) before [the signal
handler is set up](https://github.com/opencontainers/runc/blob/master/signals.go#L24). When this happens [the syscall.Wait4](https://github.com/opencontainers/runc/blob/master/signals.go#L59) never runs, the process becomes a zombie, and the exit code isn't returned to the user.

Signed-off-by: Julian Friedman <julz.friedman@uk.ibm.com>