### PR TITLE
Passing pid for user name space check

### DIFF
--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -11,6 +11,12 @@ import (
 type DevicesGroup struct {
 }
 
+type CgroupParams struct {
+	initpid int
+}
+
+var cg CgroupParams
+
 func (s *DevicesGroup) Name() string {
 	return "devices"
 }
@@ -22,11 +28,16 @@ func (s *DevicesGroup) Apply(d *cgroupData) error {
 		// cgroup is hard requirement for container's security.
 		return err
 	}
+	cg = CgroupParams{initpid: d.pid}
 	return nil
+}
+func (c *CgroupParams) getCgroupParams() int {
+	return c.initpid
 }
 
 func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if system.RunningInUserNS() {
+	initpid := cg.getCgroupParams()
+	if system.RunningInUserNS(initpid) {
 		return nil
 	}
 

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -399,7 +399,8 @@ func reOpenDevNull() error {
 
 // Create the device nodes in the container.
 func createDevices(config *configs.Config) error {
-	useBindMount := system.RunningInUserNS() || config.Namespaces.Contains(configs.NEWUSER)
+	pid := os.Getpid()
+	useBindMount := system.RunningInUserNS(pid) || config.Namespaces.Contains(configs.NEWUSER)
 	oldMask := syscall.Umask(0000)
 	for _, node := range config.Devices {
 		// containers running in a user namespace are not allowed to mknod

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -83,8 +83,9 @@ func Setctty() error {
  * Detect whether we are currently running in a user namespace.
  * Copied from github.com/lxc/lxd/shared/util.go
  */
-func RunningInUserNS() bool {
-	file, err := os.Open("/proc/self/uid_map")
+func RunningInUserNS(pid int) bool {
+	path := fmt.Sprintf("/proc/%d/uid_map", pid)
+	file, err := os.Open(path)
 	if err != nil {
 		/*
 		 * This kernel-provided file only exists if user namespaces are


### PR DESCRIPTION
With current implementation in devices.go file, it is checking for system.RunningInUserNS
If the intent of this change calling this function is to check for container name space
then RunningInUserNs will always return false when it is called from Set Interface, because as runc executes this call, /proc/self is runc here. so it give false even though the container runs in user name space
Added the pid of the container as part of this function.

Signed-off-by: rajasec <rajasec79@gmail.com>