### PR TITLE
*: correctly chown() consoles

### DIFF
--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -218,7 +218,7 @@ func TestExecInTTY(t *testing.T) {
 		Args: []string{"ps"},
 		Env:  standardEnvironment,
 	}
-	console, err := ps.NewConsole(0)
+	console, err := ps.NewConsole(0, 0)
 	copy := make(chan struct{})
 	go func() {
 		io.Copy(&stdout, console)

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -102,8 +102,8 @@ type IO struct {
 }
 
 // NewConsole creates new console for process and returns it
-func (p *Process) NewConsole(rootuid int) (Console, error) {
-	console, err := NewConsole(rootuid, rootuid)
+func (p *Process) NewConsole(rootuid, rootgid int) (Console, error) {
+	console, err := NewConsole(rootuid, rootgid)
 	if err != nil {
 		return nil, err
 	}

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -447,7 +447,7 @@ func getPipeFds(pid int) ([]string, error) {
 
 // InitializeIO creates pipes for use with the process's STDIO
 // and returns the opposite side for each
-func (p *Process) InitializeIO(rootuid int) (i *IO, err error) {
+func (p *Process) InitializeIO(rootuid, rootgid int) (i *IO, err error) {
 	var fds []uintptr
 	i = &IO{}
 	// cleanup in case of an error
@@ -479,7 +479,7 @@ func (p *Process) InitializeIO(rootuid int) (i *IO, err error) {
 	p.Stderr, i.Stderr = w, r
 	// change ownership of the pipes incase we are in a user namespace
 	for _, fd := range fds {
-		if err := syscall.Fchown(int(fd), rootuid, rootuid); err != nil {
+		if err := syscall.Fchown(int(fd), rootuid, rootgid); err != nil {
 			return nil, err
 		}
 	}

--- a/restore.go
+++ b/restore.go
@@ -117,6 +117,7 @@ using the runc checkpoint command.`,
 func restoreContainer(context *cli.Context, spec *specs.Spec, config *configs.Config, imagePath string) (code int, err error) {
 	var (
 		rootuid = 0
+		rootgid = 0
 		id      = context.Args().First()
 	)
 	factory, err := loadFactory(context)
@@ -149,7 +150,7 @@ func restoreContainer(context *cli.Context, spec *specs.Spec, config *configs.Co
 		defer destroy(container)
 	}
 	process := &libcontainer.Process{}
-	tty, err := setupIO(process, rootuid, "", false, detach)
+	tty, err := setupIO(process, rootuid, rootgid, "", false, detach)
 	if err != nil {
 		return -1, err
 	}

--- a/tty.go
+++ b/tty.go
@@ -14,8 +14,8 @@ import (
 
 // setup standard pipes so that the TTY of the calling runc process
 // is not inherited by the container.
-func createStdioPipes(p *libcontainer.Process, rootuid int) (*tty, error) {
-	i, err := p.InitializeIO(rootuid)
+func createStdioPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, error) {
+	i, err := p.InitializeIO(rootuid, rootgid)
 	if err != nil {
 		return nil, err
 	}
@@ -52,14 +52,14 @@ func (t *tty) copyIO(w io.Writer, r io.ReadCloser) {
 	r.Close()
 }
 
-func createTty(p *libcontainer.Process, rootuid int, consolePath string) (*tty, error) {
+func createTty(p *libcontainer.Process, rootuid, rootgid int, consolePath string) (*tty, error) {
 	if consolePath != "" {
 		if err := p.ConsoleFromPath(consolePath); err != nil {
 			return nil, err
 		}
 		return &tty{}, nil
 	}
-	console, err := p.NewConsole(rootuid)
+	console, err := p.NewConsole(rootuid, rootgid)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In user namespaces, we need to make sure we don't chown() the console to
unmapped users. This means we need to get both the UID and GID of the
root user in the container when changing the owner.

This is part of the cleanup I did for rootless containers, but benefits the
project as a whole so we might as well apply it now. Obviously we still
need to fix the user namespace interaction (#814).

Signed-off-by: Aleksa Sarai <asarai@suse.de>

/cc @crosbymichael 