### PR TITLE
Remove use_hierarchy check when set kernel memory

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -76,22 +76,13 @@ func (s *MemoryGroup) SetKernelMemory(path string, cgroup *configs.Cgroup) error
 		}
 
 		if !kmemInitialized {
-			// If hierarchy is set, we can't change the limit
-			usesHierarchy, err := getCgroupParamUint(path, "memory.use_hierarchy")
-			if err != nil {
-				return err
-			}
-			if usesHierarchy != 0 {
-				return fmt.Errorf("cannot initialize kmem.limit_in_bytes if use_hierarchy is already set")
-			}
-
 			// If there's already tasks in the cgroup, we can't change the limit either
 			tasks, err := getCgroupParamString(path, "tasks")
 			if err != nil {
 				return err
 			}
 			if tasks != "" {
-				return fmt.Errorf("cannot initialize kmem.limit_in_bytes after task have joined this cgroup")
+				return fmt.Errorf("cannot set kmem.limit_in_bytes after task have joined this cgroup")
 			}
 		}
 


### PR DESCRIPTION
Kernel memory cannot be set in these circumstances (before kernel 4.6):
1. kernel memory is not initialized, and there are tasks in cgroup
2. kernel memory is not initialized, and use_hierarchy is enabled,
   and there are sub-cgroups

While we don't need to cover case 2 because when we set kernel
memory in runC, it's either:
- in Apply phase when we create the container, and in this case,
  set kernel memory would definitely be valid;
- or in update operation, and in this case, there would be tasks
  in cgroup, we only need to check if kernel memory is initialized
  or not.

Even if we want to check use_hierarchy, we need to check sub-cgroups
as well, but for here, we can just leave it aside.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>