### PR TITLE
move m.GetPaths out of the loop

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -195,8 +195,9 @@ func (m *Manager) Set(container *configs.Config) error {
 	if m.Cgroups.Paths != nil {
 		return nil
 	}
+
+	paths := m.GetPaths()
 	for _, sys := range subsystems {
-		paths := m.GetPaths()
 		path := paths[sys.Name()]
 		if err := sys.Set(path, container.Cgroups); err != nil {
 			return err


### PR DESCRIPTION
only call m.GetPaths once is ok. os move it out of the loop.

Signed-off-by: Wang Long <long.wanglong@huawei.com>