### PR TITLE
Create unique session key name for every container

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -324,6 +324,7 @@ func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 		Console:          process.consolePath,
 		Capabilities:     process.Capabilities,
 		PassedFilesCount: len(process.ExtraFiles),
+		ContainerId:      c.ID(),
 	}
 }
 

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -53,6 +53,7 @@ type initConfig struct {
 	Console          string          `json:"console"`
 	Networks         []*network      `json:"network"`
 	PassedFilesCount int             `json:"passed_files_count"`
+	ContainerId      string          `json:"containerid"`
 }
 
 type initer interface {

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -3,6 +3,7 @@
 package libcontainer
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
@@ -18,9 +19,13 @@ type linuxSetnsInit struct {
 	config *initConfig
 }
 
+func (l *linuxSetnsInit) getSessionRingName() string {
+	return fmt.Sprintf("_ses.%s", l.config.ContainerId)
+}
+
 func (l *linuxSetnsInit) Init() error {
 	// do not inherit the parent's session keyring
-	if _, err := keyctl.JoinSessionKeyring("_ses"); err != nil {
+	if _, err := keyctl.JoinSessionKeyring(l.getSessionRingName()); err != nil {
 		return err
 	}
 	if err := setupRlimits(l.config.Config); err != nil {


### PR DESCRIPTION
Create a unique session key name for every container. Use the pattern
_ses.<postfix> with postfix being maximum 12 characters of the container's
Id.

This patch does not prevent containers from joining each other's session
keyring.

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>