### PR TITLE
Update man pages to refect the latest cli change

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -30,7 +30,7 @@ checkpointed.`,
 		cli.BoolFlag{Name: "shell-job", Usage: "allow shell jobs"},
 		cli.StringFlag{Name: "page-server", Value: "", Usage: "ADDRESS:PORT of the page server"},
 		cli.BoolFlag{Name: "file-locks", Usage: "handle file locks, for safety"},
-		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'."},
+		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'"},
 		cli.StringSliceFlag{Name: "empty-ns", Usage: "create a namespace, but don't restore its properies"},
 	},
 	Action: func(context *cli.Context) error {

--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -11,12 +11,13 @@ checkpointed.
    The checkpoint command saves the state of the container instance.
 
 # OPTIONS
-   --image-path                 path for saving criu image files
-   --work-path                  path for saving work files and logs
+   --image-path value           path for saving criu image files
+   --work-path value            path for saving work files and logs
    --leave-running              leave the process running after checkpointing
    --tcp-established            allow open tcp connections
    --ext-unix-sk                allow external unix sockets
    --shell-job                  allow shell jobs
-   --page-server                ADDRESS:PORT of the page server
+   --page-server value          ADDRESS:PORT of the page server
    --file-locks                 handle file locks, for safety
-   --manage-cgroups-mode        cgroups mode: 'soft' (default), 'full' and 'strict'.
+   --manage-cgroups-mode value  cgroups mode: 'soft' (default), 'full' and 'strict'
+   --empty-ns value             create a namespace, but don't restore its properies

--- a/man/runc-events.8.md
+++ b/man/runc-events.8.md
@@ -11,5 +11,5 @@ Where "<container-id>" is the name for the instance of the container.
 information is displayed once every 5 seconds.
 
 # OPTIONS
-   --interval "5s"      set the stats collection interval
+   --interval value     set the stats collection interval (default: 5s)
    --stats              display the container's stats then exit

--- a/man/runc-exec.8.md
+++ b/man/runc-exec.8.md
@@ -14,16 +14,16 @@ following will output a list of processes running in the container:
        # runc exec <container-id> ps
 
 # OPTIONS
-   --console                                    specify the pty slave path for use with the container
-   --cwd                                        current working directory in the container
-   --env, -e [--env option --env option]        set environment variables
-   --tty, -t                                    allocate a pseudo-TTY
-   --user, -u                                   UID (format: <uid>[:<gid>])
-   --process, -p                                path to the process.json
-   --detach, -d                                 detach from the container's process
-   --pid-file                                   specify the file to write the process id to
-   --process-label                              set the asm process label for the process commonly used with selinux
-   --apparmor                                   set the apparmor profile for the process
-   --no-new-privs                               set the no new privileges value for the process
-   --cap, -c [--cap option --cap option]        add a capability to the bounding set for the process
-   --no-subreaper                               disable the use of the subreaper used to reap reparented processes
+   --console value              specify the pty slave path for use with the container
+   --cwd value                  current working directory in the container
+   --env value, -e value        set environment variables
+   --tty, -t                    allocate a pseudo-TTY
+   --user value, -u value       UID (format: <uid>[:<gid>])
+   --process value, -p value    path to the process.json
+   --detach, -d                 detach from the container's process
+   --pid-file value             specify the file to write the process id to
+   --process-label value        set the asm process label for the process commonly used with selinux
+   --apparmor value             set the apparmor profile for the process
+   --no-new-privs               set the no new privileges value for the process
+   --cap value, -c value        add a capability to the bounding set for the process
+   --no-subreaper               disable the use of the subreaper used to reap reparented processes

--- a/man/runc-list.8.md
+++ b/man/runc-list.8.md
@@ -5,5 +5,5 @@
    runc list [command options] [arguments...]
 
 # OPTIONS
-   --format, -f         select one of: table(default) or json.
-   --quiet, -q          display only container IDs
+   --format value, -f value     select one of: table(default) or json
+   --quiet, -q                  display only container IDs

--- a/man/runc-ps.8.md
+++ b/man/runc-ps.8.md
@@ -5,7 +5,7 @@
    runc ps [command options] <container-id> <ps options>
 
 # OPTIONS
-   --format, -f         select one of: table(default) or json
+   --format value, -f value     select one of: table(default) or json
 
 The default format is table.  The following will output the processes of a container
 in json format:

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -12,15 +12,15 @@ restored.
 using the runc checkpoint command.
 
 # OPTIONS
-   --image-path                 path to criu image files for restoring
-   --work-path                  path for saving work files and logs
+   --image-path value           path to criu image files for restoring
+   --work-path value            path for saving work files and logs
    --tcp-established            allow open tcp connections
    --ext-unix-sk                allow external unix sockets
    --shell-job                  allow shell jobs
    --file-locks                 handle file locks, for safety
-   --manage-cgroups-mode        cgroups mode: 'soft' (default), 'full' and 'strict'.
-   --bundle, -b                 path to the root of the bundle directory
+   --manage-cgroups-mode value  cgroups mode: 'soft' (default), 'full' and 'strict'
+   --bundle value, -b value     path to the root of the bundle directory
    --detach, -d                 detach from the container's process
-   --pid-file                   specify the file to write the process id to
+   --pid-file value             specify the file to write the process id to
    --no-subreaper               disable the use of the subreaper used to reap reparented processes
    --no-pivot                   do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk

--- a/man/runc-spec.8.md
+++ b/man/runc-spec.8.md
@@ -46,4 +46,4 @@ example: "sudo runc start container1" will give runc root privilege to start the
 container on your host.
 
 # OPTIONS
-   --bundle, -b         path to the root of the bundle directory
+   --bundle value, -b value     path to the root of the bundle directory

--- a/man/runc-start.8.md
+++ b/man/runc-start.8.md
@@ -19,9 +19,9 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 "runc spec --help" for more explanation.
 
 # OPTIONS
-   --bundle, -b         path to the root of the bundle directory, defaults to the current directory
-   --console            specify the pty slave path for use with the container
-   --detach, -d         detach from the container's process
-   --pid-file           specify the file to write the process id to
-   --no-subreaper       disable the use of the subreaper used to reap reparented processes
-   --no-pivot           do not use pivot root to jail process inside rootfs. This should be used whenever the rootfs is on top of a ramdisk
+   --bundle value, -b value     path to the root of the bundle directory, defaults to the current directory
+   --console value              specify the pty slave path for use with the container
+   --detach, -d                 detach from the container's process
+   --pid-file value             specify the file to write the process id to
+   --no-subreaper               disable the use of the subreaper used to reap reparented processes
+   --no-pivot                   do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -32,15 +32,15 @@ Note: if data is to be read from a file or the standard input, all
 other options are ignored.
 
 # OPTIONS
-   --resources, -r         path to the file containing the resources to update or '-' to read from the standard input.
-   --blkio-weight "0"      Specifies per cgroup weight, range is from 10 to 1000.
-   --cpu-period            CPU period to be used for hardcapping (in usecs). 0 to use system default.
-   --cpu-quota             CPU hardcap limit (in usecs). Allowed cpu time in a given period.
-   --cpu-share             CPU shares (relative weight vs. other containers)
-   --cpuset-cpus           CPU(s) to use
-   --cpuset-mems           Memory node(s) to use
-   --kernel-memory         Kernel memory limit (in bytes)
-   --kernel-memory-tcp     Kernel memory limit (in bytes) for tcp buffer
-   --memory                Memory limit (in bytes)
-   --memory-reservation    Memory reservation or soft_limit (in bytes)
-   --memory-swap           Total memory usage (memory + swap); set `-1` to enable unlimited swap
+   --resources value, -r value  path to the file containing the resources to update or '-' to read from the standard input
+   --blkio-weight value         Specifies per cgroup weight, range is from 10 to 1000 (default: 0)
+   --cpu-period value           CPU period to be used for hardcapping (in usecs). 0 to use system default
+   --cpu-quota value            CPU hardcap limit (in usecs). Allowed cpu time in a given period
+   --cpu-share value            CPU shares (relative weight vs. other containers)
+   --cpuset-cpus value          CPU(s) to use
+   --cpuset-mems value          Memory node(s) to use
+   --kernel-memory value        Kernel memory limit (in bytes)
+   --kernel-memory-tcp value    Kernel memory limit (in bytes) for tcp buffer
+   --memory value               Memory limit (in bytes)
+   --memory-reservation value   Memory reservation or soft_limit (in bytes)
+   --memory-swap value          Total memory usage (memory + swap); set '-1' to enable unlimited swap

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -32,24 +32,25 @@ value for "bundle" is the current directory.
    delete       delete any resources held by the container often used with detached containers
    events       display container events such as OOM notifications, cpu, memory, IO and network stats
    exec         execute new process inside the container
+   init         initialize the namespaces and launch the process (do not call it outside of runc)
    kill         kill sends the specified signal (default: SIGTERM) to the container's init process
    list         lists containers started by runc with the given root
    pause        pause suspends all processes inside the container
+   ps           displays the processes running inside a container
    restore      restore a container from a previous checkpoint
    resume       resumes all processes that have been previously paused
    spec         create a new specification file
    start        create and run a container
-   update       update container resource constraints 
-   ps           displays the processes running inside a container 
    state        output the state of a container
+   update       update container resource constraints
    help, h      Shows a list of commands or help for one command
    
 # GLOBAL OPTIONS
-   --debug                                      enable debug output for logging
-   --log                                        set the log file path where internal debug information is written
-   --log-format "text"                          set the format used by logs ('text' (default), or 'json')
-   --root "/run/opencontainer/containers"       root directory for storage of container state (this should be located in tmpfs)
-   --criu "criu"                                path to the criu binary used for checkpoint and restore
-   --systemd-cgroup                             enable systemd cgroup support, expects cgroupsPath to be of form "slice:prefix:name" for e.g. "system.slice:runc:434234"
-   --help, -h                                   show help
-   --version, -v                                print the version
+   --debug              enable debug output for logging
+   --log value          set the log file path where internal debug information is written (default: "/dev/null")
+   --log-format value   set the format used by logs ('text' (default), or 'json') (default: "text")
+   --root value         root directory for storage of container state (this should be located in tmpfs) (default: "/run/runc")
+   --criu value         path to the criu binary used for checkpoint and restore (default: "criu")
+   --systemd-cgroup     enable systemd cgroup support, expects cgroupsPath to be of form "slice:prefix:name" for e.g. "system.slice:runc:434234"
+   --help, -h           show help
+   --version, -v        print the version

--- a/restore.go
+++ b/restore.go
@@ -53,7 +53,7 @@ using the runc checkpoint command.`,
 		cli.StringFlag{
 			Name:  "manage-cgroups-mode",
 			Value: "",
-			Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'.",
+			Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'",
 		},
 		cli.StringFlag{
 			Name:  "bundle, b",

--- a/update.go
+++ b/update.go
@@ -23,7 +23,7 @@ var updateCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "resources, r",
 			Value: "",
-			Usage: `path to the file containing the resources to update or '-' to read from the standard input.
+			Usage: `path to the file containing the resources to update or '-' to read from the standard input
 
 The accepted format is as follow (unchanged values can be omitted):
 
@@ -54,15 +54,15 @@ other options are ignored.
 
 		cli.IntFlag{
 			Name:  "blkio-weight",
-			Usage: "Specifies per cgroup weight, range is from 10 to 1000.",
+			Usage: "Specifies per cgroup weight, range is from 10 to 1000",
 		},
 		cli.StringFlag{
 			Name:  "cpu-period",
-			Usage: "CPU period to be used for hardcapping (in usecs). 0 to use system default.",
+			Usage: "CPU period to be used for hardcapping (in usecs). 0 to use system default",
 		},
 		cli.StringFlag{
 			Name:  "cpu-quota",
-			Usage: "CPU hardcap limit (in usecs). Allowed cpu time in a given period.",
+			Usage: "CPU hardcap limit (in usecs). Allowed cpu time in a given period",
 		},
 		cli.StringFlag{
 			Name:  "cpu-share",


### PR DESCRIPTION
The major change is the description of options, change
it as the latest cli help message shows, which specify
a "value" after an option if it takes value, and add
(default: xxx) if the option has a default value.

This also includes some other minor consistency fixes.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>