### PR TITLE
libcontainer: nsenter: nsexec.c: fix warnings

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -302,7 +302,7 @@ static struct nsenter_config process_nl_attributes(int pipenum, char *data, int 
 			int	fds[nslen];
 			char	*nslist[nslen];
 			char	*ns;
-			char	*saveptr;
+			char	*saveptr = NULL;
 
 			for (i = 0; i < nslen; i++) {
 				char *str = NULL;


### PR DESCRIPTION
Fix the following warnings when building runc (on my Fedora 24 box, gcc 6):
```
Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c:
In function ‘nsexec’:
Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c:322:6:
warning: ‘__s’ may be used uninitialized in this function
[-Wmaybe-uninitialized]
      pr_perror("Failed to open %s", ns);
Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c:273:30:
note: ‘__s’ was declared here
 static struct nsenter_config process_nl_attributes(int pipenum, char
*data, int data_size)
                              ^~~~~~~~~~~~~~~~~~~~~
```

This is weird but according to some threads around this is the only way to fix this (man pages uses the save_ptr uninitialized also...):

http://linux.die.net/man/3/strtok_r
https://stackoverflow.com/questions/25368961/strtok-r-behaviour-and-pointers
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26634
https://www.spinics.net/lists/linux-btrfs/msg22773.html

Signed-off-by: Antonio Murdaca <runcom@redhat.com>