### PR TITLE
Change git -C reset to git reset

### DIFF
--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -73,7 +73,10 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   SPEC_COMMIT=$(grep runtime-spec ${TESTDIR}/../../Godeps/Godeps.json -A 4 | grep Rev | cut -d":" -f 2 | tr -d ' "')
-  run git -C src/runtime-spec reset --hard "${SPEC_COMMIT}"
+  (
+    cd src/runtime-spec &&
+    run git reset --hard "${SPEC_COMMIT}"
+  )
   [ "$status" -eq 0 ]
   [ -e src/runtime-spec/schema/schema.json ]
 


### PR DESCRIPTION
git -C <path> reset --hard <spec commit> is not supported with older versions of git.  For tests/integration/spec.bats I changed from git -C to cd to the directory, run the git reset, then cd back where you were.  Very simple change, but it fixes problems with older versions of git.