### PR TITLE
Detect and forbid duplicated namespace in spec

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -187,6 +187,9 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		if !exists {
 			return nil, fmt.Errorf("namespace %q does not exist", ns)
 		}
+		if config.Namespaces.Contains(t) {
+			return nil, fmt.Errorf("malformed spec file: duplicated ns %q", ns)
+		}
 		config.Namespaces.Add(t, ns.Path)
 	}
 	if config.Namespaces.Contains(configs.NEWNET) {

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -38,3 +38,27 @@ func TestLinuxCgroupsPathNotSpecified(t *testing.T) {
 		t.Errorf("Wrong cgroupsPath, expected it to be empty string, got '%s'", cgroup.Path)
 	}
 }
+
+func TestDupNamespaces(t *testing.T) {
+	spec := &specs.Spec{
+		Linux: &specs.Linux{
+			Namespaces: []specs.Namespace{
+				{
+					Type: "pid",
+				},
+				{
+					Type: "pid",
+					Path: "/proc/1/ns/pid",
+				},
+			},
+		},
+	}
+
+	_, err := CreateLibcontainerConfig(&CreateOpts{
+		Spec: spec,
+	})
+
+	if err == nil {
+		t.Errorf("Duplicated namespaces should be forbidden")
+	}
+}


### PR DESCRIPTION
When spec file contains duplicated namespaces, e.g.
```
specs: specs.Spec{
        Linux: &specs.Linux{
            Namespaces: []specs.Namespace{
                {
                    Type: "pid",
                },
                {
                    Type: "pid",
                    Path: "/proc/1/ns/pid",
                },
            },
        },
    }
```
runc should report malformed spec instead of using latest one by
default, because this spec could be quite confusing.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>