### PR TITLE
Add cause to error messages

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -141,7 +141,7 @@ func (c *linuxContainer) State() (*State, error) {
 func (c *linuxContainer) Processes() ([]int, error) {
 	pids, err := c.cgroupManager.GetAllPids()
 	if err != nil {
-		return nil, newSystemError(err)
+		return nil, newSystemErrorWithCause(err, "getting all container pids from cgroups")
 	}
 	return pids, nil
 }
@@ -152,14 +152,14 @@ func (c *linuxContainer) Stats() (*Stats, error) {
 		stats = &Stats{}
 	)
 	if stats.CgroupStats, err = c.cgroupManager.GetStats(); err != nil {
-		return stats, newSystemError(err)
+		return stats, newSystemErrorWithCause(err, "getting container stats from cgroups")
 	}
 	for _, iface := range c.config.Networks {
 		switch iface.Type {
 		case "veth":
 			istats, err := getNetworkInterfaceStats(iface.HostInterfaceName)
 			if err != nil {
-				return stats, newSystemError(err)
+				return stats, newSystemErrorWithCausef(err, "getting network stats for interface %q", iface.HostInterfaceName)
 			}
 			stats.Interfaces = append(stats.Interfaces, istats)
 		}
@@ -184,14 +184,14 @@ func (c *linuxContainer) Start(process *Process) error {
 	doInit := status == Destroyed
 	parent, err := c.newParentProcess(process, doInit)
 	if err != nil {
-		return newSystemError(err)
+		return newSystemErrorWithCause(err, "creating new parent process")
 	}
 	if err := parent.start(); err != nil {
 		// terminate the process to ensure that it properly is reaped.
 		if err := parent.terminate(); err != nil {
 			logrus.Warn(err)
 		}
-		return newSystemError(err)
+		return newSystemErrorWithCause(err, "starting container process")
 	}
 	// generate a timestamp indicating when the container was started
 	c.created = time.Now().UTC()
@@ -211,12 +211,12 @@ func (c *linuxContainer) Start(process *Process) error {
 				Root:       c.config.Rootfs,
 				BundlePath: utils.SearchLabels(c.config.Labels, "bundle"),
 			}
-			for _, hook := range c.config.Hooks.Poststart {
+			for i, hook := range c.config.Hooks.Poststart {
 				if err := hook.Run(s); err != nil {
 					if err := parent.terminate(); err != nil {
 						logrus.Warn(err)
 					}
-					return newSystemError(err)
+					return newSystemErrorWithCausef(err, "running poststart hook %d", i)
 				}
 			}
 		}
@@ -226,7 +226,7 @@ func (c *linuxContainer) Start(process *Process) error {
 
 func (c *linuxContainer) Signal(s os.Signal) error {
 	if err := c.initProcess.signal(s); err != nil {
-		return newSystemError(err)
+		return newSystemErrorWithCause(err, "signaling init process")
 	}
 	return nil
 }
@@ -234,11 +234,11 @@ func (c *linuxContainer) Signal(s os.Signal) error {
 func (c *linuxContainer) newParentProcess(p *Process, doInit bool) (parentProcess, error) {
 	parentPipe, childPipe, err := newPipe()
 	if err != nil {
-		return nil, newSystemError(err)
+		return nil, newSystemErrorWithCause(err, "creating new init pipe")
 	}
 	cmd, err := c.commandTemplate(p, childPipe)
 	if err != nil {
-		return nil, newSystemError(err)
+		return nil, newSystemErrorWithCause(err, "creating new command template")
 	}
 	if !doInit {
 		return c.newSetnsProcess(p, cmd, parentPipe, childPipe)
@@ -299,7 +299,7 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 	cmd.Env = append(cmd.Env, "_LIBCONTAINER_INITTYPE="+string(initSetns))
 	state, err := c.currentState()
 	if err != nil {
-		return nil, newSystemError(err)
+		return nil, newSystemErrorWithCause(err, "getting container's current state")
 	}
 	// for setns process, we dont have to set cloneflags as the process namespaces
 	// will only be set via setns syscall
@@ -955,9 +955,9 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 				Pid:     int(notify.GetPid()),
 				Root:    c.config.Rootfs,
 			}
-			for _, hook := range c.config.Hooks.Prestart {
+			for i, hook := range c.config.Hooks.Prestart {
 				if err := hook.Run(s); err != nil {
-					return newSystemError(err)
+					return newSystemErrorWithCausef(err, "running prestart hook %d", i)
 				}
 			}
 		}
@@ -1046,7 +1046,7 @@ func (c *linuxContainer) isRunning() (bool, error) {
 		if err == syscall.ESRCH {
 			return false, nil
 		}
-		return false, newSystemError(err)
+		return false, newSystemErrorWithCausef(err, "sending signal 0 to pid %d", c.initProcess.pid())
 	}
 	return true, nil
 }
@@ -1057,7 +1057,7 @@ func (c *linuxContainer) isPaused() (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, newSystemError(err)
+		return false, newSystemErrorWithCause(err, "checking if container is paused")
 	}
 	return bytes.Equal(bytes.TrimSpace(data), []byte("FROZEN")), nil
 }
@@ -1125,7 +1125,7 @@ func (c *linuxContainer) orderNamespacePaths(namespaces map[configs.NamespaceTyp
 			}
 			// only set to join this namespace if it exists
 			if _, err := os.Lstat(p); err != nil {
-				return nil, newSystemError(err)
+				return nil, newSystemErrorWithCausef(err, "running lstat on namespace path %q", p)
 			}
 			// do not allow namespace path with comma as we use it to separate
 			// the namespace paths

--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -1,6 +1,7 @@
 package libcontainer
 
 import (
+	"fmt"
 	"io"
 	"text/template"
 	"time"
@@ -51,6 +52,21 @@ func newGenericError(err error, c ErrorCode) Error {
 }
 
 func newSystemError(err error) Error {
+	return createSystemError(err, "")
+}
+
+func newSystemErrorWithCausef(err error, cause string, v ...interface{}) Error {
+	return createSystemError(err, fmt.Sprintf(cause, v...))
+}
+
+func newSystemErrorWithCause(err error, cause string) Error {
+	return createSystemError(err, cause)
+}
+
+// createSystemError creates the specified error with the correct number of
+// stack frames skipped. This is only to be called by the other functions for
+// formatting the error.
+func createSystemError(err error, cause string) Error {
 	if le, ok := err.(Error); ok {
 		return le
 	}
@@ -58,7 +74,8 @@ func newSystemError(err error) Error {
 		Timestamp: time.Now(),
 		Err:       err,
 		ECode:     SystemError,
-		Stack:     stacktrace.Capture(1),
+		Cause:     cause,
+		Stack:     stacktrace.Capture(2),
 	}
 	if err != nil {
 		gerr.Message = err.Error()
@@ -70,12 +87,17 @@ type genericError struct {
 	Timestamp time.Time
 	ECode     ErrorCode
 	Err       error `json:"-"`
+	Cause     string
 	Message   string
 	Stack     stacktrace.Stacktrace
 }
 
 func (e *genericError) Error() string {
-	return e.Message
+	if e.Cause == "" {
+		return e.Message
+	}
+	frame := e.Stack.Frames[0]
+	return fmt.Sprintf("%s:%d: %s caused %q", frame.File, frame.Line, e.Cause, e.Message)
 }
 
 func (e *genericError) Code() ErrorCode {


### PR DESCRIPTION
This is the inital port of the libcontainer.Error to added a cause to
all the existing error messages.  Going forward, when an error can be
wrapped because it is not being checked at the higher levels for
something like `os.IsNotExist` we can add more information to the error
message like cause and stack file/line information.  This will help
higher level tools to know what cause a container start or operation to
fail.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>