### PR TITLE
Continue for list on errors

### DIFF
--- a/list.go
+++ b/list.go
@@ -121,15 +121,18 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 		if item.IsDir() {
 			container, err := factory.Load(item.Name())
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "load container %s: %v\n", item.Name(), err)
+				continue
 			}
 			containerStatus, err := container.Status()
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "status for %s: %v\n", item.Name(), err)
+				continue
 			}
 			state, err := container.State()
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "state for %s: %v\n", item.Name(), err)
+				continue
 			}
 			pid := state.BaseState.InitProcessPid
 			if containerStatus == libcontainer.Stopped {


### PR DESCRIPTION
This will print out the error on stderr when loading a container but
still list everything that was sucessful.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>