### PR TITLE
Container must not checkpoint in created state

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -38,6 +38,13 @@ checkpointed.`,
 		if err != nil {
 			return err
 		}
+		status, err := container.Status()
+		if err != nil {
+			return(err)
+		}
+		if status == libcontainer.Created {
+			fatalf("Container cannot be checkpointed in created state")
+		}
 		defer destroy(container)
 		options := criuOptions(context)
 		// these are the mandatory criu options for a container


### PR DESCRIPTION
Currently when we checkpoint an container in created state ( not an ideal case) the created container also got destroyed.
Since the container fails to checkpoint because of created state, it must not delete the created container without user awareness.
With this PR, container can not checkpoint in created state.
 
Signed-off-by: rajasec <rajasec79@gmail.com>