### PR TITLE
Check args numbers before application start

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -34,6 +34,9 @@ checkpointed.`,
 		cli.StringSliceFlag{Name: "empty-ns", Usage: "create a namespace, but don't restore its properies"},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 1, exactArgs); err != nil {
+			return err
+		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/create.go
+++ b/create.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
@@ -49,10 +48,8 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 		},
 	},
 	Action: func(context *cli.Context) error {
-		if context.NArg() != 1 {
-			fmt.Printf("Incorrect Usage.\n\n")
-			cli.ShowCommandHelp(context, "create")
-			return fmt.Errorf("runc: \"create\" requires exactly one argument")
+		if err := checkArgs(context, 1, exactArgs); err != nil {
+			return err
 		}
 		if err := revisePidFile(context); err != nil {
 			return err

--- a/delete.go
+++ b/delete.go
@@ -45,11 +45,11 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 		},
 	},
 	Action: func(context *cli.Context) error {
-		hasError := false
-		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"delete\" requires a minimum of 1 argument")
+		if err := checkArgs(context, 1, minArgs); err != nil {
+			return err
 		}
 
+		hasError := false
 		factory, err := loadFactory(context)
 		if err != nil {
 			return err

--- a/events.go
+++ b/events.go
@@ -108,6 +108,9 @@ information is displayed once every 5 seconds.`,
 		cli.BoolFlag{Name: "stats", Usage: "display the container's stats then exit"},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 1, exactArgs); err != nil {
+			return err
+		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/exec.go
+++ b/exec.go
@@ -86,6 +86,9 @@ following will output a list of processes running in the container:
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 2, minArgs); err != nil {
+			return err
+		}
 		if os.Geteuid() != 0 {
 			return fmt.Errorf("runc should be run as root")
 		}

--- a/kill.go
+++ b/kill.go
@@ -69,6 +69,9 @@ signal to the init process of the "ubuntu01" container:
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 2, exactArgs); err != nil {
+			return err
+		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/list.go
+++ b/list.go
@@ -67,6 +67,9 @@ To list containers created using a non-default value for "--root":
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 0, exactArgs); err != nil {
+			return err
+		}
 		s, err := getContainers(context)
 		if err != nil {
 			return err

--- a/pause.go
+++ b/pause.go
@@ -20,11 +20,10 @@ paused. `,
 
 Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
-		hasError := false
-		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"pause\" requires a minimum of 1 argument")
+		if err := checkArgs(context, 1, minArgs); err != nil {
+			return err
 		}
-
+		hasError := false
 		factory, err := loadFactory(context)
 		if err != nil {
 			return err
@@ -61,11 +60,10 @@ resumed.`,
 
 Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
-		hasError := false
-		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"resume\" requires a minimum of 1 argument")
+		if err := checkArgs(context, 1, minArgs); err != nil {
+			return err
 		}
-
+		hasError := false
 		factory, err := loadFactory(context)
 		if err != nil {
 			return err

--- a/ps.go
+++ b/ps.go
@@ -25,6 +25,9 @@ var psCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 1, minArgs); err != nil {
+			return err
+		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/restore.go
+++ b/restore.go
@@ -83,6 +83,9 @@ using the runc checkpoint command.`,
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 1, exactArgs); err != nil {
+			return err
+		}
 		imagePath := context.String("image-path")
 		id := context.Args().First()
 		if id == "" {

--- a/run.go
+++ b/run.go
@@ -59,6 +59,9 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 1, exactArgs); err != nil {
+			return err
+		}
 		if err := revisePidFile(context); err != nil {
 			return err
 		}

--- a/spec.go
+++ b/spec.go
@@ -65,6 +65,9 @@ container on your host.`,
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 0, exactArgs); err != nil {
+			return err
+		}
 		spec := specs.Spec{
 			Version: specs.Version,
 			Platform: specs.Platform{

--- a/start.go
+++ b/start.go
@@ -18,11 +18,10 @@ are starting. The name you provide for the container instance must be unique on
 your host.`,
 	Description: `The start command executes the user defined process in a created container .`,
 	Action: func(context *cli.Context) error {
-		hasError := false
-		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"start\" requires a minimum of 1 argument")
+		if err := checkArgs(context, 1, minArgs); err != nil {
+			return err
 		}
-
+		hasError := false
 		factory, err := loadFactory(context)
 		if err != nil {
 			return err

--- a/state.go
+++ b/state.go
@@ -20,6 +20,9 @@ Where "<container-id>" is your name for the instance of the container.`,
 	Description: `The state command outputs current state information for the
 instance of a container.`,
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 1, exactArgs); err != nil {
+			return err
+		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/update.go
+++ b/update.go
@@ -109,6 +109,9 @@ other options are ignored.
 		},
 	},
 	Action: func(context *cli.Context) error {
+		if err := checkArgs(context, 1, exactArgs); err != nil {
+			return err
+		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err

--- a/utils.go
+++ b/utils.go
@@ -10,6 +10,33 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	exactArgs = iota
+	minArgs
+)
+
+func checkArgs(context *cli.Context, expected, checkType int) error {
+	var err error
+	cmdName := context.Command.Name
+	switch checkType {
+	case exactArgs:
+		if context.NArg() != expected {
+			err = fmt.Errorf("%s: %q requires exactly %d argument(s)", os.Args[0], cmdName, expected)
+		}
+	case minArgs:
+		if context.NArg() < expected {
+			err = fmt.Errorf("%s: %q requires a minimum of %d argument(s)", os.Args[0], cmdName, expected)
+		}
+	}
+
+	if err != nil {
+		fmt.Printf("Incorrect Usage.\n\n")
+		cli.ShowCommandHelp(context, cmdName)
+		return err
+	}
+	return nil
+}
+
 // fatal prints the error's details if it is a libcontainer specific error type
 // then exits the program with an exit status of 1.
 func fatal(err error) {


### PR DESCRIPTION
Add a general args number validator for all client commands.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
