### PR TITLE
Fixing index out of range during exec of container

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -99,6 +99,10 @@ func execProcess(context *cli.Context) (int, error) {
 	if err != nil {
 		return -1, err
 	}
+	path := context.String("process")
+	if path == "" && len(context.Args()) == 1 {
+		return -1, fmt.Errorf("process args cannot be empty")
+	}
 	detach := context.Bool("detach")
 	state, err := container.State()
 	if err != nil {


### PR DESCRIPTION
During exec of container, panic thrown for index out of range
exec failed: panic from initialization: runtime error: index out of range, /home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/factory_linux.go:255 (0x4b763f)
/usr/local/go/src/runtime/asm_amd64.s:401 (0x43b525)
/usr/local/go/src/runtime/panic.go:387 (0x428ee8)
/usr/local/go/src/runtime/panic.go:12 (0x42807e)
/home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/setns_init_linux.go:52 (0x4b44e8)
/home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/factory_linux.go:263 (0x49fd04)
/home/raj/go/pkg/src/github.com/opencontainers/runc/start.go:104 (0x410fbc)
/home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/codegangsta/cli/command.go:137 (0x482213)
/home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/codegangsta/cli/app.go:176 (0x47ef35)
/home/raj/go/pkg/src/github.com/opencontainers/runc/main.go:123 (0x40763f)
/usr/local/go/src/runtime/proc.go:63 (0x42aa33)
/usr/local/go/src/runtime/asm_amd64.s:2232 (0x43d641)

Added the check so that process arguments can not be empty during exec.

Signed-off-by: rajasec <rajasec79@gmail.com>