### PR TITLE
fix the pid-file option for runc exec/run/create command

### DIFF
--- a/create.go
+++ b/create.go
@@ -54,6 +54,9 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			cli.ShowCommandHelp(context, "create")
 			return fmt.Errorf("runc: \"create\" requires exactly one argument")
 		}
+		if err := revisePidFile(context); err != nil {
+			return err
+		}
 		spec, err := setupSpec(context)
 		if err != nil {
 			return err

--- a/exec.go
+++ b/exec.go
@@ -89,6 +89,9 @@ following will output a list of processes running in the container:
 		if os.Geteuid() != 0 {
 			return fmt.Errorf("runc should be run as root")
 		}
+		if err := revisePidFile(context); err != nil {
+			return err
+		}
 		status, err := execProcess(context)
 		if err == nil {
 			os.Exit(status)

--- a/run.go
+++ b/run.go
@@ -59,6 +59,9 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := revisePidFile(context); err != nil {
+			return err
+		}
 		spec, err := setupSpec(context)
 		if err != nil {
 			return err

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -59,3 +59,29 @@ function teardown() {
 
   testcontainer test_busybox running
 }
+
+@test "runc create --pid-file with new CWD" {
+  # create pid_file directory as the CWD
+  run mkdir pid_file
+  [ "$status" -eq 0 ]
+  run cd pid_file
+  [ "$status" -eq 0 ]
+
+  runc create --pid-file pid.txt -b $BUSYBOX_BUNDLE --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  testcontainer test_busybox created
+
+  # check pid.txt was generated
+  [ -e pid.txt ]
+
+  run cat pid.txt
+  [ "$status" -eq 0 ]
+  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+
+  # start the command
+  runc start test_busybox
+  [ "$status" -eq 0 ]
+
+  testcontainer test_busybox running
+}

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -55,3 +55,27 @@ function teardown() {
   [ "$status" -eq 0 ]
   [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
 }
+
+@test "runc run detached --pid-file with new CWD" {
+  # create pid_file directory as the CWD
+  run mkdir pid_file
+  [ "$status" -eq 0 ]
+  run cd pid_file
+  [ "$status" -eq 0 ]
+
+  # run busybox detached
+  runc run --pid-file pid.txt -d  -b $BUSYBOX_BUNDLE --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  # check state
+  wait_for_container 15 1 test_busybox
+
+  testcontainer test_busybox running
+
+  # check pid.txt was generated
+  [ -e pid.txt ]
+
+  run cat pid.txt
+  [ "$status" -eq 0 ]
+  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+}

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -38,4 +39,23 @@ func setupSpec(context *cli.Context) (*specs.Spec, error) {
 		return nil, fmt.Errorf("runc should be run as root")
 	}
 	return spec, nil
+}
+
+func revisePidFile(context *cli.Context) error {
+	pidFile := context.String("pid-file")
+	if pidFile == "" {
+		return nil
+	}
+
+	// convert pid-file to an absolute path so we can write to the right
+	// file after chdir to bundle
+	pidFile, err := filepath.Abs(pidFile)
+	if err != nil {
+		return err
+	}
+	err = context.Set("pid-file", pidFile)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
When we use `--pid-file` option of the `runc exec`  command with an relative path. it will generate file in the bundle's directory.

This patch fix that. `runc exec --pid-file pid.txt` will generate file relative to the directory which we type the `runc exec` command.

Signed-off-by: Wang Long long.wanglong@huawei.com
