### PR TITLE
Allow + in container id

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	idRegex  = regexp.MustCompile(`^[\w_-]+$`)
+	idRegex  = regexp.MustCompile(`^[\w+_-]+$`)
 	maxIdLen = 1024
 )
 


### PR DESCRIPTION
This allows container names like: foo+1, foo+2