### PR TITLE
Remove unnecessary cloneflag validation

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -438,10 +438,6 @@ void nsexec(void)
 	/* Parse all of the netlink configuration. */
 	nl_parse(pipenum, &config);
 
-	/* clone(2) flags are mandatory. */
-	if (config.cloneflags == -1)
-		bail("missing cloneflags");
-
 	/* Pipe so we can tell the child when we've finished setting up. */
 	if (socketpair(AF_LOCAL, SOCK_STREAM, 0, syncpipe) < 0)
 		bail("failed to setup sync pipe between parent and child");


### PR DESCRIPTION
config.cloneflag is not mandatory, when using `runc exec`,
config.cloneflag can be empty, and even then it won't be
`-1` but `0`.

So this validation is totally wrong and unneeded.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>