### PR TITLE
Add support for cgroup namespaces

### DIFF
--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -8,13 +8,17 @@ func (n *Namespace) Syscall() int {
 	return namespaceInfo[n.Type]
 }
 
+// This is not yet in the Go stdlib.
+const syscall_CLONE_NEWCGROUP = (1 << 29)
+
 var namespaceInfo = map[NamespaceType]int{
-	NEWNET:  syscall.CLONE_NEWNET,
-	NEWNS:   syscall.CLONE_NEWNS,
-	NEWUSER: syscall.CLONE_NEWUSER,
-	NEWIPC:  syscall.CLONE_NEWIPC,
-	NEWUTS:  syscall.CLONE_NEWUTS,
-	NEWPID:  syscall.CLONE_NEWPID,
+	NEWNET:    syscall.CLONE_NEWNET,
+	NEWNS:     syscall.CLONE_NEWNS,
+	NEWUSER:   syscall.CLONE_NEWUSER,
+	NEWIPC:    syscall.CLONE_NEWIPC,
+	NEWUTS:    syscall.CLONE_NEWUTS,
+	NEWPID:    syscall.CLONE_NEWPID,
+	NEWCGROUP: syscall_CLONE_NEWCGROUP,
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct

--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -9,12 +9,13 @@ import (
 )
 
 const (
-	NEWNET  NamespaceType = "NEWNET"
-	NEWPID  NamespaceType = "NEWPID"
-	NEWNS   NamespaceType = "NEWNS"
-	NEWUTS  NamespaceType = "NEWUTS"
-	NEWIPC  NamespaceType = "NEWIPC"
-	NEWUSER NamespaceType = "NEWUSER"
+	NEWNET    NamespaceType = "NEWNET"
+	NEWPID    NamespaceType = "NEWPID"
+	NEWNS     NamespaceType = "NEWNS"
+	NEWUTS    NamespaceType = "NEWUTS"
+	NEWIPC    NamespaceType = "NEWIPC"
+	NEWUSER   NamespaceType = "NEWUSER"
+	NEWCGROUP NamespaceType = "NEWCGROUP"
 )
 
 var (
@@ -37,6 +38,8 @@ func nsToFile(ns NamespaceType) string {
 		return "user"
 	case NEWUTS:
 		return "uts"
+	case NEWCGROUP:
+		return "cgroup"
 	}
 	return ""
 }
@@ -70,6 +73,7 @@ func NamespaceTypes() []NamespaceType {
 		NEWUTS,
 		NEWIPC,
 		NEWUSER,
+		NEWCGROUP,
 	}
 }
 

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -29,6 +29,7 @@ var namespaceMapping = map[specs.NamespaceType]configs.NamespaceType{
 	specs.UserNamespace:    configs.NEWUSER,
 	specs.IPCNamespace:     configs.NEWIPC,
 	specs.UTSNamespace:     configs.NEWUTS,
+	specs.CgroupNamespace:  configs.NEWCGROUP,
 }
 
 var mountPropagationMapping = map[string]int{


### PR DESCRIPTION
This is a very simple implementation because it doesn't require any
configuration unlike the other namespaces, and in its current state it
only masks paths.

This feature is available in Linux 4.6+ and is enabled by default if
the kernel is compiled with `CONFIG_CGROUP=y`.

TODO:
- [ ] Change `rootfs_linux` setup to actually mount `cgroup` if we're in a cgroup + user namespace.

Depends on opencontainers/runtime-spec#397
