### PR TITLE
cgroup namespaces: ignore the mount.Root if we have cgroup namespaces

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -145,6 +145,14 @@ func getCgroupMountsHelper(ss map[string]bool, mi io.Reader) ([]Mount, error) {
 			if ss[opt] {
 				m.Subsystems = append(m.Subsystems, opt)
 			}
+			if strings.HasPrefix(opt, "nsroot=") {
+				nsroot := opt[7:]
+				if nsroot == m.Root {
+					m.Root = "/"
+				} else if len(nsroot) > 1 && strings.HasPrefix(m.Root, nsroot) {
+					m.Root = m.Root[len(nsroot):]
+				}
+			}
 		}
 		res = append(res, m)
 	}


### PR DESCRIPTION
In a cgroup namespace, you can mount cgroupfs, and your namespace
root (say /docker1) becomes the root of the cgroup filesystem.  This
shows up as field 3 in the mountinfo.  This is unfortunately
ambiguous with a cgroupfs bind mount, and in this case we cannot use
that root as a prefix for our cgroup, since as far as we are concerned
our cgroup is '/', not '/docker1'.

So if cgroup namespaces are enabled (/proc/$$/ns/cgroup exists), then
assume that we haven't done any silly cgroupfs bind mount trickery,
and ignore the fs root field.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>