### PR TITLE
libcontainer: cgroups: add support for kmem.tcp limits

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -81,6 +81,11 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 			return err
 		}
 	}
+	if cgroup.Resources.KernelMemoryTCP != 0 {
+		if err := writeFile(path, "memory.kmem.tcp.limit_in_bytes", strconv.FormatInt(cgroup.Resources.KernelMemoryTCP, 10)); err != nil {
+			return err
+		}
+	}
 	if cgroup.Resources.OomKillDisable {
 		if err := writeFile(path, "memory.oom_control", "1"); err != nil {
 			return err
@@ -148,6 +153,7 @@ func memoryAssigned(cgroup *configs.Cgroup) bool {
 		cgroup.Resources.MemoryReservation != 0 ||
 		cgroup.Resources.MemorySwap > 0 ||
 		cgroup.Resources.KernelMemory > 0 ||
+		cgroup.Resources.KernelMemoryTCP > 0 ||
 		cgroup.Resources.OomKillDisable ||
 		(cgroup.Resources.MemorySwappiness != nil && *cgroup.Resources.MemorySwappiness != -1)
 }

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -144,6 +144,11 @@ func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
 		return err
 	}
 	stats.MemoryStats.KernelUsage = kernelUsage
+	kernelTCPUsage, err := getMemoryData(path, "kmem.tcp")
+	if err != nil {
+		return err
+	}
+	stats.MemoryStats.KernelTCPUsage = kernelTCPUsage
 
 	return nil
 }

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -114,6 +114,34 @@ func TestMemorySetKernelMemory(t *testing.T) {
 	}
 }
 
+func TestMemorySetKernelMemoryTCP(t *testing.T) {
+	helper := NewCgroupTestUtil("memory", t)
+	defer helper.cleanup()
+
+	const (
+		kernelMemoryTCPBefore = 314572800 // 300M
+		kernelMemoryTCPAfter  = 524288000 // 500M
+	)
+
+	helper.writeFileContents(map[string]string{
+		"memory.kmem.tcp.limit_in_bytes": strconv.Itoa(kernelMemoryTCPBefore),
+	})
+
+	helper.CgroupData.config.Resources.KernelMemory = kernelMemoryTCPAfter
+	memory := &MemoryGroup{}
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
+		t.Fatal(err)
+	}
+
+	value, err := getCgroupParamUint(helper.CgroupPath, "memory.kmem.tcp.limit_in_bytes")
+	if err != nil {
+		t.Fatalf("Failed to parse memory.kmem.tcp.limit_in_bytes - %s", err)
+	}
+	if value != kernelMemoryTCPAfter {
+		t.Fatal("Got the wrong value, set memory.kmem.tcp.limit_in_bytes failed.")
+	}
+}
+
 func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
 	defer helper.cleanup()

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -47,8 +47,11 @@ type MemoryStats struct {
 	// usage of memory + swap
 	SwapUsage MemoryData `json:"swap_usage,omitempty"`
 	// usage of kernel memory
-	KernelUsage MemoryData        `json:"kernel_usage,omitempty"`
-	Stats       map[string]uint64 `json:"stats,omitempty"`
+	KernelUsage MemoryData `json:"kernel_usage,omitempty"`
+	// usage of kernel TCP memory
+	KernelTCPUsage MemoryData `json:"kernel_tcp_usage,omitempty"`
+
+	Stats map[string]uint64 `json:"stats,omitempty"`
 }
 
 type PidsStats struct {

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -56,6 +56,9 @@ type Resources struct {
 	// Kernel memory limit (in bytes)
 	KernelMemory int64 `json:"kernel_memory"`
 
+	// Kernel memory limit for TCP use (in bytes)
+	KernelMemoryTCP int64 `json:"kernel_memory_tcp"`
+
 	// CPU shares (relative weight vs. other containers)
 	CpuShares int64 `json:"cpu_shares"`
 

--- a/spec.go
+++ b/spec.go
@@ -382,6 +382,9 @@ func createCgroupConfig(name string, spec *specs.Spec) (*configs.Cgroup, error) 
 		if r.Memory.Kernel != nil {
 			c.Resources.KernelMemory = int64(*r.Memory.Kernel)
 		}
+		if r.Memory.KernelTCP != nil {
+			c.Resources.KernelMemoryTCP = int64(*r.Memory.KernelTCP)
+		}
 		if r.Memory.Swappiness != nil {
 			swappiness := int64(*r.Memory.Swappiness)
 			c.Resources.MemorySwappiness = &swappiness


### PR DESCRIPTION
This is a carry of #376, as well as adding statistics to `kmem.tcp`. This cgroup knob does not have the same requirement as `kmem` (it must be set before any processes enter the cgroup), so we can treat it like any other memory knob.

Signed-off-by: Aleksa Sarai <asarai@suse.de>