### PR TITLE
address issue #797 by adding additional documentation

### DIFF
--- a/list.go
+++ b/list.go
@@ -38,6 +38,18 @@ type containerState struct {
 var listCommand = cli.Command{
 	Name:  "list",
 	Usage: "lists containers started by runc with the given root",
+	ArgsUsage: `
+
+Where the given root is specified via the global option "--root"
+(default: "/run/runc").
+
+EXAMPLE 1:
+To list containers created via the default "--root":
+       runc list
+
+EXAMPLE 2:
+To list containers created using a non-default value for "--root":
+       runc --root value list`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "format, f",


### PR DESCRIPTION
To remove confusion over the wording of the list api.. This PR documents use of the global `--root value` option for specifying "the given root" where stats are stored and from which containers are listed via the `runc list` command. 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>