### PR TITLE
Fix the build by removing go get for vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,7 @@ endif
 static:
 	CGO_ENABLED=1 go build -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT}" -o runc .
 
-vet:
-	go get golang.org/x/tools/cmd/vet
-
-lint: vet
+lint:
 	go vet ./...
 	go fmt ./...
 
@@ -53,7 +50,7 @@ clean:
 	rm -f runc
 	rm -f $(RUNC_LINK)
 
-validate: vet
+validate:
 	script/validate-gofmt
 	go vet ./...
 


### PR DESCRIPTION
golang.org/x/tools/cmd/vet has been removed as it is available in go cmd directly

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>