### PR TITLE
Update runtime-spec to current upstream

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -58,8 +58,8 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runtime-spec/specs-go",
-			"Comment": "v1.0.0-rc1",
-			"Rev": "06479209bdc0d4135911688c18157bd39bd99c22"
+			"Comment": "v1.0.0-rc1-89-g7a36e7e",
+			"Rev": "7a36e7ed86ee3b4c6dbcdbd02052ec1ef6787c3c"
 		},
 		{
 			"ImportPath": "github.com/seccomp/libseccomp-golang",

--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -4,27 +4,27 @@ import "os"
 
 // Spec is the base configuration for the container.
 type Spec struct {
-	// Version is the version of the specification that is supported.
+	// Version of the Open Container Runtime Specification with which the bundle complies.
 	Version string `json:"ociVersion"`
-	// Platform is the host information for OS and Arch.
+	// Platform specifies the configuration's target platform.
 	Platform Platform `json:"platform"`
-	// Process is the container's main process.
+	// Process configures the container process.
 	Process Process `json:"process"`
-	// Root is the root information for the container's filesystem.
+	// Root configures the container's root filesystem.
 	Root Root `json:"root"`
-	// Hostname is the container's host name.
+	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
-	// Mounts profile configuration for adding mounts to the container's filesystem.
+	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
-	// Hooks are the commands run at various lifecycle events of the container.
+	// Hooks configures callbacks for container lifecycle events.
 	Hooks Hooks `json:"hooks"`
-	// Annotations is an unstructured key value map that may be set by external tools to store and retrieve arbitrary metadata.
+	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Linux is platform specific configuration for Linux based containers.
-	Linux Linux `json:"linux" platform:"linux,omitempty"`
+	Linux *Linux `json:"linux,omitempty" platform:"linux"`
 	// Solaris is platform specific configuration for Solaris containers.
-	Solaris Solaris `json:"solaris" platform:"solaris,omitempty"`
+	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -47,21 +47,21 @@ type Process struct {
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
 
-	// ApparmorProfile specified the apparmor profile for the container. (this field is platform dependent)
+	// ApparmorProfile specifies the apparmor profile for the container. (this field is platform dependent)
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// User specifies Linux specific user and group information for the container's
-// main process.
+// User specifies Linux/Solaris specific user and group information
+// for the container process.
 type User struct {
 	// UID is the user id. (this field is platform dependent)
-	UID uint32 `json:"uid" platform:"linux"`
+	UID uint32 `json:"uid" platform:"linux,solaris"`
 	// GID is the group id. (this field is platform dependent)
-	GID uint32 `json:"gid" platform:"linux"`
+	GID uint32 `json:"gid" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
-	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux"`
+	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
 }
 
 // Root contains information about the container's root filesystem on the host.
@@ -262,7 +262,7 @@ type Memory struct {
 	// Kernel memory limit (in bytes).
 	Kernel *uint64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
-	KernelTCP *uint64 `json:"kernelTCP"`
+	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
 	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
@@ -294,15 +294,15 @@ type Pids struct {
 // Network identification and priority configuration
 type Network struct {
 	// Set class identifier for container's network packets
-	ClassID *uint32 `json:"classID"`
+	ClassID *uint32 `json:"classID,omitempty"`
 	// Set priority of network traffic for container
 	Priorities []InterfacePriority `json:"priorities,omitempty"`
 }
 
 // Resources has container runtime resource constraints
 type Resources struct {
-	// Devices are a list of device rules for the whitelist controller
-	Devices []DeviceCgroup `json:"devices"`
+	// Devices configures the device whitelist.
+	Devices []DeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Specify an oom_score_adj for the container.
@@ -371,9 +371,9 @@ type Solaris struct {
 	// Specification for automatic creation of network resources for this container.
 	Anet []Anet `json:"anet,omitempty"`
 	// Set limit on the amount of CPU time that can be used by container.
-	CappedCPU CappedCPU `json:"cappedCPU,omitempty"`
+	CappedCPU *CappedCPU `json:"cappedCPU,omitempty"`
 	// The physical and swap caps on the memory that can be used by this container.
-	CappedMemory CappedMemory `json:"cappedMemory,omitempty"`
+	CappedMemory *CappedMemory `json:"cappedMemory,omitempty"`
 }
 
 // CappedCPU allows users to set limit on the amount of CPU time that can be used by container.

--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -8,7 +8,7 @@ type State struct {
 	ID string `json:"id"`
 	// Status is the runtime state of the container.
 	Status string `json:"status"`
-	// Pid is the process id for the container's main process.
+	// Pid is the process ID for the container process.
 	Pid int `json:"pid"`
 	// BundlePath is the path to the container's bundle directory.
 	BundlePath string `json:"bundlePath"`

--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1"
+	VersionDev = "-rc1-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -258,7 +258,7 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 		Resources: &configs.Resources{},
 	}
 
-	if spec.Linux.CgroupsPath != nil {
+	if spec.Linux != nil && spec.Linux.CgroupsPath != nil {
 		myCgroupPath = libcontainerUtils.CleanPath(*spec.Linux.CgroupsPath)
 		if useSystemdCgroup {
 			myCgroupPath = *spec.Linux.CgroupsPath
@@ -289,6 +289,9 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 	}
 
 	c.Resources.AllowedDevices = allowedDevices
+	if spec.Linux == nil {
+		return c, nil
+	}
 	r := spec.Linux.Resources
 	if r == nil {
 		return c, nil

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -12,7 +12,9 @@ func TestLinuxCgroupsPathSpecified(t *testing.T) {
 	cgroupsPath := "/user/cgroups/path/id"
 
 	spec := &specs.Spec{}
-	spec.Linux.CgroupsPath = &cgroupsPath
+	spec.Linux = &specs.Linux{
+		CgroupsPath: &cgroupsPath,
+	}
 
 	cgroup, err := createCgroupConfig("ContainerID", false, spec)
 	if err != nil {

--- a/spec.go
+++ b/spec.go
@@ -145,7 +145,7 @@ container on your host.`,
 					Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
 				},
 			},
-			Linux: specs.Linux{
+			Linux: &specs.Linux{
 				MaskedPaths: []string{
 					"/proc/kcore",
 					"/proc/latency_stats",

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -78,7 +78,7 @@ function teardown() {
     run git reset --hard "${SPEC_COMMIT}"
   )
   [ "$status" -eq 0 ]
-  [ -e src/runtime-spec/schema/schema.json ]
+  [ -e src/runtime-spec/schema/config-schema.json ]
 
   run bash -c "GOPATH='$GOPATH' go get github.com/xeipuuv/gojsonschema"
   [ "$status" -eq 0 ]
@@ -89,7 +89,7 @@ function teardown() {
   runc spec
   [ -e config.json ]
 
-  run ./validate src/runtime-spec/schema/schema.json config.json
+  run ./validate src/runtime-spec/schema/config-schema.json config.json
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == *"The document is valid"* ]]
 }


### PR DESCRIPTION
runc currently fails to build against the upstream version of runtime-spec/specs-go:

```
# github.com/opencontainers/runc
./spec.go:189: cannot use specs.Linux literal (type specs.Linux) as type *specs.Linux in field value
```

on account of https://github.com/opencontainers/runtime-spec/commit/63231576ec8460849308b78f0308506010a0f709#diff-7f24d60f0cbb9c433e165467e3d34838R25

This PR updates the dependency to current runtime-spec master, fixes the type mismatch, adds nil pointer checks, and updates spec config paths.

Fixes #1035

Signed-off-by: Adam Thomason <ad@mthomason.net>