### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ export GOPATH:=$(CURDIR)/Godeps/_workspace
 .PHONY=dbuild
 
 all: $(RUNC_LINK)
-	go build -ldflags "-X main.gitCommit=${COMMIT}" -tags "$(BUILDTAGS)" -o runc .
+	go build -i -ldflags "-X main.gitCommit=${COMMIT}" -tags "$(BUILDTAGS)" -o runc .
 
 static: $(RUNC_LINK)
-	CGO_ENABLED=1 go build -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT}" -o runc .
+	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT}" -o runc .
 
 $(RUNC_LINK):
 	ln -sfn $(CURDIR) $(RUNC_LINK)
@@ -49,6 +49,7 @@ uninstall:
 clean:
 	rm -f runc
 	rm -f $(RUNC_LINK)
+	rm -rf $(GOPATH)/pkg
 
 validate:
 	script/validate-gofmt

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RUNC_BUILD_PATH=/go/src/github.com/opencontainers/runc/runc
 RUNC_INSTANCE=runc_dev
 COMMIT=$(shell git rev-parse HEAD 2> /dev/null || true)
 RUNC_LINK=$(CURDIR)/Godeps/_workspace/src/github.com/opencontainers/runc
-export GOPATH:=$(CURDIR)/Godeps/_workspace:$(GOPATH)
+export GOPATH:=$(CURDIR)/Godeps/_workspace
 
 .PHONY=dbuild
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ export GOPATH:=$(CURDIR)/Godeps/_workspace:$(GOPATH)
 
 .PHONY=dbuild
 
-all:
-ifneq ($(RUNC_LINK), $(wildcard $(RUNC_LINK)))
-	ln -sfn $(CURDIR) $(RUNC_LINK)
-endif
+all: $(RUNC_LINK)
 	go build -ldflags "-X main.gitCommit=${COMMIT}" -tags "$(BUILDTAGS)" -o runc .
 
-static:
+static: $(RUNC_LINK)
 	CGO_ENABLED=1 go build -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT}" -o runc .
+
+$(RUNC_LINK):
+	ln -sfn $(CURDIR) $(RUNC_LINK)
 
 lint:
 	go vet ./...


### PR DESCRIPTION
The following PR fixes static builds on clean environments, and speeds up successive build times by saving the packages that are dependencies of runc:
```
$ time make
ln -sfn /tmp/runc /tmp/runc/Godeps/_workspace/src/github.com/opencontainers/runc
go build -i -ldflags "-X main.gitCommit=21e3b2f2ea9f08b901e8c20438a74a55287feae7" -tags "seccomp" -o runc .

real	0m2.641s
user	0m8.717s
sys	0m0.742s
$ time make
go build -i -ldflags "-X main.gitCommit=21e3b2f2ea9f08b901e8c20438a74a55287feae7" -tags "seccomp" -o runc .

real	0m1.214s
user	0m1.645s
sys	0m0.159s
```