### PR TITLE
Valide platform on loading config.json

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -240,6 +240,9 @@ func loadSpec(cPath string) (spec *specs.Spec, err error) {
 	if err = json.NewDecoder(cf).Decode(&spec); err != nil {
 		return nil, err
 	}
+	if err = validatePlatform(&spec.Platform); err != nil {
+		return nil, err
+	}
 	return spec, validateProcessSpec(&spec.Process)
 }
 
@@ -253,4 +256,14 @@ func createLibContainerRlimit(rlimit specs.Rlimit) (configs.Rlimit, error) {
 		Hard: uint64(rlimit.Hard),
 		Soft: uint64(rlimit.Soft),
 	}, nil
+}
+
+func validatePlatform(platform *specs.Platform) error {
+	if platform.OS != runtime.GOOS {
+		return fmt.Errorf("target os %s mismatch with current os %s", platform.OS, runtime.GOOS)
+	}
+	if platform.Arch != runtime.GOARCH {
+		return fmt.Errorf("target arch %s mismatch with current arch %s", platform.Arch, runtime.GOARCH)
+	}
+	return nil
 }


### PR DESCRIPTION
run an arm64 image on an amd64 platform, it will failed with
````
panic: standard_init_linux.go:175: exec user process caused "exec format error" [recovered]
        panic: standard_init_linux.go:175: exec user process caused "exec format error"

goroutine 1 [running, locked to thread]:
panic(0x7e7e40, 0xc820124380)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/urfave/cli.HandleAction.func1(0xc8200c52f8)
        /home/lei/opencontainers/runc/Godeps/_workspace/src/github.com/urfave/cli/app.go:478 +0x38e
panic(0x7e7e40, 0xc820124380)
        /usr/local/go/src/runtime/panic.go:443 +0x4e9
github.com/opencontainers/runc/libcontainer.(*LinuxFactory).StartInitialization.func1(0xc8200c4c08, 0xc8200220a0, 0xc8200c4d18)
        /home/lei/opencontainers/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/factory_linux.go:259 +0x136
github.com/opencontainers/runc/libcontainer.(*LinuxFactory).StartInitialization(0xc82006c780, 0x7fb9124733f8, 0xc820124380)
        /home/lei/opencontainers/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/factory_linux.go:277 +0x5b1
main.glob.func8(0xc820090780, 0x0, 0x0)
        /home/lei/opencontainers/runc/main_unix.go:26 +0x68
reflect.Value.call(0x74ca00, 0x8fda40, 0x13, 0x844470, 0x4, 0xc8200c5278, 0x1, 0x1, 0x0, 0x0, ...)
        /usr/local/go/src/reflect/value.go:435 +0x120d
reflect.Value.Call(0x74ca00, 0x8fda40, 0x13, 0xc8200c5278, 0x1, 0x1, 0x0, 0x0, 0x0)
        /usr/local/go/src/reflect/value.go:303 +0xb1
github.com/urfave/cli.HandleAction(0x74ca00, 0x8fda40, 0xc820090780, 0x0, 0x0)
        /home/lei/opencontainers/runc/Godeps/_workspace/src/github.com/urfave/cli/app.go:487 +0x2ee
github.com/urfave/cli.Command.Run(0x847330, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8dcec0, 0x51, 0x0, ...)
        /home/lei/opencontainers/runc/Godeps/_workspace/src/github.com/urfave/cli/command.go:191 +0xfec
github.com/urfave/cli.(*App).Run(0xc820001980, 0xc82000a100, 0x2, 0x2, 0x0, 0x0)
        /home/lei/opencontainers/runc/Godeps/_workspace/src/github.com/urfave/cli/app.go:240 +0xaa4
main.main()
        /home/lei/opencontainers/runc/main.go:137 +0xe24

````
instead of throwing panic on execing the container process, we should
throw the platform mismatch error at the very beginning, it's much more
clear and can tell user what's wrong.

Signed-off-by: Lei Jitang <leijitang@huawei.com>