### PR TITLE
Do not set devices cgroup entries if in a user namespace

### DIFF
--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -5,6 +5,7 @@ package fs
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/system"
 )
 
 type DevicesGroup struct {
@@ -25,6 +26,10 @@ func (s *DevicesGroup) Apply(d *cgroupData) error {
 }
 
 func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
+	if system.RunningInUserNS() {
+		return nil
+	}
+
 	devices := cgroup.Resources.Devices
 	if len(devices) > 0 {
 		for _, dev := range devices {


### PR DESCRIPTION
When in a non-initial user namespace you cannot update the devices
cgroup whitelist (or blacklist).  The kernel won't allow it.  So
detect that case and don't try.

This is a step to being able to run docker/runc containers inside a user
namespaced container.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>