### PR TITLE
Adding /proc/timer_list to the masked paths list

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -149,6 +149,7 @@ container on your host.`,
 				MaskedPaths: []string{
 					"/proc/kcore",
 					"/proc/latency_stats",
+					"/proc/timer_list",
 					"/proc/timer_stats",
 					"/proc/sched_debug",
 				},


### PR DESCRIPTION
/proc/timer_list seems to leak information about the host. Here is
an example from a busybox container running on docker+kubernetes.

 # cat /proc/timer_list | grep -i -e kube
 <ffff8800b8cc3db0>, hrtimer_wakeup, S:01, futex_wait_queue_me, kubelet/2497
 <ffff880129ac3db0>, hrtimer_wakeup, S:01, futex_wait_queue_me, kube-proxy/3478
 <ffff8800b1b77db0>, hrtimer_wakeup, S:01, futex_wait_queue_me, kube-proxy/3470
 <ffff8800bb6abdb0>, hrtimer_wakeup, S:01, futex_wait_queue_me, kubelet/2499