### PR TITLE
Add --no-subreaper flag for create command

### DIFF
--- a/create.go
+++ b/create.go
@@ -39,6 +39,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Usage: "specify the file to write the process id to",
 		},
 		cli.BoolFlag{
+			Name:  "no-subreaper",
+			Usage: "disable the use of the subreaper used to reap reparented processes",
+		},
+		cli.BoolFlag{
 			Name:  "no-pivot",
 			Usage: "do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk",
 		},

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -295,7 +295,6 @@ func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, e
 	if err != nil {
 		return -1, err
 	}
-	detach := context.Bool("detach")
 	// Support on-demand socket activation by passing file descriptors into the container init process.
 	listenFDs := []*os.File{}
 	if os.Getenv("LISTEN_FDS") != "" {
@@ -307,7 +306,7 @@ func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, e
 		container:       container,
 		listenFDs:       listenFDs,
 		console:         context.String("console"),
-		detach:          detach,
+		detach:          context.Bool("detach"),
 		pidFile:         context.String("pid-file"),
 		create:          create,
 	}


### PR DESCRIPTION
`create` command should own a `--no-subreaper` flag for consistency with
`run` command.

Also remove one unnecessary temporary variable.