### PR TITLE
restore: add the empty-ns option

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -77,6 +77,10 @@ using the runc checkpoint command.`,
 			Name:  "no-pivot",
 			Usage: "do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk",
 		},
+		cli.StringSliceFlag{
+			Name:  "empty-ns",
+			Usage: "create a namespace, but don't restore its properies",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		imagePath := context.String("image-path")
@@ -142,6 +146,10 @@ func restoreContainer(context *cli.Context, spec *specs.Spec, config *configs.Co
 	}
 
 	setManageCgroupsMode(context, options)
+
+	if err := setEmptyNsMask(context, options); err != nil {
+		return -1, err
+	}
 
 	// ensure that the container is always removed if we were the process
 	// that created it.


### PR DESCRIPTION
The same option was added for the "checkpoint" command in https://github.com/opencontainers/runc/commit/3ad3d937d280f58ead3fc7814968d86c1724d6f9

For example:
./runc restore --empty-ns network CTID

In this case criu creates a network namespace, but doesn't restore it.

We are going to use this option to restore docker containers and
Docker sets a hook to restore a network namespace.

https://github.com/xemul/criu/issues/165
Cc: @boucher 
Signed-off-by: Andrew Vagin <avagin@virtuozzo.com>