### PR TITLE
fix init.scope in cgroup paths

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -388,6 +388,8 @@ func getSubsystemPath(c *configs.Cgroup, subsystem string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// if pid 1 is systemd 226 or later, it will be in init.scope, not the root
+	initPath = strings.TrimSuffix(filepath.Clean(initPath), "init.scope")
 
 	slice := "system.slice"
 	if c.Parent != "" {


### PR DESCRIPTION
Fixes #931 

There was talk in the issue about using dbus to determine which cgroup contains systemd, but I'm not seeing how that is relevant.  Seems like we just want to always start at the cgroup root.

@derekwaynecarr @vishh @euank @mrunalp