### PR TITLE
Use absolute cgroup path for integration test

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -35,7 +35,7 @@ function check_cgroup_value() {
 
 @test "runc update --kernel-memory (initialized)" {
     # Add cgroup path
-    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
+    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
     # Set some initial known values
     DATA=$(cat <<-EOF
@@ -62,7 +62,7 @@ EOF
 
 @test "runc update --kernel-memory (uninitialized)" {
     # Add cgroup path
-    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
+    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
     # run a detached busybox to work with
     runc run -d --console /dev/pts/ptmx test_cgroups_kmem

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -13,7 +13,7 @@ function setup() {
     setup_busybox
 
     # Add cgroup path
-    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "runc-update-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
+    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-update-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
     # Set some initial known values
     DATA=$(cat <<EOF


### PR DESCRIPTION
So we can pass the test in container os local or systemd
environment.

Also fixes: #967

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>