### PR TITLE
factory: fix FIFO permissions

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -173,7 +173,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	} else if !os.IsNotExist(err) {
 		return nil, newGenericError(err, SystemError)
 	}
-	if err := os.MkdirAll(containerRoot, 0711); err != nil {
+	if err := os.MkdirAll(containerRoot, 0700); err != nil {
 		return nil, newGenericError(err, SystemError)
 	}
 	if err := os.Chown(containerRoot, uid, gid); err != nil {
@@ -181,7 +181,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	}
 	fifoName := filepath.Join(containerRoot, execFifoFilename)
 	oldMask := syscall.Umask(0000)
-	if err := syscall.Mkfifo(fifoName, 0622); err != nil {
+	if err := syscall.Mkfifo(fifoName, 0600); err != nil {
 		syscall.Umask(oldMask)
 		return nil, newGenericError(err, SystemError)
 	}


### PR DESCRIPTION
Fix overly permissive FIFO permissions for the start process. Since
we're chown-ing the FIFO we can deal with both userns and full root
containers (as well as rootless containers). The two cases are:
1. We are in a userns. The waiting side (r) owns the file and so doesn't
   need any additional group or other permissions. The "start" end does
   have root privileges (or has the same UID as the .HostUID()) and thus
   has the right permissions to start (w) the container.
2. We are root. In which case anything goes and the permissions don't
   actually matter.

However, by setting the FIFO to 0622, any user on the system could start
any other users container (including full root containers). This is
clearly a potential security hole (and violates least-suprise as well as
breaking the semantics of the signal-based create-start split that
actually had sane ACLs built into it).

This further fixes #912 and #886.

Signed-off-by: Aleksa Sarai asarai@suse.de
