### PR TITLE
cgroup: using WriteCgroupProc to write the specified pid into the cgroup's cgroup.procs file

### DIFF
--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -46,7 +46,7 @@ func (s *CpuGroup) ApplyDir(path string, cgroup *configs.Cgroup, pid int) error 
 	}
 	// because we are not using d.join we need to place the pid into the procs file
 	// unlike the other subsystems
-	if err := writeFile(path, "cgroup.procs", strconv.Itoa(pid)); err != nil {
+	if err := cgroups.WriteCgroupProc(path, pid); err != nil {
 		return err
 	}
 


### PR DESCRIPTION


cgroupData.join method using `WriteCgroupProc` to place the pid into
the proc file, it can avoid attach any pid to the cgroup if -1 is
specified as a pid.

so, replace `writeFile` with `WriteCgroupProc` like `cpuset.go`'s
ApplyDir method.

Signed-off-by: Wang Long <long.wanglong@huawei.com>