### PR TITLE
Handling error condition in loadspec

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -220,12 +220,12 @@ func loadSpec(cPath string) (spec *specs.LinuxSpec, err error) {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("JSON specification file %s not found", cPath)
 		}
-		return spec, err
+		return nil, err
 	}
 	defer cf.Close()
 
 	if err = json.NewDecoder(cf).Decode(&spec); err != nil {
-		return spec, err
+		return nil, err
 	}
 	return spec, validateSpec(spec)
 }


### PR DESCRIPTION
When there is failure in loadpsec function, return nil instead of spec
Signed-off-by: Rajasekaran <rajasec79@gmail.com>