### PR TITLE
Use %v for map structure format

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -326,7 +326,7 @@ func RemovePaths(paths map[string]string) (err error) {
 			return nil
 		}
 	}
-	return fmt.Errorf("Failed to remove paths: %s", paths)
+	return fmt.Errorf("Failed to remove paths: %v", paths)
 }
 
 func GetHugePageSize() ([]string, error) {


### PR DESCRIPTION
Based on Golang document, %s is for "the uninterpreted bytes of the
string or slice", so %v is more appropriate.

Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>