### PR TITLE
ps error logging improvement

### DIFF
--- a/ps.go
+++ b/ps.go
@@ -51,9 +51,10 @@ var psCommand = cli.Command{
 			psArgs = []string{"-ef"}
 		}
 
-		output, err := exec.Command("ps", psArgs...).Output()
+		cmd := exec.Command("ps", psArgs...)
+		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %s", err, output)
 		}
 
 		lines := strings.Split(string(output), "\n")


### PR DESCRIPTION
./runc ps ps -b
exit status 1
From end user, it is slightly not possible to understand what is the real error of the command.

With this PR, it will show detailed errors instead of exit status

For example:
./runc ps ps -z
exit status 1: error: unsupported SysV option

Usage:
 ps [options]

 Try 'ps --help <simple|list|output|threads|misc|all>'
  or 'ps --help <s|l|o|t|m|a>'
 for additional help text.

For more details see ps(1).
exit status 1


Signed-off-by: rajasec <rajasec79@gmail.com>