### PR TITLE
Move ambient capabilties behind build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ static: $(RUNC_LINK)
 	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -o runc .
 
 release: $(RUNC_LINK)
-	@flag_list=(seccomp selinux apparmor static); \
+	@flag_list=(seccomp selinux apparmor static ambient); \
 	unset expression; \
 	for flag in "$${flag_list[@]}"; do \
 		expression+="' '{'',$${flag}}"; \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ make BUILDTAGS='seccomp apparmor'
 | seccomp   | Syscall filtering                  | libseccomp  |
 | selinux   | selinux process and mount labeling | <none>      |
 | apparmor  | apparmor profile support           | libapparmor |
+| ambient   | ambient capability support         | kernel 4.3  |
 
 
 ### Running the test suite

--- a/libcontainer/capabilities_ambient.go
+++ b/libcontainer/capabilities_ambient.go
@@ -1,0 +1,7 @@
+// +build linux,ambient
+
+package libcontainer
+
+import "github.com/syndtr/gocapability/capability"
+
+const allCapabilityTypes = capability.CAPS | capability.BOUNDS | capability.AMBS

--- a/libcontainer/capabilities_linux.go
+++ b/libcontainer/capabilities_linux.go
@@ -10,8 +10,6 @@ import (
 	"github.com/syndtr/gocapability/capability"
 )
 
-const allCapabilityTypes = capability.CAPS | capability.BOUNDS | capability.AMBS
-
 var capabilityMap map[string]capability.Cap
 
 func init() {

--- a/libcontainer/capabilities_noambient.go
+++ b/libcontainer/capabilities_noambient.go
@@ -1,0 +1,7 @@
+// +build !ambient,linux
+
+package libcontainer
+
+import "github.com/syndtr/gocapability/capability"
+
+const allCapabilityTypes = capability.CAPS | capability.BOUNDS


### PR DESCRIPTION
This moves the ambient capability support behind an `ambient` build tag
so that it is only compiled upon request.

ping @justincormack 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>