### PR TITLE
Add label.GetFileLabel interface

### DIFF
--- a/libcontainer/label/label.go
+++ b/libcontainer/label/label.go
@@ -21,6 +21,10 @@ func SetProcessLabel(processLabel string) error {
 	return nil
 }
 
+func GetFileLabel(path string) (string, error) {
+	return "", nil
+}
+
 func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }

--- a/libcontainer/label/label_selinux.go
+++ b/libcontainer/label/label_selinux.go
@@ -94,6 +94,11 @@ func GetProcessLabel() (string, error) {
 	return selinux.Getexeccon()
 }
 
+// GetFileLabel returns the label for specified path
+func GetFileLabel(path string) (string, error) {
+	return selinux.Getfilecon(path)
+}
+
 // SetFileLabel modifies the "path" label to the specified file label
 func SetFileLabel(path string, fileLabel string) error {
 	if selinux.SelinuxEnabled() && fileLabel != "" {

--- a/libcontainer/selinux/selinux_test.go
+++ b/libcontainer/selinux/selinux_test.go
@@ -12,13 +12,23 @@ import (
 func TestSetfilecon(t *testing.T) {
 	if selinux.SelinuxEnabled() {
 		tmp := "selinux_test"
+		con := "system_u:object_r:bin_t:s0"
 		out, _ := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE, 0)
 		out.Close()
-		err := selinux.Setfilecon(tmp, "system_u:object_r:bin_t:s0")
+		err := selinux.Setfilecon(tmp, con)
 		if err != nil {
 			t.Log("Setfilecon failed")
 			t.Fatal(err)
 		}
+		filecon, err := selinux.Getfilecon(tmp)
+		if err != nil {
+			t.Log("Getfilecon failed")
+			t.Fatal(err)
+		}
+		if con != filecon {
+			t.Fatal("Getfilecon failed, returned %s expected %s", filecon, con)
+		}
+
 		os.Remove(tmp)
 	}
 }


### PR DESCRIPTION
One of our volume plugins needs to get the label of the target mount point
so that it can set the content inside of the volume to match.

We need label.GetFileLabel() to make this work.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>