### PR TITLE
Fix trivial style errors reported by `go vet` and `golint`

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -349,7 +349,7 @@ func writeFile(dir, file, data string) error {
 	// Normally dir should not be empty, one case is that cgroup subsystem
 	// is not mounted, we will get empty dir, and we want it fail here.
 	if dir == "" {
-		return fmt.Errorf("no such directory for %s.", file)
+		return fmt.Errorf("no such directory for %s", file)
 	}
 	if err := ioutil.WriteFile(filepath.Join(dir, file), []byte(data), 0700); err != nil {
 		return fmt.Errorf("failed to write %v to %v: %v", data, file, err)

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -106,13 +106,13 @@ func TestCpuStats(t *testing.T) {
 	defer helper.cleanup()
 
 	const (
-		kNrPeriods     = 2000
-		kNrThrottled   = 200
-		kThrottledTime = uint64(18446744073709551615)
+		nrPeriods     = 2000
+		nrThrottled   = 200
+		throttledTime = uint64(18446744073709551615)
 	)
 
 	cpuStatContent := fmt.Sprintf("nr_periods %d\n nr_throttled %d\n throttled_time %d\n",
-		kNrPeriods, kNrThrottled, kThrottledTime)
+		nrPeriods, nrThrottled, throttledTime)
 	helper.writeFileContents(map[string]string{
 		"cpu.stat": cpuStatContent,
 	})
@@ -125,9 +125,9 @@ func TestCpuStats(t *testing.T) {
 	}
 
 	expectedStats := cgroups.ThrottlingData{
-		Periods:          kNrPeriods,
-		ThrottledPeriods: kNrThrottled,
-		ThrottledTime:    kThrottledTime}
+		Periods:          nrPeriods,
+		ThrottledPeriods: nrThrottled,
+		ThrottledTime:    throttledTime}
 
 	expectThrottlingDataEquals(t, expectedStats, actualStats.CpuStats.ThrottlingData)
 }

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -430,11 +430,11 @@ func TestMemorySetOomControl(t *testing.T) {
 	defer helper.cleanup()
 
 	const (
-		oom_kill_disable = 1 // disable oom killer, default is 0
+		oomKillDisable = 1 // disable oom killer, default is 0
 	)
 
 	helper.writeFileContents(map[string]string{
-		"memory.oom_control": strconv.Itoa(oom_kill_disable),
+		"memory.oom_control": strconv.Itoa(oomKillDisable),
 	})
 
 	memory := &MemoryGroup{}
@@ -447,7 +447,7 @@ func TestMemorySetOomControl(t *testing.T) {
 		t.Fatalf("Failed to parse memory.oom_control - %s", err)
 	}
 
-	if value != oom_kill_disable {
+	if value != oomKillDisable {
 		t.Fatalf("Got the wrong value, set memory.oom_control failed.")
 	}
 }

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -11,6 +11,7 @@ type ThrottlingData struct {
 	ThrottledTime uint64 `json:"throttled_time,omitempty"`
 }
 
+// CpuUsage denotes the usage of a CPU.
 // All CPU stats are aggregate since container inception.
 type CpuUsage struct {
 	// Total CPU time consumed.

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -273,7 +273,7 @@ func writeFile(dir, file, data string) error {
 	// Normally dir should not be empty, one case is that cgroup subsystem
 	// is not mounted, we will get empty dir, and we want it fail here.
 	if dir == "" {
-		return fmt.Errorf("no such directory for %s.", file)
+		return fmt.Errorf("no such directory for %s", file)
 	}
 	return ioutil.WriteFile(filepath.Join(dir, file), []byte(data), 0700)
 }

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -173,7 +173,7 @@ func GetCgroupMounts() ([]Mount, error) {
 	return getCgroupMountsHelper(allMap, f)
 }
 
-// Returns all the cgroup subsystems supported by the kernel
+// GetAllSubsystems returns all the cgroup subsystems supported by the kernel
 func GetAllSubsystems() ([]string, error) {
 	f, err := os.Open("/proc/cgroups")
 	if err != nil {
@@ -199,7 +199,7 @@ func GetAllSubsystems() ([]string, error) {
 	return subsystems, nil
 }
 
-// Returns the relative path to the cgroup docker is running in.
+// GetThisCgroupDir returns the relative path to the cgroup docker is running in.
 func GetThisCgroupDir(subsystem string) (string, error) {
 	cgroups, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -33,7 +33,7 @@ type Seccomp struct {
 	Syscalls      []*Syscall `json:"syscalls"`
 }
 
-// An action to be taken upon rule match in Seccomp
+// Action is taken upon rule match in Seccomp
 type Action int
 
 const (
@@ -44,7 +44,7 @@ const (
 	Trace
 )
 
-// A comparison operator to be used when matching syscall arguments in Seccomp
+// Operator is a comparison operator to be used when matching syscall arguments in Seccomp
 type Operator int
 
 const (
@@ -57,7 +57,7 @@ const (
 	MaskEqualTo
 )
 
-// A rule to match a specific syscall argument in Seccomp
+// Arg is a rule to match a specific syscall argument in Seccomp
 type Arg struct {
 	Index    uint     `json:"index"`
 	Value    uint64   `json:"value"`
@@ -65,7 +65,7 @@ type Arg struct {
 	Op       Operator `json:"op"`
 }
 
-// An rule to match a syscall in Seccomp
+// Syscall is a rule to match a syscall in Seccomp
 type Syscall struct {
 	Name   string `json:"name"`
 	Action Action `json:"action"`
@@ -261,7 +261,7 @@ type Hook interface {
 	Run(HookState) error
 }
 
-// NewFunctionHooks will call the provided function when the hook is run.
+// NewFunctionHook will call the provided function when the hook is run.
 func NewFunctionHook(f func(HookState) error) FuncHook {
 	return FuncHook{
 		run: f,
@@ -284,7 +284,7 @@ type Command struct {
 	Timeout *time.Duration `json:"timeout"`
 }
 
-// NewCommandHooks will execute the provided command when the hook is run.
+// NewCommandHook will execute the provided command when the hook is run.
 func NewCommandHook(cmd Command) CommandHook {
 	return CommandHook{
 		Command: cmd,

--- a/libcontainer/configs/config_unix.go
+++ b/libcontainer/configs/config_unix.go
@@ -4,7 +4,7 @@ package configs
 
 import "fmt"
 
-// Gets the root uid for the process on host which could be non-zero
+// HostUID gets the root uid for the process on host which could be non-zero
 // when user namespaces are enabled.
 func (c Config) HostUID() (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
@@ -21,7 +21,7 @@ func (c Config) HostUID() (int, error) {
 	return 0, nil
 }
 
-// Gets the root gid for the process on host which could be non-zero
+// HostGID gets the root gid for the process on host which could be non-zero
 // when user namespaces are enabled.
 func (c Config) HostGID() (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {

--- a/libcontainer/configs/device_defaults.go
+++ b/libcontainer/configs/device_defaults.go
@@ -3,7 +3,7 @@
 package configs
 
 var (
-	// These are devices that are to be both allowed and created.
+	// DefaultSimpleDevices are devices that are to be both allowed and created.
 	DefaultSimpleDevices = []*Device{
 		// /dev/null and zero
 		{

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -1,4 +1,4 @@
-// Libcontainer provides a native Go implementation for creating containers
+// Package libcontainer provides a native Go implementation for creating containers
 // with namespaces, cgroups, capabilities, and filesystem access controls.
 // It allows you to manage the lifecycle of the container performing additional operations
 // after the container is created.
@@ -11,23 +11,23 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-// The status of a container.
+// Status is the status of a container.
 type Status int
 
 const (
-	// The container exists but has not been run yet
+	// Created is the status that denotes the container exists but has not been run yet
 	Created Status = iota
 
-	// The container exists and is running.
+	// Created is the status that denotes the container exists and is running.
 	Running
 
-	// The container exists, it is in the process of being paused.
+	// Pausing is the status that denotes the container exists, it is in the process of being paused.
 	Pausing
 
-	// The container exists, but all its processes are paused.
+	// Paused is the status that denotes the container exists, but all its processes are paused.
 	Paused
 
-	// The container does not exist.
+	// Destroyed is the status that denotes the container does not exist.
 	Destroyed
 )
 
@@ -67,7 +67,7 @@ type BaseState struct {
 	Config configs.Config `json:"config"`
 }
 
-// A libcontainer container object.
+// BaseContainer is a libcontainer container object.
 //
 // Each container is thread-safe within the same process. Since a container can
 // be destroyed by a separate process, any function may return that the container

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -62,7 +62,7 @@ type State struct {
 	ExternalDescriptors []string `json:"external_descriptors,omitempty"`
 }
 
-// A libcontainer container object.
+// Container is a libcontainer container object.
 //
 // Each container is thread-safe within the same process. Since a container can
 // be destroyed by a separate process, any function may return that the container
@@ -408,13 +408,13 @@ func (c *linuxContainer) NotifyMemoryPressure(level PressureLevel) (<-chan struc
 	return notifyMemoryPressure(c.cgroupManager.GetPaths(), level)
 }
 
-// check Criu version greater than or equal to min_version
-func (c *linuxContainer) checkCriuVersion(min_version string) error {
+// checkCriuVersion checks Criu version greater than or equal to minVersion
+func (c *linuxContainer) checkCriuVersion(minVersion string) error {
 	var x, y, z, versionReq int
 
-	_, err := fmt.Sscanf(min_version, "%d.%d.%d\n", &x, &y, &z) // 1.5.2
+	_, err := fmt.Sscanf(minVersion, "%d.%d.%d\n", &x, &y, &z) // 1.5.2
 	if err != nil {
-		_, err = fmt.Sscanf(min_version, "Version: %d.%d\n", &x, &y) // 1.6
+		_, err = fmt.Sscanf(minVersion, "Version: %d.%d\n", &x, &y) // 1.6
 	}
 	versionReq = x*10000 + y*100 + z
 
@@ -459,7 +459,7 @@ func (c *linuxContainer) checkCriuVersion(min_version string) error {
 	c.criuVersion = x*10000 + y*100 + z
 
 	if c.criuVersion < versionReq {
-		return fmt.Errorf("CRIU version must be %s or higher", min_version)
+		return fmt.Errorf("CRIU version must be %s or higher", minVersion)
 	}
 
 	return nil

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -79,11 +79,11 @@ func (m *mockProcess) signal(_ os.Signal) error {
 	return nil
 }
 
-func (p *mockProcess) externalDescriptors() []string {
+func (m *mockProcess) externalDescriptors() []string {
 	return []string{}
 }
 
-func (p *mockProcess) setExternalDescriptors(newFds []string) {
+func (m *mockProcess) setExternalDescriptors(newFds []string) {
 }
 
 func TestGetContainerPids(t *testing.T) {

--- a/libcontainer/criu_opts_unix.go
+++ b/libcontainer/criu_opts_unix.go
@@ -3,13 +3,13 @@
 package libcontainer
 
 // cgroup restoring strategy provided by criu
-type cg_mode uint32
+type cgMode uint32
 
 const (
-	CRIU_CG_MODE_SOFT    cg_mode = 3 + iota // restore cgroup properties if only dir created by criu
-	CRIU_CG_MODE_FULL                       // always restore all cgroups and their properties
-	CRIU_CG_MODE_STRICT                     // restore all, requiring them to not present in the system
-	CRIU_CG_MODE_DEFAULT                    // the same as CRIU_CG_MODE_SOFT
+	CRIU_CG_MODE_SOFT    cgMode = 3 + iota // restore cgroup properties if only dir created by criu
+	CRIU_CG_MODE_FULL                      // always restore all cgroups and their properties
+	CRIU_CG_MODE_STRICT                    // restore all, requiring them to not present in the system
+	CRIU_CG_MODE_DEFAULT                   // the same as CRIU_CG_MODE_SOFT
 )
 
 type CriuPageServerInfo struct {
@@ -32,6 +32,6 @@ type CriuOpts struct {
 	FileLocks               bool               // handle file locks, for safety
 	PageServer              CriuPageServerInfo // allow to dump to criu page server
 	VethPairs               []VethPairName     // pass the veth to criu when restore
-	ManageCgroupsMode       cg_mode            // dump or restore cgroup mode
+	ManageCgroupsMode       cgMode             // dump or restore cgroup mode
 	EmptyNs                 uint32             // don't c/r properties for namespace from this mask
 }

--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -2,7 +2,7 @@ package libcontainer
 
 import "io"
 
-// API error code type.
+// ErrorCode is the API error code type.
 type ErrorCode int
 
 // API error codes.
@@ -56,7 +56,7 @@ func (c ErrorCode) String() string {
 	}
 }
 
-// API Error type.
+// Error is the API error type.
 type Error interface {
 	error
 

--- a/libcontainer/integration/init_test.go
+++ b/libcontainer/integration/init_test.go
@@ -36,7 +36,7 @@ var (
 func TestMain(m *testing.M) {
 	var (
 		err error
-		ret int = 0
+		ret int
 	)
 
 	logrus.SetOutput(os.Stderr)

--- a/libcontainer/keys/keyctl.go
+++ b/libcontainer/keys/keyctl.go
@@ -4,9 +4,9 @@ package keyctl
 
 import (
 	"fmt"
-	"syscall"
-	"strings"
 	"strconv"
+	"strings"
+	"syscall"
 	"unsafe"
 )
 
@@ -17,7 +17,7 @@ const KEYCTL_DESCRIBE = 6
 type KeySerial uint32
 
 func JoinSessionKeyring(name string) (KeySerial, error) {
-	var _name *byte = nil
+	var _name *byte
 	var err error
 
 	if len(name) > 0 {
@@ -34,7 +34,7 @@ func JoinSessionKeyring(name string) (KeySerial, error) {
 	return KeySerial(sessKeyId), nil
 }
 
-// modify permissions on a keyring by reading the current permissions,
+// ModKeyringPerm modifies permissions on a keyring by reading the current permissions,
 // anding the bits with the given mask (clearing permissions) and setting
 // additional permission bits
 func ModKeyringPerm(ringId KeySerial, mask, setbits uint32) error {
@@ -64,4 +64,3 @@ func ModKeyringPerm(ringId KeySerial, mask, setbits uint32) error {
 
 	return nil
 }
-

--- a/libcontainer/label/label_selinux.go
+++ b/libcontainer/label/label_selinux.go
@@ -107,7 +107,7 @@ func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }
 
-// Tell the kernel the label for all files to be created
+// SetFileCreateLabel tells the kernel the label for all files to be created
 func SetFileCreateLabel(fileLabel string) error {
 	if selinux.SelinuxEnabled() {
 		return selinux.Setfscreatecon(fileLabel)
@@ -115,7 +115,7 @@ func SetFileCreateLabel(fileLabel string) error {
 	return nil
 }
 
-// Change the label of path to the filelabel string.
+// Relabel changes the label of path to the filelabel string.
 // It changes the MCS label to s0 if shared is true.
 // This will allow all containers to share the content.
 func Relabel(path string, fileLabel string, shared bool) error {

--- a/libcontainer/label/label_selinux_test.go
+++ b/libcontainer/label/label_selinux_test.go
@@ -26,7 +26,7 @@ func TestInit(t *testing.T) {
 		}
 		if plabel != "" {
 			t.Log("InitLabels Disabled Failed")
-			t.Fatal()
+			t.FailNow()
 		}
 		testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
 		plabel, mlabel, err = InitLabels(testUser)
@@ -95,22 +95,22 @@ func TestRelabel(t *testing.T) {
 	defer os.RemoveAll(testdir)
 	label := "system_u:system_r:svirt_sandbox_file_t:s0:c1,c2"
 	if err := Relabel(testdir, "", true); err != nil {
-		t.Fatal("Relabel with no label failed: %v", err)
+		t.Fatalf("Relabel with no label failed: %v", err)
 	}
 	if err := Relabel(testdir, label, true); err != nil {
-		t.Fatal("Relabel shared failed: %v", err)
+		t.Fatalf("Relabel shared failed: %v", err)
 	}
 	if err := Relabel(testdir, label, false); err != nil {
-		t.Fatal("Relabel unshared failed: %v", err)
+		t.Fatalf("Relabel unshared failed: %v", err)
 	}
 	if err := Relabel("/etc", label, false); err == nil {
-		t.Fatal("Relabel /etc succeeded")
+		t.Fatalf("Relabel /etc succeeded")
 	}
 	if err := Relabel("/", label, false); err == nil {
-		t.Fatal("Relabel / succeeded")
+		t.Fatalf("Relabel / succeeded")
 	}
 	if err := Relabel("/usr", label, false); err == nil {
-		t.Fatal("Relabel /usr succeeded")
+		t.Fatalf("Relabel /usr succeeded")
 	}
 }
 
@@ -131,13 +131,13 @@ func TestValidate(t *testing.T) {
 
 func TestIsShared(t *testing.T) {
 	if shared := IsShared("Z"); shared {
-		t.Fatal("Expected label `Z` to not be shared, got %v", shared)
+		t.Fatalf("Expected label `Z` to not be shared, got %v", shared)
 	}
 	if shared := IsShared("z"); !shared {
-		t.Fatal("Expected label `z` to be shared, got %v", shared)
+		t.Fatalf("Expected label `z` to be shared, got %v", shared)
 	}
 	if shared := IsShared("Zz"); !shared {
-		t.Fatal("Expected label `Zz` to be shared, got %v", shared)
+		t.Fatalf("Expected label `Zz` to be shared, got %v", shared)
 	}
 
 }

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -27,7 +27,8 @@ type Int32msg struct {
 	Value uint32
 }
 
-// int32msg has the following representation
+// Serialize serializes the message.
+// Int32msg has the following representation
 // | nlattr len | nlattr type |
 // | uint32 value             |
 func (msg *Int32msg) Serialize() []byte {
@@ -43,7 +44,7 @@ func (msg *Int32msg) Len() int {
 	return syscall_NLA_HDRLEN + 4
 }
 
-// bytemsg has the following representation
+// Bytemsg has the following representation
 // | nlattr len | nlattr type |
 // | value              | pad |
 type Bytemsg struct {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -25,7 +25,7 @@ import (
 
 const defaultMountFlags = syscall.MS_NOEXEC | syscall.MS_NOSUID | syscall.MS_NODEV
 
-// setupDev returns true if /dev needs to be set up.
+// needsSetupDev returns true if /dev needs to be set up.
 func needsSetupDev(config *configs.Config) bool {
 	for _, m := range config.Mounts {
 		if m.Device == "bind" && (m.Destination == "/dev" || m.Destination == "/dev/") {

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -10,7 +10,7 @@ import (
 
 var ErrSeccompNotEnabled = errors.New("seccomp: config provided but seccomp not supported")
 
-// Seccomp not supported, do nothing
+// InitSeccomp does nothing because seccomp is not supported.
 func InitSeccomp(config *configs.Seccomp) error {
 	if config != nil {
 		return ErrSeccompNotEnabled

--- a/libcontainer/selinux/selinux.go
+++ b/libcontainer/selinux/selinux.go
@@ -297,7 +297,7 @@ func IntToMcs(id int, catRange uint32) string {
 
 	for ORD > TIER {
 		ORD = ORD - TIER
-		TIER -= 1
+		TIER--
 	}
 	TIER = SETSIZE - TIER
 	ORD = ORD + TIER
@@ -438,7 +438,7 @@ func badPrefix(fpath string) error {
 	return nil
 }
 
-// Change the fpath file object to the SELinux label scon.
+// Chcon changes the fpath file object to the SELinux label scon.
 // If the fpath is a directory and recurse is true Chcon will walk the
 // directory tree setting the label
 func Chcon(fpath string, scon string, recurse bool) error {

--- a/libcontainer/stacktrace/capture.go
+++ b/libcontainer/stacktrace/capture.go
@@ -2,14 +2,14 @@ package stacktrace
 
 import "runtime"
 
-// Caputure captures a stacktrace for the current calling go program
+// Capture captures a stacktrace for the current calling go program
 //
 // skip is the number of frames to skip
 func Capture(userSkip int) Stacktrace {
 	var (
 		skip   = userSkip + 1 // add one for our own function
 		frames []Frame
-		prevPc uintptr = 0
+		prevPc uintptr
 	)
 	for i := skip; ; i++ {
 		pc, file, line, ok := runtime.Caller(i)

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -100,17 +100,12 @@ func Setctty() error {
 	return nil
 }
 
-/*
- * Detect whether we are currently running in a user namespace.
- * Copied from github.com/lxc/lxd/shared/util.go
- */
+// RunningInUserNS detects whether we are currently running in a user namespace.
+// Copied from github.com/lxc/lxd/shared/util.go
 func RunningInUserNS() bool {
 	file, err := os.Open("/proc/self/uid_map")
 	if err != nil {
-		/*
-		 * This kernel-provided file only exists if user namespaces are
-		 * supported
-		 */
+		// This kernel-provided file only exists if user namespaces are supported
 		return false
 	}
 	defer file.Close()

--- a/utils.go
+++ b/utils.go
@@ -33,7 +33,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 		if systemd.UseSystemd() {
 			cgroupManager = libcontainer.SystemdCgroups
 		} else {
-			return nil, fmt.Errorf("systemd cgroup flag passed, but systemd support for managing cgroups is not available.")
+			return nil, fmt.Errorf("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
 		}
 	}
 	return libcontainer.New(abs, cgroupManager, func(l *libcontainer.LinuxFactory) error {


### PR DESCRIPTION
No substantial code change.
Note that some style errors reported by `golint` are not fixed due to possible compatibility issues.

Signed-off-by: Akihiro Suda <suda.kyoto@gmail.com>