### PR TITLE
Prevent a panic when container fails to start

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -311,7 +311,9 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 	defer handler.Close()
 
 	if err := container.Start(process); err != nil {
-		tty.Close()
+		if tty != nil {
+			tty.Close()
+		}
 		return -1, err
 	}
 
@@ -319,7 +321,9 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 		if err := createPidFile(pidFile, process); err != nil {
 			process.Signal(syscall.SIGKILL)
 			process.Wait()
-			tty.Close()
+			if tty != nil {
+				tty.Close()
+			}
 			return -1, err
 		}
 	}


### PR DESCRIPTION
This occurs when the container was requested to be started in detached
mode and without a tty.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>