### PR TITLE
Clear groups after entering userns

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <sys/prctl.h>
 #include <unistd.h>
+#include <grp.h>
 
 #include <bits/sockaddr.h>
 #include <linux/types.h>
@@ -381,6 +382,11 @@ static void process_nl_attributes(int pipenum, char *data, int data_size)
 
 		if (setgid(0) == -1) {
 			pr_perror("setgid failed");
+			exit(1);
+		}
+    
+		if (setgroups(0, NULL) == -1) {
+			pr_perror("setgroups failed");
 			exit(1);
 		}
 


### PR DESCRIPTION
Clears supplementary groups that have effect on the
mount permissions before joining the user specified
groups happens.

cc @mlaventure @estesp 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>