### PR TITLE
integration: fix cgroup parsing

### DIFF
--- a/script/test_Dockerfile
+++ b/script/test_Dockerfile
@@ -6,6 +6,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    gawk \
     iptables \
     libaio-dev \
     libcap-dev \

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -21,7 +21,7 @@ Alternatively, you can run integration tests directly on your host through make:
 ```
 $ sudo make localintegration
 ```
-Or you can just run them directly using bats 
+Or you can just run them directly using bats
 ```
 $ sudo bats tests/integration
 ```
@@ -32,17 +32,17 @@ $ make integration TESTFLAGS="/checkpoint.bats"
 
 
 To run them on your host, you will need to setup a development environment plus
-[bats](https://github.com/sstephenson/bats#installing-bats-from-source) 
+[bats](https://github.com/sstephenson/bats#installing-bats-from-source)
 For example:
 ```
-$ cd ~/go/src/github.com 
-$ git clone https://github.com/sstephenson/bats.git 
-$ cd bats 
+$ cd ~/go/src/github.com
+$ git clone https://github.com/sstephenson/bats.git
+$ cd bats
 $ ./install.sh /usr/local
 ```
-		
-> **Note**: There are known issues running the integration tests using 
-> **devicemapper** as a storage driver, make sure that your docker daemon 
+
+> **Note**: There are known issues running the integration tests using
+> **devicemapper** as a storage driver, make sure that your docker daemon
 > is using **aufs** if you want to successfully run the integration tests.
 
 ## Writing integration tests

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -9,8 +9,8 @@ CGROUP_MEMORY=""
 TEST_CGROUP_NAME="runc-cgroups-integration-test"
 
 function init_cgroup_path() {
-   base_path=$(grep "rw,"  /proc/self/mountinfo | grep -i -m 1 'MEMORY$' | cut -d ' ' -f 5)
-   CGROUP_MEMORY="${base_path}/${TEST_CGROUP_NAME}"
+	base_path=$(grep "cgroup"  /proc/self/mountinfo | gawk 'toupper($NF) ~ /\<MEMORY\>/ { print $5; exit }')
+	CGROUP_MEMORY="${base_path}/${TEST_CGROUP_NAME}"
 }
 
 function teardown() {

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -2,10 +2,7 @@
 
 load helpers
 
-UPDATE_TEST_RUNC_ROOT="$BATS_TMPDIR/runc-cgroups-integration-test"
-
 CGROUP_MEMORY=""
-
 TEST_CGROUP_NAME="runc-cgroups-integration-test"
 
 function init_cgroup_path() {
@@ -15,7 +12,7 @@ function init_cgroup_path() {
 
 function teardown() {
     rm -f $BATS_TMPDIR/runc-update-integration-test.json
-    teardown_running_container_inroot test_cgroups_kmem $UPDATE_TEST_RUNC_ROOT
+    teardown_running_container test_cgroups_kmem
     teardown_busybox
 }
 
@@ -37,7 +34,7 @@ function check_cgroup_value() {
     [ "$current" -eq "$expected" ]
 }
 
-@test "cgroups-kernel-memory-initialized" {
+@test "runc update --kernel-memory (initialized)" {
     # Add cgroup path
     sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
@@ -52,26 +49,26 @@ EOF
     sed -i "s/\(\"resources\": {\)/\1\n${DATA}/" ${BUSYBOX_BUNDLE}/config.json
 
     # start a detached busybox to work with
-    "$RUNC" --root $UPDATE_TEST_RUNC_ROOT start -d --console /dev/pts/ptmx test_cgroups_kmem
+    run "$RUNC" start -d --console /dev/pts/ptmx test_cgroups_kmem
     [ "$status" -eq 0 ]
-    wait_for_container_inroot 15 1 test_cgroups_kmem $UPDATE_TEST_RUNC_ROOT
+    wait_for_container 15 1 test_cgroups_kmem
 
     # update kernel memory limit
-    "$RUNC" --root $UPDATE_TEST_RUNC_ROOT update test_cgroups_kmem --kernel-memory 50331648
+    run "$RUNC" update test_cgroups_kmem --kernel-memory 50331648
     [ "$status" -eq 0 ]
     check_cgroup_value $CGROUP_MEMORY "memory.kmem.limit_in_bytes" 50331648
 }
 
-@test "cgroups-kernel-memory-uninitialized" {
+@test "runc update --kernel-memory (uninitialized)" {
     # Add cgroup path
     sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
     # start a detached busybox to work with
-    run "$RUNC" --root $UPDATE_TEST_RUNC_ROOT start -d --console /dev/pts/ptmx test_cgroups_kmem
+    run "$RUNC" start -d --console /dev/pts/ptmx test_cgroups_kmem
     [ "$status" -eq 0 ]
-    wait_for_container_inroot 15 1 test_cgroups_kmem $UPDATE_TEST_RUNC_ROOT
+    wait_for_container 15 1 test_cgroups_kmem
 
     # update kernel memory limit
-    run "$RUNC" --root $UPDATE_TEST_RUNC_ROOT update test_cgroups_kmem --kernel-memory 50331648
+    run "$RUNC" update test_cgroups_kmem --kernel-memory 50331648
     [ ! "$status" -eq 0 ]
 }

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -15,27 +15,27 @@ function teardown() {
   if [ ! -e "$CRIU" ] ; then
     skip
   fi
-  
+
   # criu does not work with external terminals so..
   # setting terminal and root:readonly: to false
-  sed -i 's;"terminal": true;"terminal": false;' config.json  
-  sed -i 's;"readonly": true;"readonly": false;' config.json 
+  sed -i 's;"terminal": true;"terminal": false;' config.json
+  sed -i 's;"readonly": true;"readonly": false;' config.json
   sed -i 's/"sh"/"sh","-c","while :; do date; sleep 1; done"/' config.json
-  
-  (  
-    # start busybox (not detached) 
+
+  (
+    # start busybox (not detached)
     run "$RUNC" start test_busybox
     [ "$status" -eq 0 ]
   ) &
-  
+
   # check state
   wait_for_container 15 1 test_busybox
 
   run "$RUNC" state test_busybox
   [ "$status" -eq 0 ]
   [[ "${output}" == *"running"* ]]
-  
-  # checkpoint the running container 
+
+  # checkpoint the running container
   run "$RUNC" --criu "$CRIU" checkpoint test_busybox
   # if you are having problems getting criu to work uncomment the following dump:
   #cat /run/opencontainer/containers/test_busybox/criu.work/dump.log
@@ -44,13 +44,13 @@ function teardown() {
   # after checkpoint busybox is no longer running
   run "$RUNC" state test_busybox
   [ "$status" -ne 0 ]
-    
+
   # restore from checkpoint
   (
     run "$RUNC" --criu "$CRIU" restore test_busybox
     [ "$status" -eq 0 ]
   ) &
-  
+
   # check state
   wait_for_container 15 1 test_busybox
 

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -25,10 +25,10 @@ function teardown() {
 
   # check output does not include debug info
   [[ "${output}" != *"level=debug"* ]]
-  
-  # check log.out was generated 
+
+  # check log.out was generated
   [ -e log.out ]
-  
+
   # check expected debug output was sent to log.out
   run cat log.out
   [ "$status" -eq 0 ]
@@ -43,9 +43,9 @@ function teardown() {
   # check output does not include debug info
   [[ "${output}" != *"level=debug"* ]]
 
-  # check log.out was generated 
+  # check log.out was generated
   [ -e log.out ]
-  
+
   # check expected debug output was sent to log.out
   run cat log.out
   [ "$status" -eq 0 ]
@@ -56,13 +56,13 @@ function teardown() {
   # start hello-world
   run "$RUNC" --log log.out --log-format "json" --debug start test_hello
   [ "$status" -eq 0 ]
-  
+
   # check output does not include debug info
   [[ "${output}" != *"level=debug"* ]]
 
-  # check log.out was generated 
+  # check log.out was generated
   [ -e log.out ]
-  
+
   # check expected debug output was sent to log.out
   run cat log.out
   [ "$status" -eq 0 ]

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -20,14 +20,14 @@ function teardown() {
   wait_for_container 15 1 test_busybox
 
   testcontainer test_busybox running
-  
+
   run "$RUNC" kill test_busybox KILL
   # wait for busybox to be in the destroyed state
-  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'" 
+  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
 
   # delete test_busybox
   run "$RUNC" delete test_busybox
-  
+
   run "$RUNC" state test_busybox
   [ "$status" -ne 0 ]
 }

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -23,7 +23,7 @@ function startup_events() {
   # check state
   wait_for_container 15 1 test_busybox
 
-  # generate stats 
+  # generate stats
   run "$RUNC" events --stats test_busybox
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
@@ -37,20 +37,20 @@ function startup_events() {
 
   # check state
   wait_for_container 15 1 test_busybox
-  
-  # spawn two sub processes (shells) 
-  # the first sub process is an event logger that sends stats events to events.log 
-  # the second sub process waits for an event that incudes test_busybox then 
+
+  # spawn two sub processes (shells)
+  # the first sub process is an event logger that sends stats events to events.log
+  # the second sub process waits for an event that incudes test_busybox then
   # kills the test_busybox container which causes the event logger to exit
   ("$RUNC" events test_busybox > events.log) &
-  ( 
+  (
     retry 10 1 eval "grep -q 'test_busybox' events.log"
     teardown_running_container test_busybox
   ) &
-  wait # wait for the above sub shells to finish  
-  
+  wait # wait for the above sub shells to finish
+
   [ -e events.log ]
-  
+
   run cat events.log
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
@@ -64,21 +64,21 @@ function startup_events() {
 
   # check state
   wait_for_container 15 1 test_busybox
-  
-  # spawn two sub processes (shells) 
-  # the first sub process is an event logger that sends stats events to events.log once a second 
-  # the second sub process tries 3 times for an event that incudes test_busybox 
-  # pausing 1s between each attempt then kills the test_busybox container which 
+
+  # spawn two sub processes (shells)
+  # the first sub process is an event logger that sends stats events to events.log once a second
+  # the second sub process tries 3 times for an event that incudes test_busybox
+  # pausing 1s between each attempt then kills the test_busybox container which
   # causes the event logger to exit
   ("$RUNC" events --interval 1s test_busybox > events.log) &
-  ( 
+  (
     retry 3 1 eval "grep -q 'test_busybox' events.log"
     teardown_running_container test_busybox
   ) &
-  wait # wait for the above sub shells to finish  
-  
+  wait # wait for the above sub shells to finish
+
   [ -e events.log ]
-  
+
   run eval "grep -q 'test_busybox' events.log"
   [ "$status" -eq 0 ]
 }
@@ -90,24 +90,24 @@ function startup_events() {
 
   # check state
   wait_for_container 15 1 test_busybox
-  
+
   #prove there is no carry over of events.log from a prior test
   [ ! -e events.log ]
-    
-  # spawn two sub processes (shells) 
-  # the first sub process is an event logger that sends stats events to events.log once every 100ms 
-  # the second sub process tries 3 times for an event that incudes test_busybox 
-  # pausing 100s between each attempt then kills the test_busybox container which 
+
+  # spawn two sub processes (shells)
+  # the first sub process is an event logger that sends stats events to events.log once every 100ms
+  # the second sub process tries 3 times for an event that incudes test_busybox
+  # pausing 100s between each attempt then kills the test_busybox container which
   # causes the event logger to exit
   ("$RUNC" events --interval 100ms test_busybox > events.log) &
-  ( 
+  (
     retry 3 0.100 eval "grep -q 'test_busybox' events.log"
     teardown_running_container test_busybox
   ) &
-  wait # wait for the above sub shells to finish  
-  
+  wait # wait for the above sub shells to finish
+
   [ -e events.log ]
-  
+
   run eval "grep -q 'test_busybox' events.log"
   [ "$status" -eq 0 ]
 }

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -18,9 +18,9 @@ function teardown() {
 
   wait_for_container 15 1 test_busybox
 
-  run "$RUNC" exec test_busybox echo Hello from exec 
+  run "$RUNC" exec test_busybox echo Hello from exec
   [ "$status" -eq 0 ]
-  echo text echoed = "'""${output}""'" 
+  echo text echoed = "'""${output}""'"
   [[ "${output}" == *"Hello from exec"* ]]
 }
 
@@ -31,12 +31,12 @@ function teardown() {
 
   wait_for_container 15 1 test_busybox
 
-  run "$RUNC" exec --pid-file pid.txt test_busybox echo Hello from exec 
+  run "$RUNC" exec --pid-file pid.txt test_busybox echo Hello from exec
   [ "$status" -eq 0 ]
-  echo text echoed = "'""${output}""'" 
+  echo text echoed = "'""${output}""'"
   [[ "${output}" == *"Hello from exec"* ]]
 
-  # check pid.txt was generated 
+  # check pid.txt was generated
   [ -e pid.txt ]
 
   run cat pid.txt

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -7,7 +7,7 @@ load helpers
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
-  
+
   run "$RUNC" --help
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
@@ -18,11 +18,11 @@ load helpers
   run "$RUNC" checkpoint -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ checkpoint+ ]]
-  
+
   run "$RUNC" delete -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ delete+ ]]
-  
+
   run "$RUNC" events -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ events+ ]]
@@ -30,49 +30,49 @@ load helpers
   run "$RUNC" exec -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ exec+ ]]
-  
+
   run "$RUNC" kill -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ kill+ ]]
-  
+
   run "$RUNC" list -h
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ list+ ]]
-  
+
   run "$RUNC" list --help
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ list+ ]]
-  
+
   run "$RUNC" pause -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ pause+ ]]
-  
+
   run "$RUNC" restore -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ restore+ ]]
-  
+
   run "$RUNC" resume -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ resume+ ]]
-  
+
   run "$RUNC" spec -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ spec+ ]]
-  
+
   run "$RUNC" start -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ start+ ]]
-  
+
   run "$RUNC" state -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ state+ ]]
-  
+
   run "$RUNC" delete -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ delete+ ]]
-  
+
 }
 
 @test "runc foo -h" {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -8,11 +8,11 @@ GOPATH="${INTEGRATION_ROOT}/../../../.."
 # Test data path.
 TESTDATA="${INTEGRATION_ROOT}/testdata"
 
-# Busybox image 
+# Busybox image
 BUSYBOX_IMAGE="$BATS_TMPDIR/busybox.tar"
 BUSYBOX_BUNDLE="$BATS_TMPDIR/busyboxtest"
 
-# hello-world in tar format 
+# hello-world in tar format
 HELLO_IMAGE="$TESTDATA/hello-world.tar"
 HELLO_BUNDLE="$BATS_TMPDIR/hello-world"
 
@@ -78,20 +78,20 @@ function wait_for_container_inroot() {
 }
 
 function testcontainer() {
-  # test state of container 
+  # test state of container
   run "$RUNC" state $1
   [ "$status" -eq 0 ]
   [[ "${output}" == *"$2"* ]]
 }
 
 function setup_busybox() {
-  run mkdir "$BUSYBOX_BUNDLE" 
+  run mkdir "$BUSYBOX_BUNDLE"
   run mkdir "$BUSYBOX_BUNDLE"/rootfs
   if [ -e "/testdata/busybox.tar" ]; then
     BUSYBOX_IMAGE="/testdata/busybox.tar"
   fi
   if [ ! -e $BUSYBOX_IMAGE ]; then
-    curl -o $BUSYBOX_IMAGE -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.11/rootfs.tar' 
+    curl -o $BUSYBOX_IMAGE -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.11/rootfs.tar'
   fi
   tar -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
   cd "$BUSYBOX_BUNDLE"
@@ -99,7 +99,7 @@ function setup_busybox() {
 }
 
 function setup_hello() {
-  run mkdir "$HELLO_BUNDLE" 
+  run mkdir "$HELLO_BUNDLE"
   run mkdir "$HELLO_BUNDLE"/rootfs
   tar -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
   cd "$HELLO_BUNDLE"
@@ -108,19 +108,19 @@ function setup_hello() {
 }
 
 function teardown_running_container() {
-  run "$RUNC" list 
+  run "$RUNC" list
   if [[ "${output}" == *"$1"* ]]; then
     run "$RUNC" kill $1 KILL
-    retry 10 1 eval "'$RUNC' state '$1' | grep -q 'destroyed'" 
+    retry 10 1 eval "'$RUNC' state '$1' | grep -q 'destroyed'"
     run "$RUNC" delete $1
   fi
 }
 
 function teardown_running_container_inroot() {
-  run "$RUNC" --root $2 list 
+  run "$RUNC" --root $2 list
   if [[ "${output}" == *"$1"* ]]; then
     run "$RUNC" --root $2 kill $1 KILL
-    retry 10 1 eval "'$RUNC' --root '$2' state '$1' | grep -q 'destroyed'" 
+    retry 10 1 eval "'$RUNC' --root '$2' state '$1' | grep -q 'destroyed'"
     run "$RUNC" --root $2 delete $1
   fi
 }

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 
 @test "kill detached busybox" {
-  
+
   # start busybox detached
   run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
@@ -22,12 +22,12 @@ function teardown() {
   wait_for_container 15 1 test_busybox
 
   testcontainer test_busybox running
-  
+
   run "$RUNC" kill test_busybox KILL
   [ "$status" -eq 0 ]
-  
+
   retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
-  
+
   run "$RUNC" delete test_busybox
   [ "$status" -eq 0 ]
 }

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -22,29 +22,29 @@ function teardown() {
   run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_box1
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box1 $HELLO_BUNDLE
-  
+
   run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_box2
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box2 $HELLO_BUNDLE
-  
+
   run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_box3
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box3 $HELLO_BUNDLE
-  
-  run "$RUNC" --root $HELLO_BUNDLE list 
+
+  run "$RUNC" --root $HELLO_BUNDLE list
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
   [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-  
-  run "$RUNC" --root $HELLO_BUNDLE list --format table 
+
+  run "$RUNC" --root $HELLO_BUNDLE list --format table
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
   [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-  
+
   run "$RUNC" --root $HELLO_BUNDLE list --format json
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == [\[][\{]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"created\""[:]*[0-9]*[\}]* ]]

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -15,20 +15,20 @@ function teardown() {
   # start busybox detached
   run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
-  
+
   wait_for_container 15 1 test_busybox
-  
-  # pause busybox 
-  run "$RUNC" pause test_busybox 
+
+  # pause busybox
+  run "$RUNC" pause test_busybox
   [ "$status" -eq 0 ]
 
   # test state of busybox is paused
   testcontainer test_busybox paused
-  
-  # resume busybox 
-  run "$RUNC" resume test_busybox 
+
+  # resume busybox
+  run "$RUNC" resume test_busybox
   [ "$status" -eq 0 ]
-  
+
   # test state of busybox is back to running
   testcontainer test_busybox running
 }

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -14,41 +14,41 @@ function teardown() {
 }
 
 @test "global --root" {
-  # start busybox detached using $HELLO_BUNDLE for state  
+  # start busybox detached using $HELLO_BUNDLE for state
   run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_dotbox
   [ "$status" -eq 0 ]
 
-  # start busybox detached in default root 
+  # start busybox detached in default root
   run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
-  
+
   # check state of the busyboxes are only in their respective root path
   wait_for_container 15 1 test_busybox
   wait_for_container_inroot 15 1 test_dotbox $HELLO_BUNDLE
 
-  run "$RUNC" state test_busybox 
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
-  
-  run "$RUNC" --root $HELLO_BUNDLE state test_dotbox 
+  run "$RUNC" state test_busybox
   [ "$status" -eq 0 ]
   [[ "${output}" == *"running"* ]]
 
-  run "$RUNC" --root $HELLO_BUNDLE state test_busybox 
+  run "$RUNC" --root $HELLO_BUNDLE state test_dotbox
+  [ "$status" -eq 0 ]
+  [[ "${output}" == *"running"* ]]
+
+  run "$RUNC" --root $HELLO_BUNDLE state test_busybox
   [ "$status" -ne 0 ]
 
-  run "$RUNC" state test_dotbox 
+  run "$RUNC" state test_dotbox
   [ "$status" -ne 0 ]
-  
+
   run "$RUNC" kill test_busybox KILL
   [ "$status" -eq 0 ]
-  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'" 
+  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
   run "$RUNC" delete test_busybox
   [ "$status" -eq 0 ]
-  
+
   run "$RUNC" --root $HELLO_BUNDLE kill test_dotbox KILL
   [ "$status" -eq 0 ]
-  retry 10 1 eval "'$RUNC' --root $HELLO_BUNDLE state test_dotbox | grep -q 'destroyed'" 
-  run "$RUNC" --root $HELLO_BUNDLE delete test_dotbox  
+  retry 10 1 eval "'$RUNC' --root $HELLO_BUNDLE state test_dotbox | grep -q 'destroyed'"
+  run "$RUNC" --root $HELLO_BUNDLE delete test_dotbox
   [ "$status" -eq 0 ]
 }

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -6,9 +6,9 @@ function setup() {
   # initial cleanup in case a prior test exited and did not cleanup
   cd "$INTEGRATION_ROOT"
   run rm -f -r "$HELLO_BUNDLE"
-	  
+
   # setup hello-world for spec generation testing
-  run mkdir "$HELLO_BUNDLE" 
+  run mkdir "$HELLO_BUNDLE"
   run mkdir "$HELLO_BUNDLE"/rootfs
   run tar -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
 }
@@ -21,21 +21,21 @@ function teardown() {
 @test "spec generation cwd" {
   cd "$HELLO_BUNDLE"
   # note this test runs from the bundle not the integration root
-  
-  # test that config.json does not exist after the above partial setup 
+
+  # test that config.json does not exist after the above partial setup
   [ ! -e config.json ]
-  
-  # test generation of spec does not return an error 
+
+  # test generation of spec does not return an error
   run "$RUNC" spec
   [ "$status" -eq 0 ]
-  
-  # test generation of spec created our config.json (spec) 
+
+  # test generation of spec created our config.json (spec)
   [ -e config.json ]
 
   # test existence of required args parameter in the generated config.json
   run bash -c "grep -A2 'args' config.json | grep 'sh'"
   [[ "${output}" == *"sh"* ]]
-  
+
   # change the default args parameter from sh to hello
   sed -i 's;"sh";"/hello";' config.json
 
@@ -45,18 +45,18 @@ function teardown() {
 }
 
 @test "spec generation --bundle" {
-  # note this test runs from the integration root not the bundle 
-  
-  # test that config.json does not exist after the above partial setup 
+  # note this test runs from the integration root not the bundle
+
+  # test that config.json does not exist after the above partial setup
   [ ! -e "$HELLO_BUNDLE"/config.json ]
-  
-  # test generation of spec does not return an error 
+
+  # test generation of spec does not return an error
   run "$RUNC" spec --bundle "$HELLO_BUNDLE"
   [ "$status" -eq 0 ]
-  
-  # test generation of spec created our config.json (spec) 
+
+  # test generation of spec created our config.json (spec)
   [ -e "$HELLO_BUNDLE"/config.json ]
-  
+
   # change the default args parameter from sh to hello
   sed -i 's;"sh";"/hello";' "$HELLO_BUNDLE"/config.json
 
@@ -69,20 +69,20 @@ function teardown() {
   cd "$HELLO_BUNDLE"
   # note this test runs from the temporary bundle directory not the integration root
   # note this test is brittle against specs changes that lead runc's spec command
-  # todo get the validate program, gojsonschema, and schema/*s.json from godeps? 
-  
+  # todo get the validate program, gojsonschema, and schema/*s.json from godeps?
+
   run git clone https://github.com/opencontainers/runtime-spec.git src/runtime-spec
   [ -e src/runtime-spec/schema/schema.json ]
-  
+
   run bash -c "GOPATH='$GOPATH' go get github.com/xeipuuv/gojsonschema"
   [ "$status" -eq 0 ]
-  
+
   GOPATH="$GOPATH" go build src/runtime-spec/schema/validate.go
   [ -e ./validate ]
-  
-  run "$RUNC" spec 
+
+  run "$RUNC" spec
   [ -e config.json ]
-  
+
   run ./validate src/runtime-spec/schema/schema.json config.json
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == *"The document is valid"* ]]

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -32,7 +32,7 @@ function teardown() {
 
   testcontainer test_busybox running
 
-  # check pid.txt was generated 
+  # check pid.txt was generated
   [ -e pid.txt ]
 
   run cat pid.txt

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -13,9 +13,9 @@ function teardown() {
 
 @test "runc start" {
   # start hello-world
-  run "$RUNC" start test_hello  
+  run "$RUNC" start test_hello
   [ "$status" -eq 0 ]
-  
+
   # check expected output
   [[ "${output}" == *"Hello"* ]]
 }
@@ -37,8 +37,8 @@ function teardown() {
   run "$RUNC" start --pid-file pid.txt test_hello
   [ "$status" -eq 0 ]
   [[ "${output}" == *"Hello"* ]]
-  
-  # check pid.txt was generated 
+
+  # check pid.txt was generated
   [ -e pid.txt ]
 
   run cat pid.txt

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -14,7 +14,7 @@ function teardown() {
 @test "state" {
   run "$RUNC" state test_busybox
   [ "$status" -ne 0 ]
-  
+
   # start busybox detached
   run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
@@ -23,28 +23,28 @@ function teardown() {
   wait_for_container 15 1 test_busybox
 
   testcontainer test_busybox running
-    
-  # pause busybox 
-  run "$RUNC" pause test_busybox 
+
+  # pause busybox
+  run "$RUNC" pause test_busybox
   [ "$status" -eq 0 ]
 
   # test state of busybox is paused
   testcontainer test_busybox paused
-  
-  # resume busybox 
-  run "$RUNC" resume test_busybox 
+
+  # resume busybox
+  run "$RUNC" resume test_busybox
   [ "$status" -eq 0 ]
-  
+
   # test state of busybox is back to running
   testcontainer test_busybox running
-  
+
   run "$RUNC" kill test_busybox KILL
   # wait for busybox to be in the destroyed state
-  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'" 
-    
+  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
+
   # delete test_busybox
   run "$RUNC" delete test_busybox
-  
+
   run "$RUNC" state test_busybox
   [ "$status" -ne 0 ]
 }

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -11,7 +11,7 @@ CGROUP_BLKIO=""
 
 function init_cgroup_path() {
     for g in MEMORY CPUSET CPU BLKIO; do
-        base_path=$(grep "rw,"  /proc/self/mountinfo | grep -i -m 1 "$g\$" | cut -d ' ' -f 5)
+        base_path=$(grep "cgroup"  /proc/self/mountinfo | gawk 'toupper($NF) ~ /\<'${g}'\>/ { print $5; exit }')
         eval CGROUP_${g}="${base_path}/runc-update-integration-test"
     done
 }

--- a/tests/integration/version.bats
+++ b/tests/integration/version.bats
@@ -6,6 +6,6 @@ load helpers
   run "$RUNC" -v
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
-  [[ ${lines[1]} =~ commit:+ ]] 
+  [[ ${lines[1]} =~ commit:+ ]]
   [[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]
 }


### PR DESCRIPTION
On some systems, the cgroup hierarchies are grouped together
(cpu,cpuacct). In order to avoid fake failures, update the cgroup
parsing to just check whether or not the mountinfo options *contain* the
cgroup type.

Signed-off-by: Aleksa Sarai <asarai@suse.de>

/cc @hqhq