### PR TITLE
Fix default cgroup path

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
@@ -253,10 +252,7 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 }
 
 func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*configs.Cgroup, error) {
-	var (
-		err          error
-		myCgroupPath string
-	)
+	var myCgroupPath string
 
 	c := &configs.Cgroup{
 		Resources: &configs.Resources{},
@@ -287,11 +283,7 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 		}
 	} else {
 		if myCgroupPath == "" {
-			myCgroupPath, err = cgroups.GetThisCgroupDir("devices")
-			if err != nil {
-				return nil, err
-			}
-			myCgroupPath = filepath.Join(myCgroupPath, name)
+			c.Name = name
 		}
 		c.Path = myCgroupPath
 	}

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -3,7 +3,6 @@
 package specconv
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -33,7 +32,7 @@ func TestLinuxCgroupsPathNotSpecified(t *testing.T) {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}
 
-	if !strings.HasSuffix(cgroup.Path, "/ContainerID") {
-		t.Errorf("Wrong cgroupsPath, expected it to have suffix '%s' got '%s'", "/ContainerID", cgroup.Path)
+	if cgroup.Path != "" {
+		t.Errorf("Wrong cgroupsPath, expected it to be empty string, got '%s'", cgroup.Path)
 	}
 }


### PR DESCRIPTION
Alternative of #895 , part of #892

The intension of current behavior if to create cgroup in
parent cgroup of current process, but we did this in a
wrong way, we used devices cgroup path of current process
as the default parent path for all subsystems, this is
wrong because we don't always have the same cgroup path
for all subsystems.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>

For example, the cgroup path of current process is:
```
qhuang@ubuntu-25:~/tools/runc$ cat /proc/self/cgroup
11:hugetlb:/user/1000.user/64.session
10:perf_event:/user/1000.user/64.session
9:blkio:/user/1000.user/64.session
8:freezer:/user/1000.user/64.session
7:devices:/user/1000.user/64.session
6:memory:/user
5:name=systemd:/user/1000.user/64.session
4:cpuacct:/user/1000.user/64.session
3:cpu:/user/1000.user/64.session
2:cpuset:/user/1000.user/64.session
```

Before this patch, we create contianer cgroup in:
```
qhuang@ubuntu-25:~/tools/runc$ sudo runc run hq
root@runc:/# cat /proc/self/cgroup
11:hugetlb:/user/1000.user/64.session/hq
10:perf_event:/user/1000.user/64.session/hq
9:blkio:/user/1000.user/64.session/hq
8:freezer:/user/1000.user/64.session/hq
7:devices:/user/1000.user/64.session/hq
6:memory:/user/1000.user/64.session/hq       <<<<---- the difference
5:name=systemd:/user/1000.user/64.session/hq
4:cpuacct:/user/1000.user/64.session/hq
3:cpu:/user/1000.user/64.session/hq
2:cpuset:/user/1000.user/64.session/hq
```

After this patch:
```
qhuang@ubuntu-25:~/tools/runc$ sudo runc run hq
root@runc:/# cat /proc/self/cgroup
11:hugetlb:/user/1000.user/64.session/hq
10:perf_event:/user/1000.user/64.session/hq
9:blkio:/user/1000.user/64.session/hq
8:freezer:/user/1000.user/64.session/hq
7:devices:/user/1000.user/64.session/hq
6:memory:/user/hq                                    <<<<---- the difference
5:name=systemd:/user/1000.user/64.session/hq
4:cpuacct:/user/1000.user/64.session/hq
3:cpu:/user/1000.user/64.session/hq
2:cpuset:/user/1000.user/64.session/hq
```