### PR TITLE
Restored-from-checkpoint containers should have a start time

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1049,6 +1049,8 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 		}); err != nil {
 			return err
 		}
+		// create a timestamp indicating when the restored checkpoint was started
+		c.created = time.Now().UTC()
 		if _, err := c.updateState(r); err != nil {
 			return err
 		}


### PR DESCRIPTION
Set the start time similar to a brand new container.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)