### PR TITLE
Add flag to allow getting all mounts for cgroups subsystems

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -139,7 +139,7 @@ func (m Mount) GetThisCgroupDir(cgroups map[string]string) (string, error) {
 	return getControllerPath(m.Subsystems[0], cgroups)
 }
 
-func getCgroupMountsHelper(ss map[string]bool, mi io.Reader) ([]Mount, error) {
+func getCgroupMountsHelper(ss map[string]bool, mi io.Reader, all bool) ([]Mount, error) {
 	res := make([]Mount, 0, len(ss))
 	scanner := bufio.NewScanner(mi)
 	numFound := 0
@@ -166,7 +166,9 @@ func getCgroupMountsHelper(ss map[string]bool, mi io.Reader) ([]Mount, error) {
 			} else {
 				m.Subsystems = append(m.Subsystems, opt)
 			}
-			numFound++
+			if !all {
+				numFound++
+			}
 		}
 		res = append(res, m)
 	}
@@ -176,23 +178,25 @@ func getCgroupMountsHelper(ss map[string]bool, mi io.Reader) ([]Mount, error) {
 	return res, nil
 }
 
-func GetCgroupMounts() ([]Mount, error) {
+// GetCgroupMounts returns the mounts for the cgroup subsystems.
+// all indicates whether to return just the first instance or all the mounts.
+func GetCgroupMounts(all bool) ([]Mount, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	all, err := ParseCgroupFile("/proc/self/cgroup")
+	allSubsystems, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		return nil, err
 	}
 
 	allMap := make(map[string]bool)
-	for s := range all {
+	for s := range allSubsystems {
 		allMap[s] = true
 	}
-	return getCgroupMountsHelper(allMap, f)
+	return getCgroupMountsHelper(allMap, f, all)
 }
 
 // GetAllSubsystems returns all the cgroup subsystems supported by the kernel

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -134,7 +134,7 @@ func TestGetCgroupMounts(t *testing.T) {
 	}
 	for _, td := range testTable {
 		mi := bytes.NewBufferString(td.mountInfo)
-		cgMounts, err := getCgroupMountsHelper(td.subsystems, mi)
+		cgMounts, err := getCgroupMountsHelper(td.subsystems, mi, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -187,7 +187,7 @@ func BenchmarkGetCgroupMounts(b *testing.B) {
 		b.StopTimer()
 		mi := bytes.NewBufferString(fedoraMountinfo)
 		b.StartTimer()
-		if _, err := getCgroupMountsHelper(subsystems, mi); err != nil {
+		if _, err := getCgroupMountsHelper(subsystems, mi, false); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -270,7 +270,7 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 }
 
 func getCgroupMounts(m *configs.Mount) ([]*configs.Mount, error) {
-	mounts, err := cgroups.GetCgroupMounts()
+	mounts, err := cgroups.GetCgroupMounts(false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This requirement comes from cadvisor so it can pick the right mounts that it needs when run in a container. It shouldn't affect internal libcontainer/runc code.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>