### PR TITLE
docker/docker#27484-check if sysctls are used in host network mode.

### DIFF
--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -201,3 +201,38 @@ func TestValidateSysctl(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSysctlWithSameNs(t *testing.T) {
+	config := &configs.Config{
+		Rootfs: "/var",
+		Sysctl: map[string]string{"net.ctl": "ctl"},
+		Namespaces: configs.Namespaces(
+			[]configs.Namespace{
+				{
+					Type: configs.NEWNET,
+					Path: "/proc/self/ns/net",
+				},
+			},
+		),
+	}
+
+	validator := validate.New()
+	err := validator.Validate(config)
+	if err == nil {
+		t.Error("Expected error to occur but it was nil")
+	}
+}
+
+func TestValidateSysctlWithoutNETNamespace(t *testing.T) {
+	config := &configs.Config{
+		Rootfs:     "/var",
+		Sysctl:     map[string]string{"net.ctl": "ctl"},
+		Namespaces: []configs.Namespace{},
+	}
+
+	validator := validate.New()
+	err := validator.Validate(config)
+	if err == nil {
+		t.Error("Expected error to occur but it was nil")
+	}
+}


### PR DESCRIPTION
ref docker/docker#27484

> There are two checks we can make for seeing if the user specified the host namespace.
>
> 1. The Namespaces list does not have the NEWNET struct added to it
> 2. If it does have a NEWNET struct added and the path is not an empty string then we need to
>   1. Do a readlink on the current processes network namespace os.Readlink("/proc/self/ns/net") 
>   2. Do a readlink on the Path provided in the struct and compare the current processes network namespace with the one provided in the Path. If they match then it should be considered as the host namespace.

Signed-off-by: Ce Gao <ce.gao@outlook.com>