### PR TITLE
Unify log setting's error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 		case "json":
 			logrus.SetFormatter(new(logrus.JSONFormatter))
 		default:
-			logrus.Fatalf("unknown log-format %q", context.GlobalString("log-format"))
+			return fmt.Errorf("unknown log-format %q", context.GlobalString("log-format"))
 		}
 		return nil
 	}


### PR DESCRIPTION
When we set a wrong --log-format value, runc exit without any
message:
 # ./runc --log-format aaa list
 #
It is again "no news is good news" rule.

And it is not unified with the case when we set a wrong --log
value:
 # ./runc --log / list
 ERRO[0000] open /: is a directory
 open /: is a directory
 #

This patch unified action for above two error-setting.

After patch:
 # ./runc --log-format aaa list
 unknown log-format: aaa
 #

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>