### PR TITLE
Revert "Need to make sure labels applied to /dev"

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -69,9 +69,6 @@ func setupRootfs(config *configs.Config, console *linuxConsole, pipe io.ReadWrit
 		if err := setupDevSymlinks(config.Rootfs); err != nil {
 			return newSystemErrorWithCause(err, "setting up /dev symlinks")
 		}
-		if err := label.Relabel(filepath.Join(config.Rootfs, "dev"), config.MountLabel, false); err != nil {
-			return err
-		}
 	}
 	// Signal the parent to run the pre-start hooks.
 	// The hooks are run after the mounts are setup, but before we switch to the new


### PR DESCRIPTION
Reverts opencontainers/runc#796

As per @rhatdan's comment in #796:

> @mrunalp @crosbymichael This patch should be reverted.  /dev is mounted on a tmpfs with context="system_u:object_r:svirt_sandbox_file_t:s0:c1,c2".  Having this label will cause this relabel to fail with operation not supported.

> I am not sure how to get the other error to happen with /dev not being on a tmpfs. 

> Please revert this patch, or should I open another pull to remove it.
