### PR TITLE
Fix help info of init command

### DIFF
--- a/start.go
+++ b/start.go
@@ -80,10 +80,8 @@ is a directory with a specification file and a root filesystem.`,
 }
 
 var initCommand = cli.Command{
-	Name: "init",
-	Usage: `init is used to initialize the containers namespaces and launch the users process.
-    This command should not be called outside of runc.
-    `,
+	Name:  "init",
+	Usage: `initialize the namespaces and launch the process (do not call it outside of runc)`,
 	Action: func(context *cli.Context) {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()


### PR DESCRIPTION
Shrink it to one line so it looks consistent in help message.

Without this PR, it looks like:
```
COMMANDS:
   checkpoint   checkpoint a running container
   delete       delete any resources held by the container often used with detached containers
   events       display container events such as OOM notifications, cpu, memory, IO and network stats
   exec         execute new process inside the container
   init         init is used to initialize the containers namespaces and launch the users process.
    This command should not be called outside of runc.

   kill         kill sends the specified signal (default: SIGTERM) to the container's init process
```

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>