### PR TITLE
Fix build error on centos6

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/limits.h>
+#include <sys/socket.h>
 #include <linux/netlink.h>
 #include <sched.h>
 #include <setjmp.h>
@@ -12,7 +13,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Build failed on centos6:

```sh
#make
...
# github.com/opencontainers/runc/libcontainer/nsenter
In file included from Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c:6:
/usr/include/linux/netlink.h:35: error: expected specifier-qualifier-list before 'sa_family_t'
```

PR fix the error.

Signed-off-by: Ye Yin <eyniy@qq.com>