### PR TITLE
Add json format to ps command

### DIFF
--- a/list.go
+++ b/list.go
@@ -81,12 +81,9 @@ in json format:
 				fatal(err)
 			}
 		case "json":
-			data, err := json.Marshal(s)
-			if err != nil {
+			if err := json.NewEncoder(os.Stdout).Encode(s); err != nil {
 				fatal(err)
 			}
-			os.Stdout.Write(data)
-
 		default:
 			fatalf("invalid format option")
 		}


### PR DESCRIPTION
For programatic parsing add a json format option to the new `runc ps`
command.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>