### PR TITLE
Cleanup currentState

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1060,17 +1060,12 @@ func (c *linuxContainer) currentState() (*State, error) {
 		ExternalDescriptors: externalDescriptors,
 	}
 	if pid > 0 {
-		for _, ns := range c.config.Namespaces {
-			state.NamespacePaths[ns.Type] = ns.GetPath(pid)
-		}
 		for _, nsType := range configs.NamespaceTypes() {
 			if !configs.IsNamespaceSupported(nsType) {
 				continue
 			}
-			if _, ok := state.NamespacePaths[nsType]; !ok {
-				ns := configs.Namespace{Type: nsType}
-				state.NamespacePaths[ns.Type] = ns.GetPath(pid)
-			}
+			ns := configs.Namespace{Type: nsType}
+			state.NamespacePaths[ns.Type] = ns.GetPath(pid)
 		}
 	}
 	return state, nil


### PR DESCRIPTION
configs.NamespaceTypes will cover all namespaces, no need to
range from config.Namespaces.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>