### PR TITLE
Create pid file when not exist

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -261,7 +261,7 @@ func createPidFile(path string, process *libcontainer.Process) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently pid-file over riding the previous container pid-file and moreover there is chance of over riding the host files using create. added the fix to create the file only if not exists
Signed-off-by: rajasec <rajasec79@gmail.com>