### PR TITLE
MaskPaths: support directory

### DIFF
--- a/libcontainer/README.md
+++ b/libcontainer/README.md
@@ -83,6 +83,7 @@ config := &configs.Config{
 	},
 	MaskPaths: []string{
 		"/proc/kcore",
+		"/sys/firmware",
 	},
 	ReadonlyPaths: []string{
 		"/proc/sys", "/proc/sysrq-trigger", "/proc/irq", "/proc/bus",

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -56,6 +56,7 @@ func newTemplateConfig(rootfs string) *configs.Config {
 		},
 		MaskPaths: []string{
 			"/proc/kcore",
+			"/sys/firmware",
 		},
 		ReadonlyPaths: []string{
 			"/proc/sys", "/proc/sysrq-trigger", "/proc/irq", "/proc/bus",

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -108,7 +108,7 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 	for _, path := range l.config.Config.MaskPaths {
-		if err := maskFile(path); err != nil {
+		if err := maskPath(path); err != nil {
 			return err
 		}
 	}

--- a/spec.go
+++ b/spec.go
@@ -152,6 +152,7 @@ container on your host.`,
 					"/proc/timer_list",
 					"/proc/timer_stats",
 					"/proc/sched_debug",
+					"/sys/firmware",
 				},
 				ReadonlyPaths: []string{
 					"/proc/asound",

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+  teardown_busybox
+  setup_busybox
+}
+
+function teardown() {
+  teardown_busybox
+}
+
+@test "MaskPaths(file)" {
+  # run busybox detached
+  runc run -d --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox
+
+  runc exec test_busybox cat /proc/kcore
+  [ "$status" -eq 0 ]
+  [[ "${output}" == "" ]]
+
+  runc exec test_busybox rm -f /proc/kcore
+  [ "$status" -eq 1 ]
+  [[ "${output}" == *"Permission denied"* ]]
+
+  runc exec test_busybox umount /proc/kcore
+  [ "$status" -eq 1 ]
+  [[ "${output}" == *"Operation not permitted"* ]]
+}
+
+@test "MaskPaths(directory)" {
+  # run busybox detached
+  runc run -d --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox
+
+  runc exec test_busybox ls /sys/firmware
+  [ "$status" -eq 0 ]
+  [[ "${output}" == "" ]]
+
+  runc exec test_busybox touch /sys/firmware/foo
+  [ "$status" -eq 1 ]
+  [[ "${output}" == *"Read-only file system"* ]]
+
+  runc exec test_busybox rm -rf /sys/firmware
+  [ "$status" -eq 1 ]
+  [[ "${output}" == *"Read-only file system"* ]]
+
+  runc exec test_busybox umount /sys/firmware
+  [ "$status" -eq 1 ]
+  [[ "${output}" == *"Operation not permitted"* ]]
+}


### PR DESCRIPTION
For example, the /sys/firmware directory should be masked because it can contain some sensitive files (https://github.com/docker/docker/pull/26618):
  - /sys/firmware/acpi/tables/{SLIC,MSDM}: Windows license information:
  - /sys/firmware/ibft/target0/chap-secret: iSCSI CHAP secret


IMO the issue should be fixed but no need to get this PR in v1.0

~~~runtime-spec PR: https://github.com/opencontainers/runtime-spec/pull/582~~~


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>