### PR TITLE
Add error return to action function signature

### DIFF
--- a/main_unix.go
+++ b/main_unix.go
@@ -21,7 +21,7 @@ func init() {
 var initCommand = cli.Command{
 	Name:  "init",
 	Usage: `initialize the namespaces and launch the process (do not call it outside of runc)`,
-	Action: func(context *cli.Context) {
+	Action: func(context *cli.Context) error {
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
 			// as the error is sent back to the parent there is no need to log


### PR DESCRIPTION
Not having an error return is deprecated

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>