### PR TITLE
rootfs_linux.go: support mounting tmpfs under rofs

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -163,6 +163,11 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 		}
 		if stat != nil {
 			if err = os.Chmod(dest, stat.Mode()); err != nil {
+				if perr, ok := err.(*os.PathError); ok {
+					if perr.Err.(syscall.Errno) == syscall.EROFS {
+						return nil
+					}
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
The purpose of this PR is to mask `/sys/firmware` by mounting read-only tmpfs under the read-only sysfs.

So we can prohibit `/sys/firmware` (which is vulnerable: https://github.com/docker/docker/pull/26618) from being accessed without breaking compatibility.

Please refer to https://github.com/docker/docker/pull/26689

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>