### PR TITLE
Fix setupDev logic in rootfs_linux.go

### DIFF
--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -2,7 +2,11 @@
 
 package libcontainer
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
 
 func TestCheckMountDestOnProc(t *testing.T) {
 	dest := "/rootfs/proc/"
@@ -33,5 +37,81 @@ func TestCheckMountRoot(t *testing.T) {
 	err := checkMountDestination("/rootfs", dest)
 	if err == nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNeedsSetupDev(t *testing.T) {
+	config := &configs.Config{
+		Mounts: []*configs.Mount{
+			{
+				Device:      "bind",
+				Source:      "/dev",
+				Destination: "/dev",
+			},
+		},
+	}
+	setupDev, err := needsSetupDev(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if setupDev {
+		t.Fatalf("expected false")
+	}
+}
+
+func TestNeedsSetupDevStrangeSource(t *testing.T) {
+	config := &configs.Config{
+		Mounts: []*configs.Mount{
+			{
+				Device:      "bind",
+				Source:      "/devx",
+				Destination: "/dev",
+			},
+		},
+	}
+	setupDev, err := needsSetupDev(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if setupDev {
+		t.Fatalf("expected false")
+	}
+}
+
+func TestNeedsSetupDevStrangeDest(t *testing.T) {
+	config := &configs.Config{
+		Mounts: []*configs.Mount{
+			{
+				Device:      "bind",
+				Source:      "/dev",
+				Destination: "/devx",
+			},
+		},
+	}
+	setupDev, err := needsSetupDev(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !setupDev {
+		t.Fatalf("expected true")
+	}
+}
+
+func TestNeedsSetupDevStrangeSourceDest(t *testing.T) {
+	config := &configs.Config{
+		Mounts: []*configs.Mount{
+			{
+				Device:      "bind",
+				Source:      "/devx",
+				Destination: "/devx",
+			},
+		},
+	}
+	setupDev, err := needsSetupDev(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !setupDev {
+		t.Fatalf("expected true")
 	}
 }


### PR DESCRIPTION
setupDev was introduced in #96, but broken since #536 because spec 0.3.0 introduced default devices.

Fix #80 again
Fix docker/docker#21808

Signed-off-by: Akihiro Suda <suda.kyoto@gmail.com>

-----

This is still NOT LGTM even to myself.
We need to discuss the robust approach again (#96).
Plus of course unittest is needed.