### PR TITLE
libcontainer: rename keyctl package to keys

### DIFF
--- a/libcontainer/keys/keyctl.go
+++ b/libcontainer/keys/keyctl.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package keyctl
+package keys
 
 import (
 	"fmt"

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -26,7 +26,7 @@ func (l *linuxSetnsInit) getSessionRingName() string {
 func (l *linuxSetnsInit) Init() error {
 	if !l.config.Config.NoNewKeyring {
 		// do not inherit the parent's session keyring
-		if _, err := keyctl.JoinSessionKeyring(l.getSessionRingName()); err != nil {
+		if _, err := keys.JoinSessionKeyring(l.getSessionRingName()); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -49,12 +49,12 @@ func (l *linuxStandardInit) Init() error {
 		ringname, keepperms, newperms := l.getSessionRingParams()
 
 		// do not inherit the parent's session keyring
-		sessKeyId, err := keyctl.JoinSessionKeyring(ringname)
+		sessKeyId, err := keys.JoinSessionKeyring(ringname)
 		if err != nil {
 			return err
 		}
 		// make session keyring searcheable
-		if err := keyctl.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
+		if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This avoid the goimports tool from remove the libcontainer/keys import line due the package name is diferent from folder name