### PR TITLE
When user namespace is enabled, clear the read-only mount flag.

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -192,6 +192,10 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			}
 		}
 	case "cgroup":
+		// cgroup remount fails, when usernamespace is enabled as ro. Clear the flag.
+		if system.RunningInUserNS() {
+			m.Flags &= ^syscall.MS_RDONLY
+		}
 		binds, err := getCgroupMounts(m)
 		if err != nil {
 			return err


### PR DESCRIPTION
There's a known issue with user namespaces, where cgroup ro mounts
cause permission issues mounting containers. So clear out the ro flag.

Reference: https://github.com/docker/docker/blob/df2b74188ec51422e84ec1dbdc58abf08c215019/daemon/execdriver/native/create.go#L244

Signed-off-by: Anusha Ragunathan <anusha@docker.com>