### PR TITLE
Add bash completions for new flags of `update`

### DIFF
--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -719,6 +719,8 @@ _runc_update() {
 	   --blkio-weight
 	   --cpu-period
 	   --cpu-quota
+	   --cpu-rt-period
+	   --cpu-rt-runtime
 	   --cpu-share
 	   --cpuset-cpus
 	   --cpuset-mems


### PR DESCRIPTION
Add bash completions for flags "--cpu-rt-period" and "--cpu-rt-runtime"
for `update` command.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

This is follow up of https://github.com/opencontainers/runc/pull/1173, sorry for forgetting the bash completions, now it's here.