### PR TITLE
UNITTEST: Bypass userns test on platform without userns support

### DIFF
--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -148,6 +148,9 @@ func TestValidateSecurityWithoutNEWNS(t *testing.T) {
 }
 
 func TestValidateUsernamespace(t *testing.T) {
+	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
+		t.Skip("userns is unsupported")
+	}
 	config := &configs.Config{
 		Rootfs: "/var",
 		Namespaces: configs.Namespaces(


### PR DESCRIPTION
We should bypass userns test instead of show fail in platform without userns support.

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>