### PR TITLE
version: Add a version command

### DIFF
--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -760,6 +760,7 @@ _runc() {
 		start
 		state
 		update
+		version
 		help
 		h
 	)

--- a/main.go
+++ b/main.go
@@ -4,20 +4,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
-
-// version will be populated by the Makefile, read from
-// VERSION file of the source code.
-var version = ""
-
-// gitCommit will be the hash that the binary was built from
-// and will be populated by the Makefile
-var gitCommit = ""
 
 const (
 	specConfig = "config.json"
@@ -50,16 +40,11 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "runc"
 	app.Usage = usage
+	app.Version = ""
 
-	var v []string
-	if version != "" {
-		v = append(v, version)
+	cli.VersionPrinter = func(context *cli.Context) {
+		printVersion(context)
 	}
-	if gitCommit != "" {
-		v = append(v, fmt.Sprintf("commit: %s", gitCommit))
-	}
-	v = append(v, fmt.Sprintf("spec: %s", specs.Version))
-	app.Version = strings.Join(v, "\n")
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "debug",
@@ -108,6 +93,7 @@ func main() {
 		startCommand,
 		stateCommand,
 		updateCommand,
+		versionCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {

--- a/man/runc-version.8.md
+++ b/man/runc-version.8.md
@@ -1,0 +1,14 @@
+# NAME
+   runc version - output the runtime version
+
+# SYNOPSIS
+   runc version
+
+Write version information to stdout and exit.
+
+# DESCRIPTION
+   The version command writes version information for runc and the
+supported spec release.  This information is also exposed through
+`runc --version`, and callers can use whichever is more convenient for
+them.
+

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -44,6 +44,7 @@ value for "bundle" is the current directory.
    start        executes the user defined process in a created container
    state        output the state of a container
    update       update container resource constraints
+   version      output the runtime version
    help, h      Shows a list of commands or help for one command
    
 # GLOBAL OPTIONS

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -7,11 +7,13 @@ load helpers
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
+  [ "${output}" = "${output/VERSION/}" ]
 
   runc --help
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ NAME:+ ]]
   [[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
+  [ "${output}" = "${output/VERSION/}" ]
 }
 
 @test "runc command -h" {

--- a/tests/integration/version.bats
+++ b/tests/integration/version.bats
@@ -2,10 +2,18 @@
 
 load helpers
 
-@test "runc version" {
+@test "runc --version" {
   runc -v
   [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
+  [[ ${lines[0]} =~ runc\ [0-9]+\.[0-9]+\.[0-9]+ ]]
+  [[ ${lines[1]} =~ commit:+ ]]
+  [[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]
+}
+
+@test "runc version" {
+  runc version
+  [ "$status" -eq 0 ]
+  [[ ${lines[0]} =~ runc\ [0-9]+\.[0-9]+\.[0-9]+ ]]
   [[ ${lines[1]} =~ commit:+ ]]
   [[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urfave/cli"
+)
+
+// version will be populated by the Makefile, read from
+// VERSION file of the source code.
+var version = ""
+
+// gitCommit will be the hash that the binary was built from
+// and will be populated by the Makefile
+var gitCommit = ""
+
+var versionCommand = cli.Command{
+	Name:        "version",
+	Usage:       "output the runtime version",
+	Description: `The version command outputs the runtime version.`,
+	Action:      printVersion,
+}
+
+func printVersion(context *cli.Context) (err error) {
+	if version == "" {
+		_, err = fmt.Print("runc unknown\n")
+	} else {
+		_, err = fmt.Printf("runc %s\n", version)
+	}
+	if err != nil {
+		return err
+	}
+	if gitCommit != "" {
+		_, err = fmt.Printf("commit: %s\n", gitCommit)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Printf("spec: %s\n", specs.Version)
+	return err
+}


### PR DESCRIPTION
And adjust `runc --version` to print exactly the same content.

The

```
$ COMMAND --version
```

interface is a popular one for this information and makes a lot of sense for single-action commands.  For example, [printf(1)] is only ever going to do one meaningful thing, so `--version`, `--help`, and other command-like actions work well as options.

Umbrella commands with multiple sub-commands, on the other hand, have a more consistent interface if “... and exit” actions get their own sub-commands.  That allows you to declare an interface like:

```
$ COMMAND [global-options] SUB-COMMAND [sub-command-specific-options] [sub-command-specific-arguments]
```

without having to say “except if you use a sub-command-like global option, in which case SUB-COMMAND is not allowed”.

With this commit, we add support for `version` while keeping `--version`, because while `version` makes more sense for umbrella commands, a user may not know if `runc` is an umbrella command when they ask for the version.

Existing umbrella commands are not particularly consistent:
- git(1) supports both `--version` and `version`, `--help` and `help`.
- btrfs(8) supports both `--version` and `version`, `--help` and `help`.
- ip(1) supports `-V` / `-Version` and `help`.
- npm supports `version` and `help`.
- pip supports `--version`, `--help` and `help`.

See [related discussion](https://github.com/opencontainers/runtime-spec/pull/513#discussion_r70104934) in opencontainers/runtime-spec#513.
