### PR TITLE
Memory swap comment update

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -132,6 +132,20 @@ func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {
 			}
 		}
 	}
+	if cgroup.Resources.Memory != 0 && cgroup.Resources.MemorySwap == -1 {
+		if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
+			return err
+		}
+		if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
+			return err
+		}
+	} else {
+		if cgroup.Resources.MemorySwap == -1 {
+			if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Currently when we are trying to update the running container with swap as -1
invalid value for memory-swap: strconv.ParseUint: parsing "-1": invalid syntax

Moreover in memory.go check is added to have
cgroup.Resources.MemorySwap > 0.

Eliminated the comment for swap to have -1

Signed-off-by: rajasec rajasec79@gmail.com
