### PR TITLE
Fix setting SELinux label for mqueue when user namespaces are enabled

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -712,14 +712,24 @@ void nsexec(void)
 			/*
 			 * Unshare all of the namespaces. Now, it should be noted that this
 			 * ordering might break in the future (especially with rootless
-			 * containers). But for now, it's not possible to split this into
-			 * CLONE_NEWUSER + [the rest] because of some RHEL SELinux issues.
+			 * containers).
+			 *
+			 * CLONE_NEWIPC needs special handling here when CLONE_NEWUSER is
+			 * also specified to ensure that the user namespace root owns
+			 * mqueue. For that case, we unshare CLONE_NEWIPC after
+			 * switching to root user in the user namespace, so we can apply
+			 * the SELinux label to mqueue.
 			 *
 			 * Note that we don't merge this with clone() because there were
 			 * some old kernel versions where clone(CLONE_PARENT | CLONE_NEWPID)
 			 * was broken, so we'll just do it the long way anyway.
 			 */
-			if (unshare(config.cloneflags) < 0)
+			uint32_t apply_cloneflags = config.cloneflags;
+			if ((config.cloneflags & CLONE_NEWUSER) && (config.cloneflags & CLONE_NEWIPC)) {
+				apply_cloneflags &= ~CLONE_NEWIPC;
+			}
+
+			if (unshare(apply_cloneflags) < 0)
 				bail("failed to unshare namespaces");
 
 			/*
@@ -839,6 +849,12 @@ void nsexec(void)
 			if (!config.is_rootless && config.is_setgroup) {
 				if (setgroups(0, NULL) < 0)
 					bail("setgroups failed");
+			}
+
+			/* Unshare CLONE_NEWIPC after becoming root in user namespace */
+			if ((config.cloneflags & CLONE_NEWUSER) && (config.cloneflags & CLONE_NEWIPC)) {
+				if (unshare(CLONE_NEWIPC) < 0)
+					bail("unshare ipc failed");
 			}
 
 			s = SYNC_CHILD_READY;


### PR DESCRIPTION
If one tries to use SELinux with user namespaces, then labeling of /dev/mqueue
fails because the IPC namespace belongs to the root in init_user_ns. This
commit fixes that by unsharing IPC namespace after we clone into a new USER
namespace so the IPC namespace is owned by the new USER namespace
 as opposed to init_user_ns.

Without this fix

```
[root@localhost test]# oci-runtime-tool generate --tty --output=config.json --selinux-label system_u:system_r:svirt_lxc_net_t:s0:c1,c2 --mount-label system_u:object_r:svirt_sandbox_file_t:s0:c1,c2 --uidmappings 1000:0:32000 --gidmappings 1000:0:32000

[root@localhost test]# runc run 1234
rootfs_linux.go:53: mounting "/dev/mqueue" to rootfs "/test/rootfs" caused "operation not permitted"
```

strace output:

```
3802  select(0, NULL, NULL, NULL, {0, 20} <unfinished ...>
3801  <... mount resumed> )             = -1 EINVAL (Invalid argument)
3801  mount("mqueue", "/test/rootfs/dev/mqueue", "mqueue", MS_NOSUID|MS_NODEV|MS_NOEXEC, NULL) = 0
3801  lsetxattr("/test/rootfs/dev/mqueue", "security.selinux", "system_u:object_r:svirt_sandbox_file_t:s0:c1,c2", 47, 0) = -1 EPERM (Operation not permitted)
3802  <... select resumed> )            = 0 (Timeout)
3802  select(0, NULL, NULL, NULL, {0, 20} <unfinished ...>
```

cc: @rhatdan 

Signed-off-by: Mrunal Patel mrunalp@gmail.com
