### PR TITLE
Updating error condition in applying apparmor profile

### DIFF
--- a/libcontainer/apparmor/apparmor.go
+++ b/libcontainer/apparmor/apparmor.go
@@ -7,6 +7,7 @@ package apparmor
 // #include <stdlib.h>
 import "C"
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"unsafe"
@@ -32,7 +33,7 @@ func ApplyProfile(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 	if _, err := C.aa_change_onexec(cName); err != nil {
-		return err
+		return fmt.Errorf("apparmor failed to apply profile: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
When applying profiles, when the profile is not there, currently runc throws error saying
no such file or directory.
From user perspective, little confusion to identify where the error occured from libcontainer, so updated the message accordingly
Signed-off-by: rajasec <rajasec79@gmail.com>