### PR TITLE
Test: Make TestCaptureTestFunc pass in localunittest

### DIFF
--- a/libcontainer/stacktrace/capture_test.go
+++ b/libcontainer/stacktrace/capture_test.go
@@ -21,7 +21,7 @@ func TestCaptureTestFunc(t *testing.T) {
 	if expected := "captureFunc"; frame.Function != expected {
 		t.Fatalf("expteced function %q but recevied %q", expected, frame.Function)
 	}
-	expected := "github.com/opencontainers/runc/libcontainer/stacktrace"
+	expected := "/runc/libcontainer/stacktrace"
 	if !strings.HasSuffix(frame.Package, expected) {
 		t.Fatalf("expected package %q but received %q", expected, frame.Package)
 	}


### PR DESCRIPTION
TestCaptureTestFunc failed in localunittest:
 # make localunittest
 === RUN   TestCaptureTestFunc
 --- FAIL: TestCaptureTestFunc (0.00s)
         capture_test.go:26: expected package "github.com/opencontainers/runc/libcontainer/stacktrace" but received "_/root/runc/libcontainer/stacktrace"
 #

Reason: the path for stacktrace is a fixed string which
only valid for container environment.
And we can switch to relative path to make both in-container
and out-of-container test works.

After patch:
 # make localunittest
 === RUN   TestCaptureTestFunc
 --- PASS: TestCaptureTestFunc (0.00s)
 #

Signed-off-by: Zhao Lei <zhaolei@cn.fujitsu.com>