### PR TITLE
cli: Workaround for ps's argument

### DIFF
--- a/man/runc-ps.8.md
+++ b/man/runc-ps.8.md
@@ -2,7 +2,7 @@
    runc ps - ps displays the processes running inside a container
 
 # SYNOPSIS
-   runc ps [command options] <container-id> [ps options]
+   runc ps [command options] <container-id> [-- ps options]
 
 # OPTIONS
    --format value, -f value     select one of: table(default) or json

--- a/ps.go
+++ b/ps.go
@@ -16,7 +16,7 @@ import (
 var psCommand = cli.Command{
 	Name:      "ps",
 	Usage:     "ps displays the processes running inside a container",
-	ArgsUsage: `<container-id> [ps options]`,
+	ArgsUsage: `<container-id> [-- ps options]`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "format, f",
@@ -43,6 +43,9 @@ var psCommand = cli.Command{
 		}
 
 		psArgs := context.Args().Get(1)
+		if psArgs == "--" {
+			psArgs = context.Args().Get(2)
+		}
 		if psArgs == "" {
 			psArgs = "-ef"
 		}

--- a/ps.go
+++ b/ps.go
@@ -42,15 +42,21 @@ var psCommand = cli.Command{
 			return nil
 		}
 
-		psArgs := context.Args().Get(1)
-		if psArgs == "--" {
-			psArgs = context.Args().Get(2)
-		}
-		if psArgs == "" {
-			psArgs = "-ef"
+		// [1:] is to remove command name, ex:
+		// context.Args(): [containet_id ps_arg1 ps_arg2 ...]
+		// psArgs:         [ps_arg1 ps_arg2 ...]
+		//
+		psArgs := context.Args()[1:]
+
+		if len(psArgs) > 0 && psArgs[0] == "--" {
+			psArgs = psArgs[1:]
 		}
 
-		output, err := exec.Command("ps", strings.Split(psArgs, " ")...).Output()
+		if len(psArgs) == 0 {
+			psArgs = []string{"-ef"}
+		}
+
+		output, err := exec.Command("ps", psArgs...).Output()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, ps command can not support argument:
(But following usage is in manual)
 | # ./runc ps 123 -ef
 | Incorrect Usage.
 |
 | NAME:
 |    runc ps - ps displays the processes running inside a container
 |
 | USAGE:
 |    runc ps [command options] <container-id> [ps options]
 |
 | OPTIONS:
 |    --format value, -f value  select one of: table or json
 |
 | flag provided but not defined: -ef
 | #

Instead of using odd command like:
 | # ./runc ps -- 123 -ef

We can make it seems little better:
 | # ./runc ps 123 -- -ef
 | UID        PID  PPID  C STIME TTY          TIME CMD
 | root     29046 29038  0 11:18 pts/2    00:00:00 sh
 | #

This patch also fixed manual which can not working in current
code.

Closes #788

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>