### PR TITLE
Handling destroy of container

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -115,7 +115,6 @@ func execProcess(context *cli.Context) (int, error) {
 	}
 	r := &runner{
 		enableSubreaper: !context.Bool("no-subreaper"),
-		shouldDestroy:   false,
 		container:       container,
 		console:         context.String("console"),
 		detach:          detach,

--- a/start.go
+++ b/start.go
@@ -127,7 +127,6 @@ func startContainer(context *cli.Context, spec *specs.Spec) (int, error) {
 	}
 	r := &runner{
 		enableSubreaper: !context.Bool("no-subreaper"),
-		shouldDestroy:   true,
 		container:       container,
 		listenFDs:       listenFDs,
 		console:         context.String("console"),

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -192,7 +192,6 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcont
 
 type runner struct {
 	enableSubreaper bool
-	shouldDestroy   bool
 	detach          bool
 	listenFDs       []*os.File
 	pidFile         string
@@ -254,7 +253,11 @@ func (r *runner) run(config *specs.Process) (int, error) {
 }
 
 func (r *runner) destroy() {
-	if r.shouldDestroy {
+	pids, err := r.container.Processes()
+	if err != nil {
+		fatal(err)
+	}
+	if len(pids) == 0 {
 		destroy(r.container)
 	}
 }


### PR DESCRIPTION
After killing the detached container, it goes back to destroyed state
When container is in destroyed state, if we start the container via exec, container started. After exiting the container, it goes back to destroyed state ( still retains the state.json).

Added the logic both start and exec to depend on container Processes interface for destroying the container rather than shouldDestroy variable.
Tested the following conditions
       runc start test
        runc exec test
	exit the container
state.json is retained

       runc start test -d
        runc kill test SIGKILL
        runc exec test
              exit the container
state.json is cleared properly

runc start test -d
runc kill test SIGKILL
runc delete test

runc delete is not impacted by this change.

Signed-off-by: rajasec <rajasec79@gmail.com>