### PR TITLE
Only perform mount labelling when necessary

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -140,8 +140,9 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			if err := mountPropagate(m, rootfs, ""); err != nil {
 				return err
 			}
+			return label.SetFileLabel(dest, mountLabel)
 		}
-		return label.SetFileLabel(dest, mountLabel)
+		return nil
 	case "tmpfs":
 		stat, err := os.Stat(dest)
 		if err != nil {


### PR DESCRIPTION
Do label mqueue when mounting it with label failed/not supported.

Signed-off-by: Thomas Tanaka <thomas.tanaka@oracle.com>