### PR TITLE
Eliminate redundant parsing of mountinfo

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -23,6 +23,9 @@ func FindCgroupMountpoint(subsystem string) (string, error) {
 	// We are not using mount.GetMounts() because it's super-inefficient,
 	// parsing it directly sped up x10 times because of not using Sscanf.
 	// It was one of two major performance drawbacks in container start.
+	if !isSubsystemAvailable(subsystem) {
+		return "", NewNotFoundError(subsystem)
+	}
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return "", err
@@ -47,6 +50,9 @@ func FindCgroupMountpoint(subsystem string) (string, error) {
 }
 
 func FindCgroupMountpointAndRoot(subsystem string) (string, string, error) {
+	if !isSubsystemAvailable(subsystem) {
+		return "", "", NewNotFoundError(subsystem)
+	}
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return "", "", err
@@ -68,6 +74,15 @@ func FindCgroupMountpointAndRoot(subsystem string) (string, string, error) {
 	}
 
 	return "", "", NewNotFoundError(subsystem)
+}
+
+func isSubsystemAvailable(subsystem string) bool {
+	cgroups, err := ParseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		return false
+	}
+	_, avail := cgroups[subsystem]
+	return avail
 }
 
 func FindCgroupMountpointDir() (string, error) {
@@ -124,7 +139,8 @@ func (m Mount) GetThisCgroupDir(cgroups map[string]string) (string, error) {
 func getCgroupMountsHelper(ss map[string]bool, mi io.Reader) ([]Mount, error) {
 	res := make([]Mount, 0, len(ss))
 	scanner := bufio.NewScanner(mi)
-	for scanner.Scan() {
+	numFound := 0
+	for scanner.Scan() && numFound < len(ss) {
 		txt := scanner.Text()
 		sepIdx := strings.Index(txt, " - ")
 		if sepIdx == -1 {
@@ -139,12 +155,15 @@ func getCgroupMountsHelper(ss map[string]bool, mi io.Reader) ([]Mount, error) {
 			Root:       fields[3],
 		}
 		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
+			if !ss[opt] {
+				continue
+			}
 			if strings.HasPrefix(opt, cgroupNamePrefix) {
 				m.Subsystems = append(m.Subsystems, opt[len(cgroupNamePrefix):])
-			}
-			if ss[opt] {
+			} else {
 				m.Subsystems = append(m.Subsystems, opt)
 			}
+			numFound++
 		}
 		res = append(res, m)
 	}
@@ -161,13 +180,13 @@ func GetCgroupMounts() ([]Mount, error) {
 	}
 	defer f.Close()
 
-	all, err := GetAllSubsystems()
+	all, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		return nil, err
 	}
 
 	allMap := make(map[string]bool)
-	for _, s := range all {
+	for s := range all {
 		allMap[s] = true
 	}
 	return getCgroupMountsHelper(allMap, f)


### PR DESCRIPTION
Fixes #631 (and the corresponding issue docker/docker#20851). The solutions here are:

1. Skip parsing of `mountinfo` in [FindCgroupMountpoint()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/cgroups/utils.go#L22) and [FindCgroupMountpointAndRoot()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/cgroups/utils.go#L49) when a given cgroup subsystem is not enabled. The check is done by testing the subsystem is included in a result of [ParseCgroupFile()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/cgroups/utils.go#L246).
2. Break the parsing loop in [FindCgroupMountpointDir()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/cgroups/utils.go#L73) when all the cgroup subsystems are found.
3. Skip parsing of `mountinfo` in [getSelinuxMountPoint()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/selinux/selinux.go#L55) when the mount point is found, instead of invoking [mount.GetMounts()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/selinux/selinux.go#L61).
4. Postpone parsing `mountinfo` by invoking [rootfsParentMountPrivate()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/rootfs_linux.go#L507) and [getParentMount()](https://github.com/opencontainers/runc/blob/177f2c405cc0f4fc027f7210675350e9be2b515c/libcontainer/rootfs_linux.go#L475) until `pivot_root()` actually fails.