### PR TITLE
Make sure container is destroyed on error

### DIFF
--- a/start.go
+++ b/start.go
@@ -111,5 +111,10 @@ func startContainer(context *cli.Context, spec *specs.LinuxSpec) (int, error) {
 		listenFDs = activation.Files(false)
 	}
 
-	return runProcess(container, &spec.Process, listenFDs, context.String("console"), context.String("pid-file"), detach)
+	status, err := runProcess(container, &spec.Process, listenFDs, context.String("console"), context.String("pid-file"), detach)
+	if err != nil {
+		destroy(container)
+		return -1, err
+	}
+	return status, nil
 }


### PR DESCRIPTION
Even in the detach usecase we need to make sure that the contianer is
destroyed if there is an error starting the container or anywhere in
that workflow.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>