### PR TITLE
handling error for userns

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -540,10 +540,6 @@ func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
 	if len(spec.Linux.UIDMappings) == 0 {
 		return nil
 	}
-	// do not override the specified user namespace path
-	if config.Namespaces.PathOf(configs.NEWUSER) == "" {
-		config.Namespaces.Add(configs.NEWUSER, "")
-	}
 	create := func(m specs.IDMapping) configs.IDMap {
 		return configs.IDMap{
 			HostID:      int(m.HostID),


### PR DESCRIPTION
Currently validator code( validate/config.go) in runc implemented to throw error  if user is not specified in namespaces part of config ( even though have UID/gid mapping). But in spec userns is added by default part of config.
with this PR, it will throw an error as per existing validation logic.
"User namespace mappings specified, but USER namespace isn't enabled in the config"

@dqminh 
This was added part of #105, please confirm whether this was desired behavior.




Signed-off-by: rajasec <rajasec79@gmail.com>