### PR TITLE
add test cases for create command

### DIFF
--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -39,3 +39,23 @@ function teardown() {
 
   testcontainer test_busybox running
 }
+
+@test "runc create --pid-file" {
+  runc create --pid-file pid.txt --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  testcontainer test_busybox created
+
+  # check pid.txt was generated
+  [ -e pid.txt ]
+
+  run cat pid.txt
+  [ "$status" -eq 0 ]
+  [[ ${lines[0]} =~ [0-9]+ ]]
+
+  # start the command
+  runc start test_busybox
+  [ "$status" -eq 0 ]
+
+  testcontainer test_busybox running
+}


### PR DESCRIPTION
This patch add test `--pid-file` option for create command.

Signed-off-by: Wang Long <long.wanglong@huawei.com>