### PR TITLE
Changing the error type for max id length

### DIFF
--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -10,6 +10,7 @@ const (
 	// Factory errors
 	IdInUse ErrorCode = iota
 	InvalidIdFormat
+	InvalidIdLength
 
 	// Container errors
 	ContainerNotExists
@@ -33,6 +34,8 @@ func (c ErrorCode) String() string {
 		return "Id already in use"
 	case InvalidIdFormat:
 		return "Invalid format"
+	case InvalidIdLength:
+		return "Invalid length"
 	case ContainerPaused:
 		return "Container paused"
 	case ConfigInvalid:

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -276,7 +276,7 @@ func (l *LinuxFactory) validateID(id string) error {
 		return newGenericError(fmt.Errorf("invalid id format: %v", id), InvalidIdFormat)
 	}
 	if len(id) > maxIdLen {
-		return newGenericError(fmt.Errorf("invalid id format: %v", id), InvalidIdFormat)
+		return newGenericError(fmt.Errorf("invalid id length: %v", id), InvalidIdLength)
 	}
 	return nil
 }


### PR DESCRIPTION
Modified the error type of max error length instead of invalid format
Signed-off-by: rajasec <rajasec79@gmail.com>