### PR TITLE
Removing the nil check for process label

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -44,10 +44,8 @@ func (l *linuxSetnsInit) Init() error {
 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
 		return err
 	}
-	if l.config.ProcessLabel != "" {
-		if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
-			return err
-		}
+	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
+		return err
 	}
 	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
 }


### PR DESCRIPTION
Function SetProcessLabel is checking for nil, hence removed the redundant one from the caller.

func SetProcessLabel(processLabel string) error {
        if processLabel == "" {
                return nil
        }

Signed-off-by: rajasec <rajasec79@gmail.com>