### PR TITLE
Allow recrusive generic error

### DIFF
--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -67,9 +67,6 @@ func newSystemErrorWithCause(err error, cause string) Error {
 // stack frames skipped. This is only to be called by the other functions for
 // formatting the error.
 func createSystemError(err error, cause string) Error {
-	if le, ok := err.(Error); ok {
-		return le
-	}
 	gerr := &genericError{
 		Timestamp: time.Now(),
 		Err:       err,

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -356,7 +356,7 @@ loop:
 		}
 	}
 	if !sentRun {
-		return newSystemErrorWithCause(ierr, "container init failed")
+		return newSystemErrorWithCause(ierr, "container init")
 	}
 	if p.config.Config.Namespaces.Contains(configs.NEWNS) && !sentResume {
 		return newSystemError(fmt.Errorf("could not synchronise after executing prestart hooks with container process"))


### PR DESCRIPTION
Error sent from child process is already genericError, if
we don't allow recrusive generic error, we won't get any
cause infomation from parent process.

Before, we got:
WARN[0000] exit status 1
ERRO[0000] operation not permitted

After, we got:
WARN[0000] exit status 1
ERRO[0000] container_linux.go:247: starting container process caused "process_linux.go:359: container init caused \"operation not permitted\""

it's not pretty but useful for detecting root causes.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>