### PR TITLE
check the arguments for `runc create`

### DIFF
--- a/create.go
+++ b/create.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
@@ -48,6 +49,11 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if context.NArg() != 1 {
+			fmt.Printf("Incorrect Usage.\n\n")
+			cli.ShowCommandHelp(context, "create")
+			return fmt.Errorf("runc: \"create\" requires exactly one argument")
+		}
 		spec, err := setupSpec(context)
 		if err != nil {
 			return err


### PR DESCRIPTION
This patch checks the arguments for command  `runc create`.
the `create` command requires exactly one argument

eg:
```
root@ubuntu:~# runc create -b /mycontainer/ a
root@ubuntu:~# runc list
ID          PID         STATUS      BUNDLE         CREATED
a           61637       created     /mycontainer   2016-10-20T08:21:20.169810942Z
root@ubuntu:~# runc create -b /mycontainer/ a b
runc: "create" requires exactly one argument
root@ubuntu:~# runc create -b /mycontainer/
runc: "create" requires exactly one argument
```
Signed-off-by: Wang Long <long.wanglong@huawei.com>