### PR TITLE
Move pre-start hooks after container mounts

### DIFF
--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -15,6 +15,8 @@ const (
 	procReady syncType = iota
 	procError
 	procRun
+	procHooks
+	procResume
 )
 
 type syncT struct {

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -72,7 +72,7 @@ func (l *linuxStandardInit) Init() error {
 	label.Init()
 	// InitializeMountNamespace() can be executed only for a new mount namespace
 	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
-		if err := setupRootfs(l.config.Config, console); err != nil {
+		if err := setupRootfs(l.config.Config, console, l.pipe); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Today mounts in pre-start hooks get overriden by the default mounts.
Moving the pre-start hooks to after the container mounts and before
the pivot/move root gives better flexiblity in the hooks.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>