### PR TITLE
Adding destroyed condition for container statistics

### DIFF
--- a/events.go
+++ b/events.go
@@ -66,6 +66,9 @@ information is displayed once every 5 seconds.`,
 			for range time.Tick(context.Duration("interval")) {
 				s, err := container.Stats()
 				if err != nil {
+					if serr, ok := err.(libcontainer.Error); ok && serr.Code() == libcontainer.ContainerNotRunning {
+						fatal(err)
+					}
 					logrus.Error(err)
 					continue
 				}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -151,6 +151,13 @@ func (c *linuxContainer) Stats() (*Stats, error) {
 		err   error
 		stats = &Stats{}
 	)
+	status, err := c.Status()
+	if err != nil {
+		return stats, err
+	}
+	if status == Destroyed {
+		return stats, newGenericError(fmt.Errorf("container not running"), ContainerNotRunning)
+	}
 	if stats.CgroupStats, err = c.cgroupManager.GetStats(); err != nil {
 		return stats, newSystemError(err)
 	}


### PR DESCRIPTION
Currently for detached container, eventhough container is in destroyed state ( no processes running) runc events shows the statistics.
With this PR, for destroyed container,throws out an error 
./runc events test
container not running
Signed-off-by: rajasec <rajasec79@gmail.com>