### PR TITLE
cli: Workaround for parse -- in argument

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -382,7 +382,6 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 	cfg := &initConfig{
 		Config:           c.config,
-		Args:             process.Args,
 		Env:              process.Env,
 		User:             process.User,
 		Cwd:              process.Cwd,
@@ -395,6 +394,11 @@ func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 		ProcessLabel:     c.config.ProcessLabel,
 		Rlimits:          c.config.Rlimits,
 		ExecFifoPath:     filepath.Join(c.root, execFifoFilename),
+	}
+	if process.Args[0] == "--" {
+		cfg.Args = process.Args[1:]
+	} else {
+		cfg.Args = process.Args
 	}
 	if process.NoNewPrivileges != nil {
 		cfg.NoNewPrivileges = *process.NoNewPrivileges


### PR DESCRIPTION
CLI library add '--' into argument list, and make following
result in current code:
 #  ./runc exec 123 -- ls
 exec failed: exec: "--": executable file not found in $PATH
 #  ./runc exec 123 -- ls -l
 exec failed: exec: "--": executable file not found in $PATH
 #  ./runc exec 123 ls
 bin   dev   etc   home  proc  root  sys   tmp   usr   var
 #  ./runc exec 123 ls -l
 Incorrect Usage.
 NAME:
   runc exec - execute new process inside the container
 ...
 flag provided but not defined: -l
 #

Before CLI library got fixed, we can use a workaround to make user
feeling better:
 # ./runc exec 123 -- ls
 bin   dev   etc   home  proc  root  sys   tmp   usr   var
 # ./runc exec 123 -- ls -l
 total 16
 drwxr-xr-x    2 root     root          8192 Mar 18 16:39 bin
 drwxr-xr-x    5 root     root           360 Jun 15 10:06 dev
 ...
 #
 # ./runc exec 123 ls
 bin   dev   etc   home  proc  root  sys   tmp   usr   var
 # ./runc exec 123 ls -l
 Incorrect Usage.
 ...
 flag provided but not defined: -l
 #

And the old argument type ("--" before container-id) is also
supported after this patch.

Closes #752

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>