### PR TITLE
Add --no-pivot option for containers on ramdisk

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -73,6 +73,10 @@ using the runc checkpoint command.`,
 			Name:  "no-subreaper",
 			Usage: "disable the use of the subreaper used to reap reparented processes",
 		},
+		cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: "do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk",
+		},
 	},
 	Action: func(context *cli.Context) {
 		imagePath := context.String("image-path")
@@ -93,7 +97,12 @@ using the runc checkpoint command.`,
 		if err != nil {
 			fatal(err)
 		}
-		config, err := specconv.CreateLibcontainerConfig(id, context.GlobalBool("systemd-cgroup"), spec)
+		config, err := specconv.CreateLibcontainerConfig(&specconv.CreateOpts{
+			CgroupName:       id,
+			UseSystemdCgroup: context.GlobalBool("systemd-cgroup"),
+			NoPivotRoot:      context.Bool("no-pivot"),
+			Spec:             spec,
+		})
 		if err != nil {
 			fatal(err)
 		}

--- a/start.go
+++ b/start.go
@@ -53,6 +53,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "no-subreaper",
 			Usage: "disable the use of the subreaper used to reap reparented processes",
 		},
+		cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: "do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk",
+		},
 	},
 	Action: func(context *cli.Context) {
 		bundle := context.String("bundle")

--- a/utils.go
+++ b/utils.go
@@ -175,7 +175,12 @@ func createPidFile(path string, process *libcontainer.Process) error {
 }
 
 func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcontainer.Container, error) {
-	config, err := specconv.CreateLibcontainerConfig(id, context.GlobalBool("systemd-cgroup"), spec)
+	config, err := specconv.CreateLibcontainerConfig(&specconv.CreateOpts{
+		CgroupName:       id,
+		UseSystemdCgroup: context.GlobalBool("systemd-cgroup"),
+		NoPivotRoot:      context.Bool("no-pivot"),
+		Spec:             spec,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds a `--no-pivot` cli flag to runc so that a container's rootfs
can be located ontop of ramdisk/tmpfs and not fail because you cannot
pivot root.

This should be a cli flag and not part of the spec because this is a
detail of the host/runtime environment and not an attribute of a
container.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>