### PR TITLE
Remove check for binding to /

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -306,9 +306,6 @@ func getCgroupMounts(m *configs.Mount) ([]*configs.Mount, error) {
 // checkMountDestination checks to ensure that the mount destination is not over the top of /proc.
 // dest is required to be an abs path and have any symlinks resolved before calling this function.
 func checkMountDestination(rootfs, dest string) error {
-	if libcontainerUtils.CleanPath(rootfs) == libcontainerUtils.CleanPath(dest) {
-		return fmt.Errorf("mounting into / is prohibited")
-	}
 	invalidDestinations := []string{
 		"/proc",
 	}

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -32,14 +32,6 @@ func TestCheckMountDestFalsePositive(t *testing.T) {
 	}
 }
 
-func TestCheckMountRoot(t *testing.T) {
-	dest := "/rootfs"
-	err := checkMountDestination("/rootfs", dest)
-	if err == nil {
-		t.Fatal(err)
-	}
-}
-
 func TestNeedsSetupDev(t *testing.T) {
 	config := &configs.Config{
 		Mounts: []*configs.Mount{


### PR DESCRIPTION
In order to mount root filesystems inside the container's mount
namespace as part of the spec we need to have the ability to do a bind
mount to / as the destination.


I cannot remember why this is here specifically, I know the reasons for `/proc` and other paths and didn't know if we just added `/` just to be safe or if we had a specific reason. 


Signed-off-by: Michael Crosby <crosbymichael@gmail.com>