### PR TITLE
Makefile: install to /usr/local/sbin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,17 @@ test: runctestimage
 localtest: all
 	go test -tags "$(BUILDTAGS)" ${TESTFLAGS} -v ./...
 
-dbuild: runctestimage 
+dbuild: runctestimage
 	docker build -t $(RUNC_IMAGE) .
 	docker create --name=$(RUNC_INSTANCE) $(RUNC_IMAGE)
 	docker cp $(RUNC_INSTANCE):$(RUNC_BUILD_PATH) .
 	docker rm $(RUNC_INSTANCE)
 
 install:
-	cp runc /usr/local/bin/runc
+	install -D -m0755 runc /usr/local/sbin/runc
 
 uninstall:
-	rm -f /usr/local/bin/runc
+	rm -f /usr/local/sbin/runc
 
 clean:
 	rm -f runc


### PR DESCRIPTION
Since runC requires root in order to run, it makes more sense to put it
in /usr/sbin (which is traditionally for root-only utilities). This also
fixes the section number mismatch (man8 is usually for administrative
utilities in /usr/sbin).

Closes #693

Signed-off-by: Aleksa Sarai <asarai@suse.de>