### PR TITLE
Add force to delete

### DIFF
--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -31,3 +31,20 @@ function teardown() {
   runc state test_busybox
   [ "$status" -ne 0 ]
 }
+
+@test "runc delete --force" {
+  # run busybox detached
+  runc run -d --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  # check state
+  wait_for_container 15 1 test_busybox
+
+  testcontainer test_busybox running
+
+  # force delete test_busybox
+  runc delete --force test_busybox
+
+  runc state test_busybox
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Reasons:
- I'm lazy and I don't want to type 2 different commands :). Typing `--force` actually make it explicit that I know what I'm doing
- When using an higher level tool to control runc, it's cheaper to do only 1 exec instead of 2 (kill + delete)

P.S: This also update the `Makefile` to tag the images generated via `make` with the current branch name instead of always overriding `latest`. I can move that commit in a separate PR if needed.