### PR TITLE
runc events hang for zero duration

### DIFF
--- a/events.go
+++ b/events.go
@@ -112,6 +112,10 @@ information is displayed once every 5 seconds.`,
 		if err != nil {
 			return err
 		}
+		duration := context.Duration("interval")
+		if duration <= 0 {
+			return fmt.Errorf("duration interval must be greater than 0")
+		}
 		status, err := container.Status()
 		if err != nil {
 			return err


### PR DESCRIPTION
Tick function in go returns nil when the duration is lesser than or equal to 0. When we run the events command with interval --0s, runc hangs. So added the condition to throw out the error when the duration is lesser than or equal to.
Signed-off-by: rajasec <rajasec79@gmail.com>