### PR TITLE
Remove panic from init

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -256,11 +256,13 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		if _, ok := i.(*linuxStandardInit); ok {
 			//  Synchronisation only necessary for standard init.
 			if werr := utils.WriteJSON(pipe, syncT{procError}); werr != nil {
-				panic(err)
+				fmt.Fprintln(os.Stderr, err)
+				return
 			}
 		}
 		if werr := utils.WriteJSON(pipe, newSystemError(err)); werr != nil {
-			panic(err)
+			fmt.Fprintln(os.Stderr, err)
+			return
 		}
 		// ensure that this pipe is always closed
 		pipe.Close()


### PR DESCRIPTION
Print the error message to stderr if we are unable to return it back via
the pipe to the parent process.  Also, don't panic here as it is most
likely a system or user error and not a programmer error.

Fixes #1103

Signed-off-by: Michael Crosby crosbymichael@gmail.com
