### PR TITLE
Fix help message for memory-swap

### DIFF
--- a/update.go
+++ b/update.go
@@ -95,7 +95,7 @@ other options are ignored.
 		},
 		cli.StringFlag{
 			Name:  "memory-swap",
-			Usage: "Total memory usage (memory + swap); set `-1` to enable unlimited swap",
+			Usage: "Total memory usage (memory + swap); set '-1' to enable unlimited swap",
 		},
 	},
 	Action: func(context *cli.Context) error {


### PR DESCRIPTION
Back quotes are the placeholder feature described here:
https://github.com/urfave/cli#placeholder-values

Without this, cli will take `-1` as default value as:
```
   --memory-swap -1             Total memory usage (memory + swap); set `-1` to enable unlimited swap
```

After this patch, it'll act correctly
```
   --memory-swap value          Total memory usage (memory + swap); set '-1' to enable unlimited swap
```

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>