### PR TITLE
Consoles, consoles, consoles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/pkg
 /runc
+contrib/cmd/recvtty/recvtty
 Godeps/_workspace/src/github.com/opencontainers/runc
 man/man8
 release

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN mkdir -p /go/src/github.com/mvdan \
 # setup a playground for us to spawn containers in
 ENV ROOTFS /busybox
 RUN mkdir -p ${ROOTFS} \
-    && curl -o- -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.11/rootfs.tar' | tar -C ${ROOTFS} -xf -
+    && curl -o- -sSL 'https://github.com/docker-library/busybox/raw/a0558a9006ce0dd6f6ec5d56cfd3f32ebeeb815f/glibc/busybox.tar.xz' | tar xfJC - ${ROOTFS}
+
 
 COPY script/tmpmount /
 WORKDIR /go/src/github.com/opencontainers/runc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all dbuild man \
+.PHONY: all shell dbuild man \
 	    localtest localunittest localintegration \
 	    test unittest integration
 
@@ -102,6 +102,9 @@ integration: runcimage
 
 localintegration: all
 	bats -t tests/integration${TESTFLAGS}
+
+shell: all
+	docker run -e TESTFLAGS -ti --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) bash
 
 install:
 	install -D -m0755 runc $(BINDIR)/runc

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: dbuild man \
+.PHONY: all dbuild man \
 	    localtest localunittest localintegration \
 	    test unittest integration
 
+SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
 PREFIX := $(DESTDIR)/usr/local
 BINDIR := $(PREFIX)/sbin
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
@@ -26,13 +27,23 @@ VERSION := ${shell cat ./VERSION}
 
 SHELL := $(shell command -v bash 2>/dev/null)
 
-all: $(RUNC_LINK)
+.DEFAULT: runc
+
+runc: $(SOURCES) | $(RUNC_LINK)
 	go build -i -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o runc .
 
-static: $(RUNC_LINK)
-	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -o runc .
+all: runc recvtty
 
-release: $(RUNC_LINK)
+recvtty: contrib/cmd/recvtty/recvtty
+
+contrib/cmd/recvtty/recvtty: $(SOURCES) | $(RUNC_LINK)
+	go build -i -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
+
+static: $(SOURCES) | $(RUNC_LINK)
+	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -o runc .
+	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
+
+release: $(RUNC_LINK) | $(RUNC_LINK)
 	@flag_list=(seccomp selinux apparmor static ambient); \
 	unset expression; \
 	for flag in "$${flag_list[@]}"; do \
@@ -62,7 +73,7 @@ $(RUNC_LINK):
 	ln -sfn $(CURDIR) $(RUNC_LINK)
 
 dbuild: runcimage
-	docker run --rm -v $(CURDIR):/go/src/$(PROJECT) --privileged $(RUNC_IMAGE) make
+	docker run --rm -v $(CURDIR):/go/src/$(PROJECT) --privileged $(RUNC_IMAGE) make clean all
 
 lint:
 	go vet ./...
@@ -113,6 +124,7 @@ uninstall-man:
 
 clean:
 	rm -f runc
+	rm -f contrib/cmd/recvtty/recvtty
 	rm -f $(RUNC_LINK)
 	rm -rf $(GOPATH)/pkg
 	rm -rf $(RELEASE_DIR)

--- a/contrib/cmd/recvtty/recvtty.go
+++ b/contrib/cmd/recvtty/recvtty.go
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2016 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/urfave/cli"
+)
+
+// version will be populated by the Makefile, read from
+// VERSION file of the source code.
+var version = ""
+
+// gitCommit will be the hash that the binary was built from
+// and will be populated by the Makefile
+var gitCommit = ""
+
+const (
+	usage = `Open Container Initiative contrib/cmd/recvtty
+
+recvtty is a reference implementation of a consumer of runC's --console-socket
+API. It has two main modes of operation:
+
+  * single: Only permit one terminal to be sent to the socket, which is
+	then hooked up to the stdio of the recvtty process. This is useful
+	for rudimentary shell management of a container.
+
+  * null: Permit as many terminals to be sent to the socket, but they
+	are read to /dev/null. This is used for testing, and imitates the
+	old runC API's --console=/dev/pts/ptmx hack which would allow for a
+	similar trick. This is probably not what you want to use, unless
+	you're doing something like our bats integration tests.
+
+To use recvtty, just specify a socket path at which you want to receive
+terminals:
+
+    $ recvtty [--mode <single|null>] socket.sock
+`
+)
+
+func bail(err error) {
+	fmt.Fprintf(os.Stderr, "[recvtty] fatal error: %v\n", err)
+	os.Exit(1)
+}
+
+func handleSingle(path string) error {
+	// Open a socket.
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	// We only accept a single connection, since we can only really have
+	// one reader for os.Stdin. Plus this is all a PoC.
+	conn, err := ln.Accept()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Close ln, to allow for other instances to take over.
+	ln.Close()
+
+	// Get the fd of the connection.
+	unixconn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("failed to cast to unixconn")
+	}
+
+	socket, err := unixconn.File()
+	if err != nil {
+		return err
+	}
+	defer socket.Close()
+
+	// Get the master file descriptor from runC.
+	master, err := utils.RecvFd(socket)
+	if err != nil {
+		return err
+	}
+
+	// Print the file descriptor tag.
+	ti, err := libcontainer.GetTerminalInfo(master.Name())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("[recvtty] received masterfd: container '%s'\n", ti.ContainerID)
+
+	// Copy from our stdio to the master fd.
+	quitChan := make(chan struct{})
+	go func() {
+		io.Copy(os.Stdout, master)
+		quitChan <- struct{}{}
+	}()
+	go func() {
+		io.Copy(master, os.Stdin)
+		quitChan <- struct{}{}
+	}()
+
+	// Only close the master fd once we've stopped copying.
+	<-quitChan
+	master.Close()
+	return nil
+}
+
+func handleNull(path string) error {
+	// Open a socket.
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	// As opposed to handleSingle we accept as many connections as we get, but
+	// we don't interact with Stdin at all (and we copy stdout to /dev/null).
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return err
+		}
+		go func(conn net.Conn) {
+			// Don't leave references lying around.
+			defer conn.Close()
+
+			// Get the fd of the connection.
+			unixconn, ok := conn.(*net.UnixConn)
+			if !ok {
+				return
+			}
+
+			socket, err := unixconn.File()
+			if err != nil {
+				return
+			}
+			defer socket.Close()
+
+			// Get the master file descriptor from runC.
+			master, err := utils.RecvFd(socket)
+			if err != nil {
+				return
+			}
+
+			// Print the file descriptor tag.
+			ti, err := libcontainer.GetTerminalInfo(master.Name())
+			if err != nil {
+				bail(err)
+			}
+			fmt.Printf("[recvtty] received masterfd: container '%s'\n", ti.ContainerID)
+
+			// Just do a dumb copy to /dev/null.
+			devnull, err := os.OpenFile("/dev/null", os.O_RDWR, 0)
+			if err != nil {
+				// TODO: Handle this nicely.
+				return
+			}
+
+			io.Copy(devnull, master)
+			devnull.Close()
+		}(conn)
+	}
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "recvtty"
+	app.Usage = usage
+
+	// Set version to be the same as runC.
+	var v []string
+	if version != "" {
+		v = append(v, version)
+	}
+	if gitCommit != "" {
+		v = append(v, fmt.Sprintf("commit: %s", gitCommit))
+	}
+	app.Version = strings.Join(v, "\n")
+
+	// Set the flags.
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "mode, m",
+			Value: "single",
+			Usage: "Mode of operation (single or null)",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Value: "",
+			Usage: "Path to write daemon process ID to",
+		},
+	}
+
+	app.Action = func(ctx *cli.Context) error {
+		args := ctx.Args()
+		if len(args) != 1 {
+			return fmt.Errorf("need to specify a single socket path")
+		}
+		path := ctx.Args()[0]
+
+		pidPath := ctx.String("pid-file")
+		if pidPath != "" {
+			pid := fmt.Sprintf("%d\n", os.Getpid())
+			if err := ioutil.WriteFile(pidPath, []byte(pid), 0644); err != nil {
+				return err
+			}
+		}
+
+		switch ctx.String("mode") {
+		case "single":
+			if err := handleSingle(path); err != nil {
+				return err
+			}
+		case "null":
+			if err := handleNull(path); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("need to select a valid mode: %s", ctx.String("mode"))
+		}
+		return nil
+	}
+	if err := app.Run(os.Args); err != nil {
+		bail(err)
+	}
+}

--- a/create.go
+++ b/create.go
@@ -30,6 +30,11 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Usage: `path to the root of the bundle directory, defaults to the current directory`,
 		},
 		cli.StringFlag{
+			Name:  "console-socket",
+			Value: "",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
+		},
+		cli.StringFlag{
 			Name:  "pid-file",
 			Value: "",
 			Usage: "specify the file to write the process id to",

--- a/create.go
+++ b/create.go
@@ -30,11 +30,6 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Usage: `path to the root of the bundle directory, defaults to the current directory`,
 		},
 		cli.StringFlag{
-			Name:  "console",
-			Value: "",
-			Usage: "specify the pty slave path for use with the container",
-		},
-		cli.StringFlag{
 			Name:  "pid-file",
 			Value: "",
 			Usage: "specify the file to write the process id to",

--- a/exec.go
+++ b/exec.go
@@ -26,13 +26,9 @@ Where "<container-id>" is the name for the instance of the container and
 EXAMPLE:
 For example, if the container is configured to run the linux ps command the
 following will output a list of processes running in the container:
-	 
+
        # runc exec <container-id> ps`,
 	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "console",
-			Usage: "specify the pty slave path for use with the container",
-		},
 		cli.StringFlag{
 			Name:  "cwd",
 			Usage: "current working directory in the container",
@@ -131,7 +127,6 @@ func execProcess(context *cli.Context) (int, error) {
 		enableSubreaper: false,
 		shouldDestroy:   false,
 		container:       container,
-		console:         context.String("console"),
 		detach:          detach,
 		pidFile:         context.String("pid-file"),
 	}

--- a/exec.go
+++ b/exec.go
@@ -30,6 +30,10 @@ following will output a list of processes running in the container:
        # runc exec <container-id> ps`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
+			Name:  "console-socket",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
+		},
+		cli.StringFlag{
 			Name:  "cwd",
 			Usage: "current working directory in the container",
 		},
@@ -127,6 +131,7 @@ func execProcess(context *cli.Context) (int, error) {
 		enableSubreaper: false,
 		shouldDestroy:   false,
 		container:       container,
+		consoleSocket:   context.String("console-socket"),
 		detach:          detach,
 		pidFile:         context.String("pid-file"),
 	}

--- a/libcontainer/console.go
+++ b/libcontainer/console.go
@@ -13,3 +13,6 @@ type Console interface {
 	// Fd returns the fd for the master of the pty.
 	Fd() uintptr
 }
+
+// ConsoleData represents arbitrary setup data used when setting up console
+// handling. It is

--- a/libcontainer/console.go
+++ b/libcontainer/console.go
@@ -1,6 +1,11 @@
 package libcontainer
 
-import "io"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
 
 // Console represents a pseudo TTY.
 type Console interface {
@@ -11,8 +16,59 @@ type Console interface {
 	Path() string
 
 	// Fd returns the fd for the master of the pty.
-	Fd() uintptr
+	File() *os.File
 }
 
-// ConsoleData represents arbitrary setup data used when setting up console
-// handling. It is
+const (
+	TerminalInfoVersion uint32 = 201610041
+	TerminalInfoType    uint8  = 'T'
+)
+
+// TerminalInfo is the structure which is passed as the non-ancillary data
+// in the sendmsg(2) call when runc is run with --console-socket. It
+// contains some information about the container which the console master fd
+// relates to (to allow for consumers to use a single unix socket to handle
+// multiple containers). This structure will probably move to runtime-spec
+// at some point. But for now it lies in libcontainer.
+type TerminalInfo struct {
+	// Version of the API.
+	Version uint32 `json:"version"`
+
+	// Type of message (future proofing).
+	Type uint8 `json:"type"`
+
+	// Container contains the ID of the container.
+	ContainerID string `json:"container_id"`
+}
+
+func (ti *TerminalInfo) String() string {
+	encoded, err := json.Marshal(*ti)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func NewTerminalInfo(containerId string) *TerminalInfo {
+	return &TerminalInfo{
+		Version:     TerminalInfoVersion,
+		Type:        TerminalInfoType,
+		ContainerID: containerId,
+	}
+}
+
+func GetTerminalInfo(encoded string) (*TerminalInfo, error) {
+	ti := new(TerminalInfo)
+	if err := json.Unmarshal([]byte(encoded), ti); err != nil {
+		return nil, err
+	}
+
+	if ti.Type != TerminalInfoType {
+		return nil, fmt.Errorf("terminal info: incorrect type in payload (%q): %q", TerminalInfoType, ti.Type)
+	}
+	if ti.Version != TerminalInfoVersion {
+		return nil, fmt.Errorf("terminal info: incorrect version in payload (%q): %q", TerminalInfoVersion, ti.Version)
+	}
+
+	return ti, nil
+}

--- a/libcontainer/console_freebsd.go
+++ b/libcontainer/console_freebsd.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 )
 
-// NewConsole returns an initialized console that can be used within a container by copying bytes
+// newConsole returns an initialized console that can be used within a container by copying bytes
 // from the master side to the slave that is attached as the tty for the container's init process.
-func NewConsole(uid, gid int) (Console, error) {
+func newConsole(uid, gid int) (Console, error) {
 	return nil, errors.New("libcontainer console is not supported on FreeBSD")
 }

--- a/libcontainer/console_freebsd.go
+++ b/libcontainer/console_freebsd.go
@@ -8,6 +8,6 @@ import (
 
 // newConsole returns an initialized console that can be used within a container by copying bytes
 // from the master side to the slave that is attached as the tty for the container's init process.
-func newConsole(uid, gid int) (Console, error) {
+func newConsole() (Console, error) {
 	return nil, errors.New("libcontainer console is not supported on FreeBSD")
 }

--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
-
-	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 // newConsole returns an initialized console that can be used within a container by copying bytes
@@ -63,12 +61,9 @@ func (c *linuxConsole) Close() error {
 
 // mount initializes the console inside the rootfs mounting with the specified mount label
 // and applying the correct ownership of the console.
-func (c *linuxConsole) mount(mountLabel string) error {
+func (c *linuxConsole) mount() error {
 	oldMask := syscall.Umask(0000)
 	defer syscall.Umask(oldMask)
-	if err := label.SetFileLabel(c.slavePath, mountLabel); err != nil {
-		return err
-	}
 	f, err := os.Create("/dev/console")
 	if err != nil && !os.IsExist(err) {
 		return err

--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -11,7 +11,7 @@ import (
 
 // newConsole returns an initialized console that can be used within a container by copying bytes
 // from the master side to the slave that is attached as the tty for the container's init process.
-func newConsole(uid, gid int) (Console, error) {
+func newConsole() (Console, error) {
 	master, err := os.OpenFile("/dev/ptmx", syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
@@ -24,12 +24,6 @@ func newConsole(uid, gid int) (Console, error) {
 		return nil, err
 	}
 	if err := unlockpt(master); err != nil {
-		return nil, err
-	}
-	if err := os.Chmod(console, 0600); err != nil {
-		return nil, err
-	}
-	if err := os.Chown(console, uid, gid); err != nil {
 		return nil, err
 	}
 	return &linuxConsole{

--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -36,8 +36,8 @@ type linuxConsole struct {
 	slavePath string
 }
 
-func (c *linuxConsole) Fd() uintptr {
-	return c.master.Fd()
+func (c *linuxConsole) File() *os.File {
+	return c.master
 }
 
 func (c *linuxConsole) Path() string {

--- a/libcontainer/console_solaris.go
+++ b/libcontainer/console_solaris.go
@@ -6,6 +6,6 @@ import (
 
 // newConsole returns an initialized console that can be used within a container by copying bytes
 // from the master side to the slave that is attached as the tty for the container's init process.
-func newConsole(uid, gid int) (Console, error) {
+func newConsole() (Console, error) {
 	return nil, errors.New("libcontainer console is not supported on Solaris")
 }

--- a/libcontainer/console_solaris.go
+++ b/libcontainer/console_solaris.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 )
 
-// NewConsole returns an initialized console that can be used within a container by copying bytes
+// newConsole returns an initialized console that can be used within a container by copying bytes
 // from the master side to the slave that is attached as the tty for the container's init process.
-func NewConsole(uid, gid int) (Console, error) {
+func newConsole(uid, gid int) (Console, error) {
 	return nil, errors.New("libcontainer console is not supported on Solaris")
 }

--- a/libcontainer/console_windows.go
+++ b/libcontainer/console_windows.go
@@ -1,7 +1,7 @@
 package libcontainer
 
 // newConsole returns an initialized console that can be used within a container
-func newConsole(uid, gid int) (Console, error) {
+func newConsole() (Console, error) {
 	return &windowsConsole{}, nil
 }
 

--- a/libcontainer/console_windows.go
+++ b/libcontainer/console_windows.go
@@ -1,7 +1,7 @@
 package libcontainer
 
-// NewConsole returns an initialized console that can be used within a container
-func NewConsole(uid, gid int) (Console, error) {
+// newConsole returns an initialized console that can be used within a container
+func newConsole(uid, gid int) (Console, error) {
 	return &windowsConsole{}, nil
 }
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -253,12 +253,9 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		// send it back to the parent process in the form of an initError.
 		// If container's init successed, syscall.Exec will not return, hence
 		// this defer function will never be called.
-		if _, ok := i.(*linuxStandardInit); ok {
-			//  Synchronisation only necessary for standard init.
-			if werr := utils.WriteJSON(pipe, syncT{procError}); werr != nil {
-				fmt.Fprintln(os.Stderr, err)
-				return
-			}
+		if werr := utils.WriteJSON(pipe, syncT{procError}); werr != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return
 		}
 		if werr := utils.WriteJSON(pipe, newSystemError(err)); werr != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -9,20 +9,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/stacktrace"
 )
 
-type syncType uint8
-
-const (
-	procReady syncType = iota
-	procError
-	procRun
-	procHooks
-	procResume
-)
-
-type syncT struct {
-	Type syncType `json:"type"`
-}
-
 var errorTemplate = template.Must(template.New("error").Parse(`Timestamp: {{.Timestamp}}
 Code: {{.ECode}}
 {{if .Message }}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -155,19 +155,15 @@ func finalizeNamespace(config *initConfig) error {
 // indicate that it is cleared to Exec.
 func syncParentReady(pipe io.ReadWriter) error {
 	// Tell parent.
-	if err := utils.WriteJSON(pipe, syncT{procReady}); err != nil {
+	if err := writeSync(pipe, procReady); err != nil {
 		return err
 	}
+
 	// Wait for parent to give the all-clear.
-	var procSync syncT
-	if err := json.NewDecoder(pipe).Decode(&procSync); err != nil {
-		if err == io.EOF {
-			return fmt.Errorf("parent closed synchronisation channel")
-		}
-		if procSync.Type != procRun {
-			return fmt.Errorf("invalid synchronisation flag from parent")
-		}
+	if err := readSync(pipe, procRun); err != nil {
+		return err
 	}
+
 	return nil
 }
 
@@ -176,19 +172,15 @@ func syncParentReady(pipe io.ReadWriter) error {
 // indicate that it is cleared to resume.
 func syncParentHooks(pipe io.ReadWriter) error {
 	// Tell parent.
-	if err := utils.WriteJSON(pipe, syncT{procHooks}); err != nil {
+	if err := writeSync(pipe, procHooks); err != nil {
 		return err
 	}
+
 	// Wait for parent to give the all-clear.
-	var procSync syncT
-	if err := json.NewDecoder(pipe).Decode(&procSync); err != nil {
-		if err == io.EOF {
-			return fmt.Errorf("parent closed synchronisation channel")
-		}
-		if procSync.Type != procResume {
-			return fmt.Errorf("invalid synchronisation flag from parent")
-		}
+	if err := readSync(pipe, procResume); err != nil {
+		return err
 	}
+
 	return nil
 }
 

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -178,7 +178,7 @@ func setupConsole(pipe *os.File, config *initConfig, mount bool) error {
 
 	// Mount the console inside our rootfs.
 	if mount {
-		if err := linuxConsole.mount(config.ProcessLabel); err != nil {
+		if err := linuxConsole.mount(); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -197,8 +197,7 @@ func setupConsole(pipe *os.File, config *initConfig, mount bool) error {
 	}
 
 	// While we can access console.master, using the API is a good idea.
-	consoleFile := os.NewFile(linuxConsole.Fd(), "[master-pty]")
-	if err := utils.SendFd(pipe, consoleFile); err != nil {
+	if err := utils.SendFd(pipe, linuxConsole.File()); err != nil {
 		return err
 	}
 

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -43,7 +43,7 @@ func testExecPS(t *testing.T, userns bool) {
 		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
 	}
 
-	buffers, exitCode, err := runContainer(config, "", "ps")
+	buffers, exitCode, err := runContainer(config, "", "ps", "-o", "pid,user,comm")
 	if err != nil {
 		t.Fatalf("%s: %s", buffers, err)
 	}

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -247,6 +247,8 @@ func TestExecInError(t *testing.T) {
 	}
 }
 
+// XXX: This test will fail.
+/*
 func TestExecInTTY(t *testing.T) {
 	if testing.Short() {
 		return
@@ -306,6 +308,7 @@ func TestExecInTTY(t *testing.T) {
 		t.Fatalf("unexpected carriage-return in output")
 	}
 }
+*/
 
 func TestExecInEnvironment(t *testing.T) {
 	if testing.Short() {

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -247,8 +247,6 @@ func TestExecInError(t *testing.T) {
 	}
 }
 
-// XXX: This test will fail.
-/*
 func TestExecInTTY(t *testing.T) {
 	if testing.Short() {
 		return
@@ -281,14 +279,14 @@ func TestExecInTTY(t *testing.T) {
 		Args: []string{"ps"},
 		Env:  standardEnvironment,
 	}
-	console, err := ps.NewConsole(0, 0)
+	err = container.Run(ps)
+	ok(t, err)
+	console, err := ps.GetConsole()
 	copy := make(chan struct{})
 	go func() {
 		io.Copy(&stdout, console)
 		close(copy)
 	}()
-	ok(t, err)
-	err = container.Run(ps)
 	ok(t, err)
 	select {
 	case <-time.After(5 * time.Second):
@@ -308,7 +306,6 @@ func TestExecInTTY(t *testing.T) {
 		t.Fatalf("unexpected carriage-return in output")
 	}
 }
-*/
 
 func TestExecInEnvironment(t *testing.T) {
 	if testing.Short() {

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -11,13 +11,12 @@ import (
 // list of known message types we want to send to bootstrap program
 // The number is randomly chosen to not conflict with known netlink types
 const (
-	InitMsg         uint16 = 62000
-	CloneFlagsAttr  uint16 = 27281
-	ConsolePathAttr uint16 = 27282
-	NsPathsAttr     uint16 = 27283
-	UidmapAttr      uint16 = 27284
-	GidmapAttr      uint16 = 27285
-	SetgroupAttr    uint16 = 27286
+	InitMsg        uint16 = 62000
+	CloneFlagsAttr uint16 = 27281
+	NsPathsAttr    uint16 = 27282
+	UidmapAttr     uint16 = 27283
+	GidmapAttr     uint16 = 27284
+	SetgroupAttr   uint16 = 27285
 	// When syscall.NLA_HDRLEN is in gccgo, take this out.
 	syscall_NLA_HDRLEN = (syscall.SizeofNlAttr + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)
 )

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -71,7 +71,6 @@ struct nlconfig_t {
 	char *namespaces;
 	size_t namespaces_len;
 	uint8_t is_setgroup;
-	int consolefd;
 };
 
 /*
@@ -80,11 +79,10 @@ struct nlconfig_t {
  */
 #define INIT_MSG		62000
 #define CLONE_FLAGS_ATTR	27281
-#define CONSOLE_PATH_ATTR	27282
-#define NS_PATHS_ATTR		27283
-#define UIDMAP_ATTR		27284
-#define GIDMAP_ATTR		27285
-#define SETGROUP_ATTR		27286
+#define NS_PATHS_ATTR		27282
+#define UIDMAP_ATTR		27283
+#define GIDMAP_ATTR		27284
+#define SETGROUP_ATTR		27285
 
 /*
  * Use the raw syscall for versions of glibc which don't include a function for
@@ -306,7 +304,6 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 
 	/* Parse the netlink payload. */
 	config->data = data;
-	config->consolefd = -1;
 	while (current < data + size) {
 		struct nlattr *nlattr = (struct nlattr *)current;
 		size_t payload_len = nlattr->nla_len - NLA_HDRLEN;
@@ -318,15 +315,6 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 		switch (nlattr->nla_type) {
 		case CLONE_FLAGS_ATTR:
 			config->cloneflags = readint32(current);
-			break;
-		case CONSOLE_PATH_ATTR:
-			/*
-			 * We open the console here because we currently evaluate console
-			 * paths from the *host* namespaces.
-			 */
-			config->consolefd = open(current, O_RDWR);
-			if (config->consolefd < 0)
-				bail("failed to open console %s", current);
 			break;
 		case NS_PATHS_ATTR:
 			config->namespaces = current;
@@ -722,7 +710,6 @@ void nsexec(void)
 			 * We're inside the child now, having jumped from the
 			 * start_child() code after forking in the parent.
 			 */
-			int consolefd = config.consolefd;
 			enum sync_t s;
 
 			/* We're in a child and thus need to tell the parent if we die. */
@@ -742,17 +729,6 @@ void nsexec(void)
 
 			if (setgroups(0, NULL) < 0)
 				bail("setgroups failed");
-
-			if (consolefd != -1) {
-				if (ioctl(consolefd, TIOCSCTTY, 0) < 0)
-					bail("ioctl TIOCSCTTY failed");
-				if (dup3(consolefd, STDIN_FILENO, 0) != STDIN_FILENO)
-					bail("failed to dup stdin");
-				if (dup3(consolefd, STDOUT_FILENO, 0) != STDOUT_FILENO)
-					bail("failed to dup stdout");
-				if (dup3(consolefd, STDERR_FILENO, 0) != STDERR_FILENO)
-					bail("failed to dup stderr");
-			}
 
 			s = SYNC_CHILD_READY;
 			if (write(syncfd, &s, sizeof(s)) != sizeof(s))

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -36,19 +36,20 @@ type Process struct {
 	Cwd string
 
 	// Stdin is a pointer to a reader which provides the standard input stream.
-	Stdin io.Reader
+	Stdin *os.File
 
 	// Stdout is a pointer to a writer which receives the standard output stream.
-	Stdout io.Writer
+	Stdout *os.File
 
 	// Stderr is a pointer to a writer which receives the standard error stream.
-	Stderr io.Writer
+	Stderr *os.File
 
 	// ExtraFiles specifies additional open files to be inherited by the container
 	ExtraFiles []*os.File
 
-	// consolePath is the path to the console allocated to the container.
-	consolePath string
+	// consoleChan provides the masterfd console.
+	// TODO: Make this persistent in Process.
+	consoleChan chan *os.File
 
 	// Capabilities specify the capabilities to keep when executing the process inside the container
 	// All capabilities not specified will be dropped from the processes capability mask
@@ -105,21 +106,14 @@ type IO struct {
 	Stderr io.ReadCloser
 }
 
-// NewConsole creates new console for process and returns it
-func (p *Process) NewConsole(rootuid, rootgid int) (Console, error) {
-	console, err := NewConsole(rootuid, rootgid)
-	if err != nil {
-		return nil, err
+func (p *Process) GetConsole() (Console, error) {
+	consoleFd, ok := <-p.consoleChan
+	if !ok {
+		return nil, fmt.Errorf("failed to get console from process")
 	}
-	p.consolePath = console.Path()
-	return console, nil
-}
 
-// ConsoleFromPath sets the process's console with the path provided
-func (p *Process) ConsoleFromPath(path string) error {
-	if p.consolePath != "" {
-		return newGenericError(fmt.Errorf("console path already exists for process"), ConsoleExists)
-	}
-	p.consolePath = path
-	return nil
+	// TODO: Fix this so that it used the console API.
+	return &linuxConsole{
+		master: consoleFd,
+	}, nil
 }

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -36,13 +36,13 @@ type Process struct {
 	Cwd string
 
 	// Stdin is a pointer to a reader which provides the standard input stream.
-	Stdin *os.File
+	Stdin io.Reader
 
 	// Stdout is a pointer to a writer which receives the standard output stream.
-	Stdout *os.File
+	Stdout io.Writer
 
 	// Stderr is a pointer to a writer which receives the standard error stream.
-	Stderr *os.File
+	Stderr io.Writer
 
 	// ExtraFiles specifies additional open files to be inherited by the container
 	ExtraFiles []*os.File

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -101,8 +101,26 @@ func (p *setnsProcess) start() (err error) {
 	}
 
 	ierr := parseSync(p.parentPipe, func(sync *syncT) error {
-		// Currently this will noop.
 		switch sync.Type {
+		case procConsole:
+			if err := writeSync(p.parentPipe, procConsoleReq); err != nil {
+				return newSystemErrorWithCause(err, "writing syncT 'request fd'")
+			}
+
+			masterFile, err := utils.RecvFd(p.parentPipe)
+			if err != nil {
+				return newSystemErrorWithCause(err, "getting master pty from child pipe")
+			}
+
+			if p.process.consoleChan == nil {
+				// TODO: Don't panic here, do something more sane.
+				panic("consoleChan is nil")
+			}
+			p.process.consoleChan <- masterFile
+
+			if err := writeSync(p.parentPipe, procConsoleAck); err != nil {
+				return newSystemErrorWithCause(err, "writing syncT 'ack fd'")
+			}
 		case procReady:
 			// This shouldn't happen.
 			panic("unexpected procReady in setns")
@@ -285,6 +303,25 @@ func (p *initProcess) start() error {
 
 	ierr := parseSync(p.parentPipe, func(sync *syncT) error {
 		switch sync.Type {
+		case procConsole:
+			if err := writeSync(p.parentPipe, procConsoleReq); err != nil {
+				return newSystemErrorWithCause(err, "writing syncT 'request fd'")
+			}
+
+			masterFile, err := utils.RecvFd(p.parentPipe)
+			if err != nil {
+				return newSystemErrorWithCause(err, "getting master pty from child pipe")
+			}
+
+			if p.process.consoleChan == nil {
+				// TODO: Don't panic here, do something more sane.
+				panic("consoleChan is nil")
+			}
+			p.process.consoleChan <- masterFile
+
+			if err := writeSync(p.parentPipe, procConsoleAck); err != nil {
+				return newSystemErrorWithCause(err, "writing syncT 'ack fd'")
+			}
 		case procReady:
 			if err := p.manager.Set(p.config.Config); err != nil {
 				return newSystemErrorWithCause(err, "setting cgroup config for ready process")
@@ -316,7 +353,7 @@ func (p *initProcess) start() error {
 			}
 			// Sync with child.
 			if err := writeSync(p.parentPipe, procRun); err != nil {
-				return newSystemErrorWithCause(err, "writing syncT run type")
+				return newSystemErrorWithCause(err, "writing syncT 'run'")
 			}
 			sentRun = true
 		case procHooks:
@@ -336,7 +373,7 @@ func (p *initProcess) start() error {
 			}
 			// Sync with child.
 			if err := writeSync(p.parentPipe, procResume); err != nil {
-				return newSystemErrorWithCause(err, "writing syncT resume type")
+				return newSystemErrorWithCause(err, "writing syncT 'resume'")
 			}
 			sentResume = true
 		default:
@@ -432,6 +469,8 @@ func getPipeFds(pid int) ([]string, error) {
 
 	dirPath := filepath.Join("/proc", strconv.Itoa(pid), "/fd")
 	for i := 0; i < 3; i++ {
+		// XXX: This breaks if the path is not a valid symlink (which can
+		//      happen in certain particularly unlucky mount namespace setups).
 		f := filepath.Join(dirPath, strconv.Itoa(i))
 		target, err := os.Readlink(f)
 		if err != nil {
@@ -442,8 +481,10 @@ func getPipeFds(pid int) ([]string, error) {
 	return fds, nil
 }
 
-// InitializeIO creates pipes for use with the process's STDIO
-// and returns the opposite side for each
+// InitializeIO creates pipes for use with the process's stdio and returns the
+// opposite side for each. Do not use this if you want to have a pseudoterminal
+// set up for you by libcontainer (TODO: fix that too).
+// TODO: This is mostly unnecessary, and should be handled by clients.
 func (p *Process) InitializeIO(rootuid, rootgid int) (i *IO, err error) {
 	var fds []uintptr
 	i = &IO{}

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -16,6 +16,7 @@ import (
 // linuxSetnsInit performs the container's initialization for running a new process
 // inside an existing container.
 type linuxSetnsInit struct {
+	pipe   *os.File
 	config *initConfig
 }
 
@@ -27,6 +28,14 @@ func (l *linuxSetnsInit) Init() error {
 	if !l.config.Config.NoNewKeyring {
 		// do not inherit the parent's session keyring
 		if _, err := keys.JoinSessionKeyring(l.getSessionRingName()); err != nil {
+			return err
+		}
+	}
+	if l.config.CreateConsole {
+		if err := setupConsole(l.pipe, l.config, false); err != nil {
+			return err
+		}
+		if err := system.Setctty(); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -4,7 +4,6 @@ package libcontainer
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"syscall"
@@ -18,7 +17,7 @@ import (
 )
 
 type linuxStandardInit struct {
-	pipe       io.ReadWriteCloser
+	pipe       *os.File
 	parentPid  int
 	stateDirFD int
 	config     *initConfig
@@ -59,18 +58,6 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 
-	var console *linuxConsole
-	if l.config.Console != "" {
-		console = newConsoleFromPath(l.config.Console)
-		if err := console.dupStdio(); err != nil {
-			return err
-		}
-	}
-	if console != nil {
-		if err := system.Setctty(); err != nil {
-			return err
-		}
-	}
 	if err := setupNetwork(l.config); err != nil {
 		return err
 	}
@@ -79,12 +66,33 @@ func (l *linuxStandardInit) Init() error {
 	}
 
 	label.Init()
-	// InitializeMountNamespace() can be executed only for a new mount namespace
+
+	// prepareRootfs() can be executed only for a new mount namespace.
 	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
-		if err := setupRootfs(l.config.Config, console, l.pipe); err != nil {
+		if err := prepareRootfs(l.pipe, l.config.Config); err != nil {
 			return err
 		}
 	}
+
+	// Set up the console. This has to be done *before* we finalize the rootfs,
+	// but *after* we've given the user the chance to set up all of the mounts
+	// they wanted.
+	if l.config.CreateConsole {
+		if err := setupConsole(l.pipe, l.config, true); err != nil {
+			return err
+		}
+		if err := system.Setctty(); err != nil {
+			return err
+		}
+	}
+
+	// Finish the rootfs setup.
+	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
+		if err := finalizeRootfs(l.config.Config); err != nil {
+			return err
+		}
+	}
+
 	if hostname := l.config.Config.Hostname; hostname != "" {
 		if err := syscall.Sethostname([]byte(hostname)); err != nil {
 			return err

--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -1,0 +1,102 @@
+package libcontainer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/opencontainers/runc/libcontainer/utils"
+)
+
+type syncType uint8
+
+// Constants that are used for synchronisation between the parent and child
+// during container setup. They come in pairs (with procError being a generic
+// response which is followed by a &genericError).
+//
+// [  child  ] <-> [   parent   ]
+//
+// procHooks   --> [run hooks]
+//             <-- procResume
+//
+// procReady   --> [final setup]
+//             <-- procRun
+const (
+	procError syncType = iota
+	procReady
+	procRun
+	procHooks
+	procResume
+)
+
+type syncT struct {
+	Type syncType `json:"type"`
+}
+
+// writeSync is used to write to a synchronisation pipe. An error is returned
+// if there was a problem writing the payload.
+func writeSync(pipe io.Writer, sync syncType) error {
+	if err := utils.WriteJSON(pipe, syncT{sync}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readSync is used to read from a synchronisation pipe. An error is returned
+// if we got a genericError, the pipe was closed, or we got an unexpected flag.
+func readSync(pipe io.Reader, expected syncType) error {
+	var procSync syncT
+	if err := json.NewDecoder(pipe).Decode(&procSync); err != nil {
+		if err == io.EOF {
+			return fmt.Errorf("parent closed synchronisation channel")
+		}
+
+		if procSync.Type == procError {
+			var ierr genericError
+
+			if err := json.NewDecoder(pipe).Decode(&ierr); err != nil {
+				return fmt.Errorf("failed reading error from parent: %v", err)
+			}
+
+			return &ierr
+		}
+
+		if procSync.Type != expected {
+			return fmt.Errorf("invalid synchronisation flag from parent")
+		}
+	}
+	return nil
+}
+
+// parseSync runs the given callback function on each syncT received from the
+// child. It will return once io.EOF is returned from the given pipe.
+func parseSync(pipe io.Reader, fn func(*syncT) error) error {
+	dec := json.NewDecoder(pipe)
+	for {
+		var sync syncT
+		if err := dec.Decode(&sync); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		// We handle this case outside fn for cleanliness reasons.
+		var ierr *genericError
+		if sync.Type == procError {
+			if err := dec.Decode(&ierr); err != nil && err != io.EOF {
+				return newSystemErrorWithCause(err, "decoding proc error from init")
+			}
+			if ierr != nil {
+				return ierr
+			}
+			// Programmer error.
+			panic("No error following JSON procError payload.")
+		}
+
+		if err := fn(&sync); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -8,7 +8,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
-type syncType uint8
+type syncType string
 
 // Constants that are used for synchronisation between the parent and child
 // during container setup. They come in pairs (with procError being a generic
@@ -19,14 +19,22 @@ type syncType uint8
 // procHooks   --> [run hooks]
 //             <-- procResume
 //
+// procConsole -->
+//             <-- procConsoleReq
+//  [send(fd)] --> [recv(fd)]
+//             <-- procConsoleAck
+//
 // procReady   --> [final setup]
 //             <-- procRun
 const (
-	procError syncType = iota
-	procReady
-	procRun
-	procHooks
-	procResume
+	procError      syncType = "procError"
+	procReady      syncType = "procReady"
+	procRun        syncType = "procRun"
+	procHooks      syncType = "procHooks"
+	procResume     syncType = "procResume"
+	procConsole    syncType = "procConsole"
+	procConsoleReq syncType = "procConsoleReq"
+	procConsoleAck syncType = "procConsoleAck"
 )
 
 type syncT struct {

--- a/libcontainer/utils/cmsg.c
+++ b/libcontainer/utils/cmsg.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2016 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "cmsg.h"
+
+#define error(fmt, ...)							\
+	({								\
+		fprintf(stderr, "nsenter: " fmt ": %m\n", ##__VA_ARGS__); \
+		errno = ECOMM;						\
+		goto err; /* return value */				\
+	})
+
+/*
+ * Sends a file descriptor along the sockfd provided. Returns the return
+ * value of sendmsg(2). Any synchronisation and preparation of state
+ * should be done external to this (we expect the other side to be in
+ * recvfd() in the code).
+ */
+ssize_t sendfd(int sockfd, struct file_t file)
+{
+	struct msghdr msg = {0};
+	struct iovec iov[1] = {0};
+	struct cmsghdr *cmsg;
+	int *fdptr;
+	int ret;
+
+	union {
+		char buf[CMSG_SPACE(sizeof(file.fd))];
+		struct cmsghdr align;
+	} u;
+
+	/*
+	 * We need to send some other data along with the ancillary data,
+	 * otherwise the other side won't recieve any data. This is very
+	 * well-hidden in the documentation (and only applies to
+	 * SOCK_STREAM). See the bottom part of unix(7).
+	 */
+	iov[0].iov_base = file.name;
+	iov[0].iov_len = strlen(file.name) + 1;
+
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = u.buf;
+	msg.msg_controllen = sizeof(u.buf);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+
+	fdptr = (int *) CMSG_DATA(cmsg);
+	memcpy(fdptr, &file.fd, sizeof(int));
+
+	return sendmsg(sockfd, &msg, 0);
+}
+
+/*
+ * Receives a file descriptor from the sockfd provided. Returns the file
+ * descriptor as sent from sendfd(). It will return the file descriptor
+ * or die (literally) trying. Any synchronisation and preparation of
+ * state should be done external to this (we expect the other side to be
+ * in sendfd() in the code).
+ */
+struct file_t recvfd(int sockfd)
+{
+	struct msghdr msg = {0};
+	struct iovec iov[1] = {0};
+	struct cmsghdr *cmsg;
+	struct file_t file = {0};
+	int *fdptr;
+	int olderrno;
+
+	union {
+		char buf[CMSG_SPACE(sizeof(file.fd))];
+		struct cmsghdr align;
+	} u;
+
+	/* Allocate a buffer. */
+	/* TODO: Make this dynamic with MSG_PEEK. */
+	file.name = malloc(TAG_BUFFER);
+	if (!file.name)
+		error("recvfd: failed to allocate file.tag buffer\n");
+
+	/*
+	 * We need to "recieve" the non-ancillary data even though we don't
+	 * plan to use it at all. Otherwise, things won't work as expected.
+	 * See unix(7) and other well-hidden documentation.
+	 */
+	iov[0].iov_base = file.name;
+	iov[0].iov_len = TAG_BUFFER;
+
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = u.buf;
+	msg.msg_controllen = sizeof(u.buf);
+
+	ssize_t ret = recvmsg(sockfd, &msg, 0);
+	if (ret < 0)
+		goto err;
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	if (!cmsg)
+		error("recvfd: got NULL from CMSG_FIRSTHDR");
+	if (cmsg->cmsg_level != SOL_SOCKET)
+		error("recvfd: expected SOL_SOCKET in cmsg: %d", cmsg->cmsg_level);
+	if (cmsg->cmsg_type != SCM_RIGHTS)
+		error("recvfd: expected SCM_RIGHTS in cmsg: %d", cmsg->cmsg_type);
+	if (cmsg->cmsg_len != CMSG_LEN(sizeof(int)))
+		error("recvfd: expected correct CMSG_LEN in cmsg: %lu", cmsg->cmsg_len);
+
+	fdptr = (int *) CMSG_DATA(cmsg);
+	if (!fdptr || *fdptr < 0)
+		error("recvfd: recieved invalid pointer");
+
+	file.fd = *fdptr;
+	return file;
+
+err:
+	olderrno = errno;
+	free(file.name);
+	errno = olderrno;
+	return (struct file_t){0};
+}

--- a/libcontainer/utils/cmsg.go
+++ b/libcontainer/utils/cmsg.go
@@ -1,0 +1,57 @@
+// +build linux
+
+package utils
+
+/*
+ * Copyright 2016 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+#include <errno.h>
+#include <stdlib.h>
+#include "cmsg.h"
+*/
+import "C"
+
+import (
+	"os"
+	"unsafe"
+)
+
+// RecvFd waits for a file descriptor to be sent over the given AF_UNIX
+// socket. The file name of the remote file descriptor will be recreated
+// locally (it is sent as non-auxilliary data in the same payload).
+func RecvFd(socket *os.File) (*os.File, error) {
+	file, err := C.recvfd(C.int(socket.Fd()))
+	if err != nil {
+		return nil, err
+	}
+	defer C.free(unsafe.Pointer(file.name))
+	return os.NewFile(uintptr(file.fd), C.GoString(file.name)), nil
+}
+
+// SendFd sends a file descriptor over the given AF_UNIX socket. In
+// addition, the file.Name() of the given file will also be sent as
+// non-auxilliary data in the same payload (allowing to send contextual
+// information for a file descriptor).
+func SendFd(socket, file *os.File) error {
+	var cfile C.struct_file_t
+	cfile.fd = C.int(file.Fd())
+	cfile.name = C.CString(file.Name())
+	defer C.free(unsafe.Pointer(cfile.name))
+
+	_, err := C.sendfd(C.int(socket.Fd()), cfile)
+	return err
+}

--- a/libcontainer/utils/cmsg.h
+++ b/libcontainer/utils/cmsg.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if !defined(CMSG_H)
+#define CMSG_H
+
+#include <sys/types.h>
+
+/* TODO: Implement this properly with MSG_PEEK. */
+#define TAG_BUFFER 4096
+
+/* This mirrors Go's (*os.File). */
+struct file_t {
+	char *name;
+	int fd;
+};
+
+struct file_t recvfd(int sockfd);
+ssize_t sendfd(int sockfd, struct file_t file);
+
+#endif /* !defined(CMSG_H) */

--- a/run.go
+++ b/run.go
@@ -31,11 +31,6 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Value: "",
 			Usage: `path to the root of the bundle directory, defaults to the current directory`,
 		},
-		cli.StringFlag{
-			Name:  "console",
-			Value: "",
-			Usage: "specify the pty slave path for use with the container",
-		},
 		cli.BoolFlag{
 			Name:  "detach, d",
 			Usage: "detach from the container's process",

--- a/run.go
+++ b/run.go
@@ -31,6 +31,11 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Value: "",
 			Usage: `path to the root of the bundle directory, defaults to the current directory`,
 		},
+		cli.StringFlag{
+			Name:  "console-socket",
+			Value: "",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
+		},
 		cli.BoolFlag{
 			Name:  "detach, d",
 			Usage: "detach from the container's process",

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -43,7 +43,7 @@ EOF
     sed -i "s/\(\"resources\": {\)/\1\n${DATA}/" ${BUSYBOX_BUNDLE}/config.json
 
     # run a detached busybox to work with
-    runc run -d --console /dev/pts/ptmx test_cgroups_kmem
+    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_kmem
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_cgroups_kmem
 
@@ -61,7 +61,7 @@ EOF
     sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-cgroups-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
 
     # run a detached busybox to work with
-    runc run -d --console /dev/pts/ptmx test_cgroups_kmem
+    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_kmem
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_cgroups_kmem
 

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -12,7 +12,7 @@ function teardown() {
 }
 
 @test "runc create" {
-  runc create --console /dev/pts/ptmx test_busybox
+  runc create --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created
@@ -25,13 +25,15 @@ function teardown() {
 }
 
 @test "runc create exec" {
-  runc create --console /dev/pts/ptmx test_busybox
+  runc create --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created
 
   runc exec test_busybox true
   [ "$status" -eq 0 ]
+
+  testcontainer test_busybox created
 
   # start the command
   runc start test_busybox
@@ -41,7 +43,7 @@ function teardown() {
 }
 
 @test "runc create --pid-file" {
-  runc create --pid-file pid.txt --console /dev/pts/ptmx test_busybox
+  runc create --pid-file pid.txt --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created
@@ -67,7 +69,7 @@ function teardown() {
   run cd pid_file
   [ "$status" -eq 0 ]
 
-  runc create --pid-file pid.txt -b $BUSYBOX_BUNDLE --console /dev/pts/ptmx test_busybox
+  runc create --pid-file pid.txt -b $BUSYBOX_BUNDLE --console-socket $CONSOLE_SOCKET  test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc delete" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -34,7 +34,7 @@ function teardown() {
 
 @test "runc delete --force" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -51,13 +51,13 @@ function teardown() {
 
 @test "run delete with multi-containers" {
   # create busybox1 detached
-  runc create --console /dev/pts/ptmx test_busybox1
+  runc create --console-socket $CONSOLE_SOCKET test_busybox1
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox1 created
 
   # run busybox2 detached
-  runc run -d --console /dev/pts/ptmx test_busybox2
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox2
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox2
@@ -86,20 +86,20 @@ function teardown() {
 
 @test "run delete --force with multi-containers" {
   # create busybox1 detached
-  runc create --console /dev/pts/ptmx test_busybox1
+  runc create --console-socket $CONSOLE_SOCKET test_busybox1
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox1 created
 
   # run busybox2 detached
-  runc run -d --console /dev/pts/ptmx test_busybox2
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox2
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox2
   testcontainer test_busybox2 running
 
   # delete both test_busybox1 and test_busybox2 container
-  runc delete --force  test_busybox1 test_busybox2
+  runc delete --force test_busybox1 test_busybox2
 
   runc state test_busybox1
   [ "$status" -ne 0 ]

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "events --stats" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -28,7 +28,7 @@ function teardown() {
 
 @test "events --interval default " {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -55,7 +55,7 @@ function teardown() {
 
 @test "events --interval 1s " {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -81,7 +81,7 @@ function teardown() {
 
 @test "events --interval 100ms " {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc exec" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -26,7 +26,7 @@ function teardown() {
 
 @test "runc exec --pid-file" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -53,7 +53,7 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # run busybox detached
-  runc run -d -b $BUSYBOX_BUNDLE --console /dev/pts/ptmx test_busybox
+  runc run -d -b $BUSYBOX_BUNDLE --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -74,7 +74,7 @@ function teardown() {
 
 @test "runc exec ls -la" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -88,7 +88,7 @@ function teardown() {
 
 @test "runc exec ls -la with --cwd" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -100,7 +100,7 @@ function teardown() {
 
 @test "runc exec --env" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -113,7 +113,7 @@ function teardown() {
 
 @test "runc exec --user" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -64,11 +64,11 @@ load helpers
   runc start -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ start+ ]]
-  
+
   runc run -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ run+ ]]
-  
+
   runc state -h
   [ "$status" -eq 0 ]
   [[ ${lines[1]} =~ runc\ state+ ]]

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -149,7 +149,7 @@ function setup_busybox() {
 		BUSYBOX_IMAGE="/testdata/busybox.tar"
 	fi
 	if [ ! -e $BUSYBOX_IMAGE ]; then
-		curl -o $BUSYBOX_IMAGE -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.11/rootfs.tar'
+		curl -o $BUSYBOX_IMAGE -sSL 'https://github.com/docker-library/busybox/raw/a0558a9006ce0dd6f6ec5d56cfd3f32ebeeb815f/glibc/busybox.tar.xz'
 	fi
 	tar -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
 	cd "$BUSYBOX_BUNDLE"

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -15,7 +15,7 @@ function teardown() {
 @test "kill detached busybox" {
 
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -19,15 +19,15 @@ function teardown() {
 
 @test "list" {
   # run a few busyboxes detached
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_box1
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box1
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box1 $HELLO_BUNDLE
 
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_box2
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box2
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box2 $HELLO_BUNDLE
 
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_box3
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box3
   [ "$status" -eq 0 ]
   wait_for_container_inroot 15 1 test_box3 $HELLO_BUNDLE
 

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -20,7 +20,7 @@ function teardown() {
 
 @test "mask paths [file]" {
 	# run busybox detached
-	runc run -d --console /dev/pts/ptmx test_busybox
+	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
 
 	wait_for_container 15 1 test_busybox
@@ -40,7 +40,7 @@ function teardown() {
 
 @test "mask paths [directory]" {
 	# run busybox detached
-	runc run -d --console /dev/pts/ptmx test_busybox
+	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
 
 	wait_for_container 15 1 test_busybox

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc pause and resume" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -35,13 +35,13 @@ function teardown() {
 
 @test "runc pause and resume with multi-container" {
   # run test_busybox1 detached
-  runc run -d --console /dev/pts/ptmx test_busybox1
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox1
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox1
 
   # run test_busybox2 detached
-  runc run -d --console /dev/pts/ptmx test_busybox2
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox2
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox2
@@ -74,27 +74,27 @@ function teardown() {
 
 @test "runc pause and resume with nonexist container" {
   # run test_busybox1 detached
-  runc run -d --console /dev/pts/ptmx test_busybox1
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox1
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox1
 
   # run test_busybox2 detached
-  runc run -d --console /dev/pts/ptmx test_busybox2
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox2
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox2
 
-  # pause test_busybox1, test_busybox2 and nonexistant container
-  runc pause test_busybox1 test_busybox2 nonexistant
+  # pause test_busybox1, test_busybox2 and nonexistent container
+  runc pause test_busybox1 test_busybox2 nonexistent
   [ "$status" -ne 0 ]
 
   # test state of test_busybox1 and test_busybox2 is paused
   testcontainer test_busybox1 paused
   testcontainer test_busybox2 paused
 
-  # resume test_busybox1, test_busybox2 and nonexistant container
-  runc resume test_busybox1 test_busybox2 nonexistant
+  # resume test_busybox1, test_busybox2 and nonexistent container
+  runc resume test_busybox1 test_busybox2 nonexistent
   [ "$status" -ne 0 ]
 
   # test state of two containers is back to running

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "ps" {
   # start busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -29,7 +29,7 @@ function teardown() {
 
 @test "ps -f json" {
   # start busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -44,7 +44,7 @@ function teardown() {
 
 @test "ps -e -x" {
   # start busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -15,11 +15,11 @@ function teardown() {
 
 @test "global --root" {
   # run busybox detached using $HELLO_BUNDLE for state
-  ROOT=$HELLO_BUNDLE runc run -d --console /dev/pts/ptmx test_dotbox
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_dotbox
   [ "$status" -eq 0 ]
 
   # run busybox detached in default root
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state of the busyboxes are only in their respective root path

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -12,12 +12,12 @@ function teardown() {
 }
 
 @test "runc start" {
-  runc create --console /dev/pts/ptmx test_busybox1
+  runc create --console-socket $CONSOLE_SOCKET test_busybox1
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox1 created
 
-  runc create --console /dev/pts/ptmx test_busybox2
+  runc create --console-socket $CONSOLE_SOCKET test_busybox2
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox2 created

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc run detached" {
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -29,7 +29,7 @@ function teardown() {
   sed -i 's;"gid": 0;"gid": 100;g' config.json
 
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -40,7 +40,7 @@ function teardown() {
 
 @test "runc run detached --pid-file" {
   # run busybox detached
-  runc run --pid-file pid.txt -d --console /dev/pts/ptmx test_busybox
+  runc run --pid-file pid.txt -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -64,7 +64,7 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # run busybox detached
-  runc run --pid-file pid.txt -d  -b $BUSYBOX_BUNDLE --console /dev/pts/ptmx test_busybox
+  runc run --pid-file pid.txt -d  -b $BUSYBOX_BUNDLE --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -16,7 +16,7 @@ function teardown() {
   [ "$status" -ne 0 ]
 
   # run busybox detached
-  runc run -d --console /dev/pts/ptmx test_busybox
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	teardown_busybox
+	setup_busybox
+}
+
+function teardown() {
+	teardown_busybox
+}
+
+@test "runc run [tty ptsname]" {
+	# Replace sh script with readlink.
+    sed -i 's|"sh"|"sh", "-c", "for file in /proc/self/fd/[012]; do readlink $file; done"|' config.json
+
+	# run busybox
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ /dev/pts/+ ]]
+	[[ ${lines[1]} =~ /dev/pts/+ ]]
+	[[ ${lines[2]} =~ /dev/pts/+ ]]
+}
+
+@test "runc run [tty owner]" {
+	# Replace sh script with stat.
+	sed -i 's/"sh"/"sh", "-c", "stat -c %u:%g $(tty) | tr : \\\\\\\\n"/' config.json
+
+	# run busybox
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ 0 ]]
+	# This is set by the default config.json (it corresponds to the standard tty group).
+	[[ ${lines[1]} =~ 5 ]]
+}
+
+@test "runc run [tty owner] ({u,g}id != 0)" {
+	# replace "uid": 0 with "uid": 1000
+	# and do a similar thing for gid.
+	sed -i 's;"uid": 0;"uid": 1000;g' config.json
+	sed -i 's;"gid": 0;"gid": 100;g' config.json
+
+	# Replace sh script with stat.
+	sed -i 's/"sh"/"sh", "-c", "stat -c %u:%g $(tty) | tr : \\\\\\\\n"/' config.json
+
+	# run busybox
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ 1000 ]]
+	# This is set by the default config.json (it corresponds to the standard tty group).
+	[[ ${lines[1]} =~ 5 ]]
+}
+
+@test "runc exec [tty ptsname]" {
+	# run busybox detached
+	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	[ "$status" -eq 0 ]
+
+	# check state
+	wait_for_container 15 1 test_busybox
+
+	# make sure we're running
+	testcontainer test_busybox running
+
+	# run the exec
+    runc exec test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ /dev/pts/+ ]]
+	[[ ${lines[1]} =~ /dev/pts/+ ]]
+	[[ ${lines[2]} =~ /dev/pts/+ ]]
+}
+
+@test "runc exec [tty owner]" {
+	# run busybox detached
+	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	[ "$status" -eq 0 ]
+
+	# check state
+	wait_for_container 15 1 test_busybox
+
+	# make sure we're running
+	testcontainer test_busybox running
+
+	# run the exec
+    runc exec test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ 0 ]]
+	[[ ${lines[1]} =~ 5 ]]
+}
+
+@test "runc exec [tty owner] ({u,g}id != 0)" {
+	# replace "uid": 0 with "uid": 1000
+	# and do a similar thing for gid.
+	sed -i 's;"uid": 0;"uid": 1000;g' config.json
+	sed -i 's;"gid": 0;"gid": 100;g' config.json
+
+	# run busybox detached
+	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	[ "$status" -eq 0 ]
+
+	# check state
+	wait_for_container 15 1 test_busybox
+
+	# make sure we're running
+	testcontainer test_busybox running
+
+	# run the exec
+    runc exec test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ 1000 ]]
+	[[ ${lines[1]} =~ 5 ]]
+}

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -51,7 +51,7 @@ function check_cgroup_value() {
 @test "update" {
     requires cgroups_kmem
     # run a few busyboxes detached
-    runc run -d --console /dev/pts/ptmx test_update
+    runc run -d --console-socket $CONSOLE_SOCKET test_update
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_update
 

--- a/tty.go
+++ b/tty.go
@@ -7,10 +7,25 @@ import (
 	"io"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/docker/docker/pkg/term"
 	"github.com/opencontainers/runc/libcontainer"
 )
+
+type tty struct {
+	console   libcontainer.Console
+	state     *term.State
+	closers   []io.Closer
+	postStart []io.Closer
+	wg        sync.WaitGroup
+}
+
+func (t *tty) copyIO(w io.Writer, r io.ReadCloser) {
+	defer t.wg.Done()
+	io.Copy(w, r)
+	r.Close()
+}
 
 // setup standard pipes so that the TTY of the calling runc process
 // is not inherited by the container.
@@ -46,45 +61,43 @@ func createStdioPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, erro
 	return t, nil
 }
 
-func (t *tty) copyIO(w io.Writer, r io.ReadCloser) {
-	defer t.wg.Done()
-	io.Copy(w, r)
-	r.Close()
-}
-
-func createTty(p *libcontainer.Process, rootuid, rootgid int, consolePath string) (*tty, error) {
-	if consolePath != "" {
-		if err := p.ConsoleFromPath(consolePath); err != nil {
-			return nil, err
+func dupStdio(process *libcontainer.Process, rootuid, rootgid int) error {
+	process.Stdin = os.Stdin
+	process.Stdout = os.Stdout
+	process.Stderr = os.Stderr
+	for _, fd := range []uintptr{
+		os.Stdin.Fd(),
+		os.Stdout.Fd(),
+		os.Stderr.Fd(),
+	} {
+		if err := syscall.Fchown(int(fd), rootuid, rootgid); err != nil {
+			return err
 		}
-		return &tty{}, nil
 	}
-	console, err := p.NewConsole(rootuid, rootgid)
-	if err != nil {
-		return nil, err
-	}
-	go io.Copy(console, os.Stdin)
-	go io.Copy(os.Stdout, console)
-
-	state, err := term.SetRawTerminal(os.Stdin.Fd())
-	if err != nil {
-		return nil, fmt.Errorf("failed to set the terminal from the stdin: %v", err)
-	}
-	return &tty{
-		console: console,
-		state:   state,
-		closers: []io.Closer{
-			console,
-		},
-	}, nil
+	return nil
 }
 
-type tty struct {
-	console   libcontainer.Console
-	state     *term.State
-	closers   []io.Closer
-	postStart []io.Closer
-	wg        sync.WaitGroup
+func (t *tty) recvtty(process *libcontainer.Process, detach bool) error {
+	console, err := process.GetConsole()
+	if err != nil {
+		return err
+	}
+
+	if !detach {
+		go io.Copy(console, os.Stdin)
+		t.wg.Add(1)
+		go t.copyIO(os.Stdout, console)
+
+		state, err := term.SetRawTerminal(os.Stdin.Fd())
+		if err != nil {
+			return fmt.Errorf("failed to set the terminal from the stdin: %v", err)
+		}
+		t.state = state
+	}
+
+	t.console = console
+	t.closers = []io.Closer{console}
+	return nil
 }
 
 // ClosePostStart closes any fds that are provided to the container and dup2'd


### PR DESCRIPTION
This is the big console rewrite. For some design information, see [this](https://gist.github.com/cyphar/8c6b9db84fc1f2cc2d037ef07942ca83). TODO list:
- [x] Implement the console masterfd passing.
- [x] Rewrite parts of `tty.go` to work with the new setup.
- [x] Remove `--console` and add `--console-socket`.
  - [x] Need to figure out a sane protocol for sending things to `--console-socket`.
  - [x] Write a small implementation of a `--console-socket` consumer as a sanity check [can be done in a separate PR].
- [x] Figure out how to make the test suite behave.
  - [x] `TestExecInTTY`.
  - [x] bats `integration`.
- [x] Need to figure out why runC is blocking on `recvfd()`.

Fixes #814, #910, docker/docker#11462, docker/docker#8755 and countless other issues.
~~Depends on #975, #977.~~
docker/docker#9212 and similar issues are **not** fixed by this patchset, as we still need to consider how to handle `/dev/console` in certain cases.

Signed-off-by: Aleksa Sarai asarai@suse.de
