### PR TITLE
Give summary when client operation to containers failed

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -300,7 +300,7 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 	if r == nil {
 		return c, nil
 	}
-	for i, d := range spec.Linux.Resources.Devices {
+	for i, d := range r.Devices {
 		var (
 			t     = "a"
 			major = int64(-1)

--- a/pause.go
+++ b/pause.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli"
 )
@@ -20,7 +21,7 @@ paused. `,
 
 Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
-		hasError := false
+		var failedOnes []string
 		if !context.Args().Present() {
 			return fmt.Errorf("runc: \"pause\" requires a minimum of 1 argument")
 		}
@@ -34,17 +35,17 @@ Use runc list to identiy instances of containers and their current status.`,
 			container, err := factory.Load(id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "container %s does not exist\n", id)
-				hasError = true
+				failedOnes = append(failedOnes, id)
 				continue
 			}
 			if err := container.Pause(); err != nil {
 				fmt.Fprintf(os.Stderr, "pause container %s : %s\n", id, err)
-				hasError = true
+				failedOnes = append(failedOnes, id)
 			}
 		}
 
-		if hasError {
-			return fmt.Errorf("one or more of container pause failed")
+		if len(failedOnes) > 0 {
+			return fmt.Errorf("failed to pause containers: %s", strings.Join(failedOnes, ","))
 		}
 		return nil
 	},
@@ -61,7 +62,7 @@ resumed.`,
 
 Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
-		hasError := false
+		var failedOnes []string
 		if !context.Args().Present() {
 			return fmt.Errorf("runc: \"resume\" requires a minimum of 1 argument")
 		}
@@ -75,17 +76,17 @@ Use runc list to identiy instances of containers and their current status.`,
 			container, err := factory.Load(id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "container %s does not exist\n", id)
-				hasError = true
+				failedOnes = append(failedOnes, id)
 				continue
 			}
 			if err := container.Resume(); err != nil {
 				fmt.Fprintf(os.Stderr, "resume container %s : %s\n", id, err)
-				hasError = true
+				failedOnes = append(failedOnes, id)
 			}
 		}
 
-		if hasError {
-			return fmt.Errorf("one or more of container resume failed")
+		if len(failedOnes) > 0 {
+			return fmt.Errorf("failed to resume containers: %s", strings.Join(failedOnes, ","))
 		}
 		return nil
 	},

--- a/start.go
+++ b/start.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/urfave/cli"
@@ -18,7 +19,7 @@ are starting. The name you provide for the container instance must be unique on
 your host.`,
 	Description: `The start command executes the user defined process in a created container .`,
 	Action: func(context *cli.Context) error {
-		hasError := false
+		var failedOnes []string
 		if !context.Args().Present() {
 			return fmt.Errorf("runc: \"start\" requires a minimum of 1 argument")
 		}
@@ -32,35 +33,35 @@ your host.`,
 			container, err := factory.Load(id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "container %s does not exist\n", id)
-				hasError = true
+				failedOnes = append(failedOnes, id)
 				continue
 			}
 			status, err := container.Status()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "status for %s: %v\n", id, err)
-				hasError = true
+				failedOnes = append(failedOnes, id)
 				continue
 			}
 			switch status {
 			case libcontainer.Created:
 				if err := container.Exec(); err != nil {
 					fmt.Fprintf(os.Stderr, "start for %s failed: %v\n", id, err)
-					hasError = true
+					failedOnes = append(failedOnes, id)
 				}
 			case libcontainer.Stopped:
 				fmt.Fprintln(os.Stderr, "cannot start a container that has run and stopped")
-				hasError = true
+				failedOnes = append(failedOnes, id)
 			case libcontainer.Running:
 				fmt.Fprintln(os.Stderr, "cannot start an already running container")
-				hasError = true
+				failedOnes = append(failedOnes, id)
 			default:
 				fmt.Fprintf(os.Stderr, "cannot start a container in the %s state\n", status)
-				hasError = true
+				failedOnes = append(failedOnes, id)
 			}
 		}
 
-		if hasError {
-			return fmt.Errorf("one or more of container start failed")
+		if len(failedOnes) > 0 {
+			return fmt.Errorf("failed to start containers: %s", strings.Join(failedOnes, ","))
 		}
 		return nil
 	},

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -81,6 +81,11 @@ function teardown() {
 
   runc state test_busybox2
   [ "$status" -ne 0 ]
+
+  # delete nonexisting containers will report error
+  runc delete non_exists1 non_exists2
+  [ "$status" -ne 0 ]
+  [[ ${lines[-1]} == "failed to delete containers: non_exists1,non_exists2" ]]
 }
 
 

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -85,17 +85,19 @@ function teardown() {
 
   wait_for_container 15 1 test_busybox2
 
-  # pause test_busybox1, test_busybox2 and nonexistant container
-  runc pause test_busybox1 test_busybox2 nonexistant
+  # pause test_busybox1, test_busybox2 and nonexistent container
+  runc pause test_busybox1 test_busybox2 nonexistent
   [ "$status" -ne 0 ]
+  [[ ${lines[-1]} =~ "failed to pause containers: nonexistent" ]] 
 
   # test state of test_busybox1 and test_busybox2 is paused
   testcontainer test_busybox1 paused
   testcontainer test_busybox2 paused
 
-  # resume test_busybox1, test_busybox2 and nonexistant container
-  runc resume test_busybox1 test_busybox2 nonexistant
+  # resume test_busybox1, test_busybox2 and nonexistent container
+  runc resume test_busybox1 test_busybox2 nonexistent
   [ "$status" -ne 0 ]
+  [[ ${lines[-1]} == "failed to resume containers: nonexistent" ]]
 
   # test state of two containers is back to running
   testcontainer test_busybox1 running

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -38,4 +38,8 @@ function teardown() {
 
   runc state test_busybox2
   [ "$status" -ne 0 ]
+
+  runc start non_exists1 non_exists2
+  [ "$status" -ne 0 ]
+  [[ ${lines[-1]} == "failed to start containers: non_exists1,non_exists2" ]]
 }


### PR DESCRIPTION
When we failed to delete one or more containers, besides the error
message for each container, we should give a more useful summary
information e.g. "failed to delete containers: ctrA,ctrB", instead of
"one or more of the container deletions failed", the old summary info is
totally useless.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

Update: this can also apply to other commands including `start/pause/resume`
