### PR TITLE
move util function

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -199,17 +199,6 @@ func testRlimit(t *testing.T, userns bool) {
 	}
 }
 
-func newTestRoot() (string, error) {
-	dir, err := ioutil.TempDir("", "libcontainer")
-	if err != nil {
-		return "", err
-	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return "", err
-	}
-	return dir, nil
-}
-
 func TestEnter(t *testing.T) {
 	if testing.Short() {
 		return

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -65,6 +65,17 @@ func waitProcess(p *libcontainer.Process, t *testing.T) {
 	}
 }
 
+func newTestRoot() (string, error) {
+	dir, err := ioutil.TempDir("", "libcontainer")
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
 // newRootfs creates a new tmp directory and copies the busybox root filesystem
 func newRootfs() (string, error) {
 	dir, err := ioutil.TempDir("", "")


### PR DESCRIPTION
`newTestRoot` is an util function which is called in some files. So it seems had better to be located in `utils_test.go`.
Signed-off-by: xiekeyang <xiekeyang@huawei.com>