### PR TITLE
checkMountDesktionation: add swaps and uptime to /proc whitelist

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -320,6 +320,8 @@ func checkMountDestination(rootfs, dest string) error {
 		"/proc/diskstats",
 		"/proc/meminfo",
 		"/proc/stat",
+		"/proc/swaps",
+		"/proc/uptime",
 		"/proc/net/dev",
 	}
 	for _, valid := range validDestinations {


### PR DESCRIPTION
These are provided by lxcfs.

Signed-off-by: Serge Hallyn <serge@hallyn.com>