### PR TITLE
bug fix, LeafWeight nil err

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -392,7 +392,14 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 		}
 		if r.BlockIO.WeightDevice != nil {
 			for _, wd := range r.BlockIO.WeightDevice {
-				weightDevice := configs.NewWeightDevice(wd.Major, wd.Minor, *wd.Weight, *wd.LeafWeight)
+				var weight, leafWeight uint16
+				if wd.Weight != nil {
+					weight = *wd.Weight
+				}
+				if wd.LeafWeight != nil {
+					leafWeight = *wd.LeafWeight
+				}
+				weightDevice := configs.NewWeightDevice(wd.Major, wd.Minor, weight, leafWeight)
 				c.Resources.BlkioWeightDevice = append(c.Resources.BlkioWeightDevice, weightDevice)
 			}
 		}


### PR DESCRIPTION
There is no judgment whether LeafWeight is nil which can cause runc panic.
this pr fix it.
e.g.
```
root@ubuntu:~# docker run -ti --blkio-weight-device "/dev/sda:200" ubuntu
docker: Error response from daemon: rpc error: code = 2 desc = "containerd: container not started".
message form daemon:
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x554179]

goroutine 1 [running]:
github.com/opencontainers/runc/libcontainer/specconv.createCgroupConfig(0x7fffe03bbd1d, 0x40, 0x0, 0xc82009ea00, 0xc8200b3870, 0x0, 0x0)
        /root/workspace/gocode/src/github.com/opencontainer/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go:394 +0xe99
github.com/opencontainers/runc/libcontainer/specconv.CreateLibcontainerConfig(0xc8200c6e10, 0x82dd60, 0x0, 0x0)
```

Signed-off-by: Shukui Yang <yangshukui@huawei.com>