### PR TITLE
Fix CgroupsPath interpretation

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -341,10 +341,11 @@ func createCgroupConfig(name string, spec *specs.LinuxSpec) (*configs.Cgroup, er
 		if err != nil {
 			return nil, err
 		}
+		myCgroupPath = filepath.Join(myCgroupPath, name)
 	}
 
 	c := &configs.Cgroup{
-		Path:      filepath.Join(myCgroupPath, name),
+		Path:      myCgroupPath,
 		Resources: &configs.Resources{},
 	}
 	c.Resources.AllowedDevices = allowedDevices

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,39 @@
+// build +linux
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/specs"
+)
+
+func TestLinuxCgroupsPathSpecified(t *testing.T) {
+	cgroupsPath := "/user/cgroups/path/id"
+
+	spec := &specs.LinuxSpec{}
+	spec.Linux.CgroupsPath = &cgroupsPath
+
+	cgroup, err := createCgroupConfig("ContainerID", spec)
+	if err != nil {
+		t.Errorf("Couldn't create Cgroup config: %v", err)
+	}
+
+	if cgroup.Path != cgroupsPath {
+		t.Errorf("Wrong cgroupsPath, expected '%s' got '%s'", cgroupsPath, cgroup.Path)
+	}
+}
+
+func TestLinuxCgroupsPathNotSpecified(t *testing.T) {
+	spec := &specs.LinuxSpec{}
+
+	cgroup, err := createCgroupConfig("ContainerID", spec)
+	if err != nil {
+		t.Errorf("Couldn't create Cgroup config: %v", err)
+	}
+
+	if !strings.HasSuffix(cgroup.Path, "/ContainerID") {
+		t.Errorf("Wrong cgroupsPath, expected it to have suffix '%s' got '%s'", "/ContainerID", cgroup.Path)
+	}
+}


### PR DESCRIPTION
When CgroupsPath code was introduced with #497 it was mistakenly made
to act as the equivalent of docker CgroupsParent. This ensure that it
is taken as the final cgroup path.

A couple of unit tests have been added to prevent future regression.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--- 

This basically fix a mistake I made within #497. I somehow only realized this now while trying to use v0.0.8 with docker.
