### PR TITLE
Refactor enum map range to slice range

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -223,17 +223,21 @@ func (l *LinuxFactory) Type() string {
 // This is a low level implementation detail of the reexec and should not be consumed externally
 func (l *LinuxFactory) StartInitialization() (err error) {
 	var pipefd, rootfd int
-	for k, v := range map[string]*int{
-		"_LIBCONTAINER_INITPIPE": &pipefd,
-		"_LIBCONTAINER_STATEDIR": &rootfd,
+	for _, pair := range []struct {
+		k string
+		v *int
+	}{
+		{"_LIBCONTAINER_INITPIPE", &pipefd},
+		{"_LIBCONTAINER_STATEDIR", &rootfd},
 	} {
-		s := os.Getenv(k)
+
+		s := os.Getenv(pair.k)
 
 		i, err := strconv.Atoi(s)
 		if err != nil {
-			return fmt.Errorf("unable to convert %s=%s to int", k, s)
+			return fmt.Errorf("unable to convert %s=%s to int", pair.k, s)
 		}
-		*v = i
+		*pair.v = i
 	}
 	var (
 		pipe = os.NewFile(uintptr(pipefd), "pipe")

--- a/update.go
+++ b/update.go
@@ -155,33 +155,39 @@ other options are ignored.
 				r.CPU.Mems = &val
 			}
 
-			for opt, dest := range map[string]*uint64{
-				"cpu-period": r.CPU.Period,
-				"cpu-quota":  r.CPU.Quota,
-				"cpu-share":  r.CPU.Shares,
+			for _, pair := range []struct {
+				opt  string
+				dest *uint64
+			}{
+
+				{"cpu-period", r.CPU.Period},
+				{"cpu-quota", r.CPU.Quota},
+				{"cpu-share", r.CPU.Shares},
 			} {
-				if val := context.String(opt); val != "" {
+				if val := context.String(pair.opt); val != "" {
 					var err error
-					*dest, err = strconv.ParseUint(val, 10, 64)
+					*pair.dest, err = strconv.ParseUint(val, 10, 64)
 					if err != nil {
-						return fmt.Errorf("invalid value for %s: %s", opt, err)
+						return fmt.Errorf("invalid value for %s: %s", pair.opt, err)
 					}
 				}
 			}
-
-			for opt, dest := range map[string]*uint64{
-				"kernel-memory":      r.Memory.Kernel,
-				"kernel-memory-tcp":  r.Memory.KernelTCP,
-				"memory":             r.Memory.Limit,
-				"memory-reservation": r.Memory.Reservation,
-				"memory-swap":        r.Memory.Swap,
+			for _, pair := range []struct {
+				opt  string
+				dest *uint64
+			}{
+				{"kernel-memory", r.Memory.Kernel},
+				{"kernel-memory-tcp", r.Memory.KernelTCP},
+				{"memory", r.Memory.Limit},
+				{"memory-reservation", r.Memory.Reservation},
+				{"memory-swap", r.Memory.Swap},
 			} {
-				if val := context.String(opt); val != "" {
+				if val := context.String(pair.opt); val != "" {
 					v, err := units.RAMInBytes(val)
 					if err != nil {
-						return fmt.Errorf("invalid value for %s: %s", opt, err)
+						return fmt.Errorf("invalid value for %s: %s", pair.opt, err)
 					}
-					*dest = uint64(v)
+					*pair.dest = uint64(v)
 				}
 			}
 		}


### PR DESCRIPTION
grep -r "range map" shows 3 parts use map to
range enum types, use slice instead can get
better performance and less memory usage.

Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>