### PR TITLE
Do not create /dev/fuse by default

### DIFF
--- a/libcontainer/SPEC.md
+++ b/libcontainer/SPEC.md
@@ -71,7 +71,6 @@ that are required for executing a container's process.
 | /dev/tty     | 0666 |  rwm       |
 | /dev/random  | 0666 |  rwm       |
 | /dev/urandom | 0666 |  rwm       |
-| /dev/fuse    | 0666 |  rwm       |
 
 
 **ptmx**

--- a/libcontainer/configs/device_defaults.go
+++ b/libcontainer/configs/device_defaults.go
@@ -107,19 +107,5 @@ var (
 			Permissions: "rwm",
 		},
 	}, DefaultSimpleDevices...)
-	DefaultAutoCreatedDevices = append([]*Device{
-		{
-			// /dev/fuse is created but not allowed.
-			// This is to allow java to work.  Because java
-			// Insists on there being a /dev/fuse
-			// https://github.com/docker/docker/issues/514
-			// https://github.com/docker/docker/issues/2393
-			//
-			Path:        "/dev/fuse",
-			Type:        'c',
-			Major:       10,
-			Minor:       229,
-			Permissions: "rwm",
-		},
-	}, DefaultSimpleDevices...)
+	DefaultAutoCreatedDevices = append([]*Device{}, DefaultSimpleDevices...)
 )


### PR DESCRIPTION
This device is not required by the OCI spec.

The rationale for this was linked to https://github.com/docker/docker/issues/2393

So a non functional /dev/fuse was created, and actual fuse use still is
required to add the device explicitly. However even old versions of the JVM
on Ubuntu 12.04 no longer require the fuse package, and this is all not
needed.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>