### PR TITLE
Fix update kernel memory test

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -70,5 +70,12 @@ EOF
 
     # update kernel memory limit
     run "$RUNC" update test_cgroups_kmem --kernel-memory 50331648
-    [ ! "$status" -eq 0 ]
+    # Since kernel 4.6, we can update kernel memory without initialization
+    # because it's accounted by default.
+    if [ "$KERNEL_MAJOR" -lt 4 ] || [ "$KERNEL_MAJOR" -eq 4 -a "$KERNEL_MINOR" -le 5 ]; then
+        [ ! "$status" -eq 0 ]
+    else
+        [ "$status" -eq 0 ]
+        check_cgroup_value $CGROUP_MEMORY "memory.kmem.limit_in_bytes" 50331648
+    fi
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -19,6 +19,12 @@ HELLO_BUNDLE="$BATS_TMPDIR/hello-world"
 # CRIU PATH
 CRIU="/usr/local/sbin/criu"
 
+# Kernel version
+KERNEL_VERSION="$(uname -r)"
+KERNEL_MAJOR="${KERNEL_VERSION%%.*}"
+KERNEL_MINOR="${KERNEL_VERSION#$KERNEL_MAJOR.}"
+KERNEL_MINOR="${KERNEL_MINOR%%.*}"
+
 # Retry a command $1 times until it succeeds. Wait $2 seconds between retries.
 function retry() {
   local attempts=$1


### PR DESCRIPTION
Since kernel 4.6, we can update kernel memory without
initialization, because it's accounted by default.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>