### PR TITLE
Properly setuid/setgid after entering userns

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -325,9 +325,10 @@ func setupRlimits(config *configs.Config) error {
 	return nil
 }
 
-func setOomScoreAdj(oomScoreAdj int) error {
-	path := "/proc/self/oom_score_adj"
-	return ioutil.WriteFile(path, []byte(strconv.Itoa(oomScoreAdj)), 0700)
+func setOomScoreAdj(oomScoreAdj int, pid int) error {
+	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+
+	return ioutil.WriteFile(path, []byte(strconv.Itoa(oomScoreAdj)), 0600)
 }
 
 // killCgroupProcesses freezes then iterates over all the processes inside the

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -368,6 +368,16 @@ static void process_nl_attributes(int pipenum, char *data, int data_size)
 			exit(1);
 		}
 
+		if (setuid(0) == -1) {
+			pr_perror("setuid failed");
+			exit(1);
+		}
+
+		if (setgid(0) == -1) {
+			pr_perror("setgid failed");
+			exit(1);
+		}
+
 		if (consolefd != -1) {
 			if (ioctl(consolefd, TIOCSCTTY, 0) == -1) {
 				pr_perror("ioctl TIOCSCTTY failed");

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -88,6 +88,10 @@ func (p *setnsProcess) start() (err error) {
 	if err := utils.WriteJSON(p.parentPipe, p.config); err != nil {
 		return newSystemError(err)
 	}
+	// set oom_score_adj
+	if err := setOomScoreAdj(p.config.Config.OomScoreAdj, p.pid()); err != nil {
+		return newSystemError(err)
+	}
 
 	if err := syscall.Shutdown(int(p.parentPipe.Fd()), syscall.SHUT_WR); err != nil {
 		return newSystemError(err)
@@ -274,6 +278,10 @@ loop:
 		switch procSync.Type {
 		case procReady:
 			if err := p.manager.Set(p.config.Config); err != nil {
+				return newSystemError(err)
+			}
+			// set oom_score_adj
+			if err := setOomScoreAdj(p.config.Config.OomScoreAdj, p.pid()); err != nil {
 				return newSystemError(err)
 			}
 			// call prestart hooks

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -31,9 +31,6 @@ func (l *linuxSetnsInit) Init() error {
 	if err := setupRlimits(l.config.Config); err != nil {
 		return err
 	}
-	if err := setOomScoreAdj(l.config.Config.OomScoreAdj); err != nil {
-		return err
-	}
 	if l.config.NoNewPrivileges {
 		if err := system.Prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
 			return err

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -76,9 +76,7 @@ func (l *linuxStandardInit) Init() error {
 	if err := setupRlimits(l.config.Config); err != nil {
 		return err
 	}
-	if err := setOomScoreAdj(l.config.Config.OomScoreAdj); err != nil {
-		return err
-	}
+
 	label.Init()
 	// InitializeMountNamespace() can be executed only for a new mount namespace
 	if l.config.Config.Namespaces.Contains(configs.NEWNS) {


### PR DESCRIPTION
The re-work of namespace entering lost the setuid/setgid that was part
of the Go-routine based process exec in the prior code. A side issue was
found with setting oom_score_adj before execve() in a userns that is
also solved here.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)