### PR TITLE
Error handling when container not exists

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -188,7 +188,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		return nil, newGenericError(fmt.Errorf("invalid root"), ConfigInvalid)
 	}
 	containerRoot := filepath.Join(l.Root, id)
-	state, err := l.loadState(containerRoot)
+	state, err := l.loadState(containerRoot, id)
 	if err != nil {
 		return nil, err
 	}
@@ -273,11 +273,11 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	return i.Init()
 }
 
-func (l *LinuxFactory) loadState(root string) (*State, error) {
+func (l *LinuxFactory) loadState(root, id string) (*State, error) {
 	f, err := os.Open(filepath.Join(root, stateFilename))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, newGenericError(err, ContainerNotExists)
+			return nil, newGenericError(fmt.Errorf("container %q does not exists", id), ContainerNotExists)
 		}
 		return nil, newGenericError(err, SystemError)
 	}


### PR DESCRIPTION
When the container not exists, user gets the error saying
open /run/runc/container1/state.json: no such file or directory
 From end user perspective, if we do any operation on container we can show whether the container ID is valid one, instead of giving the state.json error.

Hence the change in this PR , upon executing runc on invalid ID, it will show as below.
"container not exist"
Signed-off-by: rajasec <rajasec79@gmail.com>