### PR TITLE
Fixing runc panic for missing file mode

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -537,6 +537,8 @@ func createDevices(spec *specs.Spec, config *configs.Config) error {
 	// merge in additional devices from the spec
 	for _, d := range spec.Linux.Devices {
 		var uid, gid uint32
+		var filemode os.FileMode = 0666
+
 		if d.UID != nil {
 			uid = *d.UID
 		}
@@ -547,12 +549,15 @@ func createDevices(spec *specs.Spec, config *configs.Config) error {
 		if err != nil {
 			return err
 		}
+		if d.FileMode != nil {
+			filemode = *d.FileMode
+		}
 		device := &configs.Device{
 			Type:     dt,
 			Path:     d.Path,
 			Major:    d.Major,
 			Minor:    d.Minor,
-			FileMode: *d.FileMode,
+			FileMode: filemode,
 			Uid:      uid,
 			Gid:      gid,
 		}


### PR DESCRIPTION
If the file mode is missing in devices configuration ( config.json), runc panics.

goroutine 1 [running]:
panic(0x7ca4e0, 0xc8200100d0)
        /home/raj/go/src/runtime/panic.go:481 +0x3e6
github.com/urfave/cli.HandleAction.func1(0xc8200bf2f8)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/urfave/cli/app.go:478 +0x38e
panic(0x7ca4e0, 0xc8200100d0)
        /home/raj/go/src/runtime/panic.go:443 +0x4e9
github.com/opencontainers/runc/libcontainer/specconv.createDevices(0xc820112000, 0xc82010c200, 0x0, 0x0)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go:552 +0x59b
github.com/opencontainers/runc/libcontainer/specconv.CreateLibcontainerConfig(0xc8200beb88, 0x855bc0, 0x0, 0x0)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/Godeps/_workspace/src/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go:202 +0xfcd
main.createContainer(0xc8200d43c0, 0x7ffd99456557, 0x3, 0xc820112000, 0x0, 0x0, 0x0, 0x0)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/utils_linux.go:177 +0x144
main.startContainer(0xc8200d43c0, 0xc820112000, 0x0, 0x0, 0x0, 0x0)
        /home/raj/go/pkg/src/github.com/opencontainers/runc/utils_linux.go:294 +0x189
main.glob.func13(0xc8200d43c0, 0x0, 0x0)


Signed-off-by: rajasec <rajasec79@gmail.com>