### PR TITLE
fix setting net_cls classid

### DIFF
--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -3,6 +3,8 @@
 package fs
 
 import (
+	"strconv"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
@@ -23,8 +25,8 @@ func (s *NetClsGroup) Apply(d *cgroupData) error {
 }
 
 func (s *NetClsGroup) Set(path string, cgroup *configs.Cgroup) error {
-	if cgroup.Resources.NetClsClassid != "" {
-		if err := writeFile(path, "net_cls.classid", cgroup.Resources.NetClsClassid); err != nil {
+	if cgroup.Resources.NetClsClassid != 0 {
+		if err := writeFile(path, "net_cls.classid", strconv.FormatUint(uint64(cgroup.Resources.NetClsClassid), 10)); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -3,12 +3,13 @@
 package fs
 
 import (
+	"strconv"
 	"testing"
 )
 
 const (
-	classidBefore = "0x100002"
-	classidAfter  = "0x100001"
+	classidBefore = 0x100002
+	classidAfter  = 0x100001
 )
 
 func TestNetClsSetClassid(t *testing.T) {
@@ -16,7 +17,7 @@ func TestNetClsSetClassid(t *testing.T) {
 	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
-		"net_cls.classid": classidBefore,
+		"net_cls.classid": strconv.FormatUint(classidBefore, 10),
 	})
 
 	helper.CgroupData.config.Resources.NetClsClassid = classidAfter
@@ -28,7 +29,7 @@ func TestNetClsSetClassid(t *testing.T) {
 	// As we are in mock environment, we can't get correct value of classid from
 	// net_cls.classid.
 	// So. we just judge if we successfully write classid into file
-	value, err := getCgroupParamString(helper.CgroupPath, "net_cls.classid")
+	value, err := getCgroupParamUint(helper.CgroupPath, "net_cls.classid")
 	if err != nil {
 		t.Fatalf("Failed to parse net_cls.classid - %s", err)
 	}

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -120,5 +120,5 @@ type Resources struct {
 	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap"`
 
 	// Set class identifier for container's network packets
-	NetClsClassid string `json:"net_cls_classid"`
+	NetClsClassid uint32 `json:"net_cls_classid"`
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -441,7 +441,7 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 	}
 	if r.Network != nil {
 		if r.Network.ClassID != nil {
-			c.Resources.NetClsClassid = string(*r.Network.ClassID)
+			c.Resources.NetClsClassid = *r.Network.ClassID
 		}
 		for _, m := range r.Network.Priorities {
 			c.Resources.NetPrioIfpriomap = append(c.Resources.NetPrioIfpriomap, &configs.IfPrioMap{


### PR DESCRIPTION
Setting classid of net_cls cgroup failed:

ERRO[0000] process_linux.go:291: setting cgroup config for ready process caused "failed to write 𐀁 to net_cls.classid: write /sys/fs/cgroup/net_cls,net_prio/user.slice/abc/net_cls.classid: invalid argument"
process_linux.go:291: setting cgroup config for ready process caused "failed to write 𐀁 to net_cls.classid: write /sys/fs/cgroup/net_cls,net_prio/user.slice/abc/net_cls.classid: invalid argument"

The classid is a *uint32, use strconv to convert to string.

Signed-off-by: Hushan Jia <hushan.jia@gmail.com>