### PR TITLE
update the man for runc delete command

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -27,8 +27,8 @@ func killContainer(container libcontainer.Container) error {
 
 var deleteCommand = cli.Command{
 	Name:  "delete",
-	Usage: "delete any resources held by one container or more containers often used with detached containers",
-	ArgsUsage: `container-id [container-id...]
+	Usage: "delete any resources held by one or more containers often used with detached containers",
+	ArgsUsage: `<container-id> [container-id...]
 
 Where "<container-id>" is the name for the instance of the container.
 
@@ -41,7 +41,7 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "force, f",
-			Usage: "Forcibly kills the container if it is still running",
+			Usage: "Forcibly deletes the container if it is still running (uses SIGKILL)",
 		},
 	},
 	Action: func(context *cli.Context) error {

--- a/man/runc-delete.8.md
+++ b/man/runc-delete.8.md
@@ -1,10 +1,13 @@
 # NAME
-   runc delete - delete any resources held by the container often used with detached containers
+   runc delete - delete any resources held by one or more containers often used with detached containers
 
 # SYNOPSIS
-   runc delete <container-id>
+   runc delete [command options] <container-id> [container-id...]
 
 Where "<container-id>" is the name for the instance of the container.
+
+# OPTIONS
+   --force, -f		Forcibly deletes the container if it is still running (uses SIGKILL)
 
 # EXAMPLE
 For example, if the container id is "ubuntu01" and runc list currently shows the


### PR DESCRIPTION
This patch also update the description in `delete.go` in order to
keep consistent with the manual.


Signed-off-by: Wang Long <long.wanglong@huawei.com>