### PR TITLE
pause and resume multi-containers

### DIFF
--- a/man/runc-pause.8.md
+++ b/man/runc-pause.8.md
@@ -2,7 +2,7 @@
    runc pause - pause suspends all processes inside the container
 
 # SYNOPSIS
-   runc pause <container-id>
+   runc pause <container-id> [container-id...]
 
 Where "<container-id>" is the name for the instance of the container to be
 paused. 

--- a/man/runc-resume.8.md
+++ b/man/runc-resume.8.md
@@ -2,7 +2,7 @@
    runc resume - resumes all processes that have been previously paused
 
 # SYNOPSIS
-   runc resume <container-id>
+   runc resume <container-id> [container-id...]
 
 Where "<container-id>" is the name for the instance of the container to be
 resumed.

--- a/pause.go
+++ b/pause.go
@@ -2,12 +2,17 @@
 
 package main
 
-import "github.com/urfave/cli"
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+)
 
 var pauseCommand = cli.Command{
 	Name:  "pause",
 	Usage: "pause suspends all processes inside the container",
-	ArgsUsage: `<container-id>
+	ArgsUsage: `<container-id> [container-id...]
 
 Where "<container-id>" is the name for the instance of the container to be
 paused. `,
@@ -15,12 +20,31 @@ paused. `,
 
 Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
-		container, err := getContainer(context)
+		hasError := false
+		if !context.Args().Present() {
+			return fmt.Errorf("runc: \"pause\" requires a minimum of 1 argument")
+		}
+
+		factory, err := loadFactory(context)
 		if err != nil {
 			return err
 		}
-		if err := container.Pause(); err != nil {
-			return err
+
+		for _, id := range context.Args() {
+			container, err := factory.Load(id)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "container %s is not exist\n", id)
+				hasError = true
+				continue
+			}
+			if err := container.Pause(); err != nil {
+				fmt.Fprintf(os.Stderr, "pause container %s : %s\n", id, err)
+				hasError = true
+			}
+		}
+
+		if hasError {
+			return fmt.Errorf("one or more of container pause failed")
 		}
 		return nil
 	},
@@ -29,7 +53,7 @@ Use runc list to identiy instances of containers and their current status.`,
 var resumeCommand = cli.Command{
 	Name:  "resume",
 	Usage: "resumes all processes that have been previously paused",
-	ArgsUsage: `<container-id>
+	ArgsUsage: `<container-id> [container-id...]
 
 Where "<container-id>" is the name for the instance of the container to be
 resumed.`,
@@ -37,12 +61,31 @@ resumed.`,
 
 Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
-		container, err := getContainer(context)
+		hasError := false
+		if !context.Args().Present() {
+			return fmt.Errorf("runc: \"resume\" requires a minimum of 1 argument")
+		}
+
+		factory, err := loadFactory(context)
 		if err != nil {
 			return err
 		}
-		if err := container.Resume(); err != nil {
-			return err
+
+		for _, id := range context.Args() {
+			container, err := factory.Load(id)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "container %s is not exist\n", id)
+				hasError = true
+				continue
+			}
+			if err := container.Resume(); err != nil {
+				fmt.Fprintf(os.Stderr, "resume container %s : %s\n", id, err)
+				hasError = true
+			}
+		}
+
+		if hasError {
+			return fmt.Errorf("one or more of container resume failed")
 		}
 		return nil
 	},

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -32,3 +32,81 @@ function teardown() {
   # test state of busybox is back to running
   testcontainer test_busybox running
 }
+
+@test "runc pause and resume with multi-container" {
+  # run test_busybox1 detached
+  runc run -d --console /dev/pts/ptmx test_busybox1
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox1
+
+  # run test_busybox2 detached
+  runc run -d --console /dev/pts/ptmx test_busybox2
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox2
+
+  # pause test_busybox1 and test_busybox2
+  runc pause test_busybox1 test_busybox2
+  [ "$status" -eq 0 ]
+
+  # test state of test_busybox1 and test_busybox2 is paused
+  testcontainer test_busybox1 paused
+  testcontainer test_busybox2 paused
+
+  # resume test_busybox1 and test_busybox2
+  runc resume test_busybox1 test_busybox2
+  [ "$status" -eq 0 ]
+
+  # test state of two containers is back to running
+  testcontainer test_busybox1 running
+  testcontainer test_busybox2 running
+
+  # delete test_busybox1 and test_busybox2
+  runc delete --force test_busybox1 test_busybox2
+
+  runc state test_busybox1
+  [ "$status" -ne 0 ]
+
+  runc state test_busybox2
+  [ "$status" -ne 0 ]
+}
+
+@test "runc pause and resume with nonexist container" {
+  # run test_busybox1 detached
+  runc run -d --console /dev/pts/ptmx test_busybox1
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox1
+
+  # run test_busybox2 detached
+  runc run -d --console /dev/pts/ptmx test_busybox2
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox2
+
+  # pause test_busybox1, test_busybox2 and nonexistant container
+  runc pause test_busybox1 test_busybox2 nonexistant
+  [ "$status" -ne 0 ]
+
+  # test state of test_busybox1 and test_busybox2 is paused
+  testcontainer test_busybox1 paused
+  testcontainer test_busybox2 paused
+
+  # resume test_busybox1, test_busybox2 and nonexistant container
+  runc resume test_busybox1 test_busybox2 nonexistant
+  [ "$status" -ne 0 ]
+
+  # test state of two containers is back to running
+  testcontainer test_busybox1 running
+  testcontainer test_busybox2 running
+
+  # delete test_busybox1 and test_busybox2
+  runc delete --force test_busybox1 test_busybox2
+
+  runc state test_busybox1
+  [ "$status" -ne 0 ]
+
+  runc state test_busybox2
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
With this patch, `runc pasue` and `runc resume` can
pause and resume multi-containers.

Signed-off-by: Wang Long <long.wanglong@huawei.com>