### PR TITLE
Fix argument typo in Makefile to enable commit output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ MAN_PAGES_BASE = $(notdir $(MAN_PAGES))
 MAN_INSTALL_PATH := /usr/local/share/man/man8/
 
 all: $(RUNC_LINK)
-	go build -i -ldflags "-X main.gitCommit=${COMMIT}" -tags "$(BUILDTAGS)" -o runc .
+	go build -i -ldflags "-X main.gitCommit ${COMMIT}" -tags "$(BUILDTAGS)" -o runc .
 
 static: $(RUNC_LINK)
-	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT}" -o runc .
+	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit ${COMMIT}" -o runc .
 
 $(RUNC_LINK):
 	ln -sfn $(CURDIR) $(RUNC_LINK)


### PR DESCRIPTION
Before patch:
 # ./runc --version
 runc version 0.1.1
 spec: 0.6.0-dev
 #
 (no commit information)

Reason:
 -X option pass to linker don't need "=" between variable name and
 data, as in manual:
 -X name value
        define string data

Fixed by replace "=" with BLANK for -X option in Makefile.

After patch:
 # ./runc  -v
 runc version 0.1.1
 commit: c8b20e7706babba65afd16f9e1f83c76f15f74c5
 spec: 0.6.0-dev
 #

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>