### PR TITLE
Fix the err info of chdir(cwd) failure

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -144,7 +144,7 @@ func finalizeNamespace(config *initConfig) error {
 	}
 	if config.Cwd != "" {
 		if err := syscall.Chdir(config.Cwd); err != nil {
-			return err
+			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently, if the `cwd` set in the config.json does not exist under `rootfs`, `runc create ...` only fails with the following error info: `no such file or directory`, which is not helpful enough to allow the user to diagnose the problem.

This PR changes the error info to be:
```
chdir to cwd ("/testdir") set in config.json failed: no such file or directory
```
Signed-off-by: Haiyan Meng <haiyanalady@gmail.com>