### PR TITLE
Support 32 bit UID on i386

### DIFF
--- a/libcontainer/system/syscall_linux_386.go
+++ b/libcontainer/system/syscall_linux_386.go
@@ -8,7 +8,7 @@ import (
 
 // Setuid sets the uid of the calling thread to the specified uid.
 func Setuid(uid int) (err error) {
-	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETUID, uintptr(uid), 0, 0)
+	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETUID32, uintptr(uid), 0, 0)
 	if e1 != 0 {
 		err = e1
 	}


### PR DESCRIPTION
The original SETUID takes a 16 bit UID.  Linux 2.4 introduced  a new
syscall, SETUID32, with support for 32 bit UIDs.  The setgid wrapper
already uses SETGID32.

Signed-off-by: Carl Henrik Lunde <chlunde@ifi.uio.no>