### PR TITLE
libcontainer: cgroups: deal with unlimited case for pids.max

### DIFF
--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -81,7 +81,31 @@ func TestPidsStats(t *testing.T) {
 		t.Fatalf("Expected %d, got %d for pids.current", 1337, stats.PidsStats.Current)
 	}
 
-	if stats.PidsStats.Max != maxLimited {
-		t.Fatalf("Expected %d, got %d for pids.max", maxLimited, stats.PidsStats.Max)
+	if stats.PidsStats.Limit != maxLimited {
+		t.Fatalf("Expected %d, got %d for pids.max", maxLimited, stats.PidsStats.Limit)
+	}
+}
+
+func TestPidsStatsUnlimited(t *testing.T) {
+	helper := NewCgroupTestUtil("pids", t)
+	defer helper.cleanup()
+
+	helper.writeFileContents(map[string]string{
+		"pids.current": strconv.Itoa(4096),
+		"pids.max":     "max",
+	})
+
+	pids := &PidsGroup{}
+	stats := *cgroups.NewStats()
+	if err := pids.GetStats(helper.CgroupPath, &stats); err != nil {
+		t.Fatal(err)
+	}
+
+	if stats.PidsStats.Current != 4096 {
+		t.Fatalf("Expected %d, got %d for pids.current", 4096, stats.PidsStats.Current)
+	}
+
+	if stats.PidsStats.Limit != 0 {
+		t.Fatalf("Expected %d, got %d for pids.max", 0, stats.PidsStats.Limit)
 	}
 }

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -55,7 +55,7 @@ type PidsStats struct {
 	// number of pids in the cgroup
 	Current uint64 `json:"current,omitempty"`
 	// active pids hard limit
-	Max uint64 `json:"max,omitempty"`
+	Limit uint64 `json:"limit,omitempty"`
 }
 
 type BlkioStatEntry struct {


### PR DESCRIPTION
Make sure we don't error out collecting statistics for cases where
pids.max == "max". In that case, we can use a limit of 0 which means
"unlimited".

Signed-off-by: Aleksa Sarai <asarai@suse.de>

Sorry, I forgot about this case in #640. This should fix it.

/cc @hqhq @mrunalp 