### PR TITLE
Fix make release error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ RELEASE_DIR := $(CURDIR)/release
 
 VERSION := ${shell cat ./VERSION}
 
-SHELL ?= $(shell command -v bash 2>/dev/null)
+SHELL := $(shell command -v bash 2>/dev/null)
 
 all: $(RUNC_LINK)
 	go build -i -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o runc .


### PR DESCRIPTION
currently make release may have a error in some distribution(e.g. Ubuntu 14.04.3)
/bin/sh: 1: Syntax error: "(" unexpected
make: *** [release] Error 2
this pr will fix this.

Signed-off-by: Shukui Yang <yangshukui@huawei.com>