### PR TITLE
Allow mounting cgroups as read-only when user namespace is configured

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -266,8 +266,10 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 		if m.Flags&syscall.MS_RDONLY != 0 {
 			// remount cgroup root as readonly
 			mcgrouproot := &configs.Mount{
+				Source:      m.Destination,
+				Device:      "bind",
 				Destination: m.Destination,
-				Flags:       defaultMountFlags | syscall.MS_RDONLY,
+				Flags:       defaultMountFlags | syscall.MS_RDONLY | syscall.MS_BIND,
 			}
 			if err := remount(mcgrouproot, rootfs); err != nil {
 				return err


### PR DESCRIPTION
We use bind mount to achieve this as other file system remounts are disallowed
in a user namespace.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>