### PR TITLE
Send signal to a container process inside the container's PID

### DIFF
--- a/man/runc-kill.8.md
+++ b/man/runc-kill.8.md
@@ -1,11 +1,11 @@
 # NAME
-   runc kill - kill sends the specified signal (default: SIGTERM) to the container's init process
+   runc kill - kill sends the specified signal (default: SIGTERM) to any of the container's processes (default: init process)
 
 # SYNOPSIS
-   runc kill <container-id> <signal>
+   runc kill [command options] <container-id> <signal>
 
 Where "<container-id>" is the name for the instance of the container and
-"<signal>" is the signal to be sent to the init process.
+"<signal>" is the signal to be sent to the process of the container.
 
 # EXAMPLE
 
@@ -13,3 +13,6 @@ For example, if the container id is "ubuntu01" the following will send a "KILL"
 signal to the init process of the "ubuntu01" container:
 
        # runc kill ubuntu01 KILL
+
+OPTIONS:
+   --pid value, -p value  specify the pid to which process the signal would be sent (default: init process) (default: 0)


### PR DESCRIPTION
As https://github.com/opencontainers/runc/pull/808 mentioned, I try another way to send signal to container, it send signal to a container process inside the container's PID.
this pr dependent upon https://github.com/opencontainers/runc/pull/1013
test code:
```
root@ubuntu:~/workspace/gocode/src/own/test/bin# cat sig.go 
package main

import (
        "fmt"
        "os"
        "os/signal"
        "syscall"
)

func main() {
        fmt.Println(os.Getpid())
        c := make(chan os.Signal, 0)
        signal.Notify(c)
        for {
                s := <-c
                fmt.Println("Got signal:", s)
                if s == syscall.SIGINT {
                        signal.Stop(c)
                        break
                }
        }
        fmt.Println("recv SIGINT, signal done")
}
go build sig.go
```
test:
```
root@ubuntu:~/workspace/runc-test# ./runc run test
/ # ./sig 
7
Got signal: user defined signal 1
Got signal: user defined signal 1
...
root@ubuntu:~/workspace/runc-test# ./runc kill --pid 7 test SIGUSR1
```








Signed-off-by: Shukui Yang <yangshukui@huawei.com>