### PR TITLE
Removing unused variable for cgroup subsystem

### DIFF
--- a/libcontainer/cgroups/fs/utils.go
+++ b/libcontainer/cgroups/fs/utils.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	ErrNotSupportStat = errors.New("stats are not supported for subsystem")
 	ErrNotValidFormat = errors.New("line is not a valid key value format")
 )
 


### PR DESCRIPTION
Removed the unused variable, as we are returning nil for subsystems( freezer & devices) when there is no statistics.
Signed-off-by: rajasec <rajasec79@gmail.com>