### PR TITLE
Rootless Containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    sudo \
     gawk \
     iptables \
     jq \
@@ -21,6 +22,12 @@ RUN apt-get update && apt-get install -y \
     python-minimal \
     --no-install-recommends \
     && apt-get clean
+
+# Add a dummy user for the rootless integration tests. While runC does
+# not require an entry in /etc/passwd to operate, one of the tests uses
+# `git clone` -- and `git clone` does not allow you to clone a
+# repository if the current uid does not have an entry in /etc/passwd.
+RUN useradd -u1000 -m -d/home/rootless -s/bin/bash rootless
 
 # install bats
 RUN cd /tmp \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
 PREFIX := $(DESTDIR)/usr/local
-BINDIR := $(PREFIX)/sbin
+BINDIR := $(PREFIX)/bin
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -39,6 +39,11 @@ checkpointed.`,
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}
+		// XXX: Currently this is untested with rootless containers.
+		if isRootless() {
+			return fmt.Errorf("runc checkpoint requires root")
+		}
+
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/exec.go
+++ b/exec.go
@@ -90,9 +90,6 @@ following will output a list of processes running in the container:
 		if err := checkArgs(context, 1, minArgs); err != nil {
 			return err
 		}
-		if os.Geteuid() != 0 {
-			return fmt.Errorf("runc should be run as root")
-		}
 		if err := revisePidFile(context); err != nil {
 			return err
 		}

--- a/libcontainer/cgroups/rootless/rootless.go
+++ b/libcontainer/cgroups/rootless/rootless.go
@@ -1,0 +1,128 @@
+// +build linux
+
+package rootless
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/configs/validate"
+)
+
+// TODO: This is copied from libcontainer/cgroups/fs, which duplicates this code
+//       needlessly. We should probably export this list.
+
+var subsystems = []subsystem{
+	&fs.CpusetGroup{},
+	&fs.DevicesGroup{},
+	&fs.MemoryGroup{},
+	&fs.CpuGroup{},
+	&fs.CpuacctGroup{},
+	&fs.PidsGroup{},
+	&fs.BlkioGroup{},
+	&fs.HugetlbGroup{},
+	&fs.NetClsGroup{},
+	&fs.NetPrioGroup{},
+	&fs.PerfEventGroup{},
+	&fs.FreezerGroup{},
+	&fs.NameGroup{GroupName: "name=systemd"},
+}
+
+type subsystem interface {
+	// Name returns the name of the subsystem.
+	Name() string
+
+	// Returns the stats, as 'stats', corresponding to the cgroup under 'path'.
+	GetStats(path string, stats *cgroups.Stats) error
+}
+
+// The noop cgroup manager is used for rootless containers, because we currently
+// cannot manage cgroups if we are in a rootless setup. This manager is chosen
+// by factory if we are in rootless mode. We error out if any cgroup options are
+// set in the config -- this may change in the future with upcoming kernel features
+// like the cgroup namespace.
+
+type Manager struct {
+	Cgroups *configs.Cgroup
+	Paths   map[string]string
+}
+
+func (m *Manager) Apply(pid int) error {
+	// If there are no cgroup settings, there's nothing to do.
+	if m.Cgroups == nil {
+		return nil
+	}
+
+	// We can't set paths.
+	// TODO(cyphar): Implement the case where the runner of a rootless container
+	//               owns their own cgroup, which would allow us to set up a
+	//               cgroup for each path.
+	if m.Cgroups.Paths != nil {
+		return fmt.Errorf("cannot change cgroup path in rootless container")
+	}
+
+	// We load the paths into the manager.
+	paths := make(map[string]string)
+	for _, sys := range subsystems {
+		name := sys.Name()
+
+		path, err := cgroups.GetOwnCgroupPath(name)
+		if err != nil {
+			// Ignore paths we couldn't resolve.
+			continue
+		}
+
+		paths[name] = path
+	}
+
+	m.Paths = paths
+	return nil
+}
+
+func (m *Manager) GetPaths() map[string]string {
+	return m.Paths
+}
+
+func (m *Manager) Set(container *configs.Config) error {
+	// We have to re-do the validation here, since someone might decide to
+	// update a rootless container.
+	return validate.New().Validate(container)
+}
+
+func (m *Manager) GetPids() ([]int, error) {
+	dir, err := cgroups.GetOwnCgroupPath("devices")
+	if err != nil {
+		return nil, err
+	}
+	return cgroups.GetPids(dir)
+}
+
+func (m *Manager) GetAllPids() ([]int, error) {
+	dir, err := cgroups.GetOwnCgroupPath("devices")
+	if err != nil {
+		return nil, err
+	}
+	return cgroups.GetAllPids(dir)
+}
+
+func (m *Manager) GetStats() (*cgroups.Stats, error) {
+	// TODO(cyphar): We can make this work if we figure out a way to allow usage
+	//               of cgroups with a rootless container. While this doesn't
+	//               actually require write access to a cgroup directory, the
+	//               statistics are not useful if they can be affected by
+	//               non-container processes.
+	return nil, fmt.Errorf("cannot get cgroup stats in rootless container")
+}
+
+func (m *Manager) Freeze(state configs.FreezerState) error {
+	// TODO(cyphar): We can make this work if we figure out a way to allow usage
+	//               of cgroups with a rootless container.
+	return fmt.Errorf("cannot use freezer cgroup in rootless container")
+}
+
+func (m *Manager) Destroy() error {
+	// We don't have to do anything here because we didn't do any setup.
+	return nil
+}

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -426,7 +426,7 @@ func getSubsystemPath(c *configs.Cgroup, subsystem string) (string, error) {
 		return "", err
 	}
 
-	initPath, err := cgroups.GetInitCgroupDir(subsystem)
+	initPath, err := cgroups.GetInitCgroup(subsystem)
 	if err != nil {
 		return "", err
 	}

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -109,7 +109,7 @@ type Mount struct {
 	Subsystems []string
 }
 
-func (m Mount) GetThisCgroupDir(cgroups map[string]string) (string, error) {
+func (m Mount) GetOwnCgroup(cgroups map[string]string) (string, error) {
 	if len(m.Subsystems) == 0 {
 		return "", fmt.Errorf("no subsystem for mount")
 	}
@@ -203,8 +203,8 @@ func GetAllSubsystems() ([]string, error) {
 	return subsystems, nil
 }
 
-// GetThisCgroupDir returns the relative path to the cgroup docker is running in.
-func GetThisCgroupDir(subsystem string) (string, error) {
+// GetOwnCgroup returns the relative path to the cgroup docker is running in.
+func GetOwnCgroup(subsystem string) (string, error) {
 	cgroups, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		return "", err
@@ -213,14 +213,47 @@ func GetThisCgroupDir(subsystem string) (string, error) {
 	return getControllerPath(subsystem, cgroups)
 }
 
-func GetInitCgroupDir(subsystem string) (string, error) {
+func GetOwnCgroupPath(subsystem string) (string, error) {
+	cgroup, err := GetOwnCgroup(subsystem)
+	if err != nil {
+		return "", err
+	}
 
+	return getCgroupPathHelper(subsystem, cgroup)
+}
+
+func GetInitCgroup(subsystem string) (string, error) {
 	cgroups, err := ParseCgroupFile("/proc/1/cgroup")
 	if err != nil {
 		return "", err
 	}
 
 	return getControllerPath(subsystem, cgroups)
+}
+
+func GetInitCgroupPath(subsystem string) (string, error) {
+	cgroup, err := GetInitCgroup(subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	return getCgroupPathHelper(subsystem, cgroup)
+}
+
+func getCgroupPathHelper(subsystem, cgroup string) (string, error) {
+	mnt, root, err := FindCgroupMountpointAndRoot(subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	// This is needed for nested containers, because in /proc/self/cgroup we
+	// see pathes from host, which don't exist in container.
+	relCgroup, err := filepath.Rel(root, cgroup)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(mnt, relCgroup), nil
 }
 
 func readProcsFile(dir string) ([]int, error) {

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -183,6 +183,9 @@ type Config struct {
 	// NoNewKeyring will not allocated a new session keyring for the container.  It will use the
 	// callers keyring in this case.
 	NoNewKeyring bool `json:"no_new_keyring"`
+
+	// Rootless specifies whether the container is a rootless container.
+	Rootless bool `json:"rootless"`
 }
 
 type Hooks struct {

--- a/libcontainer/configs/config_unix.go
+++ b/libcontainer/configs/config_unix.go
@@ -4,38 +4,50 @@ package configs
 
 import "fmt"
 
-// HostUID gets the root uid for the process on host which could be non-zero
-// when user namespaces are enabled.
-func (c Config) HostUID() (int, error) {
+// HostUID gets the translated uid for the process on host which could be
+// different when user namespaces are enabled.
+func (c Config) HostUID(containerId int) (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.UidMappings == nil {
-			return -1, fmt.Errorf("User namespaces enabled, but no user mappings found.")
+			return -1, fmt.Errorf("User namespaces enabled, but no uid mappings found.")
 		}
-		id, found := c.hostIDFromMapping(0, c.UidMappings)
+		id, found := c.hostIDFromMapping(containerId, c.UidMappings)
 		if !found {
-			return -1, fmt.Errorf("User namespaces enabled, but no root user mapping found.")
+			return -1, fmt.Errorf("User namespaces enabled, but no user mapping found.")
 		}
 		return id, nil
 	}
-	// Return default root uid 0
-	return 0, nil
+	// Return unchanged id.
+	return containerId, nil
 }
 
-// HostGID gets the root gid for the process on host which could be non-zero
+// HostRootUID gets the root uid for the process on host which could be non-zero
 // when user namespaces are enabled.
-func (c Config) HostGID() (int, error) {
+func (c Config) HostRootUID() (int, error) {
+	return c.HostUID(0)
+}
+
+// HostGID gets the translated gid for the process on host which could be
+// different when user namespaces are enabled.
+func (c Config) HostGID(containerId int) (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.GidMappings == nil {
 			return -1, fmt.Errorf("User namespaces enabled, but no gid mappings found.")
 		}
-		id, found := c.hostIDFromMapping(0, c.GidMappings)
+		id, found := c.hostIDFromMapping(containerId, c.GidMappings)
 		if !found {
-			return -1, fmt.Errorf("User namespaces enabled, but no root group mapping found.")
+			return -1, fmt.Errorf("User namespaces enabled, but no group mapping found.")
 		}
 		return id, nil
 	}
-	// Return default root gid 0
-	return 0, nil
+	// Return unchanged id.
+	return containerId, nil
+}
+
+// HostRootGID gets the root gid for the process on host which could be non-zero
+// when user namespaces are enabled.
+func (c Config) HostRootGID() (int, error) {
+	return c.HostGID(0)
 }
 
 // Utility function that gets a host ID for a container ID from user namespace map

--- a/libcontainer/configs/config_unix_test.go
+++ b/libcontainer/configs/config_unix_test.go
@@ -65,11 +65,11 @@ func TestRemoveNamespace(t *testing.T) {
 	}
 }
 
-func TestHostUIDNoUSERNS(t *testing.T) {
+func TestHostRootUIDNoUSERNS(t *testing.T) {
 	config := &Config{
 		Namespaces: Namespaces{},
 	}
-	uid, err := config.HostUID()
+	uid, err := config.HostRootUID()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestHostUIDNoUSERNS(t *testing.T) {
 	}
 }
 
-func TestHostUIDWithUSERNS(t *testing.T) {
+func TestHostRootUIDWithUSERNS(t *testing.T) {
 	config := &Config{
 		Namespaces: Namespaces{{Type: NEWUSER}},
 		UidMappings: []IDMap{
@@ -89,7 +89,7 @@ func TestHostUIDWithUSERNS(t *testing.T) {
 			},
 		},
 	}
-	uid, err := config.HostUID()
+	uid, err := config.HostRootUID()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,11 +98,11 @@ func TestHostUIDWithUSERNS(t *testing.T) {
 	}
 }
 
-func TestHostGIDNoUSERNS(t *testing.T) {
+func TestHostRootGIDNoUSERNS(t *testing.T) {
 	config := &Config{
 		Namespaces: Namespaces{},
 	}
-	uid, err := config.HostGID()
+	uid, err := config.HostRootGID()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestHostGIDNoUSERNS(t *testing.T) {
 	}
 }
 
-func TestHostGIDWithUSERNS(t *testing.T) {
+func TestHostRootGIDWithUSERNS(t *testing.T) {
 	config := &Config{
 		Namespaces: Namespaces{{Type: NEWUSER}},
 		GidMappings: []IDMap{
@@ -122,7 +122,7 @@ func TestHostGIDWithUSERNS(t *testing.T) {
 			},
 		},
 	}
-	uid, err := config.HostGID()
+	uid, err := config.HostRootGID()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/configs/validate/rootless.go
+++ b/libcontainer/configs/validate/rootless.go
@@ -1,0 +1,117 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+var (
+	geteuid = os.Geteuid
+	getegid = os.Getegid
+)
+
+func (v *ConfigValidator) rootless(config *configs.Config) error {
+	if err := rootlessMappings(config); err != nil {
+		return err
+	}
+	if err := rootlessMount(config); err != nil {
+		return err
+	}
+	// Currently, cgroups cannot effectively be used in rootless containers.
+	// The new cgroup namespace doesn't really help us either because it doesn't
+	// have nice interactions with the user namespace (we're working with upstream
+	// to fix this).
+	if err := rootlessCgroup(config); err != nil {
+		return err
+	}
+
+	// XXX: We currently can't verify the user config at all, because
+	//      configs.Config doesn't store the user-related configs. So this
+	//      has to be verified by setupUser() in init_linux.go.
+
+	return nil
+}
+
+func rootlessMappings(config *configs.Config) error {
+	rootuid, err := config.HostUID()
+	if err != nil {
+		return fmt.Errorf("failed to get root uid from uidMappings: %v", err)
+	}
+	if euid := geteuid(); euid != 0 {
+		if !config.Namespaces.Contains(configs.NEWUSER) {
+			return fmt.Errorf("rootless containers require user namespaces")
+		}
+		if rootuid != euid {
+			return fmt.Errorf("rootless containers cannot map container root to a different host user")
+		}
+	}
+
+	rootgid, err := config.HostGID()
+	if err != nil {
+		return fmt.Errorf("failed to get root gid from gidMappings: %v", err)
+	}
+
+	// Similar to the above test, we need to make sure that we aren't trying to
+	// map to a group ID that we don't have the right to be.
+	if rootgid != getegid() {
+		return fmt.Errorf("rootless containers cannot map container root to a different host group")
+	}
+
+	// We can only map one user and group inside a container (our own).
+	if len(config.UidMappings) != 1 || config.UidMappings[0].Size != 1 {
+		return fmt.Errorf("rootless containers cannot map more than one user")
+	}
+	if len(config.GidMappings) != 1 || config.GidMappings[0].Size != 1 {
+		return fmt.Errorf("rootless containers cannot map more than one group")
+	}
+
+	return nil
+}
+
+// cgroup verifies that the user isn't trying to set any cgroup limits or paths.
+func rootlessCgroup(config *configs.Config) error {
+	// Nothing set at all.
+	if config.Cgroups == nil || config.Cgroups.Resources == nil {
+		return nil
+	}
+
+	// Used for comparing to the zero value.
+	left := reflect.ValueOf(*config.Cgroups.Resources)
+	right := reflect.Zero(left.Type())
+
+	// This is all we need to do, since specconv won't add cgroup options in
+	// rootless mode.
+	if !reflect.DeepEqual(left.Interface(), right.Interface()) {
+		return fmt.Errorf("cannot specify resource limits in rootless container")
+	}
+
+	return nil
+}
+
+// mount verifies that the user isn't trying to set up any mounts they don't have
+// the rights to do. In addition, it makes sure that no mount has a `uid=` or
+// `gid=` option that doesn't resolve to root.
+func rootlessMount(config *configs.Config) error {
+	// XXX: We could whitelist allowed devices at this point, but I'm not
+	//      convinced that's a good idea. The kernel is the best arbiter of
+	//      access control.
+
+	for _, mount := range config.Mounts {
+		// Check that the options list doesn't contain any uid= or gid= entries
+		// that don't resolve to root.
+		for _, opt := range strings.Split(mount.Data, ",") {
+			if strings.HasPrefix(opt, "uid=") && opt != "uid=0" {
+				return fmt.Errorf("cannot specify uid= mount options in rootless containers where argument isn't 0")
+			}
+			if strings.HasPrefix(opt, "gid=") && opt != "gid=0" {
+				return fmt.Errorf("cannot specify gid= mount options in rootless containers where argument isn't 0")
+			}
+		}
+	}
+
+	return nil
+}

--- a/libcontainer/configs/validate/rootless.go
+++ b/libcontainer/configs/validate/rootless.go
@@ -37,7 +37,7 @@ func (v *ConfigValidator) rootless(config *configs.Config) error {
 }
 
 func rootlessMappings(config *configs.Config) error {
-	rootuid, err := config.HostUID()
+	rootuid, err := config.HostRootUID()
 	if err != nil {
 		return fmt.Errorf("failed to get root uid from uidMappings: %v", err)
 	}
@@ -50,7 +50,7 @@ func rootlessMappings(config *configs.Config) error {
 		}
 	}
 
-	rootgid, err := config.HostGID()
+	rootgid, err := config.HostRootGID()
 	if err != nil {
 		return fmt.Errorf("failed to get root gid from gidMappings: %v", err)
 	}

--- a/libcontainer/configs/validate/rootless_test.go
+++ b/libcontainer/configs/validate/rootless_test.go
@@ -1,0 +1,195 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func init() {
+	geteuid = func() int { return 1337 }
+	getegid = func() int { return 7331 }
+}
+
+func rootlessConfig() *configs.Config {
+	return &configs.Config{
+		Rootfs:   "/var",
+		Rootless: true,
+		Namespaces: configs.Namespaces(
+			[]configs.Namespace{
+				{Type: configs.NEWUSER},
+			},
+		),
+		UidMappings: []configs.IDMap{
+			{
+				HostID:      geteuid(),
+				ContainerID: 0,
+				Size:        1,
+			},
+		},
+		GidMappings: []configs.IDMap{
+			{
+				HostID:      getegid(),
+				ContainerID: 0,
+				Size:        1,
+			},
+		},
+	}
+}
+
+func TestValidateRootless(t *testing.T) {
+	validator := New()
+
+	config := rootlessConfig()
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur: %+v", err)
+	}
+}
+
+/* rootlessMappings() */
+
+func TestValidateRootlessUserns(t *testing.T) {
+	validator := New()
+
+	config := rootlessConfig()
+	config.Namespaces = nil
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if user namespaces not set")
+	}
+}
+
+func TestValidateRootlessMappingUid(t *testing.T) {
+	validator := New()
+
+	config := rootlessConfig()
+	config.UidMappings = nil
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if no uid mappings provided")
+	}
+
+	config = rootlessConfig()
+	config.UidMappings[0].HostID = geteuid() + 1
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if geteuid() != mapped uid")
+	}
+
+	config = rootlessConfig()
+	config.UidMappings[0].Size = 1024
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if more than one uid mapped")
+	}
+
+	config = rootlessConfig()
+	config.UidMappings = append(config.UidMappings, configs.IDMap{
+		HostID:      geteuid() + 1,
+		ContainerID: 0,
+		Size:        1,
+	})
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if more than one uid extent mapped")
+	}
+}
+
+func TestValidateRootlessMappingGid(t *testing.T) {
+	validator := New()
+
+	config := rootlessConfig()
+	config.GidMappings = nil
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if no gid mappings provided")
+	}
+
+	config = rootlessConfig()
+	config.GidMappings[0].HostID = getegid() + 1
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if getegid() != mapped gid")
+	}
+
+	config = rootlessConfig()
+	config.GidMappings[0].Size = 1024
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if more than one gid mapped")
+	}
+
+	config = rootlessConfig()
+	config.GidMappings = append(config.GidMappings, configs.IDMap{
+		HostID:      getegid() + 1,
+		ContainerID: 0,
+		Size:        1,
+	})
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if more than one gid extent mapped")
+	}
+}
+
+/* rootlessMount() */
+
+func TestValidateRootlessMountUid(t *testing.T) {
+	config := rootlessConfig()
+	validator := New()
+
+	config.Mounts = []*configs.Mount{
+		{
+			Source:      "devpts",
+			Destination: "/dev/pts",
+			Device:      "devpts",
+		},
+	}
+
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur when uid= not set in mount options: %+v", err)
+	}
+
+	config.Mounts[0].Data = "uid=5"
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur when setting uid=5 in mount options")
+	}
+
+	config.Mounts[0].Data = "uid=0"
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur when setting uid=0 in mount options: %+v", err)
+	}
+}
+
+func TestValidateRootlessMountGid(t *testing.T) {
+	config := rootlessConfig()
+	validator := New()
+
+	config.Mounts = []*configs.Mount{
+		{
+			Source:      "devpts",
+			Destination: "/dev/pts",
+			Device:      "devpts",
+		},
+	}
+
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur when gid= not set in mount options: %+v", err)
+	}
+
+	config.Mounts[0].Data = "gid=5"
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur when setting gid=5 in mount options")
+	}
+
+	config.Mounts[0].Data = "gid=0"
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur when setting gid=0 in mount options: %+v", err)
+	}
+}
+
+/* rootlessCgroup() */
+
+func TestValidateRootlessCgroup(t *testing.T) {
+	validator := New()
+
+	config := rootlessConfig()
+	config.Cgroups = &configs.Cgroup{
+		Resources: &configs.Resources{
+			PidsLimit: 1337,
+		},
+	}
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur if cgroup limits set")
+	}
+}

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -40,6 +40,11 @@ func (v *ConfigValidator) Validate(config *configs.Config) error {
 	if err := v.sysctl(config); err != nil {
 		return err
 	}
+	if config.Rootless {
+		if err := v.rootless(config); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -307,11 +307,11 @@ func (c *linuxContainer) Signal(s os.Signal, all bool) error {
 }
 
 func (c *linuxContainer) createExecFifo() error {
-	rootuid, err := c.Config().HostUID()
+	rootuid, err := c.Config().HostRootUID()
 	if err != nil {
 		return err
 	}
-	rootgid, err := c.Config().HostGID()
+	rootgid, err := c.Config().HostRootGID()
 	if err != nil {
 		return err
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1455,5 +1455,11 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 		}
 	}
 
+	// write oom_score_adj
+	r.AddData(&Bytemsg{
+		Type:  OomScoreAdjAttr,
+		Value: []byte(fmt.Sprintf("%d", c.config.OomScoreAdj)),
+	})
+
 	return bytes.NewReader(r.Serialize()), nil
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -51,6 +51,9 @@ type State struct {
 
 	// Platform specific fields below here
 
+	// Specifies if the container was started under the rootless mode.
+	Rootless bool `json:"rootless"`
+
 	// Path to all the cgroups setup for a container. Key is cgroup subsystem name
 	// with the value as the path.
 	CgroupPaths map[string]string `json:"cgroup_paths"`
@@ -452,6 +455,7 @@ func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 		PassedFilesCount: len(process.ExtraFiles),
 		ContainerId:      c.ID(),
 		NoNewPrivileges:  c.config.NoNewPrivileges,
+		Rootless:         c.config.Rootless,
 		AppArmorProfile:  c.config.AppArmorProfile,
 		ProcessLabel:     c.config.ProcessLabel,
 		Rlimits:          c.config.Rlimits,
@@ -622,6 +626,13 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	// TODO(avagin): Figure out how to make this work nicely. CRIU 2.0 has
+	//               support for doing unprivileged dumps, but the setup of
+	//               rootless containers might make this complicated.
+	if c.config.Rootless {
+		return fmt.Errorf("cannot checkpoint a rootless container")
+	}
+
 	if err := c.checkCriuVersion("1.5.2"); err != nil {
 		return err
 	}
@@ -791,6 +802,13 @@ func (c *linuxContainer) restoreNetwork(req *criurpc.CriuReq, criuOpts *CriuOpts
 func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 	c.m.Lock()
 	defer c.m.Unlock()
+
+	// TODO(avagin): Figure out how to make this work nicely. CRIU doesn't have
+	//               support for unprivileged restore at the moment.
+	if c.config.Rootless {
+		return fmt.Errorf("cannot restore a rootless container")
+	}
+
 	if err := c.checkCriuVersion("1.5.2"); err != nil {
 		return err
 	}
@@ -918,6 +936,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 }
 
 func (c *linuxContainer) criuApplyCgroups(pid int, req *criurpc.CriuReq) error {
+	// XXX: Do we need to deal with this case? AFAIK criu still requires root.
 	if err := c.cgroupManager.Apply(pid); err != nil {
 		return err
 	}
@@ -1314,6 +1333,7 @@ func (c *linuxContainer) currentState() (*State, error) {
 			InitProcessStartTime: startTime,
 			Created:              c.created,
 		},
+		Rootless:            c.config.Rootless,
 		CgroupPaths:         c.cgroupManager.GetPaths(),
 		NamespacePaths:      make(map[configs.NamespaceType]string),
 		ExternalDescriptors: externalDescriptors,
@@ -1441,16 +1461,19 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 				Type:  GidmapAttr,
 				Value: b,
 			})
-			// check if we have CAP_SETGID to setgroup properly
-			pid, err := capability.NewPid(os.Getpid())
-			if err != nil {
-				return nil, err
-			}
-			if !pid.Get(capability.EFFECTIVE, capability.CAP_SETGID) {
-				r.AddData(&Boolmsg{
-					Type:  SetgroupAttr,
-					Value: true,
-				})
+			// The following only applies if we are root.
+			if !c.config.Rootless {
+				// check if we have CAP_SETGID to setgroup properly
+				pid, err := capability.NewPid(os.Getpid())
+				if err != nil {
+					return nil, err
+				}
+				if !pid.Get(capability.EFFECTIVE, capability.CAP_SETGID) {
+					r.AddData(&Boolmsg{
+						Type:  SetgroupAttr,
+						Value: true,
+					})
+				}
 			}
 		}
 	}
@@ -1459,6 +1482,12 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 	r.AddData(&Bytemsg{
 		Type:  OomScoreAdjAttr,
 		Value: []byte(fmt.Sprintf("%d", c.config.OomScoreAdj)),
+	})
+
+	// write rootless
+	r.AddData(&Boolmsg{
+		Type:  RootlessAttr,
+		Value: c.config.Rootless,
 	})
 
 	return bytes.NewReader(r.Serialize()), nil

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -520,10 +520,18 @@ func (c *linuxContainer) Resume() error {
 }
 
 func (c *linuxContainer) NotifyOOM() (<-chan struct{}, error) {
+	// XXX(cyphar): This requires cgroups.
+	if c.config.Rootless {
+		return nil, fmt.Errorf("cannot get OOM notifications from rootless container")
+	}
 	return notifyOnOOM(c.cgroupManager.GetPaths())
 }
 
 func (c *linuxContainer) NotifyMemoryPressure(level PressureLevel) (<-chan struct{}, error) {
+	// XXX(cyphar): This requires cgroups.
+	if c.config.Rootless {
+		return nil, fmt.Errorf("cannot get memory pressure notifications from rootless container")
+	}
 	return notifyMemoryPressure(c.cgroupManager.GetPaths(), level)
 }
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/mount"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/cgroups/rootless"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/configs/validate"
@@ -66,6 +67,20 @@ func SystemdCgroups(l *LinuxFactory) error {
 func Cgroupfs(l *LinuxFactory) error {
 	l.NewCgroupsManager = func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
 		return &fs.Manager{
+			Cgroups: config,
+			Paths:   paths,
+		}
+	}
+	return nil
+}
+
+// RootlessCgroups is an options func to configure a LinuxFactory to
+// return containers that use the "rootless" cgroup manager, which will
+// fail to do any operations not possible to do with an unprivileged user.
+// It should only be used in conjunction with rootless containers.
+func RootlessCgroups(l *LinuxFactory) error {
+	l.NewCgroupsManager = func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
+		return &rootless.Manager{
 			Cgroups: config,
 			Paths:   paths,
 		}
@@ -169,6 +184,9 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	if err := os.Chown(containerRoot, uid, gid); err != nil {
 		return nil, newGenericError(err, SystemError)
 	}
+	if config.Rootless {
+		RootlessCgroups(l)
+	}
 	c := &linuxContainer{
 		id:            id,
 		root:          containerRoot,
@@ -194,6 +212,10 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		processPid:       state.InitProcessPid,
 		processStartTime: state.InitProcessStartTime,
 		fds:              state.ExternalDescriptors,
+	}
+	// We have to use the RootlessManager.
+	if state.Rootless {
+		RootlessCgroups(l)
 	}
 	c := &linuxContainer{
 		initProcess:          r,

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -164,11 +164,11 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	if err := l.Validator.Validate(config); err != nil {
 		return nil, newGenericError(err, ConfigInvalid)
 	}
-	uid, err := config.HostUID()
+	uid, err := config.HostRootUID()
 	if err != nil {
 		return nil, newGenericError(err, SystemError)
 	}
-	gid, err := config.HostGID()
+	gid, err := config.HostRootGID()
 	if err != nil {
 		return nil, newGenericError(err, SystemError)
 	}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -6,10 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
-	"strconv"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -367,12 +365,6 @@ func setupRlimits(limits []configs.Rlimit, pid int) error {
 		}
 	}
 	return nil
-}
-
-func setOomScoreAdj(oomScoreAdj int, pid int) error {
-	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
-
-	return ioutil.WriteFile(path, []byte(strconv.Itoa(oomScoreAdj)), 0600)
 }
 
 const _P_PID = 1

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -277,7 +277,7 @@ func setupUser(config *initConfig) error {
 
 	// before we change to the container's user make sure that the processes STDIO
 	// is correctly owned by the user that we are switching to.
-	if err := fixStdioPermissions(execUser); err != nil {
+	if err := fixStdioPermissions(config, execUser); err != nil {
 		return err
 	}
 
@@ -312,7 +312,7 @@ func setupUser(config *initConfig) error {
 // fixStdioPermissions fixes the permissions of PID 1's STDIO within the container to the specified user.
 // The ownership needs to match because it is created outside of the container and needs to be
 // localized.
-func fixStdioPermissions(u *user.ExecUser) error {
+func fixStdioPermissions(config *initConfig, u *user.ExecUser) error {
 	var null syscall.Stat_t
 	if err := syscall.Stat("/dev/null", &null); err != nil {
 		return err
@@ -326,10 +326,20 @@ func fixStdioPermissions(u *user.ExecUser) error {
 		if err := syscall.Fstat(int(fd), &s); err != nil {
 			return err
 		}
+
 		// Skip chown of /dev/null if it was used as one of the STDIO fds.
 		if s.Rdev == null.Rdev {
 			continue
 		}
+
+		// Skip chown if s.Gid is actually an unmapped gid in the host. While
+		// this is a bit dodgy if it just so happens that the console _is_
+		// owned by overflow_gid, there's no way for us to disambiguate this as
+		// a userspace program.
+		if _, err := config.Config.HostGID(int(s.Gid)); err != nil {
+			continue
+		}
+
 		// We only change the uid owner (as it is possible for the mount to
 		// prefer a different gid, and there's no reason for us to change it).
 		// The reason why we don't just leave the default uid=X mount setup is

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -11,12 +11,14 @@ import (
 // list of known message types we want to send to bootstrap program
 // The number is randomly chosen to not conflict with known netlink types
 const (
-	InitMsg        uint16 = 62000
-	CloneFlagsAttr uint16 = 27281
-	NsPathsAttr    uint16 = 27282
-	UidmapAttr     uint16 = 27283
-	GidmapAttr     uint16 = 27284
-	SetgroupAttr   uint16 = 27285
+	InitMsg         uint16 = 62000
+	CloneFlagsAttr  uint16 = 27281
+	NsPathsAttr     uint16 = 27282
+	UidmapAttr      uint16 = 27283
+	GidmapAttr      uint16 = 27284
+	SetgroupAttr    uint16 = 27285
+	OomScoreAdjAttr uint16 = 27286
+
 	// When syscall.NLA_HDRLEN is in gccgo, take this out.
 	syscall_NLA_HDRLEN = (syscall.SizeofNlAttr + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)
 )

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -18,6 +18,7 @@ const (
 	GidmapAttr      uint16 = 27284
 	SetgroupAttr    uint16 = 27285
 	OomScoreAdjAttr uint16 = 27286
+	RootlessAttr    uint16 = 27287
 
 	// When syscall.NLA_HDRLEN is in gccgo, take this out.
 	syscall_NLA_HDRLEN = (syscall.SizeofNlAttr + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -85,10 +85,6 @@ func (p *setnsProcess) start() (err error) {
 			return newSystemErrorWithCausef(err, "adding pid %d to cgroups", p.pid())
 		}
 	}
-	// set oom_score_adj
-	if err := setOomScoreAdj(p.config.Config.OomScoreAdj, p.pid()); err != nil {
-		return newSystemErrorWithCause(err, "setting oom score")
-	}
 	// set rlimits, this has to be done here because we lose permissions
 	// to raise the limits once we enter a user-namespace
 	if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
@@ -284,10 +280,6 @@ func (p *initProcess) start() error {
 		case procReady:
 			if err := p.manager.Set(p.config.Config); err != nil {
 				return newSystemErrorWithCause(err, "setting cgroup config for ready process")
-			}
-			// set oom_score_adj
-			if err := setOomScoreAdj(p.config.Config.OomScoreAdj, p.pid()); err != nil {
-				return newSystemErrorWithCause(err, "setting oom score for ready process")
 			}
 			// set rlimits, this has to be done here because we lose permissions
 			// to raise the limits once we enter a user-namespace

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -348,7 +348,7 @@ func getCgroupMounts(m *configs.Mount) ([]*configs.Mount, error) {
 	var binds []*configs.Mount
 
 	for _, mm := range mounts {
-		dir, err := mm.GetThisCgroupDir(cgroupPaths)
+		dir, err := mm.GetOwnCgroup(cgroupPaths)
 		if err != nil {
 			return nil, err
 		}

--- a/libcontainer/specconv/example.go
+++ b/libcontainer/specconv/example.go
@@ -1,0 +1,160 @@
+package specconv
+
+import (
+	"runtime"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func sPtr(s string) *string { return &s }
+
+// ExampleSpec returns an example spec file, with many options set so a user
+// can see what a standard spec file looks like.
+func ExampleSpec() *specs.Spec {
+	return &specs.Spec{
+		Version: specs.Version,
+		Platform: specs.Platform{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+		},
+		Root: specs.Root{
+			Path:     "rootfs",
+			Readonly: true,
+		},
+		Process: specs.Process{
+			Terminal: true,
+			User:     specs.User{},
+			Args: []string{
+				"sh",
+			},
+			Env: []string{
+				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"TERM=xterm",
+			},
+			Cwd:             "/",
+			NoNewPrivileges: true,
+			Capabilities: &specs.LinuxCapabilities{
+				Bounding: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Permitted: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Inheritable: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Ambient: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Effective: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+			},
+			Rlimits: []specs.LinuxRlimit{
+				{
+					Type: "RLIMIT_NOFILE",
+					Hard: uint64(1024),
+					Soft: uint64(1024),
+				},
+			},
+		},
+		Hostname: "runc",
+		Mounts: []specs.Mount{
+			{
+				Destination: "/proc",
+				Type:        "proc",
+				Source:      "proc",
+				Options:     nil,
+			},
+			{
+				Destination: "/dev",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
+			{
+				Destination: "/dev/pts",
+				Type:        "devpts",
+				Source:      "devpts",
+				Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			},
+			{
+				Destination: "/dev/shm",
+				Type:        "tmpfs",
+				Source:      "shm",
+				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			},
+			{
+				Destination: "/dev/mqueue",
+				Type:        "mqueue",
+				Source:      "mqueue",
+				Options:     []string{"nosuid", "noexec", "nodev"},
+			},
+			{
+				Destination: "/sys",
+				Type:        "sysfs",
+				Source:      "sysfs",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			},
+			{
+				Destination: "/sys/fs/cgroup",
+				Type:        "cgroup",
+				Source:      "cgroup",
+				Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
+			},
+		},
+		Linux: &specs.Linux{
+			MaskedPaths: []string{
+				"/proc/kcore",
+				"/proc/latency_stats",
+				"/proc/timer_list",
+				"/proc/timer_stats",
+				"/proc/sched_debug",
+				"/sys/firmware",
+			},
+			ReadonlyPaths: []string{
+				"/proc/asound",
+				"/proc/bus",
+				"/proc/fs",
+				"/proc/irq",
+				"/proc/sys",
+				"/proc/sysrq-trigger",
+			},
+			Resources: &specs.LinuxResources{
+				Devices: []specs.LinuxDeviceCgroup{
+					{
+						Allow:  false,
+						Access: "rwm",
+					},
+				},
+			},
+			Namespaces: []specs.LinuxNamespace{
+				{
+					Type: "pid",
+				},
+				{
+					Type: "network",
+				},
+				{
+					Type: "ipc",
+				},
+				{
+					Type: "uts",
+				},
+				{
+					Type: "mount",
+				},
+			},
+		},
+	}
+}

--- a/libcontainer/specconv/example.go
+++ b/libcontainer/specconv/example.go
@@ -1,16 +1,18 @@
 package specconv
 
 import (
+	"os"
 	"runtime"
+	"strings"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func sPtr(s string) *string { return &s }
 
-// ExampleSpec returns an example spec file, with many options set so a user
-// can see what a standard spec file looks like.
-func ExampleSpec() *specs.Spec {
+// Example returns an example spec file, with many options set so a user can
+// see what a standard spec file looks like.
+func Example() *specs.Spec {
 	return &specs.Spec{
 		Version: specs.Version,
 		Platform: specs.Platform{
@@ -157,4 +159,69 @@ func ExampleSpec() *specs.Spec {
 			},
 		},
 	}
+}
+
+// ExampleRootless returns an example spec file that works with rootless
+// containers. It's essentially a modified version of the specfile from
+// Example().
+func ToRootless(spec *specs.Spec) {
+	var namespaces []specs.LinuxNamespace
+
+	// Remove networkns from the spec.
+	for _, ns := range spec.Linux.Namespaces {
+		switch ns.Type {
+		case specs.NetworkNamespace, specs.UserNamespace:
+			// Do nothing.
+		default:
+			namespaces = append(namespaces, ns)
+		}
+	}
+	// Add userns to the spec.
+	namespaces = append(namespaces, specs.LinuxNamespace{
+		Type: specs.UserNamespace,
+	})
+	spec.Linux.Namespaces = namespaces
+
+	// Add mappings for the current user.
+	spec.Linux.UIDMappings = []specs.LinuxIDMapping{{
+		HostID:      uint32(os.Geteuid()),
+		ContainerID: 0,
+		Size:        1,
+	}}
+	spec.Linux.GIDMappings = []specs.LinuxIDMapping{{
+		HostID:      uint32(os.Getegid()),
+		ContainerID: 0,
+		Size:        1,
+	}}
+
+	// Fix up mounts.
+	var mounts []specs.Mount
+	for _, mount := range spec.Mounts {
+		// Ignore all mounts that are under /sys.
+		if strings.HasPrefix(mount.Destination, "/sys") {
+			continue
+		}
+
+		// Remove all gid= and uid= mappings.
+		var options []string
+		for _, option := range mount.Options {
+			if !strings.HasPrefix(option, "gid=") && !strings.HasPrefix(option, "uid=") {
+				options = append(options, option)
+			}
+		}
+
+		mount.Options = options
+		mounts = append(mounts, mount)
+	}
+	// Add the sysfs mount as an rbind.
+	mounts = append(mounts, specs.Mount{
+		Source:      "/sys",
+		Destination: "/sys",
+		Type:        "none",
+		Options:     []string{"rbind", "nosuid", "noexec", "nodev", "ro"},
+	})
+	spec.Mounts = mounts
+
+	// Remove cgroup settings.
+	spec.Linux.Resources = nil
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -610,11 +610,11 @@ func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
 	for _, m := range spec.Linux.GIDMappings {
 		config.GidMappings = append(config.GidMappings, create(m))
 	}
-	rootUID, err := config.HostUID()
+	rootUID, err := config.HostRootUID()
 	if err != nil {
 		return err
 	}
-	rootGID, err := config.HostGID()
+	rootGID, err := config.HostRootGID()
 	if err != nil {
 		return err
 	}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -145,6 +145,7 @@ type CreateOpts struct {
 	NoPivotRoot      bool
 	NoNewKeyring     bool
 	Spec             *specs.Spec
+	Rootless         bool
 }
 
 // CreateLibcontainerConfig creates a new libcontainer configuration from a
@@ -175,6 +176,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		Hostname:     spec.Hostname,
 		Labels:       append(labels, fmt.Sprintf("bundle=%s", cwd)),
 		NoNewKeyring: opts.NoNewKeyring,
+		Rootless:     opts.Rootless,
 	}
 
 	exists := false
@@ -208,7 +210,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	if err := setupUserNamespace(spec, config); err != nil {
 		return nil, err
 	}
-	c, err := createCgroupConfig(opts.CgroupName, opts.UseSystemdCgroup, spec)
+	c, err := createCgroupConfig(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -264,8 +266,14 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	}
 }
 
-func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*configs.Cgroup, error) {
-	var myCgroupPath string
+func createCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
+	var (
+		myCgroupPath string
+
+		spec             = opts.Spec
+		useSystemdCgroup = opts.UseSystemdCgroup
+		name             = opts.CgroupName
+	)
 
 	c := &configs.Cgroup{
 		Resources: &configs.Resources{},
@@ -301,9 +309,14 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 		c.Path = myCgroupPath
 	}
 
-	c.Resources.AllowedDevices = allowedDevices
-	if spec.Linux == nil {
-		return c, nil
+	// In rootless containers, any attempt to make cgroup changes will fail.
+	// libcontainer will validate this and we shouldn't add any cgroup options
+	// the user didn't specify.
+	if !opts.Rootless {
+		c.Resources.AllowedDevices = allowedDevices
+		if spec.Linux == nil {
+			return c, nil
+		}
 	}
 	r := spec.Linux.Resources
 	if r == nil {
@@ -340,8 +353,10 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 		}
 		c.Resources.Devices = append(c.Resources.Devices, dd)
 	}
-	// append the default allowed devices to the end of the list
-	c.Resources.Devices = append(c.Resources.Devices, allowedDevices...)
+	if !opts.Rootless {
+		// append the default allowed devices to the end of the list
+		c.Resources.Devices = append(c.Resources.Devices, allowedDevices...)
+	}
 	if r.Memory != nil {
 		if r.Memory.Limit != nil {
 			c.Resources.Memory = *r.Memory.Limit

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -3,7 +3,6 @@
 package specconv
 
 import (
-	"os"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/configs/validate"
@@ -53,8 +52,9 @@ func TestLinuxCgroupsPathNotSpecified(t *testing.T) {
 }
 
 func TestSpecconvExampleValidate(t *testing.T) {
-	spec := ExampleSpec()
+	spec := Example()
 	spec.Root.Path = "/"
+
 	opts := &CreateOpts{
 		CgroupName:       "ContainerID",
 		UseSystemdCgroup: false,
@@ -97,29 +97,9 @@ func TestDupNamespaces(t *testing.T) {
 }
 
 func TestRootlessSpecconvValidate(t *testing.T) {
-	spec := &specs.Spec{
-		Linux: specs.Linux{
-			Namespaces: []specs.Namespace{
-				{
-					Type: specs.UserNamespace,
-				},
-			},
-			UIDMappings: []specs.IDMapping{
-				{
-					HostID:      uint32(os.Geteuid()),
-					ContainerID: 0,
-					Size:        1,
-				},
-			},
-			GIDMappings: []specs.IDMapping{
-				{
-					HostID:      uint32(os.Getegid()),
-					ContainerID: 0,
-					Size:        1,
-				},
-			},
-		},
-	}
+	spec := Example()
+	spec.Root.Path = "/"
+	ToRootless(spec)
 
 	opts := &CreateOpts{
 		CgroupName:       "ContainerID",

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -3,8 +3,10 @@
 package specconv
 
 import (
+	"os"
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/configs/validate"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -16,7 +18,13 @@ func TestLinuxCgroupsPathSpecified(t *testing.T) {
 		CgroupsPath: cgroupsPath,
 	}
 
-	cgroup, err := createCgroupConfig("ContainerID", false, spec)
+	opts := &CreateOpts{
+		CgroupName:       "ContainerID",
+		UseSystemdCgroup: false,
+		Spec:             spec,
+	}
+
+	cgroup, err := createCgroupConfig(opts)
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}
@@ -28,14 +36,39 @@ func TestLinuxCgroupsPathSpecified(t *testing.T) {
 
 func TestLinuxCgroupsPathNotSpecified(t *testing.T) {
 	spec := &specs.Spec{}
+	opts := &CreateOpts{
+		CgroupName:       "ContainerID",
+		UseSystemdCgroup: false,
+		Spec:             spec,
+	}
 
-	cgroup, err := createCgroupConfig("ContainerID", false, spec)
+	cgroup, err := createCgroupConfig(opts)
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}
 
 	if cgroup.Path != "" {
 		t.Errorf("Wrong cgroupsPath, expected it to be empty string, got '%s'", cgroup.Path)
+	}
+}
+
+func TestSpecconvExampleValidate(t *testing.T) {
+	spec := ExampleSpec()
+	spec.Root.Path = "/"
+	opts := &CreateOpts{
+		CgroupName:       "ContainerID",
+		UseSystemdCgroup: false,
+		Spec:             spec,
+	}
+
+	config, err := CreateLibcontainerConfig(opts)
+	if err != nil {
+		t.Errorf("Couldn't create libcontainer config: %v", err)
+	}
+
+	validator := validate.New()
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected specconv to produce valid container config: %v", err)
 	}
 }
 
@@ -60,5 +93,48 @@ func TestDupNamespaces(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("Duplicated namespaces should be forbidden")
+	}
+}
+
+func TestRootlessSpecconvValidate(t *testing.T) {
+	spec := &specs.Spec{
+		Linux: specs.Linux{
+			Namespaces: []specs.Namespace{
+				{
+					Type: specs.UserNamespace,
+				},
+			},
+			UIDMappings: []specs.IDMapping{
+				{
+					HostID:      uint32(os.Geteuid()),
+					ContainerID: 0,
+					Size:        1,
+				},
+			},
+			GIDMappings: []specs.IDMapping{
+				{
+					HostID:      uint32(os.Getegid()),
+					ContainerID: 0,
+					Size:        1,
+				},
+			},
+		},
+	}
+
+	opts := &CreateOpts{
+		CgroupName:       "ContainerID",
+		UseSystemdCgroup: false,
+		Spec:             spec,
+		Rootless:         true,
+	}
+
+	config, err := CreateLibcontainerConfig(opts)
+	if err != nil {
+		t.Errorf("Couldn't create libcontainer config: %v", err)
+	}
+
+	validator := validate.New()
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected specconv to produce valid rootless container config: %v", err)
 	}
 }

--- a/list.go
+++ b/list.go
@@ -7,12 +7,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 	"text/tabwriter"
 	"time"
 
 	"encoding/json"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/urfave/cli"
 )
@@ -38,6 +40,8 @@ type containerState struct {
 	Created time.Time `json:"created"`
 	// Annotations is the user defined annotations added to the config.
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// The owner of the state directory (the owner of the container).
+	Owner string `json:"owner"`
 }
 
 var listCommand = cli.Command{
@@ -85,14 +89,15 @@ To list containers created using a non-default value for "--root":
 		switch context.String("format") {
 		case "table":
 			w := tabwriter.NewWriter(os.Stdout, 12, 1, 3, ' ', 0)
-			fmt.Fprint(w, "ID\tPID\tSTATUS\tBUNDLE\tCREATED\n")
+			fmt.Fprint(w, "ID\tPID\tSTATUS\tBUNDLE\tCREATED\tOWNER\n")
 			for _, item := range s {
-				fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n",
+				fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\n",
 					item.ID,
 					item.InitProcessPid,
 					item.Status,
 					item.Bundle,
-					item.Created.Format(time.RFC3339Nano))
+					item.Created.Format(time.RFC3339Nano),
+					item.Owner)
 			}
 			if err := w.Flush(); err != nil {
 				return err
@@ -126,6 +131,13 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 	var s []containerState
 	for _, item := range list {
 		if item.IsDir() {
+			// This cast is safe on Linux.
+			stat := item.Sys().(*syscall.Stat_t)
+			owner, err := user.LookupUid(int(stat.Uid))
+			if err != nil {
+				owner.Name = string(stat.Uid)
+			}
+
 			container, err := factory.Load(item.Name())
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "load container %s: %v\n", item.Name(), err)
@@ -155,6 +167,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 				Rootfs:         state.BaseState.Config.Rootfs,
 				Created:        state.BaseState.Created,
 				Annotations:    annotations,
+				Owner:          owner.Name,
 			})
 		}
 	}

--- a/ps.go
+++ b/ps.go
@@ -28,6 +28,11 @@ var psCommand = cli.Command{
 		if err := checkArgs(context, 1, minArgs); err != nil {
 			return err
 		}
+		// XXX: Currently not supported with rootless containers.
+		if isRootless() {
+			return fmt.Errorf("runc ps requires root")
+		}
+
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/restore.go
+++ b/restore.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 
@@ -86,6 +87,11 @@ using the runc checkpoint command.`,
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}
+		// XXX: Currently this is untested with rootless containers.
+		if isRootless() {
+			return fmt.Errorf("runc restore requires root")
+		}
+
 		imagePath := context.String("image-path")
 		id := context.Args().First()
 		if id == "" {

--- a/spec.go
+++ b/spec.go
@@ -64,12 +64,21 @@ container on your host.`,
 			Value: "",
 			Usage: "path to the root of the bundle directory",
 		},
+		cli.BoolFlag{
+			Name:  "rootless",
+			Usage: "generate a configuration for a rootless container",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 0, exactArgs); err != nil {
 			return err
 		}
-		spec := specconv.ExampleSpec()
+		spec := specconv.Example()
+
+		rootless := context.Bool("rootless")
+		if rootless {
+			specconv.ToRootless(spec)
+		}
 
 		checkNoFile := func(name string) error {
 			_, err := os.Stat(name)

--- a/spec.go
+++ b/spec.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/specconv"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
@@ -68,152 +69,7 @@ container on your host.`,
 		if err := checkArgs(context, 0, exactArgs); err != nil {
 			return err
 		}
-		spec := specs.Spec{
-			Version: specs.Version,
-			Platform: specs.Platform{
-				OS:   runtime.GOOS,
-				Arch: runtime.GOARCH,
-			},
-			Root: specs.Root{
-				Path:     "rootfs",
-				Readonly: true,
-			},
-			Process: specs.Process{
-				Terminal: true,
-				User:     specs.User{},
-				Args: []string{
-					"sh",
-				},
-				Env: []string{
-					"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-					"TERM=xterm",
-				},
-				Cwd:             "/",
-				NoNewPrivileges: true,
-				Capabilities: &specs.LinuxCapabilities{
-					Bounding: []string{
-						"CAP_AUDIT_WRITE",
-						"CAP_KILL",
-						"CAP_NET_BIND_SERVICE",
-					},
-					Permitted: []string{
-						"CAP_AUDIT_WRITE",
-						"CAP_KILL",
-						"CAP_NET_BIND_SERVICE",
-					},
-					Inheritable: []string{
-						"CAP_AUDIT_WRITE",
-						"CAP_KILL",
-						"CAP_NET_BIND_SERVICE",
-					},
-					Ambient: []string{
-						"CAP_AUDIT_WRITE",
-						"CAP_KILL",
-						"CAP_NET_BIND_SERVICE",
-					},
-					Effective: []string{
-						"CAP_AUDIT_WRITE",
-						"CAP_KILL",
-						"CAP_NET_BIND_SERVICE",
-					},
-				},
-				Rlimits: []specs.LinuxRlimit{
-					{
-						Type: "RLIMIT_NOFILE",
-						Hard: uint64(1024),
-						Soft: uint64(1024),
-					},
-				},
-			},
-			Hostname: "runc",
-			Mounts: []specs.Mount{
-				{
-					Destination: "/proc",
-					Type:        "proc",
-					Source:      "proc",
-					Options:     nil,
-				},
-				{
-					Destination: "/dev",
-					Type:        "tmpfs",
-					Source:      "tmpfs",
-					Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
-				},
-				{
-					Destination: "/dev/pts",
-					Type:        "devpts",
-					Source:      "devpts",
-					Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
-				},
-				{
-					Destination: "/dev/shm",
-					Type:        "tmpfs",
-					Source:      "shm",
-					Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
-				},
-				{
-					Destination: "/dev/mqueue",
-					Type:        "mqueue",
-					Source:      "mqueue",
-					Options:     []string{"nosuid", "noexec", "nodev"},
-				},
-				{
-					Destination: "/sys",
-					Type:        "sysfs",
-					Source:      "sysfs",
-					Options:     []string{"nosuid", "noexec", "nodev", "ro"},
-				},
-				{
-					Destination: "/sys/fs/cgroup",
-					Type:        "cgroup",
-					Source:      "cgroup",
-					Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
-				},
-			},
-			Linux: &specs.Linux{
-				MaskedPaths: []string{
-					"/proc/kcore",
-					"/proc/latency_stats",
-					"/proc/timer_list",
-					"/proc/timer_stats",
-					"/proc/sched_debug",
-					"/sys/firmware",
-				},
-				ReadonlyPaths: []string{
-					"/proc/asound",
-					"/proc/bus",
-					"/proc/fs",
-					"/proc/irq",
-					"/proc/sys",
-					"/proc/sysrq-trigger",
-				},
-				Resources: &specs.LinuxResources{
-					Devices: []specs.LinuxDeviceCgroup{
-						{
-							Allow:  false,
-							Access: "rwm",
-						},
-					},
-				},
-				Namespaces: []specs.LinuxNamespace{
-					{
-						Type: "pid",
-					},
-					{
-						Type: "network",
-					},
-					{
-						Type: "ipc",
-					},
-					{
-						Type: "uts",
-					},
-					{
-						Type: "mount",
-					},
-				},
-			},
-		}
+		spec := specconv.ExampleSpec()
 
 		checkNoFile := func(name string) error {
 			_, err := os.Stat(name)
@@ -234,7 +90,7 @@ container on your host.`,
 		if err := checkNoFile(specConfig); err != nil {
 			return err
 		}
-		data, err := json.MarshalIndent(&spec, "", "\t")
+		data, err := json.MarshalIndent(spec, "", "\t")
 		if err != nil {
 			return err
 		}

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -28,7 +28,9 @@ function check_cgroup_value() {
 }
 
 @test "runc update --kernel-memory (initialized)" {
-    requires cgroups_kmem
+	# XXX: currently cgroups require root containers.
+    requires cgroups_kmem root
+
     # Add cgroup path
     sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
@@ -56,7 +58,9 @@ EOF
 }
 
 @test "runc update --kernel-memory (uninitialized)" {
-    requires cgroups_kmem
+	# XXX: currently cgroups require root containers.
+    requires cgroups_kmem root
+
     # Add cgroup path
     sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -59,8 +59,9 @@ function teardown() {
   [[ "${output}" == *"running"* ]]
 }
 
-@test "checkpoint(pre-dump) and restore" {
-  requires criu
+@test "checkpoint --pre-dump and restore" {
+  # XXX: currently criu require root containers.
+  requires criu root
 
   # criu does not work with external terminals so..
   # setting terminal and root:readonly: to false

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -12,7 +12,8 @@ function teardown() {
 }
 
 @test "checkpoint and restore" {
-  requires criu
+  # XXX: currently criu require root containers.
+  requires criu root
 
   # criu does not work with external terminals so..
   # setting terminal and root:readonly: to false

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -22,11 +22,13 @@ function teardown() {
   testcontainer test_busybox running
 
   runc kill test_busybox KILL
+  [ "$status" -eq 0 ]
   # wait for busybox to be in the destroyed state
   retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
 
   # delete test_busybox
   runc delete test_busybox
+  [ "$status" -eq 0 ]
 
   runc state test_busybox
   [ "$status" -ne 0 ]

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -12,6 +12,9 @@ function teardown() {
 }
 
 @test "events --stats" {
+  # XXX: currently cgroups require root containers.
+  requires root
+
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
@@ -27,6 +30,9 @@ function teardown() {
 }
 
 @test "events --interval default " {
+  # XXX: currently cgroups require root containers.
+  requires root
+
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
@@ -54,6 +60,9 @@ function teardown() {
 }
 
 @test "events --interval 1s " {
+  # XXX: currently cgroups require root containers.
+  requires root
+
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
@@ -80,6 +89,9 @@ function teardown() {
 }
 
 @test "events --interval 100ms " {
+  # XXX: currently cgroups require root containers.
+  requires root
+
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -112,6 +112,9 @@ function teardown() {
 }
 
 @test "runc exec --user" {
+  # --user can't work in rootless containers
+  requires root
+
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -57,6 +57,7 @@ load helpers
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ resume+ ]]
 
+  # We don't use runc_spec here, because we're just testing the help page.
   runc spec -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ spec+ ]]

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -4,7 +4,7 @@
 INTEGRATION_ROOT=$(dirname "$(readlink -f "$BASH_SOURCE")")
 RUNC="${INTEGRATION_ROOT}/../../runc"
 RECVTTY="${INTEGRATION_ROOT}/../../contrib/cmd/recvtty/recvtty"
-GOPATH="${INTEGRATION_ROOT}/../../../.."
+GOPATH="$(mktemp -d --tmpdir runc-integration-gopath.XXXXXX)"
 
 # Test data path.
 TESTDATA="${INTEGRATION_ROOT}/testdata"
@@ -27,7 +27,7 @@ KERNEL_MINOR="${KERNEL_VERSION#$KERNEL_MAJOR.}"
 KERNEL_MINOR="${KERNEL_MINOR%%.*}"
 
 # Root state path.
-ROOT="$BATS_TMPDIR/runc"
+ROOT=$(mktemp -d "$BATS_TMPDIR/runc.XXXXXX")
 
 # Path to console socket.
 CONSOLE_SOCKET="$BATS_TMPDIR/console.sock"
@@ -56,6 +56,17 @@ function runc() {
 # Raw wrapper for runc.
 function __runc() {
 	"$RUNC" --root "$ROOT" "$@"
+}
+
+# Wrapper for runc spec.
+function runc_spec() {
+	local args=""
+
+	if [ "$ROOTLESS" -ne 0 ]; then
+		args+="--rootless"
+	fi
+
+	runc spec $args "$@"
 }
 
 # Fails the current test, providing the error given.
@@ -187,18 +198,18 @@ function setup_busybox() {
 	if [ ! -e $BUSYBOX_IMAGE ]; then
 		curl -o $BUSYBOX_IMAGE -sSL 'https://github.com/docker-library/busybox/raw/a0558a9006ce0dd6f6ec5d56cfd3f32ebeeb815f/glibc/busybox.tar.xz'
 	fi
-	tar -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
+	tar --exclude './dev/*' -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
 	cd "$BUSYBOX_BUNDLE"
-	runc spec
+	runc_spec
 }
 
 function setup_hello() {
 	setup_recvtty
 	run mkdir "$HELLO_BUNDLE"
 	run mkdir "$HELLO_BUNDLE"/rootfs
-	tar -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
+	tar --exclude './dev/*' -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
 	cd "$HELLO_BUNDLE"
-	runc spec
+	runc_spec
 	sed -i 's;"sh";"/hello";' config.json
 }
 

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -40,6 +40,9 @@ CGROUP_CPU_BASE_PATH=$(grep "cgroup" /proc/self/mountinfo | gawk 'toupper($NF) ~
 KMEM="${CGROUP_MEMORY_BASE_PATH}/memory.kmem.limit_in_bytes"
 RT_PERIOD="${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us"
 
+# Check if we're in rootless mode.
+ROOTLESS=$(id -u)
+
 # Wrapper for runc.
 function runc() {
 	run __runc "$@"
@@ -68,7 +71,12 @@ function requires() {
 		case $var in
 			criu)
 				if [ ! -e "$CRIU" ]; then
-					skip "Test requires ${var}."
+					skip "test requires ${var}"
+				fi
+				;;
+			root)
+				if [ "$ROOTLESS" -ne 0 ]; then
+					skip "test requires ${var}"
 				fi
 				;;
 			cgroups_kmem)

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -13,7 +13,6 @@ function teardown() {
 
 
 @test "kill detached busybox" {
-
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -12,6 +12,9 @@ function teardown() {
 }
 
 @test "runc pause and resume" {
+  # XXX: currently cgroups require root containers.
+  requires root
+
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
@@ -34,6 +37,9 @@ function teardown() {
 }
 
 @test "runc pause and resume with nonexist container" {
+  # XXX: currently cgroups require root containers.
+  requires root
+
   # run test_busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -12,6 +12,9 @@ function teardown() {
 }
 
 @test "ps" {
+  # ps is not supported, it requires cgroups
+  requires root
+
   # start busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
@@ -24,10 +27,13 @@ function teardown() {
   runc ps test_busybox
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
-  [[ "${lines[1]}" == *"root"*[0-9]* ]]
+  [[ "${lines[1]}" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
 }
 
 @test "ps -f json" {
+  # ps is not supported, it requires cgroups
+  requires root
+
   # start busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
@@ -43,6 +49,9 @@ function teardown() {
 }
 
 @test "ps -e -x" {
+  # ps is not supported, it requires cgroups
+  requires root
+
   # start busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -26,7 +26,7 @@ function teardown() {
   [ ! -e config.json ]
 
   # test generation of spec does not return an error
-  runc spec
+  runc_spec
   [ "$status" -eq 0 ]
 
   # test generation of spec created our config.json (spec)
@@ -51,7 +51,7 @@ function teardown() {
   [ ! -e "$HELLO_BUNDLE"/config.json ]
 
   # test generation of spec does not return an error
-  runc spec --bundle "$HELLO_BUNDLE"
+  runc_spec --bundle "$HELLO_BUNDLE"
   [ "$status" -eq 0 ]
 
   # test generation of spec created our config.json (spec)

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -23,6 +23,9 @@ function teardown() {
 }
 
 @test "runc run detached ({u,g}id != 0)" {
+  # cannot start containers as another user in rootless setup
+  requires root
+
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.
   sed -i 's;"uid": 0;"uid": 1000;g' config.json

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -21,6 +21,9 @@ function teardown() {
 }
 
 @test "runc run ({u,g}id != 0)" {
+  # cannot start containers as another user in rootless setup
+  requires root
+
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.
   sed -i 's;"uid": 0;"uid": 1000;g' config.json

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -11,7 +11,37 @@ function teardown() {
   teardown_busybox
 }
 
-@test "state" {
+@test "state (kill + delete)" {
+  runc state test_busybox
+  [ "$status" -ne 0 ]
+
+  # run busybox detached
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  [ "$status" -eq 0 ]
+
+  # check state
+  wait_for_container 15 1 test_busybox
+
+  testcontainer test_busybox running
+
+  runc kill test_busybox KILL
+  [ "$status" -eq 0 ]
+
+  # wait for busybox to be in the destroyed state
+  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+
+  # delete test_busybox
+  runc delete test_busybox
+  [ "$status" -eq 0 ]
+
+  runc state test_busybox
+  [ "$status" -ne 0 ]
+}
+
+@test "state (pause + resume)" {
+  # XXX: pause and resume require cgroups.
+  requires root
+
   runc state test_busybox
   [ "$status" -ne 0 ]
 
@@ -37,14 +67,4 @@ function teardown() {
 
   # test state of busybox is back to running
   testcontainer test_busybox running
-
-  runc kill test_busybox KILL
-  # wait for busybox to be in the destroyed state
-  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
-
-  # delete test_busybox
-  runc delete test_busybox
-
-  runc state test_busybox
-  [ "$status" -ne 0 ]
 }

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -24,6 +24,10 @@ function teardown() {
 }
 
 @test "runc run [tty owner]" {
+	# tty chmod is not doable in rootless containers.
+	# TODO: this can be made as a change to the gid test.
+	requires root
+
 	# Replace sh script with stat.
 	sed -i 's/"sh"/"sh", "-c", "stat -c %u:%g $(tty) | tr : \\\\\\\\n"/' config.json
 
@@ -36,6 +40,9 @@ function teardown() {
 }
 
 @test "runc run [tty owner] ({u,g}id != 0)" {
+	# tty chmod is not doable in rootless containers.
+	requires root
+
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
 	sed -i 's;"uid": 0;"uid": 1000;g' config.json
@@ -72,6 +79,10 @@ function teardown() {
 }
 
 @test "runc exec [tty owner]" {
+	# tty chmod is not doable in rootless containers.
+	# TODO: this can be made as a change to the gid test.
+	requires root
+
 	# run busybox detached
 	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
@@ -90,6 +101,9 @@ function teardown() {
 }
 
 @test "runc exec [tty owner] ({u,g}id != 0)" {
+	# tty chmod is not doable in rootless containers.
+	requires root
+
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
 	sed -i 's;"uid": 0;"uid": 1000;g' config.json

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -50,7 +50,11 @@ function check_cgroup_value() {
 
 # TODO: test rt cgroup updating
 @test "update" {
-    requires cgroups_kmem
+    # XXX: currently cgroups require root containers.
+	# XXX: Also, this test should be split into separate sections so that we
+	#      can skip kmem without skipping update tests overall.
+    requires cgroups_kmem root
+
     # run a few busyboxes detached
     runc run -d --console-socket $CONSOLE_SOCKET test_update
     [ "$status" -eq 0 ]

--- a/utils.go
+++ b/utils.go
@@ -63,9 +63,6 @@ func setupSpec(context *cli.Context) (*specs.Spec, error) {
 	if err != nil {
 		return nil, err
 	}
-	if os.Geteuid() != 0 {
-		return nil, fmt.Errorf("runc should be run as root")
-	}
 	return spec, nil
 }
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -186,6 +186,11 @@ func createPidFile(path string, process *libcontainer.Process) error {
 	return os.Rename(tmpName, path)
 }
 
+// XXX: Currently we autodetect rootless mode.
+func isRootless() bool {
+	return os.Geteuid() != 0
+}
+
 func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcontainer.Container, error) {
 	config, err := specconv.CreateLibcontainerConfig(&specconv.CreateOpts{
 		CgroupName:       id,
@@ -193,6 +198,7 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcont
 		NoPivotRoot:      context.Bool("no-pivot"),
 		NoNewKeyring:     context.Bool("no-new-keyring"),
 		Spec:             spec,
+		Rootless:         isRootless(),
 	})
 	if err != nil {
 		return nil, err

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -242,12 +242,12 @@ func (r *runner) run(config *specs.Process) (int, error) {
 	for i := baseFd; i < baseFd+r.preserveFDs; i++ {
 		process.ExtraFiles = append(process.ExtraFiles, os.NewFile(uintptr(i), "PreserveFD:"+strconv.Itoa(i)))
 	}
-	rootuid, err := r.container.Config().HostUID()
+	rootuid, err := r.container.Config().HostRootUID()
 	if err != nil {
 		r.destroy()
 		return -1, err
 	}
-	rootgid, err := r.container.Config().HostGID()
+	rootgid, err := r.container.Config().HostRootGID()
 	if err != nil {
 		r.destroy()
 		return -1, err


### PR DESCRIPTION
This enables the support for "rootless container mode". There are
certain restrictions on what non-root users can do, resulting in several
runC features not being available. ~~There are no checks in place at
the moment to make this clear to users.~~ I've implemented the config
validation.
- All cgroup operations require having write access to your current
  cgroup directory. By default, the directories are owned by `root` and have
  the mode `0755`. This means that we cannot set up _any_ cgroups, or join
  cgroups. Therefore new cgroup namespace doesn't fix this for us either, but
  hopefully we can get a patch upstream to fix this. **But** we should still
  improve cgroup handling so that we apply any cgroups we can if we have
  write access to the directory.
- setgroups(2) cannot be used in a non-privileged user namespace setup.
  We also have to set `/proc/self/setgroups` to "deny".
- We cannot map any user other than ourselves in a rootless container,
  which means that any user-related directives won't work. You can only be
  "root".

If you want to use this, you have to make sure you remove the `gid=5` entry from the `/dev/pts` mount, and only map **your own user** in the namespace.

Here's `runc start` working in both `root` and `rootless` setup:
![it works](https://cloud.githubusercontent.com/assets/2888411/14762626/5c7cb66c-09c2-11e6-8ae2-59a3bc56c244.png)

And here's `runc exec` working in both `root` and `rootless` setup:
![it also works](https://cloud.githubusercontent.com/assets/2888411/14762631/75724e70-09c2-11e6-80de-bf3978cc1766.png)
### `TODO`
- [x] Provide a meaningful error message if the user specifies a configuration which maps more than one user (or doesn't map the effective user).
- [x] Provide a meaningful error message (don't just ignore it) if the user tries to use the `user` directive to run as a different user.
- [x] Provide a meaningful error message (don't just ignore it) if the user tries to specify any cgroup settings. Currently we can't provide cgroup settings (though it should be possible if the user just so happens to own the cgroup they currently reside in).
- [x] `runc exec` doesn't work, and we should be able to implement it. This actually complicates the code in `nsenter.c` which checks whether the container is unprivileged. `setgroup` needs special treatment.
- [x] `runc exec` doesnt' work with `root` running the exec and a rootless container (ironically). This is because we autodetect the `rootless` parameter on run, which isn't accurate. This can be fixed by storing the `rootless` flag in the `state.json`.
- [x] `rootless` should be passed to the init through netlink. Currently we are doing the `rootless` check in two places and it doesn't make sense to do the check in `nsenter.c` -- we might actually have to do it with capability checks in the future.
- [x] `runc events` doesn't work because the `rootless.Manager` doesn't appear to manage the paths properly, so it can't get any data from the cgroups.
- [x] Add `runc spec --rootless`.
- [x] `loadContainer` doesn't properly load the cgroup manager for the container, because the API forces that to happen (`libcontainer.New()` takes the cgroup manager as an argument). We can probably fix this by making it load the cgroup manager from the container state (but it might be ugly). Without this, we can't even hope to have `runc pause` and `runc resume` working.
- :x: Currently the cgroup setup is binary (either we use cgroups or we don't). But since cgroupv1 lets you have different permissions on different hierarchies, we should check for each subsystem that we have access to create a subtree in that cgroup. Then we can support several setups (as well as the kernel patch I've proposed). This would require many changes in config validation. In addition, we would have to store what cgroups we are using in a bitmask (like in the kernel).
  - :x: This would require adding a bunch of tests to `libcontainer/cgroup/rootless`. Luckily we already all of the mock stuff we need in `cgroupfs`.
- [x] Add unit tests to:
  - [x] `libcontainer/config/validate/rootless`
  - [x] `libcontainer/specconv/spec_linux.go` with `Rootless == true`.
  - :x: ~~`libcontainer/cgroup/rootless`~~ (not necessary at the moment)
- [x] ~~Detaching doesn't work due to a bug in runC with `--console` and user namespaces. #814 and #883~~
- [x] Add a setup for testing the rootless containers so we can make sure there's no regressions in this set up. We can try running the whole test suite (minus cgroups and a few other things). ~~All of the sniff tests should work.~~ The sniff tests are no more. ~~**THIS IS CURRENTLY BLOCKED ON FIXING THE `--console` BUG**.~~ The console bug has been fixed as part of #1018.
  - [x] We have to refactor all of the tests to use a wrapper around `runc` (so we can mess around with arguments in rootless mode).
  - [x] Also, we need to skip certain tests in rootless mode, since they are not supported.
- [x] We currently cannot use network namespaces in a rootless container setup (and still connect to the network). A fix for this is to use the host network, but that currently doesn't work in runC (#799). It should also be noted that things like `ping` don't work in rootless containers (user namespace issues). #807 fixes the validation issue.
  - [x] Figure out why we still can't talk to the internet.
- :x: Switch `container.Processes()` to join the container PID namespace, enumerate the list of PIDs and then send them over a UNIX socket (this causes the PIDs to be translated). The end result is to not require cgroups to enumerate PIDs (which actually isn't a good idea since processes may join sub-cgroups). This is necessary for `runc ps` and similar things to work properly.
  - :x: There are some unanswered questions about sending the PIDs though, because you need `CAP_SYS_ADMIN` in order to send a different PID. And there's also a valid question about atomicity (enumeration is not atomic, reading from `cgroup.procs` is).
### Open Questions
- [x] Make sure that the cgroup namespace actually allows us to set cgroups. **It doesn't**. I've sent [an email to upstream proposing a potential solution](http://article.gmane.org/gmane.linux.kernel.cgroups/15948). You can also [take a look at the state of my (probably broken) kernel patchset](https://github.com/cyphar/linux/tree/cgroupns-rootless-containers).
- [x] Should we move `runc` back to `/usr/bin`, since it's no longer an admin piece of software? This would also mean moving the `man` pages to `man1`.
### What works?
- As unprivileged user:
  - :x: ~~`runc checkpoint`~~ (while potentially possible, not implemented)
  - [x] `runc create` (#814)
  - [x] `runc create --console` (#814)
  - [x] `runc delete`
  - :x: ~~`runc events`~~ (not _really_ useful -- cgroups)
  - [x] `runc exec`
  - [x] `runc exec --console` (#814)
  - [x] `runc kill`
  - [x] `runc list`
    - [x] with containers not readable by us.
  - :x: ~~`runc pause`~~ (cgroups)
  - :x: ~~`runc ps`~~ (cgroups)
  - :x: ~~`runc restore`~~ (while potentially possible, not implemented)
  - :x: ~~`runc resume`~~ (cgroups)
  - [x] `runc run`
  - [x] `runc run -d --console` (#814)
  - [x] `runc spec`
  - [x] `runc start` (`create` doesn't work -- #814)
  - [x] `runc state`
  - :x: ~~`runc update`~~ (cgroups)
- As `root`:
  - :x: ~~`runc checkpoint`~~ (while potentially possible, not implemented)
  - [x] `runc delete`
  - :x: ~~`runc events`~~ (not _really_ useful -- cgroups)
  - [x] `runc exec`
  - [x] `runc exec --console` (#814)
  - [x] `runc kill`
  - [x] `runc list`
  - :x: ~~`runc pause`~~ (cgroups)
  - :x: `runc ps` (cgroups)
  - :x: ~~`runc restore`~~ (while potentially possible, not implemented)
  - :x: ~~`runc resume`~~ (cgroups)
  - [x] `runc run`
  - [x] `runc run -d --console` (#814)
  - [x] `runc spec`
  - [x] `runc start` (`create` doesn't work -- #814)
  - [x] `runc state`
  - :x: ~~`runc update`~~ (cgroups)
### Kernel Patches
- `CLONE_NEWCGROUP` fix to allow unprivileged processes to allow us to create subtrees.
  - [x] v1: https://lkml.org/lkml/2016/5/1/77
  - [x] v2: https://lkml.org/lkml/2016/5/1/87
  - [x] v3: https://lkml.org/lkml/2016/5/2/280
  - :x: v4: https://lkml.org/lkml/2016/5/13/576

Implements #38.

Signed-off-by: Aleksa Sarai asarai@suse.de
