### PR TITLE
Fix to allow for build in different path

### DIFF
--- a/libcontainer/stacktrace/capture_test.go
+++ b/libcontainer/stacktrace/capture_test.go
@@ -1,6 +1,9 @@
 package stacktrace
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func captureFunc() Stacktrace {
 	return Capture(0)
@@ -18,7 +21,8 @@ func TestCaptureTestFunc(t *testing.T) {
 	if expected := "captureFunc"; frame.Function != expected {
 		t.Fatalf("expteced function %q but recevied %q", expected, frame.Function)
 	}
-	if expected := "github.com/opencontainers/runc/libcontainer/stacktrace"; frame.Package != expected {
+	expected := "github.com/opencontainers/runc/libcontainer/stacktrace"
+	if !strings.HasSuffix(frame.Package, expected) {
 		t.Fatalf("expected package %q but received %q", expected, frame.Package)
 	}
 	if expected := "capture_test.go"; frame.File != expected {


### PR DESCRIPTION
The path in the stacktrace might not be:
  "github.com/opencontainers/runc/libcontainer/stacktrace"
For example, for me its:
  "_/go/src/github.com/opencontainers/runc/libcontainer/stacktrace"
so I changed the check to make sure the tail end of the path matches instead
of the entire thing

Signed-off-by: Doug Davis <dug@us.ibm.com>