### PR TITLE
Remove the workaround which add a -- flag to runc ps command

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -18,7 +18,7 @@ import (
 var execCommand = cli.Command{
 	Name:  "exec",
 	Usage: "execute new process inside the container",
-	ArgsUsage: `<container-id> -- <container command> [command options]
+	ArgsUsage: `<container-id> <container command> [command options]
 
 Where "<container-id>" is the name for the instance of the container and
 "<container command>" is the command to be executed in the container.
@@ -158,9 +158,6 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 	}
 	p := spec.Process
 	p.Args = context.Args()[1:]
-	if len(p.Args) > 1 && p.Args[0] == "--" {
-		p.Args = p.Args[1:]
-	}
 	// override the cwd, if passed
 	if context.String("cwd") != "" {
 		p.Cwd = context.String("cwd")

--- a/ps.go
+++ b/ps.go
@@ -16,7 +16,7 @@ import (
 var psCommand = cli.Command{
 	Name:      "ps",
 	Usage:     "ps displays the processes running inside a container",
-	ArgsUsage: `<container-id> [-- ps options]`,
+	ArgsUsage: `<container-id> [ps options]`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "format, f",
@@ -47,11 +47,6 @@ var psCommand = cli.Command{
 		// psArgs:         [ps_arg1 ps_arg2 ...]
 		//
 		psArgs := context.Args()[1:]
-
-		if len(psArgs) > 0 && psArgs[0] == "--" {
-			psArgs = psArgs[1:]
-		}
-
 		if len(psArgs) == 0 {
 			psArgs = []string{"-ef"}
 		}

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -43,3 +43,17 @@ function teardown() {
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ [0-9]+ ]]
 }
+
+@test "runc exec ls -la" {
+  # run busybox detached
+  runc run -d --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox
+
+  runc exec test_busybox ls -la
+  [ "$status" -eq 0 ]
+  [[ ${lines[0]} == *"total"* ]]
+  [[ ${lines[1]} == *"."* ]]
+  [[ ${lines[2]} == *".."* ]]
+}

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+  teardown_busybox
+  setup_busybox
+}
+
+function teardown() {
+  teardown_busybox
+}
+
+@test "ps -eaf" {
+  # start busybox detached
+  runc run -d --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  # check state
+  wait_for_container 15 1 test_busybox
+
+  testcontainer test_busybox running
+
+  runc ps test_busybox -eaf
+  [ "$status" -eq 0 ]
+  [[ ${lines[0]} =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
+  [[ "${lines[1]}" == *"root"*[0-9]* ]]
+}


### PR DESCRIPTION
https://github.com/opencontainers/runc/pull/1051 has been merged to fix ps/exec parameter error, so we can remove the redundant workaround for runc ps.


Signed-off-by: Shukui Yang <yangshukui@huawei.com>