### PR TITLE
Fix GetLongBit() returns value when _SC_LONG_BIT is not available

### DIFF
--- a/libcontainer/system/sysconfig.go
+++ b/libcontainer/system/sysconfig.go
@@ -4,6 +4,21 @@ package system
 
 /*
 #include <unistd.h>
+#include <limits.h>
+
+int GetLongBit() {
+#ifdef _SC_LONG_BIT
+    int longbits;
+
+    longbits = sysconf(_SC_LONG_BIT);
+    if (longbits <  0) {
+        longbits = (CHAR_BIT * sizeof(long));
+    }
+    return longbits;
+#else
+    return (CHAR_BIT * sizeof(long));
+#endif
+}
 */
 import "C"
 
@@ -12,5 +27,5 @@ func GetClockTicks() int {
 }
 
 func GetLongBit() int {
-	return int(C.sysconf(C._SC_LONG_BIT))
+	return int(C.GetLongBit())
 }


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

Following the discussion [here](https://github.com/opencontainers/runc/pull/790#discussion-diff-63080859) updated the `GetLongBit()` definition to handle platform without support for `_SC_LONG_BIT` in which case we will default to 64bits