### PR TITLE
libcontainer: cgroups: add pids.max to PidsStats

### DIFF
--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -47,11 +47,17 @@ func (s *PidsGroup) Remove(d *cgroupData) error {
 }
 
 func (s *PidsGroup) GetStats(path string, stats *cgroups.Stats) error {
-	value, err := getCgroupParamUint(path, "pids.current")
+	current, err := getCgroupParamUint(path, "pids.current")
 	if err != nil {
 		return fmt.Errorf("failed to parse pids.current - %s", err)
 	}
 
-	stats.PidsStats.Current = value
+	max, err := getCgroupParamUint(path, "pids.max")
+	if err != nil {
+		return fmt.Errorf("failed to parse pids.max - %s", err)
+	}
+
+	stats.PidsStats.Current = current
+	stats.PidsStats.Max = max
 	return nil
 }

--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -80,4 +80,8 @@ func TestPidsStats(t *testing.T) {
 	if stats.PidsStats.Current != 1337 {
 		t.Fatalf("Expected %d, got %d for pids.current", 1337, stats.PidsStats.Current)
 	}
+
+	if stats.PidsStats.Max != maxLimited {
+		t.Fatalf("Expected %d, got %d for pids.max", maxLimited, stats.PidsStats.Max)
+	}
 }

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -54,6 +54,8 @@ type MemoryStats struct {
 type PidsStats struct {
 	// number of pids in the cgroup
 	Current uint64 `json:"current,omitempty"`
+	// active pids hard limit
+	Max uint64 `json:"max,omitempty"`
 }
 
 type BlkioStatEntry struct {


### PR DESCRIPTION
In order to allow nice usage statistics (in terms of percentages and
other such data), add the value of pids.max to the PidsStats struct
returned from the pids cgroup controller.

Signed-off-by: Aleksa Sarai <asarai@suse.de>