### PR TITLE
Need to unshare(CLONE_NEWIPC) before mounting mqueue fs.

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -80,6 +80,10 @@ func (l *linuxStandardInit) Init() error {
 	label.Init()
 	// InitializeMountNamespace() can be executed only for a new mount namespace
 	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
+		if err := syscall.Unshare(syscall.CLONE_NEWIPC); err != nil {
+			return err
+		}
+
 		if err := setupRootfs(l.config.Config, console, l.pipe); err != nil {
 			return err
 		}


### PR DESCRIPTION
This problem is discovered when using usernamespace in docker-1.10.2.
Here is the link on the issue open for the docker:
https://github.com/docker/docker/issues/20798

The problem here is when mounting a mqueue fs as a cloned process
with (CLONE_NEWIPC|CLONE_NEWNS ..), the mounted mqueue ipc namespace is
still pointing to the initial init parent namespace (i.e &init_ipc_ns).
We should do a unshare(CLONE_NEWIPC) prior to mounting mqueue fs,
such that the ipc namespace will be switched accordingly.

Signed-off-by: Thomas Tanaka <thomas.tanaka@oracle.com>