### PR TITLE
Use fifo for create / start instead of signal handling 

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -124,8 +124,8 @@ type BaseContainer interface {
 	Start(process *Process) (err error)
 
 	// Run immediatly starts the process inside the conatiner.  Returns error if process
-	// fails to start.  It does not block waiting for a SIGCONT after start returns but
-	// sends the signal when the process has completed.
+	// fails to start.  It does not block waiting for the exec fifo  after start returns but
+	// opens the fifo after start returns.
 	//
 	// errors:
 	// ContainerDestroyed - Container no longer exists,
@@ -148,4 +148,10 @@ type BaseContainer interface {
 	// errors:
 	// SystemError - System error.
 	Signal(s os.Signal) error
+
+	// Exec signals the container to exec the users process at the end of the init.
+	//
+	// errors:
+	// SystemError - System error.
+	Exec() error
 }

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -58,13 +58,14 @@ type initConfig struct {
 	PassedFilesCount int              `json:"passed_files_count"`
 	ContainerId      string           `json:"containerid"`
 	Rlimits          []configs.Rlimit `json:"rlimits"`
+	ExecFifoPath     string           `json:"start_pipe_path"`
 }
 
 type initer interface {
-	Init(s chan os.Signal) error
+	Init() error
 }
 
-func newContainerInit(t initType, pipe *os.File) (initer, error) {
+func newContainerInit(t initType, pipe *os.File, stateDirFD int) (initer, error) {
 	var config *initConfig
 	if err := json.NewDecoder(pipe).Decode(&config); err != nil {
 		return nil, err
@@ -79,9 +80,10 @@ func newContainerInit(t initType, pipe *os.File) (initer, error) {
 		}, nil
 	case initStandard:
 		return &linuxStandardInit{
-			pipe:      pipe,
-			parentPid: syscall.Getppid(),
-			config:    config,
+			pipe:       pipe,
+			parentPid:  syscall.Getppid(),
+			config:     config,
+			stateDirFD: stateDirFD,
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown init type %q", t)

--- a/libcontainer/integration/init_test.go
+++ b/libcontainer/integration/init_test.go
@@ -42,13 +42,13 @@ func TestMain(m *testing.M) {
 	logrus.SetOutput(os.Stderr)
 	logrus.SetLevel(logrus.InfoLevel)
 
-	factory, err = libcontainer.New(".", libcontainer.Cgroupfs)
+	factory, err = libcontainer.New("/run/libctTests", libcontainer.Cgroupfs)
 	if err != nil {
 		logrus.Error(err)
 		os.Exit(1)
 	}
 	if systemd.UseSystemd() {
-		systemdFactory, err = libcontainer.New(".", libcontainer.SystemdCgroups)
+		systemdFactory, err = libcontainer.New("/run/libctTests", libcontainer.SystemdCgroups)
 		if err != nil {
 			logrus.Error(err)
 			os.Exit(1)

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -101,8 +101,8 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 				Args: []*configs.Arg{
 					{
 						Index: 0,
-						Value: 1,
-						Op:    configs.GreaterThan,
+						Value: 2,
+						Op:    configs.EqualTo,
 					},
 				},
 			},
@@ -162,8 +162,8 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 				Args: []*configs.Arg{
 					{
 						Index: 0,
-						Value: 1,
-						Op:    configs.GreaterThan,
+						Value: 2,
+						Op:    configs.EqualTo,
 					},
 				},
 			},

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -92,7 +95,9 @@ func copyBusybox(dest string) error {
 }
 
 func newContainer(config *configs.Config) (libcontainer.Container, error) {
-	return newContainerWithName("testCT", config)
+	h := md5.New()
+	h.Write([]byte(time.Now().String()))
+	return newContainerWithName(hex.EncodeToString(h.Sum(nil)), config)
 }
 
 func newContainerWithName(name string, config *configs.Config) (libcontainer.Container, error) {

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -51,6 +51,7 @@ type setnsProcess struct {
 	fds           []string
 	process       *Process
 	bootstrapData io.Reader
+	rootDir       *os.File
 }
 
 func (p *setnsProcess) startTime() (string, error) {
@@ -69,6 +70,7 @@ func (p *setnsProcess) start() (err error) {
 	defer p.parentPipe.Close()
 	err = p.cmd.Start()
 	p.childPipe.Close()
+	p.rootDir.Close()
 	if err != nil {
 		return newSystemErrorWithCause(err, "starting setns process")
 	}
@@ -186,6 +188,7 @@ type initProcess struct {
 	process       *Process
 	bootstrapData io.Reader
 	sharePidns    bool
+	rootDir       *os.File
 }
 
 func (p *initProcess) pid() int {
@@ -230,6 +233,7 @@ func (p *initProcess) start() error {
 	err := p.cmd.Start()
 	p.process.ops = p
 	p.childPipe.Close()
+	p.rootDir.Close()
 	if err != nil {
 		p.process.ops = nil
 		return newSystemErrorWithCause(err, "starting init process command")

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -5,7 +5,6 @@ package libcontainer
 import (
 	"fmt"
 	"os"
-	"os/signal"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/keys"
@@ -24,7 +23,7 @@ func (l *linuxSetnsInit) getSessionRingName() string {
 	return fmt.Sprintf("_ses.%s", l.config.ContainerId)
 }
 
-func (l *linuxSetnsInit) Init(s chan os.Signal) error {
+func (l *linuxSetnsInit) Init() error {
 	if !l.config.Config.NoNewKeyring {
 		// do not inherit the parent's session keyring
 		if _, err := keyctl.JoinSessionKeyring(l.getSessionRingName()); err != nil {
@@ -50,7 +49,5 @@ func (l *linuxSetnsInit) Init(s chan os.Signal) error {
 	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
 		return err
 	}
-	signal.Stop(s)
-	close(s)
 	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
 }

--- a/start.go
+++ b/start.go
@@ -27,7 +27,7 @@ your host.`,
 		}
 		switch status {
 		case libcontainer.Created:
-			return container.Signal(libcontainer.InitContinueSignal)
+			return container.Exec()
 		case libcontainer.Stopped:
 			return fmt.Errorf("cannot start a container that has run and stopped")
 		case libcontainer.Running:


### PR DESCRIPTION
This removes the use of a signal handler and SIGCONT to signal the init
process to exec the users process.

Closes #871 