### PR TITLE
Correct outdated URL

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -18,7 +18,7 @@ import (
 
 const cgroupNamePrefix = "name="
 
-// https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt
+// https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
 func FindCgroupMountpoint(subsystem string) (string, error) {
 	// We are not using mount.GetMounts() because it's super-inefficient,
 	// parsing it directly sped up x10 times because of not using Sscanf.


### PR DESCRIPTION
`libcontainer/cgroups/utils.go` uses an incorrect path to the
documentation for cgroups.  This updates the comment to use the correct
URL.  Fixes #794.

Signed-off-by: Jim Berlage <james.berlage@gmail.com>