### PR TITLE
Return error for GetLongBit

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -68,7 +68,11 @@ func (s *MemoryGroup) SetKernelMemory(path string, cgroup *configs.Cgroup) error
 		if err != nil {
 			return err
 		}
-		switch system.GetLongBit() {
+		lb, err := system.GetLongBit()
+		if err != nil {
+			return err
+		}
+		switch lb {
 		case 32:
 			kmemInitialized = uint32(kmemValue) != uint32(math.MaxUint32)
 		case 64:

--- a/libcontainer/system/sysconfig.go
+++ b/libcontainer/system/sysconfig.go
@@ -26,6 +26,6 @@ func GetClockTicks() int {
 	return int(C.sysconf(C._SC_CLK_TCK))
 }
 
-func GetLongBit() int {
-	return int(C.GetLongBit())
+func GetLongBit() (int, error) {
+	return int(C.GetLongBit()), nil
 }

--- a/libcontainer/system/sysconfig_notcgo.go
+++ b/libcontainer/system/sysconfig_notcgo.go
@@ -2,6 +2,8 @@
 
 package system
 
+import "errors"
+
 func GetClockTicks() int {
 	// TODO figure out a better alternative for platforms where we're missing cgo
 	//
@@ -12,4 +14,8 @@ func GetClockTicks() int {
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/dn553408(v=vs.85).aspx
 
 	return 100
+}
+
+func GetLongBit() (int, error) {
+	return -1, errors.New("GetLongBit only supported when compile with CGO")
 }


### PR DESCRIPTION
For systems that are not compiled with CGO GetLongBit function is
unreliable and should return an error.

Fixes #841

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>