### PR TITLE
Switch from mixed jessie/testing to jessie+backports for libseccomp

### DIFF
--- a/script/test_Dockerfile
+++ b/script/test_Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.5.3
 
-RUN echo "deb http://ftp.us.debian.org/debian testing main contrib" >> /etc/apt/sources.list
+# libseccomp in jessie is not _quite_ new enough -- need backports version
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
@@ -9,8 +11,8 @@ RUN apt-get update && apt-get install -y \
     libcap-dev \
     libprotobuf-dev \
     libprotobuf-c0-dev \
-    libseccomp2 \
-    libseccomp-dev \
+    libseccomp2/jessie-backports \
+    libseccomp-dev/jessie-backports \
     protobuf-c-compiler \
     protobuf-compiler \
     python-minimal \


### PR DESCRIPTION
This is a WIP to fix the issues discussed over in https://github.com/opencontainers/runc/pull/749#issuecomment-209571860.

I'm seeing CRIU issues locally, but I don't know if that's related to this change or my local setup (so hopefully Jenkins can help shed more light on that).