### PR TITLE
remove unused returned variables name

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -118,7 +118,7 @@ using the runc checkpoint command.`,
 	},
 }
 
-func restoreContainer(context *cli.Context, spec *specs.Spec, config *configs.Config, imagePath string) (code int, err error) {
+func restoreContainer(context *cli.Context, spec *specs.Spec, config *configs.Config, imagePath string) (int, error) {
 	var (
 		rootuid = 0
 		rootgid = 0


### PR DESCRIPTION
The returned variables name seems be able to removed.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>