### PR TITLE
Use single decoder instance for one stream

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -241,9 +241,10 @@ func (p *initProcess) start() (err error) {
 		ierr       *genericError
 	)
 
+	dec := json.NewDecoder(p.parentPipe)
 loop:
 	for {
-		if err := json.NewDecoder(p.parentPipe).Decode(&procSync); err != nil {
+		if err := dec.Decode(&procSync); err != nil {
 			if err == io.EOF {
 				break loop
 			}
@@ -281,7 +282,7 @@ loop:
 		case procError:
 			// wait for the child process to fully complete and receive an error message
 			// if one was encoutered
-			if err := json.NewDecoder(p.parentPipe).Decode(&ierr); err != nil && err != io.EOF {
+			if err := dec.Decode(&ierr); err != nil && err != io.EOF {
 				return newSystemError(err)
 			}
 			if ierr != nil {


### PR DESCRIPTION
Sometimes when the process finishes, runc fails with error like:

error: [10] System error: invalid character 'a' looking for beginning of value

This is because part of encoded string was read and abandoned when decoding a smaller type.

This fix will avoid part of the stream be read and abandomed by using a single instance of Decoder
for the stream.

Signed-off-by: Hushan Jia <hushan.jia@gmail.com>