### PR TITLE
Setup default stdio for child process

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -76,6 +76,9 @@ func newProcess(p specs.Process) (*libcontainer.Process, error) {
 		// TODO: fix libcontainer's API to better support uid/gid in a typesafe way.
 		User:            fmt.Sprintf("%d:%d", p.User.UID, p.User.GID),
 		Cwd:             p.Cwd,
+		Stdin:           os.Stdin,
+		Stdout:          os.Stdout,
+		Stderr:          os.Stderr,
 		Capabilities:    p.Capabilities,
 		Label:           p.SelinuxLabel,
 		NoNewPrivileges: &p.NoNewPrivileges,


### PR DESCRIPTION
Otherwise if we enable process.terminal, we won't see
any output in child process before it dup stdio from
pty slave.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
