### PR TITLE
libcontainer: config: validate default filesystems

### DIFF
--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -106,6 +106,13 @@ func TestValidateSecurityWithMaskPaths(t *testing.T) {
 				{Type: configs.NEWNS},
 			},
 		),
+		// Required to pass mount validation.
+		Mounts: []*configs.Mount{
+			{Destination: "/proc"},
+			{Destination: "/sys"},
+			{Destination: "/dev/shm"},
+			{Destination: "/dev/pts"},
+		},
 	}
 
 	validator := validate.New()
@@ -124,6 +131,13 @@ func TestValidateSecurityWithROPaths(t *testing.T) {
 				{Type: configs.NEWNS},
 			},
 		),
+		// Required to pass mount validation.
+		Mounts: []*configs.Mount{
+			{Destination: "/proc"},
+			{Destination: "/sys"},
+			{Destination: "/dev/shm"},
+			{Destination: "/dev/pts"},
+		},
 	}
 
 	validator := validate.New()


### PR DESCRIPTION
[According to the runtime-spec](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config-linux.md#default-filesystems), some filesystems must be mounted in all
containers'. So, add verification to make sure someone doesn't ask us to
create a rootfs that is missing key features.

Signed-off-by: Aleksa Sarai <asarai@suse.de>