### PR TITLE
seccomp: Add ppc and s390x to seccomp/config.go

### DIFF
--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -36,6 +36,11 @@ var archs = map[string]string{
 	"SCMP_ARCH_MIPSEL":      "mipsel",
 	"SCMP_ARCH_MIPSEL64":    "mipsel64",
 	"SCMP_ARCH_MIPSEL64N32": "mipsel64n32",
+	"SCMP_ARCH_PPC":         "ppc",
+	"SCMP_ARCH_PPC64":       "ppc64",
+	"SCMP_ARCH_PPC64LE":     "ppc64le",
+	"SCMP_ARCH_S390":        "s390",
+	"SCMP_ARCH_S390X":       "s390x",
 }
 
 // ConvertStringToOperator converts a string into a Seccomp comparison operator.


### PR DESCRIPTION
Proably needed to complete docker/docker#22922

Signed-off-by: Michael Holzheu <holzheu@linux.vnet.ibm.com>