### PR TITLE
Add support for r/o mount labels

### DIFF
--- a/libcontainer/label/label.go
+++ b/libcontainer/label/label.go
@@ -9,6 +9,10 @@ func InitLabels(options []string) (string, string, error) {
 	return "", "", nil
 }
 
+func GetROMountLabel() string {
+	return ""
+}
+
 func GenLabels(options string) (string, string, error) {
 	return "", "", nil
 }

--- a/libcontainer/label/label_selinux.go
+++ b/libcontainer/label/label_selinux.go
@@ -59,6 +59,10 @@ func InitLabels(options []string) (string, string, error) {
 	return processLabel, mountLabel, nil
 }
 
+func GetROMountLabel() string {
+	return selinux.GetROFileLabel()
+}
+
 // DEPRECATED: The GenLabels function is only to be used during the transition to the official API.
 func GenLabels(options string) (string, string, error) {
 	return InitLabels(strings.Fields(options))

--- a/libcontainer/label/label_selinux_test.go
+++ b/libcontainer/label/label_selinux_test.go
@@ -19,6 +19,10 @@ func TestInit(t *testing.T) {
 			t.Fatal(err)
 		}
 		testDisabled := []string{"label=disable"}
+		roMountLabel := GetROMountLabel()
+		if roMountLabel == "" {
+			t.Errorf("GetROMountLabel Failed")
+		}
 		plabel, mlabel, err = InitLabels(testDisabled)
 		if err != nil {
 			t.Log("InitLabels Disabled Failed")

--- a/libcontainer/selinux/selinux.go
+++ b/libcontainer/selinux/selinux.go
@@ -355,6 +355,12 @@ func FreeLxcContexts(scon string) {
 	}
 }
 
+var roFileLabel string
+
+func GetROFileLabel() (fileLabel string) {
+	return roFileLabel
+}
+
 func GetLxcContexts() (processLabel string, fileLabel string) {
 	var (
 		val, key string
@@ -399,6 +405,9 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 			if key == "file" {
 				fileLabel = strings.Trim(val, "\"")
 			}
+			if key == "ro_file" {
+				roFileLabel = strings.Trim(val, "\"")
+			}
 		}
 	}
 
@@ -406,6 +415,9 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 		return "", ""
 	}
 
+	if roFileLabel == "" {
+		roFileLabel = fileLabel
+	}
 exit:
 	//	mcs := IntToMcs(os.Getpid(), 1024)
 	mcs := uniqMcs(1024)


### PR DESCRIPTION
We need support for read/only mounts in SELinux to allow a bunch of
containers to share the same read/only image.  In order to do this
we need a new label which allows container processes to read/execute
all files but not write them.

Existing mount label is either shared write or private write.  This
label is shared read/execute.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>