### PR TITLE
Not showing up the events for destroyed container

### DIFF
--- a/events.go
+++ b/events.go
@@ -37,13 +37,12 @@ information is displayed once every 5 seconds.`,
 		if err != nil {
 			fatal(err)
 		}
-		id := context.Args().First()
 		status, err := container.Status()
 		if err != nil {
 			fatal(err)
 		}
 		if status == libcontainer.Destroyed {
-			fatalf("container with id %s is not running",id)
+			fatalf("container with id %s is not running", container.ID())
 		}
 		var (
 			stats  = make(chan *libcontainer.Stats, 1)

--- a/events.go
+++ b/events.go
@@ -37,6 +37,14 @@ information is displayed once every 5 seconds.`,
 		if err != nil {
 			fatal(err)
 		}
+		id := context.Args().First()
+		status, err := container.Status()
+		if err != nil {
+			fatal(err)
+		}
+		if status == libcontainer.Destroyed {
+			fatalf("container with id %s is not running",id)
+		}
 		var (
 			stats  = make(chan *libcontainer.Stats, 1)
 			events = make(chan *event, 1024)


### PR DESCRIPTION
When the container is destroyed state, there is no process associated with that. Looks like there is no process activity associated with cgroup ( cgroup.procs is empty). Do not show the event statistics for destroyed container.
Signed-off-by: rajasec <rajasec79@gmail.com>