### PR TITLE
Report hook output on error

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -307,7 +307,11 @@ func (c Command) Run(s HookState) error {
 	}
 	errC := make(chan error, 1)
 	go func() {
-		errC <- cmd.Run()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			err = fmt.Errorf("%s: %s", err, out)
+		}
+		errC <- err
 	}()
 	if c.Timeout != nil {
 		select {


### PR DESCRIPTION
Fixes #733

This reports the stdout/err for a hook if it returns a non-zero exit
status.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>