### PR TITLE
Fix for runc failing when rootfs has a trailing slash

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -52,7 +52,7 @@ func (v *ConfigValidator) rootfs(config *configs.Config) error {
 	if cleaned, err = filepath.EvalSymlinks(cleaned); err != nil {
 		return err
 	}
-	if config.Rootfs != cleaned {
+	if filepath.Clean(config.Rootfs) != cleaned {
 		return fmt.Errorf("%s is not an absolute path or is a symlink", config.Rootfs)
 	}
 	return nil


### PR DESCRIPTION
Without this, we fail with an error when the rootfs property has a trailing slash
```
# runc start cont-1
/runc/containers/fedora/ is not an absolute path or is a symlink
```
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>