### PR TITLE
configs: add json tags for some config

### DIFF
--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -27,7 +27,7 @@ type Cgroup struct {
 
 	// Paths represent the absolute cgroups paths to join.
 	// This takes precedence over Path.
-	Paths map[string]string
+	Paths map[string]string `json:"paths"`
 
 	// Resources contains various cgroups settings to apply
 	*Resources

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -98,7 +98,7 @@ type Config struct {
 	Readonlyfs bool `json:"readonlyfs"`
 
 	// Specifies the mount propagation flags to be applied to /.
-	RootPropagation int `json:"rootPropagation"`
+	RootPropagation int `json:"root_propagation"`
 
 	// Mounts specify additional source and destination paths that will be mounted inside the container's
 	// rootfs and mount namespace if specified
@@ -176,7 +176,7 @@ type Config struct {
 
 	// Hooks are a collection of actions to perform at various container lifecycle events.
 	// CommandHooks are serialized to JSON, but other hooks are not.
-	Hooks *Hooks
+	Hooks *Hooks `json:"hooks"`
 
 	// Version is the version of opencontainer specification that is supported.
 	Version string `json:"version"`


### PR DESCRIPTION
This patch add json tags for Cgroup.Paths and Config.Hooks.
so the content of state.json are all lowercases words.

Also this patch change `rootPropagation` to `root_propagation`

Signed-off-by: Wang Long <long.wanglong@huawei.com>