### PR TITLE
Fix ps argument manual

### DIFF
--- a/man/runc-ps.8.md
+++ b/man/runc-ps.8.md
@@ -2,7 +2,7 @@
    runc ps - ps displays the processes running inside a container
 
 # SYNOPSIS
-   runc ps [command options] <container-id> <ps options>
+   runc ps [command options] <container-id> [ps options]
 
 # OPTIONS
    --format value, -f value     select one of: table(default) or json

--- a/ps.go
+++ b/ps.go
@@ -16,7 +16,7 @@ import (
 var psCommand = cli.Command{
 	Name:      "ps",
 	Usage:     "ps displays the processes running inside a container",
-	ArgsUsage: `<container-id> <ps options>`,
+	ArgsUsage: `<container-id> [ps options]`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "format, f",


### PR DESCRIPTION
Argument of "ps options" for ps command is a optional parameter.
Should use [] instead of <> in manual.

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>