### PR TITLE
Add backwards compat for net classid 

### DIFF
--- a/libcontainer/cgroups/fs/util_test.go
+++ b/libcontainer/cgroups/fs/util_test.go
@@ -33,7 +33,6 @@ func NewCgroupTestUtil(subsystem string, t *testing.T) *cgroupTestUtil {
 	d := &cgroupData{
 		config: &configs.Cgroup{},
 	}
-	d.config.Resources = &configs.Resources{}
 	tempDir, err := ioutil.TempDir("", "cgroup_test")
 	if err != nil {
 		t.Fatal(err)

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -48,10 +48,12 @@ func newTemplateConfig(rootfs string) *configs.Config {
 		}),
 		Cgroups: &configs.Cgroup{
 			Path: "integration/test",
-			Resources: &configs.Resources{
-				MemorySwappiness: nil,
-				AllowAllDevices:  &allowAllDevices,
-				AllowedDevices:   configs.DefaultAllowedDevices,
+			Resources: configs.Resources{
+				BaseResources: configs.BaseResources{
+					MemorySwappiness: nil,
+					AllowAllDevices:  &allowAllDevices,
+					AllowedDevices:   configs.DefaultAllowedDevices,
+				},
 			},
 		},
 		MaskPaths: []string{

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -254,10 +254,7 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*configs.Cgroup, error) {
 	var myCgroupPath string
 
-	c := &configs.Cgroup{
-		Resources: &configs.Resources{},
-	}
-
+	c := &configs.Cgroup{}
 	if spec.Linux.CgroupsPath != nil {
 		myCgroupPath = libcontainerUtils.CleanPath(*spec.Linux.CgroupsPath)
 		if useSystemdCgroup {

--- a/list.go
+++ b/list.go
@@ -113,23 +113,25 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 	}
 	list, err := ioutil.ReadDir(absRoot)
 	if err != nil {
-		fatal(err)
+		return nil, err
 	}
-
 	var s []containerState
 	for _, item := range list {
 		if item.IsDir() {
 			container, err := factory.Load(item.Name())
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "unable to load %s: %v\n", item.Name(), err)
+				continue
 			}
 			containerStatus, err := container.Status()
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "unable to get status on %s: %v\n", item.Name(), err)
+				continue
 			}
 			state, err := container.State()
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "unable to set state for %s: %v\n", item.Name(), err)
+				continue
 			}
 			pid := state.BaseState.InitProcessPid
 			if containerStatus == libcontainer.Stopped {


### PR DESCRIPTION
Fixes #999

This makes the list command handle errors better and still list containers that could be loaded.  

It also handles the unmarshaling issues for the backwards incompatable change with the net class id which changed from a string to a uint32