### PR TITLE
Add num check for kill command

### DIFF
--- a/kill.go
+++ b/kill.go
@@ -77,7 +77,6 @@ signal to the init process of the "ubuntu01" container:
 		if err != nil {
 			return err
 		}
-
 		if err := container.Signal(signal); err != nil {
 			return err
 		}
@@ -88,7 +87,13 @@ signal to the init process of the "ubuntu01" container:
 func parseSignal(rawSignal string) (syscall.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
-		return syscall.Signal(s), nil
+		sig := syscall.Signal(s)
+		for _, msig := range signalMap {
+			if sig == msig {
+				return sig, nil
+			}
+		}
+		return -1, fmt.Errorf("unknown signal %q", rawSignal)
 	}
 	signal, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
 	if !ok {


### PR DESCRIPTION
Before this pr 
```
root@ubuntu:~/workspace/runc-test# ./runc kill test 35
container_linux.go:290: signaling init process caused "invalid argument"
```
After this pr 
```
root@ubuntu:~/workspace/runc-test# ./runc kill test 35
unknown signal "35"
```
Signed-off-by: Shukui Yang <yangshukui@huawei.com>