### PR TITLE
remove O_SYNC flag to improve logrus' efficiency

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 		if path := context.GlobalString("log"); path != "" {
-			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
* Why remove O_SYNC
as we know, OpenFile with O_SYNC flag, sync operation come with write every time, this can lead to low efficiency.

* Necessity of O_SYNC
O_SYNC make sure the data in buffer can be flushed to disk timely, and the log data will not lost。
but the data in buffer will not lost actually except kernel is panic, so O_SYNC is not necessary for logrus. On the other hand,as practice shows, O_SYNC is not necessary for log, and docker'log (json log driver) also have no use O_SYNC.

Signed-off-by: Shukui Yang <yangshukui@huawei.com>