### PR TITLE
Adding spec validation for exec and start

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -118,7 +118,7 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 		if err := json.NewDecoder(f).Decode(&p); err != nil {
 			return nil, err
 		}
-		return &p, nil
+		return &p, validateProcessSpec(&p)
 	}
 	// process via cli flags
 	if err := os.Chdir(bundle); err != nil {

--- a/spec.go
+++ b/spec.go
@@ -197,18 +197,6 @@ var mountPropagationMapping = map[string]int{
 	"":         syscall.MS_PRIVATE | syscall.MS_REC,
 }
 
-// validateSpec validates the fields in the spec
-// TODO: Add validation for other fields where applicable
-func validateSpec(spec *specs.Spec) error {
-	if spec.Process.Cwd == "" {
-		return fmt.Errorf("Cwd property must not be empty")
-	}
-	if !filepath.IsAbs(spec.Process.Cwd) {
-		return fmt.Errorf("Cwd must be an absolute path")
-	}
-	return nil
-}
-
 // loadSpec loads the specification from the provided path.
 // If the path is empty then the default path will be "config.json"
 func loadSpec(cPath string) (spec *specs.Spec, err error) {
@@ -224,7 +212,7 @@ func loadSpec(cPath string) (spec *specs.Spec, err error) {
 	if err = json.NewDecoder(cf).Decode(&spec); err != nil {
 		return nil, err
 	}
-	return spec, validateSpec(spec)
+	return spec, validateProcessSpec(&spec.Process)
 }
 
 func createLibcontainerConfig(cgroupName string, spec *specs.Spec) (*configs.Config, error) {

--- a/utils.go
+++ b/utils.go
@@ -365,3 +365,25 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 	}
 	return handler.forward(process)
 }
+
+func validateProcessSpec(spec ...interface{}) error {
+	for _, arg := range spec {
+		switch a := arg.(type) {
+		case *specs.Process:
+			if a.Cwd == "" {
+				return fmt.Errorf("Cwd property must not be empty")
+			}
+			if !filepath.IsAbs(a.Cwd) {
+				return fmt.Errorf("Cwd must be an absolute path")
+			}
+			if len(a.Args) == 0 {
+				return fmt.Errorf("args must not be empty")
+			}
+		//TODO
+		//Add for remaining spec validation
+		default:
+			return fmt.Errorf("not a valid spec")
+		}
+	}
+	return nil
+}

--- a/utils.go
+++ b/utils.go
@@ -366,24 +366,15 @@ func runProcess(container libcontainer.Container, config *specs.Process, listenF
 	return handler.forward(process)
 }
 
-func validateProcessSpec(spec ...interface{}) error {
-	for _, arg := range spec {
-		switch a := arg.(type) {
-		case *specs.Process:
-			if a.Cwd == "" {
-				return fmt.Errorf("Cwd property must not be empty")
-			}
-			if !filepath.IsAbs(a.Cwd) {
-				return fmt.Errorf("Cwd must be an absolute path")
-			}
-			if len(a.Args) == 0 {
-				return fmt.Errorf("args must not be empty")
-			}
-		//TODO
-		//Add for remaining spec validation
-		default:
-			return fmt.Errorf("not a valid spec")
-		}
+func validateProcessSpec(spec *specs.Process) error {
+	if spec.Cwd == "" {
+		return fmt.Errorf("Cwd property must not be empty")
+	}
+	if !filepath.IsAbs(spec.Cwd) {
+		return fmt.Errorf("Cwd must be an absolute path")
+	}
+	if len(spec.Args) == 0 {
+		return fmt.Errorf("args must not be empty")
 	}
 	return nil
 }


### PR DESCRIPTION
Handling the validation of spec in exec and start of container.
Added the args check in validation check to avoid index out of bounds during container exec.
Signed-off-by: Rajasekaran <rajasec79@gmail.com>