### PR TITLE
Eliminating checkpoint state in container

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -27,9 +27,6 @@ const (
 	// The container exists, but all its processes are paused.
 	Paused
 
-	// The container exists, but its state is saved on disk
-	Checkpointed
-
 	// The container does not exist.
 	Destroyed
 )
@@ -44,8 +41,6 @@ func (s Status) String() string {
 		return "pausing"
 	case Paused:
 		return "paused"
-	case Checkpointed:
-		return "checkpointed"
 	case Destroyed:
 		return "destroyed"
 	default:


### PR DESCRIPTION
As per the state implementation currently checkpoint is not an state transition. Upon checkpoint we are cleaning up the state.json  & respective directory too. Eliminated the string corresponding to checkpoint.

Signed-off-by: Rajasekaran <rajasec79@gmail.com>