### PR TITLE
Add bundle to runc list

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 
@@ -79,19 +78,17 @@ func execProcess(context *cli.Context) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-
-	var (
-		detach = context.Bool("detach")
-		rootfs = container.Config().Rootfs
-	)
-
-	p, err := getProcess(context, path.Dir(rootfs))
+	detach := context.Bool("detach")
+	state, err := container.State()
 	if err != nil {
 		return -1, err
 	}
-
+	bundle := searchLabels(state.Config.Labels, "bundle")
+	p, err := getProcess(context, bundle)
+	if err != nil {
+		return -1, err
+	}
 	return runProcess(container, p, nil, context.String("console"), context.String("pid-file"), detach)
-
 }
 
 func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -180,6 +180,9 @@ type Config struct {
 
 	// Version is the version of opencontainer specification that is supported.
 	Version string `json:"version"`
+
+	// Labels are user defined metadata that is stored in the config and populated on the state
+	Labels []string `json:"labels"`
 }
 
 type Hooks struct {

--- a/list.go
+++ b/list.go
@@ -117,20 +117,20 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 				ID:             state.BaseState.ID,
 				InitProcessPid: state.BaseState.InitProcessPid,
 				Status:         containerStatus.String(),
-				Bundle:         getBundlePath(state.Config.Labels),
+				Bundle:         searchLabels(state.Config.Labels, "bundle"),
 				Created:        state.BaseState.Created})
 		}
 	}
 	return s, nil
 }
 
-func getBundlePath(labels []string) string {
+func searchLabels(labels []string, query string) string {
 	for _, l := range labels {
 		parts := strings.SplitN(l, "=", 2)
-		if len(parts) < 1 {
+		if len(parts) < 2 {
 			continue
 		}
-		if parts[0] == "bundle" {
+		if parts[0] == query {
 			return parts[1]
 		}
 	}

--- a/list.go
+++ b/list.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -21,15 +22,14 @@ const formatOptions = `table or json`
 // containerState represents the platform agnostic pieces relating to a
 // running container's status and state
 type containerState struct {
-	// ID is the container ID.
+	// ID is the container ID
 	ID string `json:"id"`
-
-	// InitProcessPid is the init process id in the parent namespace.
+	// InitProcessPid is the init process id in the parent namespace
 	InitProcessPid int `json:"pid"`
-
 	// Status is the current status of the container, running, paused, ...
 	Status string `json:"status"`
-
+	// Bundle is the path on the filesystem to the bundle
+	Bundle string `json:"bundle"`
 	// Created is the unix timestamp for the creation time of the container in UTC
 	Created time.Time `json:"created"`
 }
@@ -58,12 +58,13 @@ in json format:
 		switch context.String("format") {
 		case "", "table":
 			w := tabwriter.NewWriter(os.Stdout, 12, 1, 3, ' ', 0)
-			fmt.Fprint(w, "ID\tPID\tSTATUS\tCREATED\n")
+			fmt.Fprint(w, "ID\tPID\tSTATUS\tBUNDLE\tCREATED\n")
 			for _, item := range s {
-				fmt.Fprintf(w, "%s\t%d\t%s\t%s\n",
+				fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n",
 					item.ID,
 					item.InitProcessPid,
 					item.Status,
+					item.Bundle,
 					item.Created.Format(time.RFC3339Nano))
 			}
 			if err := w.Flush(); err != nil {
@@ -116,8 +117,22 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 				ID:             state.BaseState.ID,
 				InitProcessPid: state.BaseState.InitProcessPid,
 				Status:         containerStatus.String(),
+				Bundle:         getBundlePath(state.Config.Labels),
 				Created:        state.BaseState.Created})
 		}
 	}
 	return s, nil
+}
+
+func getBundlePath(labels []string) string {
+	for _, l := range labels {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) < 1 {
+			continue
+		}
+		if parts[0] == "bundle" {
+			return parts[1]
+		}
+	}
+	return ""
 }

--- a/spec.go
+++ b/spec.go
@@ -231,7 +231,12 @@ func loadSpec(cPath string) (spec *specs.LinuxSpec, err error) {
 }
 
 func createLibcontainerConfig(cgroupName string, spec *specs.LinuxSpec) (*configs.Config, error) {
-	cwd, err := os.Getwd()
+	// runc's cwd will always be the bundle path
+	rcwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	cwd, err := filepath.Abs(rcwd)
 	if err != nil {
 		return nil, err
 	}
@@ -244,6 +249,9 @@ func createLibcontainerConfig(cgroupName string, spec *specs.LinuxSpec) (*config
 		Capabilities: spec.Linux.Capabilities,
 		Readonlyfs:   spec.Root.Readonly,
 		Hostname:     spec.Hostname,
+		Labels: []string{
+			"bundle=" + cwd,
+		},
 	}
 
 	exists := false


### PR DESCRIPTION
This adds the bundle path to runc list via labels added to the libcontainer config.  This allows any type of information to be added to the container and its state.

Fixes #548  
Closes #559 