### PR TITLE
tests: add debug information for failing tests

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -31,6 +31,11 @@ ROOT="$BATS_TMPDIR/runc"
 # Wrapper for runc.
 function runc() {
   run __runc "$@"
+
+  # Some debug information to make life easier. bats will only print it if the
+  # test failed, in which case the output is useful.
+  echo "runc $@ (status=$status):" >&2
+  echo "$output" >&2
 }
 
 # Raw wrapper for runc.


### PR DESCRIPTION
bats doesn't automatically print the entirety of $output when an error
has occurred in a test. This makes debugging much harder, so add to the
runc wrapper some more debug information to make maintainers' lives
easier.

Signed-off-by: Aleksa Sarai <asarai@suse.de>