### PR TITLE
Check pid file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     gawk \
     iptables \
+    jq \
     pkg-config \
     libaio-dev \
     libcap-dev \

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -51,7 +51,7 @@ function teardown() {
 
   run cat pid.txt
   [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ [0-9]+ ]]
+  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
 
   # start the command
   runc start test_busybox

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -42,6 +42,7 @@ function teardown() {
   run cat pid.txt
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ [0-9]+ ]]
+  [[ ${lines[0]} != $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec ls -la" {

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -53,5 +53,5 @@ function teardown() {
 
   run cat pid.txt
   [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ [0-9]+ ]]
+  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
 }


### PR DESCRIPTION
At https://github.com/opencontainers/runc/pull/1132#pullrequestreview-5017081, It is necessary to make sure that pid-file contains the right information.

This patch employ `jq` and `runc state` command to achieve it.

Signed-off-by: Wang Long long.wanglong@huawei.com