### PR TITLE
Restoring container not in created state

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -144,7 +144,9 @@ func restoreContainer(context *cli.Context, spec *specs.Spec, config *configs.Co
 	if status == libcontainer.Running {
 		fatalf("Container with id %s already running", id)
 	}
-
+	if status == libcontainer.Created {
+		fatalf("Container cannot be restored from created state")
+	}
 	setManageCgroupsMode(context, options)
 
 	if err := setEmptyNsMask(context, options); err != nil {


### PR DESCRIPTION
Two use cases where the container is destroyed upon restore.

1) I have created the container using runc create.
post that when I tried to call runc restore, since the container was not in checkpoint
it failed and destroyed the created container.
Not an valid use case though :) 

Ideally created container should not get destroyed (  unless asked by delete  command or through proper container life cycle operations)

2) runc create test
   runc exec -p ~/process.json test 
 I  logged to terminal and application was running
 runc restore test

Since the restore failed, it went and deleted the container.

For both the scenarios, container was in created state.

Added the condition to prevent restore when the container in created state.

Signed-off-by: rajasec rajasec79@gmail.com
