### PR TITLE
Integration framework cleanup

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -71,7 +71,7 @@ function teardown() {
 }
 
 @test "this is a simple test" {
-  run "$RUNC" start containerid
+  runc start containerid
   # "run" automatically populates $status, $output and $lines.
   # Please refer to bats documentation to find out more.
   [ "$status" -eq 0 ]

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -19,7 +19,6 @@ function teardown() {
 function setup() {
     teardown
     setup_busybox
-
     init_cgroup_path
 }
 
@@ -49,13 +48,15 @@ EOF
     sed -i "s/\(\"resources\": {\)/\1\n${DATA}/" ${BUSYBOX_BUNDLE}/config.json
 
     # start a detached busybox to work with
-    run "$RUNC" start -d --console /dev/pts/ptmx test_cgroups_kmem
+    runc start -d --console /dev/pts/ptmx test_cgroups_kmem
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_cgroups_kmem
 
     # update kernel memory limit
-    run "$RUNC" update test_cgroups_kmem --kernel-memory 50331648
+    runc update test_cgroups_kmem --kernel-memory 50331648
     [ "$status" -eq 0 ]
+
+	# check the value
     check_cgroup_value $CGROUP_MEMORY "memory.kmem.limit_in_bytes" 50331648
 }
 
@@ -64,12 +65,12 @@ EOF
     sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
     # start a detached busybox to work with
-    run "$RUNC" start -d --console /dev/pts/ptmx test_cgroups_kmem
+    runc start -d --console /dev/pts/ptmx test_cgroups_kmem
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_cgroups_kmem
 
     # update kernel memory limit
-    run "$RUNC" update test_cgroups_kmem --kernel-memory 50331648
+    runc update test_cgroups_kmem --kernel-memory 50331648
     # Since kernel 4.6, we can update kernel memory without initialization
     # because it's accounted by default.
     if [ "$KERNEL_MAJOR" -lt 4 ] || [ "$KERNEL_MAJOR" -eq 4 -a "$KERNEL_MINOR" -le 5 ]; then

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -24,30 +24,30 @@ function teardown() {
 
   (
     # start busybox (not detached)
-    run "$RUNC" start test_busybox
+    runc start test_busybox
     [ "$status" -eq 0 ]
   ) &
 
   # check state
   wait_for_container 15 1 test_busybox
 
-  run "$RUNC" state test_busybox
+  runc state test_busybox
   [ "$status" -eq 0 ]
   [[ "${output}" == *"running"* ]]
 
   # checkpoint the running container
-  run "$RUNC" --criu "$CRIU" checkpoint test_busybox
+  runc --criu "$CRIU" checkpoint test_busybox
   # if you are having problems getting criu to work uncomment the following dump:
   #cat /run/opencontainer/containers/test_busybox/criu.work/dump.log
   [ "$status" -eq 0 ]
 
   # after checkpoint busybox is no longer running
-  run "$RUNC" state test_busybox
+  runc state test_busybox
   [ "$status" -ne 0 ]
 
   # restore from checkpoint
   (
-    run "$RUNC" --criu "$CRIU" restore test_busybox
+    runc --criu "$CRIU" restore test_busybox
     [ "$status" -eq 0 ]
   ) &
 
@@ -55,7 +55,7 @@ function teardown() {
   wait_for_container 15 1 test_busybox
 
   # busybox should be back up and running
-  run "$RUNC" state test_busybox
+  runc state test_busybox
   [ "$status" -eq 0 ]
   [[ "${output}" == *"running"* ]]
 }

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -12,9 +12,7 @@ function teardown() {
 }
 
 @test "checkpoint and restore" {
-  if [ ! -e "$CRIU" ] ; then
-    skip
-  fi
+  requires criu
 
   # criu does not work with external terminals so..
   # setting terminal and root:readonly: to false

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -13,14 +13,14 @@ function teardown() {
 
 @test "global --debug" {
   # start hello-world
-  run "$RUNC" --debug start test_hello
+  runc --debug start test_hello
   echo "${output}"
   [ "$status" -eq 0 ]
 }
 
 @test "global --debug to --log" {
   # start hello-world
-  run "$RUNC" --log log.out --debug start test_hello
+  runc --log log.out --debug start test_hello
   [ "$status" -eq 0 ]
 
   # check output does not include debug info
@@ -37,7 +37,7 @@ function teardown() {
 
 @test "global --debug to --log --log-format 'text'" {
   # start hello-world
-  run "$RUNC" --log log.out --log-format "text" --debug start test_hello
+  runc --log log.out --log-format "text" --debug start test_hello
   [ "$status" -eq 0 ]
 
   # check output does not include debug info
@@ -54,7 +54,7 @@ function teardown() {
 
 @test "global --debug to --log --log-format 'json'" {
   # start hello-world
-  run "$RUNC" --log log.out --log-format "json" --debug start test_hello
+  runc --log log.out --log-format "json" --debug start test_hello
   [ "$status" -eq 0 ]
 
   # check output does not include debug info

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc delete" {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -21,13 +21,13 @@ function teardown() {
 
   testcontainer test_busybox running
 
-  run "$RUNC" kill test_busybox KILL
+  runc kill test_busybox KILL
   # wait for busybox to be in the destroyed state
-  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
+  retry 10 1 eval "__runc state test_busybox | grep -q 'destroyed'"
 
   # delete test_busybox
-  run "$RUNC" delete test_busybox
+  runc delete test_busybox
 
-  run "$RUNC" state test_busybox
+  runc state test_busybox
   [ "$status" -ne 0 ]
 }

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -11,20 +11,16 @@ function teardown() {
   teardown_busybox
 }
 
-function startup_events() {
-  ("$RUNC" events test_busybox > events.log)
-}
-
 @test "events --stats" {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
   wait_for_container 15 1 test_busybox
 
   # generate stats
-  run "$RUNC" events --stats test_busybox
+  runc events --stats test_busybox
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
   [[ "${lines[0]}" == *"data"* ]]
@@ -32,7 +28,7 @@ function startup_events() {
 
 @test "events --interval default " {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -42,7 +38,7 @@ function startup_events() {
   # the first sub process is an event logger that sends stats events to events.log
   # the second sub process waits for an event that incudes test_busybox then
   # kills the test_busybox container which causes the event logger to exit
-  ("$RUNC" events test_busybox > events.log) &
+  (__runc events test_busybox > events.log) &
   (
     retry 10 1 eval "grep -q 'test_busybox' events.log"
     teardown_running_container test_busybox
@@ -59,7 +55,7 @@ function startup_events() {
 
 @test "events --interval 1s " {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -70,7 +66,7 @@ function startup_events() {
   # the second sub process tries 3 times for an event that incudes test_busybox
   # pausing 1s between each attempt then kills the test_busybox container which
   # causes the event logger to exit
-  ("$RUNC" events --interval 1s test_busybox > events.log) &
+  (__runc events --interval 1s test_busybox > events.log) &
   (
     retry 3 1 eval "grep -q 'test_busybox' events.log"
     teardown_running_container test_busybox
@@ -85,7 +81,7 @@ function startup_events() {
 
 @test "events --interval 100ms " {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -99,7 +95,7 @@ function startup_events() {
   # the second sub process tries 3 times for an event that incudes test_busybox
   # pausing 100s between each attempt then kills the test_busybox container which
   # causes the event logger to exit
-  ("$RUNC" events --interval 100ms test_busybox > events.log) &
+  (__runc events --interval 100ms test_busybox > events.log) &
   (
     retry 3 0.100 eval "grep -q 'test_busybox' events.log"
     teardown_running_container test_busybox

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -13,12 +13,12 @@ function teardown() {
 
 @test "runc exec" {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
 
-  run "$RUNC" exec test_busybox echo Hello from exec
+  runc exec test_busybox echo Hello from exec
   [ "$status" -eq 0 ]
   echo text echoed = "'""${output}""'"
   [[ "${output}" == *"Hello from exec"* ]]
@@ -26,12 +26,12 @@ function teardown() {
 
 @test "runc exec --pid-file" {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
 
-  run "$RUNC" exec --pid-file pid.txt test_busybox echo Hello from exec
+  runc exec --pid-file pid.txt test_busybox echo Hello from exec
   [ "$status" -eq 0 ]
   echo text echoed = "'""${output}""'"
   [[ "${output}" == *"Hello from exec"* ]]

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -3,80 +3,80 @@
 load helpers
 
 @test "runc -h" {
-  run "$RUNC" -h
+  runc -h
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 
-  run "$RUNC" --help
+  runc --help
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 }
 
 @test "runc command -h" {
-  run "$RUNC" checkpoint -h
+  runc checkpoint -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ checkpoint+ ]]
 
-  run "$RUNC" delete -h
+  runc delete -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ delete+ ]]
 
-  run "$RUNC" events -h
+  runc events -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ events+ ]]
 
-  run "$RUNC" exec -h
+  runc exec -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ exec+ ]]
 
-  run "$RUNC" kill -h
+  runc kill -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ kill+ ]]
 
-  run "$RUNC" list -h
+  runc list -h
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ list+ ]]
 
-  run "$RUNC" list --help
+  runc list --help
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ list+ ]]
 
-  run "$RUNC" pause -h
+  runc pause -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ pause+ ]]
 
-  run "$RUNC" restore -h
+  runc restore -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ restore+ ]]
 
-  run "$RUNC" resume -h
+  runc resume -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ resume+ ]]
 
-  run "$RUNC" spec -h
+  runc spec -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ spec+ ]]
 
-  run "$RUNC" start -h
+  runc start -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ start+ ]]
 
-  run "$RUNC" state -h
+  runc state -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ state+ ]]
 
-  run "$RUNC" delete -h
+  runc delete -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ delete+ ]]
 
 }
 
 @test "runc foo -h" {
-  run "$RUNC" foo -h
+  runc foo -h
   [ "$status" -ne 0 ]
   [[ "${output}" == *"No help topic for 'foo'"* ]]
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -25,6 +25,18 @@ KERNEL_MAJOR="${KERNEL_VERSION%%.*}"
 KERNEL_MINOR="${KERNEL_VERSION#$KERNEL_MAJOR.}"
 KERNEL_MINOR="${KERNEL_MINOR%%.*}"
 
+# Root state path.
+ROOT="$BATS_TMPDIR/runc"
+
+# Wrapper for runc.
+function runc() {
+  run __runc "$@"
+}
+
+function __runc() {
+  "$RUNC" --root "$ROOT" "$@"
+}
+
 # Retry a command $1 times until it succeeds. Wait $2 seconds between retries.
 function retry() {
   local attempts=$1
@@ -53,7 +65,7 @@ function wait_for_container() {
   local i
 
   for ((i=0; i < attempts; i++)); do
-    run "$RUNC" state $cid
+    runc state $cid
     if [[ "$status" -eq 0 ]] ; then
       return 0
     fi
@@ -72,7 +84,7 @@ function wait_for_container_inroot() {
   local i
 
   for ((i=0; i < attempts; i++)); do
-    run "$RUNC" --root $4 state $cid
+    ROOT=$4 runc state $cid
     if [[ "$status" -eq 0 ]] ; then
       return 0
     fi
@@ -85,7 +97,7 @@ function wait_for_container_inroot() {
 
 function testcontainer() {
   # test state of container
-  run "$RUNC" state $1
+  runc state $1
   [ "$status" -eq 0 ]
   [[ "${output}" == *"$2"* ]]
 }
@@ -101,7 +113,7 @@ function setup_busybox() {
   fi
   tar -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
   cd "$BUSYBOX_BUNDLE"
-  run "$RUNC" spec
+  runc spec
 }
 
 function setup_hello() {
@@ -109,25 +121,25 @@ function setup_hello() {
   run mkdir "$HELLO_BUNDLE"/rootfs
   tar -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
   cd "$HELLO_BUNDLE"
-  "$RUNC" spec
+  runc spec
   sed -i 's;"sh";"/hello";' config.json
 }
 
 function teardown_running_container() {
-  run "$RUNC" list
+  runc list
   if [[ "${output}" == *"$1"* ]]; then
-    run "$RUNC" kill $1 KILL
-    retry 10 1 eval "'$RUNC' state '$1' | grep -q 'destroyed'"
-    run "$RUNC" delete $1
+    runc kill $1 KILL
+    retry 10 1 eval "__runc state '$1' | grep -q 'destroyed'"
+    runc delete $1
   fi
 }
 
 function teardown_running_container_inroot() {
-  run "$RUNC" --root $2 list
+  ROOT=$2 runc list
   if [[ "${output}" == *"$1"* ]]; then
-    run "$RUNC" --root $2 kill $1 KILL
-    retry 10 1 eval "'$RUNC' --root '$2' state '$1' | grep -q 'destroyed'"
-    run "$RUNC" --root $2 delete $1
+    ROOT=$2 runc kill $1 KILL
+    retry 10 1 eval "ROOT='$2' __runc state '$1' | grep -q 'destroyed'"
+    ROOT=$2 runc delete $1
   fi
 }
 

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -33,8 +33,32 @@ function runc() {
   run __runc "$@"
 }
 
+# Raw wrapper for runc.
 function __runc() {
   "$RUNC" --root "$ROOT" "$@"
+}
+
+# Fails the current test, providing the error given.
+function fail() {
+	echo "$@" >&2
+	exit 1
+}
+
+# Allows a test to specify what things it requires. If the environment can't
+# support it, the test is skipped with a message.
+function requires() {
+	for var in "$@"; do
+		case $var in
+			criu)
+				if [ ! -e "$CRIU" ]; then
+					skip "Test requires ${var}."
+				fi
+				;;
+			*)
+				fail "BUG: Invalid requires ${var}."
+				;;
+		esac
+	done
 }
 
 # Retry a command $1 times until it succeeds. Wait $2 seconds between retries.

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -15,7 +15,7 @@ function teardown() {
 @test "kill detached busybox" {
 
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -23,11 +23,11 @@ function teardown() {
 
   testcontainer test_busybox running
 
-  run "$RUNC" kill test_busybox KILL
+  runc kill test_busybox KILL
   [ "$status" -eq 0 ]
 
-  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
+  retry 10 1 eval "__runc state test_busybox | grep -q 'destroyed'"
 
-  run "$RUNC" delete test_busybox
+  runc delete test_busybox
   [ "$status" -eq 0 ]
 }

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -19,33 +19,33 @@ function teardown() {
 
 @test "list" {
   # start a few busyboxes detached
-  run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_box1
+  ROOT=$HELLO_BUNDLE runc start -d --console /dev/pts/ptmx test_box1
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box1 $HELLO_BUNDLE
 
-  run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_box2
+  ROOT=$HELLO_BUNDLE runc start -d --console /dev/pts/ptmx test_box2
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box2 $HELLO_BUNDLE
 
-  run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_box3
+  ROOT=$HELLO_BUNDLE runc start -d --console /dev/pts/ptmx test_box3
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box3 $HELLO_BUNDLE
 
-  run "$RUNC" --root $HELLO_BUNDLE list
+  ROOT=$HELLO_BUNDLE runc list
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
   [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 
-  run "$RUNC" --root $HELLO_BUNDLE list --format table
+  ROOT=$HELLO_BUNDLE runc list --format table
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
   [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 
-  run "$RUNC" --root $HELLO_BUNDLE list --format json
+  ROOT=$HELLO_BUNDLE runc list --format json
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == [\[][\{]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"created\""[:]*[0-9]*[\}]* ]]
   [[ "${lines[0]}" == *[,][\{]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"created\""[:]*[0-9]*[\}]* ]]

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -13,20 +13,20 @@ function teardown() {
 
 @test "runc pause and resume" {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
 
   # pause busybox
-  run "$RUNC" pause test_busybox
+  runc pause test_busybox
   [ "$status" -eq 0 ]
 
   # test state of busybox is paused
   testcontainer test_busybox paused
 
   # resume busybox
-  run "$RUNC" resume test_busybox
+  runc resume test_busybox
   [ "$status" -eq 0 ]
 
   # test state of busybox is back to running

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -15,40 +15,40 @@ function teardown() {
 
 @test "global --root" {
   # start busybox detached using $HELLO_BUNDLE for state
-  run "$RUNC" --root $HELLO_BUNDLE start -d --console /dev/pts/ptmx test_dotbox
+  ROOT=$HELLO_BUNDLE runc start -d --console /dev/pts/ptmx test_dotbox
   [ "$status" -eq 0 ]
 
   # start busybox detached in default root
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state of the busyboxes are only in their respective root path
   wait_for_container 15 1 test_busybox
   wait_for_container_inroot 15 1 test_dotbox $HELLO_BUNDLE
 
-  run "$RUNC" state test_busybox
+  runc state test_busybox
   [ "$status" -eq 0 ]
   [[ "${output}" == *"running"* ]]
 
-  run "$RUNC" --root $HELLO_BUNDLE state test_dotbox
+  ROOT=$HELLO_BUNDLE runc state test_dotbox
   [ "$status" -eq 0 ]
   [[ "${output}" == *"running"* ]]
 
-  run "$RUNC" --root $HELLO_BUNDLE state test_busybox
+  ROOT=$HELLO_BUNDLE runc state test_busybox
   [ "$status" -ne 0 ]
 
-  run "$RUNC" state test_dotbox
+  runc state test_dotbox
   [ "$status" -ne 0 ]
 
-  run "$RUNC" kill test_busybox KILL
+  runc kill test_busybox KILL
   [ "$status" -eq 0 ]
-  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
-  run "$RUNC" delete test_busybox
+  retry 10 1 eval "__runc state test_busybox | grep -q 'destroyed'"
+  runc delete test_busybox
   [ "$status" -eq 0 ]
 
-  run "$RUNC" --root $HELLO_BUNDLE kill test_dotbox KILL
+  ROOT=$HELLO_BUNDLE runc kill test_dotbox KILL
   [ "$status" -eq 0 ]
-  retry 10 1 eval "'$RUNC' --root $HELLO_BUNDLE state test_dotbox | grep -q 'destroyed'"
-  run "$RUNC" --root $HELLO_BUNDLE delete test_dotbox
+  retry 10 1 eval "ROOT='$HELLO_BUNDLE' __runc state test_dotbox | grep -q 'destroyed'"
+  ROOT=$HELLO_BUNDLE runc delete test_dotbox
   [ "$status" -eq 0 ]
 }

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -26,7 +26,7 @@ function teardown() {
   [ ! -e config.json ]
 
   # test generation of spec does not return an error
-  run "$RUNC" spec
+  runc spec
   [ "$status" -eq 0 ]
 
   # test generation of spec created our config.json (spec)
@@ -40,7 +40,7 @@ function teardown() {
   sed -i 's;"sh";"/hello";' config.json
 
   # ensure the generated spec works by starting hello-world
-  run "$RUNC" start test_hello
+  runc start test_hello
   [ "$status" -eq 0 ]
 }
 
@@ -51,7 +51,7 @@ function teardown() {
   [ ! -e "$HELLO_BUNDLE"/config.json ]
 
   # test generation of spec does not return an error
-  run "$RUNC" spec --bundle "$HELLO_BUNDLE"
+  runc spec --bundle "$HELLO_BUNDLE"
   [ "$status" -eq 0 ]
 
   # test generation of spec created our config.json (spec)
@@ -61,7 +61,7 @@ function teardown() {
   sed -i 's;"sh";"/hello";' "$HELLO_BUNDLE"/config.json
 
   # ensure the generated spec works by starting hello-world
-  run "$RUNC" start --bundle "$HELLO_BUNDLE" test_hello
+  runc start --bundle "$HELLO_BUNDLE" test_hello
   [ "$status" -eq 0 ]
 }
 
@@ -80,7 +80,7 @@ function teardown() {
   GOPATH="$GOPATH" go build src/runtime-spec/schema/validate.go
   [ -e ./validate ]
 
-  run "$RUNC" spec
+  runc spec
   [ -e config.json ]
 
   run ./validate src/runtime-spec/schema/schema.json config.json

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc start detached" {
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -24,7 +24,7 @@ function teardown() {
 
 @test "runc start detached --pid-file" {
   # start busybox detached
-  run "$RUNC" start --pid-file pid.txt -d --console /dev/pts/ptmx test_busybox
+  runc start --pid-file pid.txt -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc start" {
   # start hello-world
-  run "$RUNC" start test_hello
+  runc start test_hello
   [ "$status" -eq 0 ]
 
   # check expected output
@@ -27,14 +27,14 @@ function teardown() {
   sed -i 's;"rootfs";".";' config.json
 
   # start hello-world
-  run "$RUNC" start test_hello
+  runc start test_hello
   [ "$status" -eq 0 ]
   [[ "${output}" == *"Hello"* ]]
 }
 
 @test "runc start --pid-file" {
   # start hello-world
-  run "$RUNC" start --pid-file pid.txt test_hello
+  runc start --pid-file pid.txt test_hello
   [ "$status" -eq 0 ]
   [[ "${output}" == *"Hello"* ]]
 

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -12,11 +12,11 @@ function teardown() {
 }
 
 @test "state" {
-  run "$RUNC" state test_busybox
+  runc state test_busybox
   [ "$status" -ne 0 ]
 
   # start busybox detached
-  run "$RUNC" start -d --console /dev/pts/ptmx test_busybox
+  runc start -d --console /dev/pts/ptmx test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -25,26 +25,26 @@ function teardown() {
   testcontainer test_busybox running
 
   # pause busybox
-  run "$RUNC" pause test_busybox
+  runc pause test_busybox
   [ "$status" -eq 0 ]
 
   # test state of busybox is paused
   testcontainer test_busybox paused
 
   # resume busybox
-  run "$RUNC" resume test_busybox
+  runc resume test_busybox
   [ "$status" -eq 0 ]
 
   # test state of busybox is back to running
   testcontainer test_busybox running
 
-  run "$RUNC" kill test_busybox KILL
+  runc kill test_busybox KILL
   # wait for busybox to be in the destroyed state
-  retry 10 1 eval "'$RUNC' state test_busybox | grep -q 'destroyed'"
+  retry 10 1 eval "__runc state test_busybox | grep -q 'destroyed'"
 
   # delete test_busybox
-  run "$RUNC" delete test_busybox
+  runc delete test_busybox
 
-  run "$RUNC" state test_busybox
+  runc state test_busybox
   [ "$status" -ne 0 ]
 }

--- a/tests/integration/version.bats
+++ b/tests/integration/version.bats
@@ -3,7 +3,7 @@
 load helpers
 
 @test "runc version" {
-  run "$RUNC" -v
+  runc -v
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
   [[ ${lines[1]} =~ commit:+ ]]


### PR DESCRIPTION
This makes it much simpler to write tests, and you don't have to worry
about some of the oddness with bats.

This is part of the cleanup I did for rootless containers, but benefits the
project as a whole so we might as well apply it now.

Signed-off-by: Aleksa Sarai <asarai@suse.de>