### PR TITLE
Set Delegate to true for cgroups transient units

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -193,6 +193,8 @@ func (m *Manager) Apply(pid int) error {
 		systemdDbus.PropSlice(slice),
 		systemdDbus.PropDescription("docker container "+c.Name),
 		newProp("PIDs", []uint32{uint32(pid)}),
+		// This is only supported on systemd versions 218 and above.
+		newProp("Delegate", true),
 	)
 
 	// Always enable accounting, this gets us the same behaviour as the fs implementation,


### PR DESCRIPTION
This is required because we manage some of the cgroups ourselves.
This recommendation came from talking with systemd devs about
some of the issues that we see when using the systemd cgroups driver.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>