### PR TITLE
Dont cleanPath for systemd cgroup paths.

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -356,6 +356,9 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 
 	if spec.Linux.CgroupsPath != nil {
 		myCgroupPath = libcontainerUtils.CleanPath(*spec.Linux.CgroupsPath)
+		if useSystemdCgroup {
+			myCgroupPath = *spec.Linux.CgroupsPath
+		}
 	}
 
 	if useSystemdCgroup {


### PR DESCRIPTION
systemd expects cgroupsPath to be of form "slice:prefix:name".
So dont call cleanPath on it anymore.

Signed-off-by: Anusha Ragunathan <anusha@docker.com>