### PR TITLE
Update masked and ro paths

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -286,15 +286,9 @@ func createLibcontainerConfig(cgroupName string, spec *specs.LinuxSpec) (*config
 		return nil, err
 	}
 	config.Cgroups = c
-	if config.Readonlyfs {
-		setReadonly(config)
-		config.MaskPaths = []string{
-			"/proc/kcore",
-		}
-		config.ReadonlyPaths = []string{
-			"/proc/sys", "/proc/sysrq-trigger", "/proc/irq", "/proc/bus",
-		}
-	}
+	// set extra path masking for libcontainer for the various unsafe places in proc
+	config.MaskPaths = maskedPaths
+	config.ReadonlyPaths = readonlyPaths
 	seccomp, err := setupSeccomp(&spec.Linux.Seccomp)
 	if err != nil {
 		return nil, err

--- a/utils.go
+++ b/utils.go
@@ -120,6 +120,23 @@ var allowedDevices = []*configs.Device{
 	},
 }
 
+var (
+	maskedPaths = []string{
+		"/proc/kcore",
+		"/proc/latency_stats",
+		"/proc/timer_stats",
+		"/proc/sched_debug",
+	}
+	readonlyPaths = []string{
+		"/proc/asound",
+		"/proc/bus",
+		"/proc/fs",
+		"/proc/irq",
+		"/proc/sys",
+		"/proc/sysrq-trigger",
+	}
+)
+
 var container libcontainer.Container
 
 func containerPreload(context *cli.Context) error {


### PR DESCRIPTION
This updates the current list to what we have now in docker and also
makes these always added so that these are masked out.  Privileged
containers can always unmount these if they want to read from kcore or
something like that.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>