### PR TITLE
Add "--" exec cli support for command arguments

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -17,7 +17,7 @@ import (
 var execCommand = cli.Command{
 	Name:  "exec",
 	Usage: "execute new process inside the container",
-	ArgsUsage: `<container-id> <container command>
+	ArgsUsage: `<container-id> -- <container command> [command options]
 
 Where "<container-id>" is the name for the instance of the container and
 "<container command>" is the command to be executed in the container.
@@ -149,6 +149,9 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 	}
 	p := spec.Process
 	p.Args = context.Args()[1:]
+	if len(p.Args) > 1 && p.Args[0] == "--" {
+		p.Args = p.Args[1:]
+	}
 	// override the cwd, if passed
 	if context.String("cwd") != "" {
 		p.Cwd = context.String("cwd")

--- a/man/runc-exec.8.md
+++ b/man/runc-exec.8.md
@@ -2,7 +2,7 @@
    runc exec - execute new process inside the container
 
 # SYNOPSIS
-   runc exec [command options] <container-id> <container command>
+   runc exec [command options] <container-id> -- <container command> [args...]
 
 Where "<container-id>" is the name for the instance of the container and
 "<container command>" is the command to be executed in the container.


### PR DESCRIPTION
This flag allows using parameters starting with a - such as:
  ps --args -afx