### PR TITLE
DupSecOpt needs to match InitLabels

### DIFF
--- a/libcontainer/label/label_selinux.go
+++ b/libcontainer/label/label_selinux.go
@@ -33,15 +33,19 @@ func InitLabels(options []string) (string, string, error) {
 		pcon := selinux.NewContext(processLabel)
 		mcon := selinux.NewContext(mountLabel)
 		for _, opt := range options {
-			if opt == "disable" {
+			val := strings.SplitN(opt, "=", 2)
+			if val[0] != "label" {
+				continue
+			}
+			if len(val) < 2 {
+				return "", "", fmt.Errorf("bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
+			}
+			if val[1] == "disable" {
 				return "", "", nil
 			}
-			if i := strings.Index(opt, ":"); i == -1 {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
-			}
-			con := strings.SplitN(opt, ":", 2)
-			if !validOptions[con[0]] {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type'", con[0])
+			con := strings.SplitN(val[1], ":", 2)
+			if len(con) < 2 || !validOptions[con[0]] {
+				return "", "", fmt.Errorf("bad label option %q, valid options 'disable, user, role, level, type'", con[0])
 
 			}
 			pcon[con[0]] = con[1]

--- a/libcontainer/label/label_selinux_test.go
+++ b/libcontainer/label/label_selinux_test.go
@@ -18,7 +18,7 @@ func TestInit(t *testing.T) {
 			t.Log("InitLabels Failed")
 			t.Fatal(err)
 		}
-		testDisabled := []string{"disable"}
+		testDisabled := []string{"label=disable"}
 		plabel, mlabel, err = InitLabels(testDisabled)
 		if err != nil {
 			t.Log("InitLabels Disabled Failed")
@@ -28,7 +28,7 @@ func TestInit(t *testing.T) {
 			t.Log("InitLabels Disabled Failed")
 			t.FailNow()
 		}
-		testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
+		testUser := []string{"label=user:user_u", "label=role:user_r", "label=type:user_t", "label=level:s0:c1,c15"}
 		plabel, mlabel, err = InitLabels(testUser)
 		if err != nil {
 			t.Log("InitLabels User Failed")
@@ -40,7 +40,7 @@ func TestInit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testBadData := []string{"user", "role:user_r", "type:user_t", "level:s0:c1,c15"}
+		testBadData := []string{"label=user", "label=role:user_r", "label=type:user_t", "label=level:s0:c1,c15"}
 		if _, _, err = InitLabels(testBadData); err == nil {
 			t.Log("InitLabels Bad Failed")
 			t.Fatal(err)
@@ -94,7 +94,7 @@ func TestRelabel(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(testdir)
-	label := "system_u:system_r:svirt_sandbox_file_t:s0:c1,c2"
+	label := "system_u:object_r:svirt_sandbox_file_t:s0:c1,c2"
 	if err := Relabel(testdir, "", true); err != nil {
 		t.Fatalf("Relabel with no label failed: %v", err)
 	}


### PR DESCRIPTION
At some point InitLabels was changed to look for SecuritOptions
separated by a ":" rather then an "=", but DupSecOpt was never
changed to match this default.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>