### PR TITLE
Add Dockerfile.dev to improve development efficiency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,11 @@ man:
 	man/md2man-all.sh
 
 runcimage:
+ifneq ($(FORCE_RUNC_IMAGE), )
+	docker tag $(FORCE_RUNC_IMAGE) $(RUNC_IMAGE)
+else
 	docker build -t $(RUNC_IMAGE) .
+endif
 
 test:
 	make unittest integration


### PR DESCRIPTION
If we have a new branch and then we make test, it will spend a long time to build the runc_dev:**(branch name) image, but most of the time it is not  necessary. This pr will modify it to use a runc-dev:latest image,if we  need ot update runc_dev:latest image,just make image-update.

Signed-off-by: Shukui Yang <yangshukui@huawei.com>