### PR TITLE
tests: remove --console usage

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -48,7 +48,7 @@ EOF
     sed -i "s/\(\"resources\": {\)/\1\n${DATA}/" ${BUSYBOX_BUNDLE}/config.json
 
     # run a detached busybox to work with
-    runc run -d --console /dev/pts/ptmx test_cgroups_kmem
+    runc run -d test_cgroups_kmem
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_cgroups_kmem
 
@@ -65,7 +65,7 @@ EOF
     sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
     # run a detached busybox to work with
-    runc run -d --console /dev/pts/ptmx test_cgroups_kmem
+    runc run -d test_cgroups_kmem
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_cgroups_kmem
 

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -12,7 +12,7 @@ function teardown() {
 }
 
 @test "runc create" {
-  runc create --console /dev/pts/ptmx test_busybox
+  runc create test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created
@@ -25,7 +25,7 @@ function teardown() {
 }
 
 @test "runc create exec" {
-  runc create --console /dev/pts/ptmx test_busybox
+  runc create test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc delete" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "events --stats" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -28,7 +28,7 @@ function teardown() {
 
 @test "events --interval default " {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -55,7 +55,7 @@ function teardown() {
 
 @test "events --interval 1s " {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -81,7 +81,7 @@ function teardown() {
 
 @test "events --interval 100ms " {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc exec" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -26,7 +26,7 @@ function teardown() {
 
 @test "runc exec --pid-file" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -64,11 +64,11 @@ load helpers
   runc start -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ start+ ]]
-  
+
   runc run -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ run+ ]]
-  
+
   runc state -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ state+ ]]

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -143,6 +143,7 @@ function setup_busybox() {
   tar -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
   cd "$BUSYBOX_BUNDLE"
   runc spec
+  sed -i 's;"terminal": true;"terminal": false;' config.json
 }
 
 function setup_hello() {
@@ -151,6 +152,7 @@ function setup_hello() {
   tar -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
   cd "$HELLO_BUNDLE"
   runc spec
+  sed -i 's;"terminal": true;"terminal": false;' config.json
   sed -i 's;"sh";"/hello";' config.json
 }
 

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -15,7 +15,7 @@ function teardown() {
 @test "kill detached busybox" {
 
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -19,15 +19,15 @@ function teardown() {
 
 @test "list" {
   # run a few busyboxes detached
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_box1
+  ROOT=$HELLO_BUNDLE runc run -d test_box1
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box1 $HELLO_BUNDLE
 
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_box2
+  ROOT=$HELLO_BUNDLE runc run -d test_box2
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box2 $HELLO_BUNDLE
 
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_box3
+  ROOT=$HELLO_BUNDLE runc run -d test_box3
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box3 $HELLO_BUNDLE
 

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc pause and resume" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -15,11 +15,11 @@ function teardown() {
 
 @test "global --root" {
   # run busybox detached using $HELLO_BUNDLE for state
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_dotbox
+  ROOT=$HELLO_BUNDLE runc run -d test_dotbox
   [ "$status" -eq 0 ]
 
   # run busybox detached in default root
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state of the busyboxes are only in their respective root path

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc run detached" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -24,7 +24,7 @@ function teardown() {
 
 @test "runc run detached --pid-file" {
   # run busybox detached
-  runc run --pid-file pid.txt -d --console /dev/pts/ptmx test_busybox
+  runc run --pid-file pid.txt -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -16,7 +16,7 @@ function teardown() {
   [ "$status" -ne 0 ]
 
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -49,7 +49,7 @@ function check_cgroup_value() {
 
 @test "update" {
     # run a few busyboxes detached
-    runc run -d --console /dev/pts/ptmx test_update
+    runc run -d test_update
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_update
 


### PR DESCRIPTION
The previous usage of --console was very misleading, and is not how the
flag should be used by users. In addition, due to other bugs and design
issues, --console does not work in user namespaces. By removing
--console usage in the tests, we can now (in principle) run all of the
tests in user namespaces.

Signed-off-by: Aleksa Sarai <asarai@suse.de>