### PR TITLE
Remove add command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,3 @@ RUN mkdir -p ${ROOTFS} \
 COPY script/tmpmount /
 WORKDIR /go/src/github.com/opencontainers/runc
 ENTRYPOINT ["/tmpmount"]
-
-ADD . /go/src/github.com/opencontainers/runc


### PR DESCRIPTION
Now, all the `docker run` command in Makefile use `-v $(CURDIR):/go/src/github.com/
opencontainers/runc`. So we do not need to add the repo in RUNC_IMAGE.

Signed-off-by: Wang Long long.wanglong@huawei.com
