### PR TITLE
configs: fix json tags for CpuRt* options

### DIFF
--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -69,10 +69,10 @@ type Resources struct {
 	CpuPeriod int64 `json:"cpu_period"`
 
 	// How many time CPU will use in realtime scheduling (in usecs).
-	CpuRtRuntime int64 `json:"cpu_quota"`
+	CpuRtRuntime int64 `json:"cpu_rt_quota"`
 
 	// CPU period to be used for realtime scheduling (in usecs).
-	CpuRtPeriod int64 `json:"cpu_period"`
+	CpuRtPeriod int64 `json:"cpu_rt_period"`
 
 	// CPU to use
 	CpusetCpus string `json:"cpuset_cpus"`


### PR DESCRIPTION
Previously we used the same JSON tag name for the regular and realtime
versions of the CpuRt* fields, which causes issues when you want to use
two different values for the fields.

Fixes #948

Signed-off-by: Aleksa Sarai <asarai@suse.de>