### PR TITLE
Move lockthread to package level

### DIFF
--- a/start.go
+++ b/start.go
@@ -85,12 +85,17 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 	},
 }
 
+func init() {
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		runtime.GOMAXPROCS(1)
+		runtime.LockOSThread()
+	}
+}
+
 var initCommand = cli.Command{
 	Name:  "init",
 	Usage: `initialize the namespaces and launch the process (do not call it outside of runc)`,
 	Action: func(context *cli.Context) {
-		runtime.GOMAXPROCS(1)
-		runtime.LockOSThread()
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
 			// as the error is sent back to the parent there is no need to log


### PR DESCRIPTION
Move this to be one of the first things that is done in the main if we
are executing the init as it is causing some inconsistencies with capset on ARM systems.  

Fixes #684

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>