### PR TITLE
manual: Add space lines for md

### DIFF
--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -12,12 +12,21 @@ checkpointed.
 
 # OPTIONS
    --image-path value           path for saving criu image files
+
    --work-path value            path for saving work files and logs
+
    --leave-running              leave the process running after checkpointing
+
    --tcp-established            allow open tcp connections
+
    --ext-unix-sk                allow external unix sockets
+
    --shell-job                  allow shell jobs
+
    --page-server value          ADDRESS:PORT of the page server
+
    --file-locks                 handle file locks, for safety
+
    --manage-cgroups-mode value  cgroups mode: 'soft' (default), 'full' and 'strict'
+
    --empty-ns value             create a namespace, but don't restore its properies

--- a/man/runc-events.8.md
+++ b/man/runc-events.8.md
@@ -12,4 +12,5 @@ information is displayed once every 5 seconds.
 
 # OPTIONS
    --interval value     set the stats collection interval (default: 5s)
+
    --stats              display the container's stats then exit

--- a/man/runc-exec.8.md
+++ b/man/runc-exec.8.md
@@ -15,15 +15,27 @@ following will output a list of processes running in the container:
 
 # OPTIONS
    --console value              specify the pty slave path for use with the container
+
    --cwd value                  current working directory in the container
+
    --env value, -e value        set environment variables
+
    --tty, -t                    allocate a pseudo-TTY
+
    --user value, -u value       UID (format: <uid>[:<gid>])
+
    --process value, -p value    path to the process.json
+
    --detach, -d                 detach from the container's process
+
    --pid-file value             specify the file to write the process id to
+
    --process-label value        set the asm process label for the process commonly used with selinux
+
    --apparmor value             set the apparmor profile for the process
+
    --no-new-privs               set the no new privileges value for the process
+
    --cap value, -c value        add a capability to the bounding set for the process
+
    --no-subreaper               disable the use of the subreaper used to reap reparented processes

--- a/man/runc-list.8.md
+++ b/man/runc-list.8.md
@@ -6,4 +6,5 @@
 
 # OPTIONS
    --format value, -f value     select one of: table(default) or json
+
    --quiet, -q                  display only container IDs

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -13,14 +13,25 @@ using the runc checkpoint command.
 
 # OPTIONS
    --image-path value           path to criu image files for restoring
+
    --work-path value            path for saving work files and logs
+
    --tcp-established            allow open tcp connections
+
    --ext-unix-sk                allow external unix sockets
+
    --shell-job                  allow shell jobs
+
    --file-locks                 handle file locks, for safety
+
    --manage-cgroups-mode value  cgroups mode: 'soft' (default), 'full' and 'strict'
+
    --bundle value, -b value     path to the root of the bundle directory
+
    --detach, -d                 detach from the container's process
+
    --pid-file value             specify the file to write the process id to
+
    --no-subreaper               disable the use of the subreaper used to reap reparented processes
+
    --no-pivot                   do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk

--- a/man/runc-start.8.md
+++ b/man/runc-start.8.md
@@ -20,8 +20,13 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 
 # OPTIONS
    --bundle value, -b value     path to the root of the bundle directory, defaults to the current directory
+
    --console value              specify the pty slave path for use with the container
+
    --detach, -d                 detach from the container's process
+
    --pid-file value             specify the file to write the process id to
+
    --no-subreaper               disable the use of the subreaper used to reap reparented processes
+
    --no-pivot                   do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -33,14 +33,25 @@ other options are ignored.
 
 # OPTIONS
    --resources value, -r value  path to the file containing the resources to update or '-' to read from the standard input
+
    --blkio-weight value         Specifies per cgroup weight, range is from 10 to 1000 (default: 0)
+
    --cpu-period value           CPU period to be used for hardcapping (in usecs). 0 to use system default
+
    --cpu-quota value            CPU hardcap limit (in usecs). Allowed cpu time in a given period
+
    --cpu-share value            CPU shares (relative weight vs. other containers)
+
    --cpuset-cpus value          CPU(s) to use
+
    --cpuset-mems value          Memory node(s) to use
+
    --kernel-memory value        Kernel memory limit (in bytes)
+
    --kernel-memory-tcp value    Kernel memory limit (in bytes) for tcp buffer
+
    --memory value               Memory limit (in bytes)
+
    --memory-reservation value   Memory reservation or soft_limit (in bytes)
+
    --memory-swap value          Total memory usage (memory + swap); set '-1' to enable unlimited swap

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -29,28 +29,50 @@ value for "bundle" is the current directory.
 
 # COMMANDS
    checkpoint   checkpoint a running container
+
    delete       delete any resources held by the container often used with detached containers
+
    events       display container events such as OOM notifications, cpu, memory, IO and network stats
+
    exec         execute new process inside the container
+
    init         initialize the namespaces and launch the process (do not call it outside of runc)
+
    kill         kill sends the specified signal (default: SIGTERM) to the container's init process
+
    list         lists containers started by runc with the given root
+
    pause        pause suspends all processes inside the container
+
    ps           displays the processes running inside a container
+
    restore      restore a container from a previous checkpoint
+
    resume       resumes all processes that have been previously paused
+
    spec         create a new specification file
+
    start        create and run a container
+
    state        output the state of a container
+
    update       update container resource constraints
+
    help, h      Shows a list of commands or help for one command
    
 # GLOBAL OPTIONS
    --debug              enable debug output for logging
+
    --log value          set the log file path where internal debug information is written (default: "/dev/null")
+
    --log-format value   set the format used by logs ('text' (default), or 'json') (default: "text")
+
    --root value         root directory for storage of container state (this should be located in tmpfs) (default: "/run/runc")
+
    --criu value         path to the criu binary used for checkpoint and restore (default: "criu")
+
    --systemd-cgroup     enable systemd cgroup support, expects cgroupsPath to be of form "slice:prefix:name" for e.g. "system.slice:runc:434234"
+
    --help, -h           show help
+
    --version, -v        print the version


### PR DESCRIPTION
In md format, "enter" in contents are automatically trimed into
single line, except there exist a blank line.

For example, current runc-exec.8.md show all options in single
line in standard md format, as:
 | --console value specify the pty slave path for use with the
 | container --cwd value current working directory in the container
 | --env value, -e value set environment variables --tty, -t
 | allocate a pseudo-TTY --user value, -u value UID (format: [:])
 | ...

And go-md2man do a little favour that it translate above md content
into following(not align):
 | OPTIONS
 |      --console                                    specify the ...
 |         --cwd                                        current  ...
 |         --env, -e [--env option --env option]        set      ...
 |         --tty, -t                                    allocate ...

This patch add blank lines into option content for md files, to
make them in standard md format.

After patch:
 | OPTIONS
 |      --console value              specify the pty slave path ...
 |
 |      --cwd value                  current working directory  ...
 |
 |      --env value, -e value        set environment variables
 |
 |      --tty, -t                    allocate a pseudo-TTY
 |
 |      ...

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>