### PR TITLE
Stub RunningInUserNS for non-Linux

### DIFF
--- a/libcontainer/system/unsupported.go
+++ b/libcontainer/system/unsupported.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package system
+
+// RunningInUserNS is a stub for non-Linux systems
+// Always returns false
+func RunningInUserNS() bool {
+	return false
+}


### PR DESCRIPTION
Add a stub for non-Linux that always returns false

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)