### PR TITLE
Add option to disable new session keys

### DIFF
--- a/create.go
+++ b/create.go
@@ -42,6 +42,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "no-pivot",
 			Usage: "do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk",
 		},
+		cli.BoolFlag{
+			Name:  "no-new-keyring",
+			Usage: "do not create a new session keyring for the container.  This will cause the container to inherit the calling processes session key",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		spec, err := setupSpec(context)

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -187,6 +187,10 @@ type Config struct {
 
 	// Labels are user defined metadata that is stored in the config and populated on the state
 	Labels []string `json:"labels"`
+
+	// NoNewKeyring will not allocated a new session keyring for the container.  It will use the
+	// callers keyring in this case.
+	NoNewKeyring bool `json:"no_new_keyring"`
 }
 
 type Hooks struct {

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -25,9 +25,11 @@ func (l *linuxSetnsInit) getSessionRingName() string {
 }
 
 func (l *linuxSetnsInit) Init(s chan os.Signal) error {
-	// do not inherit the parent's session keyring
-	if _, err := keyctl.JoinSessionKeyring(l.getSessionRingName()); err != nil {
-		return err
+	if !l.config.Config.NoNewKeyring {
+		// do not inherit the parent's session keyring
+		if _, err := keyctl.JoinSessionKeyring(l.getSessionRingName()); err != nil {
+			return err
+		}
 	}
 	if l.config.NoNewPrivileges {
 		if err := system.Prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -145,6 +145,7 @@ type CreateOpts struct {
 	CgroupName       string
 	UseSystemdCgroup bool
 	NoPivotRoot      bool
+	NoNewKeyring     bool
 	Spec             *specs.Spec
 }
 
@@ -170,11 +171,12 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
 	}
 	config := &configs.Config{
-		Rootfs:      rootfsPath,
-		NoPivotRoot: opts.NoPivotRoot,
-		Readonlyfs:  spec.Root.Readonly,
-		Hostname:    spec.Hostname,
-		Labels:      append(labels, fmt.Sprintf("bundle=%s", cwd)),
+		Rootfs:       rootfsPath,
+		NoPivotRoot:  opts.NoPivotRoot,
+		Readonlyfs:   spec.Root.Readonly,
+		Hostname:     spec.Hostname,
+		Labels:       append(labels, fmt.Sprintf("bundle=%s", cwd)),
+		NoNewKeyring: opts.NoNewKeyring,
 	}
 
 	exists := false

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -45,16 +45,18 @@ func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
 const PR_SET_NO_NEW_PRIVS = 0x26
 
 func (l *linuxStandardInit) Init(s chan os.Signal) error {
-	ringname, keepperms, newperms := l.getSessionRingParams()
+	if !l.config.Config.NoNewKeyring {
+		ringname, keepperms, newperms := l.getSessionRingParams()
 
-	// do not inherit the parent's session keyring
-	sessKeyId, err := keyctl.JoinSessionKeyring(ringname)
-	if err != nil {
-		return err
-	}
-	// make session keyring searcheable
-	if err := keyctl.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
-		return err
+		// do not inherit the parent's session keyring
+		sessKeyId, err := keyctl.JoinSessionKeyring(ringname)
+		if err != nil {
+			return err
+		}
+		// make session keyring searcheable
+		if err := keyctl.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
+			return err
+		}
 	}
 
 	var console *linuxConsole

--- a/run.go
+++ b/run.go
@@ -53,6 +53,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "no-pivot",
 			Usage: "do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk",
 		},
+		cli.BoolFlag{
+			Name:  "no-new-keyring",
+			Usage: "do not create a new session keyring for the container.  This will cause the container to inherit the calling processes session key",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		spec, err := setupSpec(context)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -171,6 +171,7 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcont
 		CgroupName:       id,
 		UseSystemdCgroup: context.GlobalBool("systemd-cgroup"),
 		NoPivotRoot:      context.Bool("no-pivot"),
+		NoNewKeyring:     context.Bool("no-new-keyring"),
 		Spec:             spec,
 	})
 	if err != nil {


### PR DESCRIPTION
This adds an `--no-new-keyring` flag to run and create so that a new
session keyring is not created for the container and the calling
processes keyring is inherited.

Fixes #818

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>