### PR TITLE
Set rlimits using prlimit in parent

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -316,10 +316,9 @@ func setupRoute(config *configs.Config) error {
 	return nil
 }
 
-func setupRlimits(limits []configs.Rlimit) error {
+func setupRlimits(limits []configs.Rlimit, pid int) error {
 	for _, rlimit := range limits {
-		l := &syscall.Rlimit{Max: rlimit.Hard, Cur: rlimit.Soft}
-		if err := syscall.Setrlimit(rlimit.Type, l); err != nil {
+		if err := system.Prlimit(pid, rlimit.Type, syscall.Rlimit{Max: rlimit.Hard, Cur: rlimit.Soft}); err != nil {
 			return fmt.Errorf("error setting rlimit type %v: %v", rlimit.Type, err)
 		}
 	}

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -89,6 +89,11 @@ func (p *setnsProcess) start() (err error) {
 	if err := setOomScoreAdj(p.config.Config.OomScoreAdj, p.pid()); err != nil {
 		return newSystemError(err)
 	}
+	// set rlimits, this has to be done here because we lose permissions
+	// to raise the limits once we enter a user-namespace
+	if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
+		return newSystemError(err)
+	}
 	if err := utils.WriteJSON(p.parentPipe, p.config); err != nil {
 		return newSystemError(err)
 	}
@@ -282,6 +287,11 @@ loop:
 			}
 			// set oom_score_adj
 			if err := setOomScoreAdj(p.config.Config.OomScoreAdj, p.pid()); err != nil {
+				return newSystemError(err)
+			}
+			// set rlimits, this has to be done here because we lose permissions
+			// to raise the limits once we enter a user-namespace
+			if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
 				return newSystemError(err)
 			}
 			// call prestart hooks

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -28,9 +28,6 @@ func (l *linuxSetnsInit) Init() error {
 	if _, err := keyctl.JoinSessionKeyring(l.getSessionRingName()); err != nil {
 		return err
 	}
-	if err := setupRlimits(l.config.Rlimits); err != nil {
-		return err
-	}
 	if l.config.NoNewPrivileges {
 		if err := system.Prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
 			return err

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -73,9 +73,6 @@ func (l *linuxStandardInit) Init() error {
 	if err := setupRoute(l.config.Config); err != nil {
 		return err
 	}
-	if err := setupRlimits(l.config.Rlimits); err != nil {
-		return err
-	}
 
 	label.Init()
 	// InitializeMountNamespace() can be executed only for a new mount namespace

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -53,6 +53,14 @@ func Execv(cmd string, args []string, env []string) error {
 	return syscall.Exec(name, args, env)
 }
 
+func Prlimit(pid, resource int, limit syscall.Rlimit) error {
+	_, _, err := syscall.RawSyscall6(syscall.SYS_PRLIMIT64, uintptr(pid), uintptr(resource), uintptr(unsafe.Pointer(&limit)), uintptr(unsafe.Pointer(&limit)), 0, 0)
+	if err != 0 {
+		return err
+	}
+	return nil
+}
+
 func SetParentDeathSignal(sig uintptr) error {
 	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_PDEATHSIG, sig, 0); err != 0 {
 		return err


### PR DESCRIPTION
Fixes #680

This changes setupRlimit to use the Prlimit syscall (rather than
Setrlimit) and moves the call to the parent process. This is necessary
because Setrlimit would affect the libcontainer consumer if called in
the parent, and would fail if called from the child if the
child process is in a user namespace and the requested rlimit is higher
than that in the parent.

Signed-off-by: Julian Friedman <julz.friedman@uk.ibm.com>