### PR TITLE
Introduce make release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/pkg
 /runc
 Godeps/_workspace/src/github.com/opencontainers/runc
 man/man8
+release


### PR DESCRIPTION
So we can make all types of release binary with combination
of following flags:
 seccomp
 selinux
 apparmor
 static

All binary files are put in release/ dir, like:
 [root@zlosvm1 runc]# ls -l release
 total 53488
 -rwxr-xr-x. 1 root root 9517965 Jun 14 18:11 runc
 -rwxr-xr-x. 1 root root 9673533 Jun 14 18:10 runc.seccomp
 -rwxr-xr-x. 1 root root 9705839 Jun 14 18:09 runc.seccomp.selinux
 -rwxr-xr-x. 1 root root 9546175 Jun 14 18:10 runc.selinux
 -rwxr-xr-x. 1 root root 8169190 Jun 14 18:10 runc.selinux.static
 -rwxr-xr-x. 1 root root 8150060 Jun 14 18:11 runc.static
 ...

Closes #899

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>