### PR TITLE
Update for stopped container

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -174,6 +174,13 @@ func (c *linuxContainer) Stats() (*Stats, error) {
 func (c *linuxContainer) Set(config configs.Config) error {
 	c.m.Lock()
 	defer c.m.Unlock()
+	status, err := c.currentStatus()
+	if err != nil {
+		return err
+	}
+	if status == Stopped {
+		return newGenericError(fmt.Errorf("container not running"), ContainerNotRunning)
+	}
 	c.config = &config
 	return c.cgroupManager.Set(c.config)
 }


### PR DESCRIPTION
Currently runc allows to update the resource constraints for all container states. With new create start changes, runc doesnt allow to start an container from stopped state. So we dont need to update the container resource constraints in stopped state.
With this PR change container can be updated in Created/Running/Paused state ( except stopped state).
Signed-off-by: rajasec <rajasec79@gmail.com>