### PR TITLE
fix make dbuild error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ man:
 
 runctestimage:
 	docker build -t $(RUNC_TEST_IMAGE) -f $(TEST_DOCKERFILE) .
+	docker tag $(RUNC_TEST_IMAGE) runc_test
 
 test:
 	make unittest integration


### PR DESCRIPTION
when type "make dbuild" command, it report the following error:

Pulling repository docker.io/library/runc_test
Error: image library/runc_test:latest not found
Makefile:37: recipe for target 'dbuild' failed
make: *** [dbuild] Error 1

just add "docker tag" command on runctestimage to fix it.

Signed-off-by: Wang Long <long.wanglong@huawei.com>