### PR TITLE
libcontainer: specconv: fix nil dereference in resource setup

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -219,8 +219,8 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		config.Seccomp = seccomp
 	}
 	config.Sysctl = spec.Linux.Sysctl
-	if oomScoreAdj := spec.Linux.Resources.OOMScoreAdj; oomScoreAdj != nil {
-		config.OomScoreAdj = *oomScoreAdj
+	if spec.Linux.Resources != nil && spec.Linux.Resources.OOMScoreAdj != nil {
+		config.OomScoreAdj = *spec.Linux.Resources.OOMScoreAdj
 	}
 	for _, g := range spec.Process.User.AdditionalGids {
 		config.AdditionalGroups = append(config.AdditionalGroups, strconv.FormatUint(uint64(g), 10))


### PR DESCRIPTION
This caused issues if someone omitted or set "resources": null, in the
runC config. The panic follows.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x545b53]

goroutine 1 [running]:
panic(0x7aed40, 0xc820014260)
        /usr/lib64/go/src/runtime/panic.go:464 +0x3e6
github.com/opencontainers/runc/libcontainer/specconv.CreateLibcontainerConfig(0xc8200b0e30, 0x836480, 0x0, 0x0)
        /home/cyphar/src/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go:222 +0xe83
main.createContainer(0xc82007eb40, 0x7ffd8024e439, 0x4, 0xc82008e780, 0x0, 0x0, 0x0, 0x0)
        /home/cyphar/src/runc/utils_linux.go:174 +0x105
main.startContainer(0xc82007eb40, 0xc82008e780, 0x0, 0x0, 0x0)
        /home/cyphar/src/runc/start.go:114 +0x189
main.glob.func11(0xc82007eb40)
        /home/cyphar/src/runc/start.go:78 +0x13e
github.com/codegangsta/cli.Command.Run(0x829a58, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x87ada0, 0x1a, 0x8dff80, ...)
        /home/cyphar/src/runc/Godeps/_workspace/src/github.com/codegangsta/cli/command.go:137 +0x1081
github.com/codegangsta/cli.(*App).Run(0xc82007e900, 0xc82000a050, 0x5, 0x5, 0x0, 0x0)
        /home/cyphar/src/runc/Godeps/_workspace/src/github.com/codegangsta/cli/app.go:176 +0xffa
main.main()
        /home/cyphar/src/runc/main.go:123 +0xc8e
```

Signed-off-by: Aleksa Sarai <asarai@suse.de>