### PR TITLE
Bump to v0.1.1 for selinux mount label fix

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -58,8 +58,8 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runtime-spec/specs-go",
-			"Comment": "v0.5.0",
-			"Rev": "78e6667ae2d67aad100b28ee9580b41b7a24e667"
+			"Comment": "v0.5.0-34-g6e08c69",
+			"Rev": "6e08c6983ef8c2173f10ca09266907d4e9e71716"
 		},
 		{
 			"ImportPath": "github.com/seccomp/libseccomp-golang",

--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -140,6 +140,8 @@ type Linux struct {
 	MaskedPaths []string `json:"maskedPaths,omitempty"`
 	// ReadonlyPaths sets the provided paths as RO inside the container.
 	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
+	// MountLabel specifies the selinux context for the mounts in the container.
+	MountLabel string `json:"mountLabel,omitempty"`
 }
 
 // Namespace is the configuration for a Linux namespace

--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 0
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 5
+	VersionMinor = 6
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -226,6 +226,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		config.AdditionalGroups = append(config.AdditionalGroups, strconv.FormatUint(uint64(g), 10))
 	}
 	createHooks(spec, config)
+	config.MountLabel = spec.Linux.MountLabel
 	config.Version = specs.Version
 	return config, nil
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 var gitCommit = ""
 
 const (
-	version    = "0.1.0"
+	version    = "0.1.1"
 	specConfig = "config.json"
 	usage      = `Open Container Initiative runtime
 	


### PR DESCRIPTION
This will merged the version bump back into master.