### PR TITLE
add output option for runc state command

### DIFF
--- a/man/runc-state.8.md
+++ b/man/runc-state.8.md
@@ -9,3 +9,6 @@ Where "<container-id>" is your name for the instance of the container.
 # DESCRIPTION
    The state command outputs current state information for the
 instance of a container.
+
+OPTIONS:
+   --output value, -o value  select one of: ociVersion, pid, status, bundle, rootfs, created

--- a/state.go
+++ b/state.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/opencontainers/runc/libcontainer"
@@ -19,6 +20,13 @@ var stateCommand = cli.Command{
 Where "<container-id>" is your name for the instance of the container.`,
 	Description: `The state command outputs current state information for the
 instance of a container.`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "select one of: ociVersion, pid, status, bundle, rootfs, created",
+			Value: "",
+		},
+	},
 	Action: func(context *cli.Context) error {
 		container, err := getContainer(context)
 		if err != nil {
@@ -47,11 +55,29 @@ instance of a container.`,
 			Created:        state.BaseState.Created,
 			Annotations:    annotations,
 		}
-		data, err := json.MarshalIndent(cs, "", "  ")
-		if err != nil {
-			return err
+
+		switch context.String("output") {
+		case "":
+			data, err := json.MarshalIndent(cs, "", "  ")
+			if err != nil {
+				return err
+			}
+			os.Stdout.Write(data)
+		case "ociVersion":
+			fmt.Println(cs.Version)
+		case "pid":
+			fmt.Println(cs.InitProcessPid)
+		case "status":
+			fmt.Println(cs.Status)
+		case "bundle":
+			fmt.Println(cs.Bundle)
+		case "rootfs":
+			fmt.Println(cs.Rootfs)
+		case "created":
+			fmt.Println(cs.Created)
+		default:
+			return fmt.Errorf("invalid output option")
 		}
-		os.Stdout.Write(data)
 		return nil
 	},
 }

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -48,3 +48,52 @@ function teardown() {
   runc state test_busybox
   [ "$status" -ne 0 ]
 }
+
+@test "state with different option" {
+  runc state test_busybox
+  [ "$status" -ne 0 ]
+
+  # run busybox detached
+  runc run -d --console /dev/pts/ptmx test_busybox
+  [ "$status" -eq 0 ]
+
+  # check state
+  wait_for_container 15 1 test_busybox
+
+  testcontainer test_busybox running
+
+  runc state --output ociVersion test_busybox
+  [ "$status" -eq 0 ]
+  [[ ${output} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]
+
+  runc state --output pid test_busybox
+  [ "$status" -eq 0 ]
+  [[ ${output} =~ [0-9]+  ]]
+
+  runc state --output bundle test_busybox
+  [ "$status" -eq 0 ]
+
+  runc state --output rootfs test_busybox
+  [ "$status" -eq 0 ]
+
+  runc state --output status test_busybox
+  [ "$status" -eq 0 ]
+  [[ $(echo "${output}" | tr -d '\r') == "running" ]]
+
+  runc state --output created test_busybox
+  [ "$status" -eq 0 ]
+  [[ ${output} =~ [0-9]+  ]]
+
+  runc state --output other test_busybox
+  [ "$status" -ne 0 ]
+
+  runc kill test_busybox KILL
+  # wait for busybox to be in the destroyed state
+  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+
+  # delete test_busybox
+  runc delete test_busybox
+
+  runc state test_busybox
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
```
root@localhost:~# runc list
ID          PID         STATUS      BUNDLE         CREATED
test        114145      created     /mycontainer   2016-10-21T07:29:38.372060948Z
root@localhost:~# runc state test
{
  "ociVersion": "1.0.0-rc2-dev",
  "id": "test",
  "pid": 114145,
  "status": "created",
  "bundle": "/mycontainer",
  "rootfs": "/mycontainer/rootfs",
  "created": "2016-10-21T07:29:38.372060948Z"
}root@localhost:~# runc state -o ociVersion test
1.0.0-rc2-dev
root@localhost:~# runc state -o pid test
114145
root@localhost:~# runc state -o status test
created
root@localhost:~# runc state -o bundle  test
/mycontainer
root@localhost:~# runc state -o rootfs  test
/mycontainer/rootfs
root@localhost:~# runc state -o created   test
2016-10-21 07:29:38.372060948 +0000 UTC
root@localhost:~# runc state -o other  test
invalid output option
```

Signed-off-by: Wang Long <long.wanglong@huawei.com>