### PR TITLE
Allow update rt_period_us and rt_runtime_us

### DIFF
--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -20,6 +20,8 @@ accepted format is as follow (unchanged values can be omitted):
        "shares": 0,
        "quota": 0,
        "period": 0,
+       "realtimeRuntime": 0,
+       "realtimePeriod": 0,
        "cpus": "",
        "mems": ""
      },
@@ -34,8 +36,10 @@ other options are ignored.
 # OPTIONS
    --resources value, -r value  path to the file containing the resources to update or '-' to read from the standard input
    --blkio-weight value         Specifies per cgroup weight, range is from 10 to 1000 (default: 0)
-   --cpu-period value           CPU period to be used for hardcapping (in usecs). 0 to use system default
-   --cpu-quota value            CPU hardcap limit (in usecs). Allowed cpu time in a given period
+   --cpu-period value           CPU CFS period to be used for hardcapping (in usecs). 0 to use system default
+   --cpu-quota value            CPU CFS hardcap limit (in usecs). Allowed cpu time in a given period
+   --cpu-rt-period value        CPU realtime period to be used for hardcapping (in usecs). 0 to use system default
+   --cpu-rt-runtime value       CPU realtime hardcap limit (in usecs). Allowed cpu time in a given period
    --cpu-share value            CPU shares (relative weight vs. other containers)
    --cpuset-cpus value          CPU(s) to use
    --cpuset-mems value          Memory node(s) to use

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -47,6 +47,7 @@ function check_cgroup_value() {
     [ "$current" -eq "$expected" ]
 }
 
+# TODO: test rt cgroup updating
 @test "update" {
     requires cgroups_kmem
     # run a few busyboxes detached

--- a/update.go
+++ b/update.go
@@ -40,6 +40,8 @@ The accepted format is as follow (unchanged values can be omitted):
     "shares": 0,
     "quota": 0,
     "period": 0,
+    "realtimeRuntime": 0,
+    "realtimePeriod": 0,
     "cpus": "",
     "mems": ""
   },
@@ -59,15 +61,23 @@ other options are ignored.
 		},
 		cli.StringFlag{
 			Name:  "cpu-period",
-			Usage: "CPU period to be used for hardcapping (in usecs). 0 to use system default",
+			Usage: "CPU CFS period to be used for hardcapping (in usecs). 0 to use system default",
 		},
 		cli.StringFlag{
 			Name:  "cpu-quota",
-			Usage: "CPU hardcap limit (in usecs). Allowed cpu time in a given period",
+			Usage: "CPU CFS hardcap limit (in usecs). Allowed cpu time in a given period",
 		},
 		cli.StringFlag{
 			Name:  "cpu-share",
 			Usage: "CPU shares (relative weight vs. other containers)",
+		},
+		cli.StringFlag{
+			Name:  "cpu-rt-period",
+			Usage: "CPU realtime period to be used for hardcapping (in usecs). 0 to use system default",
+		},
+		cli.StringFlag{
+			Name:  "cpu-rt-runtime",
+			Usage: "CPU realtime hardcap limit (in usecs). Allowed cpu time in a given period",
 		},
 		cli.StringFlag{
 			Name:  "cpuset-cpus",
@@ -113,11 +123,13 @@ other options are ignored.
 				KernelTCP:   u64Ptr(0),
 			},
 			CPU: &specs.CPU{
-				Shares: u64Ptr(0),
-				Quota:  u64Ptr(0),
-				Period: u64Ptr(0),
-				Cpus:   sPtr(""),
-				Mems:   sPtr(""),
+				Shares:          u64Ptr(0),
+				Quota:           u64Ptr(0),
+				Period:          u64Ptr(0),
+				RealtimeRuntime: u64Ptr(0),
+				RealtimePeriod:  u64Ptr(0),
+				Cpus:            sPtr(""),
+				Mems:            sPtr(""),
 			},
 			BlockIO: &specs.BlockIO{
 				Weight: u16Ptr(0),
@@ -162,6 +174,8 @@ other options are ignored.
 
 				{"cpu-period", r.CPU.Period},
 				{"cpu-quota", r.CPU.Quota},
+				{"cpu-rt-period", r.CPU.RealtimePeriod},
+				{"cpu-rt-runtime", r.CPU.RealtimeRuntime},
 				{"cpu-share", r.CPU.Shares},
 			} {
 				if val := context.String(pair.opt); val != "" {
@@ -197,6 +211,8 @@ other options are ignored.
 		config.Cgroups.Resources.CpuPeriod = int64(*r.CPU.Period)
 		config.Cgroups.Resources.CpuQuota = int64(*r.CPU.Quota)
 		config.Cgroups.Resources.CpuShares = int64(*r.CPU.Shares)
+		config.Cgroups.Resources.CpuRtPeriod = int64(*r.CPU.RealtimePeriod)
+		config.Cgroups.Resources.CpuRtRuntime = int64(*r.CPU.RealtimeRuntime)
 		config.Cgroups.Resources.CpusetCpus = *r.CPU.Cpus
 		config.Cgroups.Resources.CpusetMems = *r.CPU.Mems
 		config.Cgroups.Resources.KernelMemory = int64(*r.Memory.Kernel)


### PR DESCRIPTION
Currently runc already supports setting realtime runtime and period
before container processes start, this commit will add update support
for realtime scheduler resources.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

PS: I searched github issues and PRs and didn't find why `runc` didn't support updating real time scheduler resources, as I can see, setting the rt_period_us and rt_runtime_us when container is booting already works, so `updating` should be a reasonable enhancement.

Let me know if I miss something. :smile: 