### PR TITLE
Ensure logs are flushed

### DIFF
--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -1,7 +1,6 @@
 package libcontainer
 
 import (
-	"fmt"
 	"io"
 	"text/template"
 	"time"
@@ -76,7 +75,7 @@ type genericError struct {
 }
 
 func (e *genericError) Error() string {
-	return fmt.Sprintf("[%d] %s: %s", e.ECode, e.ECode, e.Message)
+	return e.Message
 }
 
 func (e *genericError) Code() ErrorCode {

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 		if path := context.GlobalString("log"); path != "" {
-			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)
 			if err != nil {
 				return err
 			}

--- a/start.go
+++ b/start.go
@@ -85,7 +85,9 @@ var initCommand = cli.Command{
 		runtime.LockOSThread()
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
-			fatal(err)
+			// as the error is sent back to the parent there is no need to log
+			// or write it to stderr because the parent process will handle this
+			os.Exit(1)
 		}
 		panic("libcontainer: container init failed to exec")
 	},

--- a/utils.go
+++ b/utils.go
@@ -150,33 +150,15 @@ func containerPreload(context *cli.Context) error {
 
 // loadFactory returns the configured factory instance for execing containers.
 func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
-	var (
-		debug = "false"
-		root  = context.GlobalString("root")
-	)
-	if context.GlobalBool("debug") {
-		debug = "true"
-	}
+	root := context.GlobalString("root")
 	abs, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err
 	}
-	var logAbs string
-	if l := context.GlobalString("log"); l != "" {
-		if logAbs, err = filepath.Abs(context.GlobalString("log")); err != nil {
-			return nil, err
-		}
-	}
 	return libcontainer.New(abs, libcontainer.Cgroupfs, func(l *libcontainer.LinuxFactory) error {
 		l.CriuPath = context.GlobalString("criu")
 		return nil
-	},
-		libcontainer.InitArgs(os.Args[0],
-			"--log", logAbs,
-			"--log-format", context.GlobalString("log-format"),
-			fmt.Sprintf("--debug=%s", debug),
-			"init"),
-	)
+	})
 }
 
 // getContainer returns the specified container instance by loading it from state


### PR DESCRIPTION
This ensures that anything written to the logs are synced as they
happen.

This also changes the error message of the libcontainer error.  The
original idea was to have this extra information in the message but it
makes it hard to parse and if the caller needed this information they
can just get it from the error type.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>