### PR TITLE
integration: Make sure pivot_root() works even if parent mount is shared

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ integration: runcimage
 	docker run -e TESTFLAGS -t --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) make localintegration
 
 localintegration: all
-	bats -t tests/integration${TESTFLAGS}
+	unshare -m bats -t tests/integration${TESTFLAGS}
 
 install:
 	install -D -m0755 runc $(BINDIR)/runc

--- a/tests/integration/mount_propagation.bats
+++ b/tests/integration/mount_propagation.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+  teardown_busybox
+  setup_busybox
+
+  # Create a "shared" parent mount point for container
+  # rootfs and make sure pivot_root() still works. This
+  cd ${BUSYBOX_BUNDLE}
+  mount --bind . .
+  mount --make-private .
+  mount --make-shared .
+
+  # Also use rootPropagation=private (and not rprivate) so that shared volumes
+  # can possibly work.
+  sed -i '/"linux": {/ a "rootfsPropagation":"private"', config.json
+}
+
+function teardown() {
+  cd ${BUSYBOX_BUNDLE}/../
+  umount -R ${BUSYBOX_BUNDLE}
+  teardown_busybox
+}
+
+@test "mount propagation parent mount shared" {
+  runc create --console /dev/pts/ptmx test_busybox1
+  [ "$status" -eq 0 ]
+
+  testcontainer test_busybox1 created
+
+  # start conatiner test_busybox1
+  runc start test_busybox1
+  [ "$status" -eq 0 ]
+
+  testcontainer test_busybox1 running
+
+  # delete test_busybox1
+  runc delete --force test_busybox1
+
+  runc state test_busybox1
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
We recently had regression where parent mount of rootfs is "shared" and
rootfsPropataion=private. Write an integration test to test this
configuration, to make avoid future regressions.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
