### PR TITLE
Change netclassid json tag

### DIFF
--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -120,5 +120,5 @@ type Resources struct {
 	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap"`
 
 	// Set class identifier for container's network packets
-	NetClsClassid uint32 `json:"net_cls_classid"`
+	NetClsClassid uint32 `json:"net_cls_classid_u"`
 }


### PR DESCRIPTION
Fixes #999

This allows older state files to be loaded without the unmarshal error
of the string to int conversion.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>