### PR TITLE
make `runc list` print the command

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -61,6 +61,9 @@ type BaseState struct {
 
 	// Config is the container's configuration.
 	Config configs.Config `json:"config"`
+
+	// Process
+	Process Process `json:"process"`
 }
 
 // BaseContainer is a libcontainer container object.

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -248,6 +248,7 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 	}
 	// generate a timestamp indicating when the container was started
 	c.created = time.Now().UTC()
+
 	c.state = &runningState{
 		c: c,
 	}
@@ -1183,12 +1184,17 @@ func (c *linuxContainer) currentState() (*State, error) {
 	var (
 		startTime           string
 		externalDescriptors []string
-		pid                 = -1
+		pid                          = -1
+		process             *Process = &Process{}
 	)
 	if c.initProcess != nil {
 		pid = c.initProcess.pid()
 		startTime, _ = c.initProcess.startTime()
 		externalDescriptors = c.initProcess.externalDescriptors()
+		p := c.initProcess.processInfo()
+		if p != nil {
+			process = p
+		}
 	}
 	state := &State{
 		BaseState: BaseState{
@@ -1197,6 +1203,7 @@ func (c *linuxContainer) currentState() (*State, error) {
 			InitProcessPid:       pid,
 			InitProcessStartTime: startTime,
 			Created:              c.created,
+			Process:              *process,
 		},
 		CgroupPaths:         c.cgroupManager.GetPaths(),
 		NamespacePaths:      make(map[configs.NamespaceType]string),

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -67,6 +67,10 @@ func (m *mockProcess) startTime() (string, error) {
 	return m.started, nil
 }
 
+func (m *mockProcess) processInfo() *Process {
+	return nil
+}
+
 func (m *mockProcess) start() error {
 	return nil
 }

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -196,6 +196,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		processPid:       state.InitProcessPid,
 		processStartTime: state.InitProcessStartTime,
 		fds:              state.ExternalDescriptors,
+		process:          &state.BaseState.Process,
 	}
 	c := &linuxContainer{
 		initProcess:          r,

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -19,54 +19,54 @@ type processOperations interface {
 // a container.
 type Process struct {
 	// The command to be run followed by any arguments.
-	Args []string
+	Args []string `json:"args"`
 
 	// Env specifies the environment variables for the process.
-	Env []string
+	Env []string `json:"env,omitempty"`
 
 	// User will set the uid and gid of the executing process running inside the container
 	// local to the container's user and group configuration.
-	User string
+	User string `json:"user"`
 
 	// AdditionalGroups specifies the gids that should be added to supplementary groups
 	// in addition to those that the user belongs to.
-	AdditionalGroups []string
+	AdditionalGroups []string `json:"additional_groups,omitempty"`
 
 	// Cwd will change the processes current working directory inside the container's rootfs.
-	Cwd string
+	Cwd string `json:"cwd"`
 
 	// Stdin is a pointer to a reader which provides the standard input stream.
-	Stdin io.Reader
+	Stdin io.Reader `json:"-"`
 
 	// Stdout is a pointer to a writer which receives the standard output stream.
-	Stdout io.Writer
+	Stdout io.Writer `json:"-"`
 
 	// Stderr is a pointer to a writer which receives the standard error stream.
-	Stderr io.Writer
+	Stderr io.Writer `json:"-"`
 
 	// ExtraFiles specifies additional open files to be inherited by the container
-	ExtraFiles []*os.File
+	ExtraFiles []*os.File `json:"-"`
 
 	// consolePath is the path to the console allocated to the container.
 	consolePath string
 
 	// Capabilities specify the capabilities to keep when executing the process inside the container
 	// All capabilities not specified will be dropped from the processes capability mask
-	Capabilities []string
+	Capabilities []string `json:"capabilities,omitempty"`
 
 	// AppArmorProfile specifies the profile to apply to the process and is
 	// changed at the time the process is execed
-	AppArmorProfile string
+	AppArmorProfile string `json:"apparmor_profile,omitempty"`
 
 	// Label specifies the label to apply to the process.  It is commonly used by selinux
-	Label string
+	Label string `json:"label,omitempty"`
 
 	// NoNewPrivileges controls whether processes can gain additional privileges.
-	NoNewPrivileges *bool
+	NoNewPrivileges *bool `json:"no_new_privileges,omitempty"`
 
 	// Rlimits specifies the resource limits, such as max open files, to set in the container
 	// If Rlimits are not set, the container will inherit rlimits from the parent process
-	Rlimits []configs.Rlimit
+	Rlimits []configs.Rlimit `json:"rlimits,omitempty"`
 
 	ops processOperations
 }

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -35,6 +35,9 @@ type parentProcess interface {
 	// startTime returns the process start time.
 	startTime() (string, error)
 
+	// processInfo returns the process's info
+	processInfo() *Process
+
 	signal(os.Signal) error
 
 	externalDescriptors() []string
@@ -56,6 +59,10 @@ type setnsProcess struct {
 
 func (p *setnsProcess) startTime() (string, error) {
 	return system.GetProcessStartTime(p.pid())
+}
+
+func (p *setnsProcess) processInfo() *Process {
+	return p.process
 }
 
 func (p *setnsProcess) signal(sig os.Signal) error {
@@ -397,6 +404,10 @@ func (p *initProcess) terminate() error {
 
 func (p *initProcess) startTime() (string, error) {
 	return system.GetProcessStartTime(p.pid())
+}
+
+func (p *initProcess) processInfo() *Process {
+	return p.process
 }
 
 func (p *initProcess) sendConfig() error {

--- a/libcontainer/restored_process.go
+++ b/libcontainer/restored_process.go
@@ -32,6 +32,7 @@ type restoredProcess struct {
 	proc             *os.Process
 	processStartTime string
 	fds              []string
+	process          *Process
 }
 
 func (p *restoredProcess) start() error {
@@ -64,6 +65,10 @@ func (p *restoredProcess) startTime() (string, error) {
 	return p.processStartTime, nil
 }
 
+func (p *restoredProcess) processInfo() *Process {
+	return p.process
+}
+
 func (p *restoredProcess) signal(s os.Signal) error {
 	return p.proc.Signal(s)
 }
@@ -83,6 +88,7 @@ type nonChildProcess struct {
 	processPid       int
 	processStartTime string
 	fds              []string
+	process          *Process
 }
 
 func (p *nonChildProcess) start() error {
@@ -103,6 +109,10 @@ func (p *nonChildProcess) wait() (*os.ProcessState, error) {
 
 func (p *nonChildProcess) startTime() (string, error) {
 	return p.processStartTime, nil
+}
+
+func (p *nonChildProcess) processInfo() *Process {
+	return p.process
 }
 
 func (p *nonChildProcess) signal(s os.Signal) error {

--- a/state.go
+++ b/state.go
@@ -45,6 +45,7 @@ instance of a container.`,
 			Bundle:         bundle,
 			Rootfs:         state.BaseState.Config.Rootfs,
 			Created:        state.BaseState.Created,
+			Command:        state.BaseState.Process.Args,
 			Annotations:    annotations,
 		}
 		data, err := json.MarshalIndent(cs, "", "  ")

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -33,14 +33,14 @@ function teardown() {
 
   ROOT=$HELLO_BUNDLE runc list
   [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
+  [[ ${lines[0]} =~ ID\ +PID\ +COMMAND\ +STATUS\ +BUNDLE\ +CREATED+ ]]
   [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 
   ROOT=$HELLO_BUNDLE runc list --format table
   [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
+  [[ ${lines[0]} =~ ID\ +PID\ +COMMAND\ +STATUS\ +BUNDLE\ +CREATED+ ]]
   [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
   [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]


### PR DESCRIPTION
this patch add `COMMAND` column when we type `runc list` command,

``` bash
root@ubuntu:~# runc list
ID          PID         COMMAND          STATUS      BUNDLE                        CREATED
3           124705      "sleep 20"       created     /mycontainer                  2016-09-21T12:21:57.299298318Z
4           124742      "sleep 20"       created     /mycontainer                  2016-09-21T12:22:29.311509961Z
5           124937      "sleep 20"       created     /mycontainer                  2016-09-21T12:29:03.171447434Z
zzz         0           "/runtimetest"   stopped     /tmp/tmp.37nKu55OYq/busybox   2016-09-22T10:59:30.475271129Z

```
