### PR TITLE
Add command itself to the result of runc ps

### DIFF
--- a/ps.go
+++ b/ps.go
@@ -56,10 +56,12 @@ var psCommand = cli.Command{
 			psArgs = []string{"-ef"}
 		}
 
-		output, err := exec.Command("ps", psArgs...).Output()
+		cmd := exec.Command("ps", psArgs...)
+		output, err := cmd.Output()
 		if err != nil {
 			return err
 		}
+		pids = append(pids, cmd.Process.Pid)
 
 		lines := strings.Split(string(output), "\n")
 		pidIndex, err := getPidIndex(lines[0])


### PR DESCRIPTION
currently ps itself is not in the result of runc ps 
```
root@ubuntu:~/# ./runc ps  test
UID        PID  PPID  C STIME TTY          TIME CMD
root      6129  6119  0 20:11 pts/12   00:00:00 sh
```
this pr will add it(the result is similar to runc exec test ps)
```
root@ubuntu:~/# ./runc ps  test
UID        PID  PPID  C STIME TTY          TIME CMD
root      6129  6119  0 20:11 pts/12   00:00:00 sh
root      6206  6201  0 20:17 pts/6    00:00:00 ps -ef
```
Signed-off-by: Shukui Yang <yangshukui@huawei.com>