### PR TITLE
Fixing valid-id in regex

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	idRegex  = regexp.MustCompile(`^[\w_-]+$`)
+	idRegex  = regexp.MustCompile(`^[\w-\.]+$`)
 	maxIdLen = 1024
 )
 


### PR DESCRIPTION
Fixes #635
Also removed _ ,as _ is part of \w
Signed-off-by: rajasec <rajasec79@gmail.com>