### PR TITLE
set default cgroup path to /runc

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
@@ -255,10 +254,7 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 }
 
 func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*configs.Cgroup, error) {
-	var (
-		err          error
-		myCgroupPath string
-	)
+	var myCgroupPath string
 
 	c := &configs.Cgroup{
 		Resources: &configs.Resources{},
@@ -289,11 +285,7 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 		}
 	} else {
 		if myCgroupPath == "" {
-			myCgroupPath, err = cgroups.GetThisCgroupDir("devices")
-			if err != nil {
-				return nil, err
-			}
-			myCgroupPath = filepath.Join(myCgroupPath, name)
+			myCgroupPath = filepath.Join("/runc", name)
 		}
 		c.Path = myCgroupPath
 	}


### PR DESCRIPTION
So far when "cgroupsPath" was not specified in the config.json file runC
containers used the prefix associated with the "devices" subsystem and placed
the container in a subhierarchy starting with prefix for all subystems. For
example, if the user starting the container was located in
"/sys/fs/cgroup/devices/user.slice/random-cgroup" then runC would retrieve the
"/user.slice/random-cgroup" string and place the container in a subcgroup
"/sys/fs/cgroup/*/user.slice/random-cgroup/CONTAINERNAME" for all subsystems.
Let's rather use "/runc" as the default cgroup for all subsystems. This seems
cleaner and falls in line with Docker/LXC et al.

Signed-off-by: Christian Brauner <cbrauner@suse.com>