### PR TITLE
validator: unbreak sysctl net.* validation

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -125,13 +125,15 @@ func (v *ConfigValidator) sysctl(config *configs.Config) error {
 			}
 		}
 		if strings.HasPrefix(s, "net.") {
-			if !config.Namespaces.Contains(configs.NEWNET) {
-				return fmt.Errorf("sysctl %q is not allowed in the hosts network namespace", s)
-			}
-			if path := config.Namespaces.PathOf(configs.NEWNET); path != "" {
-				if err := checkHostNs(s, path); err != nil {
-					return err
+			if config.Namespaces.Contains(configs.NEWNET) {
+				if path := config.Namespaces.PathOf(configs.NEWNET); path != "" {
+					if err := checkHostNs(s, path); err != nil {
+						return err
+					}
 				}
+				continue
+			} else {
+				return fmt.Errorf("sysctl %q is not allowed in the hosts network namespace", s)
 			}
 		}
 		return fmt.Errorf("sysctl %q is not in a separate kernel namespace", s)

--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -202,6 +202,35 @@ func TestValidateSysctl(t *testing.T) {
 	}
 }
 
+func TestValidateValidSysctl(t *testing.T) {
+	sysctl := map[string]string{
+		"fs.mqueue.ctl": "ctl",
+		"net.ctl":       "ctl",
+		"kernel.msgmax": "ctl",
+	}
+
+	for k, v := range sysctl {
+		config := &configs.Config{
+			Rootfs: "/var",
+			Sysctl: map[string]string{k: v},
+			Namespaces: []configs.Namespace{
+				{
+					Type: configs.NEWNET,
+				},
+				{
+					Type: configs.NEWIPC,
+				},
+			},
+		}
+
+		validator := validate.New()
+		err := validator.Validate(config)
+		if err != nil {
+			t.Errorf("Expected error to not occur with {%s=%s} but got: %q", k, v, err)
+		}
+	}
+}
+
 func TestValidateSysctlWithSameNs(t *testing.T) {
 	config := &configs.Config{
 		Rootfs: "/var",


### PR DESCRIPTION
When changing this validation, the code actually allowing the validation
to pass was removed. This meant that any net.* sysctl would always fail
to validate.

Fixes: bc84f83344fd ("fix docker/docker#27484")
Reported-by: Justin Cormack <justin.cormack@docker.com>
Signed-off-by: Aleksa Sarai <asarai@suse.de>

Fixes #1138

/cc @justincormack Does this fix the issue you mentioned?