### PR TITLE
Forbid adding duplicated namespace

### DIFF
--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -96,13 +96,13 @@ func (n *Namespaces) Remove(t NamespaceType) bool {
 	return true
 }
 
-func (n *Namespaces) Add(t NamespaceType, path string) {
+func (n *Namespaces) Add(t NamespaceType, path string) bool {
 	i := n.index(t)
 	if i == -1 {
 		*n = append(*n, Namespace{Type: t, Path: path})
-		return
+		return true
 	}
-	(*n)[i].Path = path
+	return false
 }
 
 func (n *Namespaces) index(t NamespaceType) int {


### PR DESCRIPTION
We now forbid duplicated namespace in spec([#1150](https://github.com/opencontainers/runc/pull/1150)), if there is a duplicated namespace, then it'll just return with error in `CreateLibcontainerConfig()`:

```bash
for _, ns := range spec.Linux.Namespaces {
                t, exists := namespaceMapping[ns.Type]
                if !exists {
                        return nil, fmt.Errorf("namespace %q does not exist", ns)
                }
                if config.Namespaces.Contains(t) {
                        return nil, fmt.Errorf("malformed spec file: duplicated ns %q", ns)
                }
                config.Namespaces.Add(t, ns.Path)
        }
```

So, as far as I can see, the last line of code in `Add()` will never be reached here. Therefore, I just modified this func to be consistent with `Remove()`. Besides, this modification also forbids adding duplicated namespace to make the logic more clear.

Signed-off-by: Yuanhong Peng pengyuanhong@huawei.com