### PR TITLE
Revert "Return proper exit code for exec errors"

### DIFF
--- a/libcontainer/integration/init_test.go
+++ b/libcontainer/integration/init_test.go
@@ -1,11 +1,8 @@
 package integration
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
-	"strconv"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
@@ -27,25 +24,8 @@ func init() {
 		logrus.Fatalf("unable to initialize for container: %s", err)
 	}
 	if err := factory.StartInitialization(); err != nil {
-		// return proper unix error codes
-		if exerr, ok := err.(*exec.Error); ok {
-			switch exerr.Err {
-			case os.ErrPermission:
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(126)
-			case exec.ErrNotFound:
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(127)
-			default:
-				if os.IsNotExist(exerr.Err) {
-					fmt.Fprintf(os.Stderr, "exec: %s: %v\n", strconv.Quote(exerr.Name), os.ErrNotExist)
-					os.Exit(127)
-				}
-			}
-		}
 		logrus.Fatal(err)
 	}
-	panic("init: init failed to start contianer")
 }
 
 var (

--- a/start.go
+++ b/start.go
@@ -67,7 +67,7 @@ is a directory with a specification file and a root filesystem.`,
 
 		status, err := startContainer(context, spec)
 		if err != nil {
-			fatalf("Container start failed: %v", err)
+			fatal(err)
 		}
 		// exit with the container's exit status so any external supervisor is
 		// notified of the exit with the correct exit status.


### PR DESCRIPTION
This reverts commit 6bb653a6e881594eebd9532f6ed95339d3856ac6.

I made this original commit to help runc handle exit status from containers.  However, it was not the right place to do this.  With the current code there is no way to synchronously know that the container failed to start because of the exec error, especially with `runc start -d`.