### PR TITLE
Removing tty0 tty1 from allowed devices

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -92,22 +92,6 @@ var allowedDevices = []*configs.Device{
 		Permissions: "rwm",
 		Allow:       true,
 	},
-	{
-		Path:        "/dev/tty0",
-		Type:        'c',
-		Major:       4,
-		Minor:       0,
-		Permissions: "rwm",
-		Allow:       true,
-	},
-	{
-		Path:        "/dev/tty1",
-		Type:        'c',
-		Major:       4,
-		Minor:       1,
-		Permissions: "rwm",
-		Allow:       true,
-	},
 	// /dev/pts/ - pts namespaces are "coming soon"
 	{
 		Path:        "",


### PR DESCRIPTION
Removing the host devices tty0 and tty1 from allowed devices.

Signed-off-by: rajasec <rajasec79@gmail.com>