### PR TITLE
start: use SIGUSR1 for start signal

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -29,9 +29,10 @@ import (
 
 const stdioFdCount = 3
 
-// InitContinueSignal is used to signal the container init process to
-// start the users specified process after the container create has finished.
-const InitContinueSignal = syscall.SIGCONT
+// InitContinueSignal is used to signal the container init process to start the
+// users specified process after the container create has finished. We can't
+// use SIGCONT, because Go < 1.6 would not allow us to wait for that signal.
+const InitContinueSignal = syscall.SIGUSR1
 
 type linuxContainer struct {
 	id            string


### PR DESCRIPTION
Since we don't use SIGSTOP, the choice of wait signal is arbitrary.
However, Go versions before 1.6 did not support waiting for SIGCONT --
this is a problem for platforms which do not have the gc compiler (as
gcc-go implements Go 1.4).

This is an alternative to #886.

Signed-off-by: Aleksa Sarai <asarai@suse.de>