### PR TITLE
pullapprove: use the right team

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,6 +4,6 @@ reject_regex: ^Rejected
 reset_on_push: true
 reviewers:
   teams:
-  - runtime-spec-maintainers
+    - runc-maintainers
   name: default
   required: 2


### PR DESCRIPTION
On GitHub the maintainers of runC are *not* the same as the maintainers
of runtime-spec. Fix this, and use the right team.

Fixes #847.

Signed-off-by: Aleksa Sarai <asarai@suse.de>