### PR TITLE
Showing the command helper when args are missing

### DIFF
--- a/create.go
+++ b/create.go
@@ -51,7 +51,7 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 	Action: func(context *cli.Context) error {
 		if context.NArg() != 1 {
 			fmt.Printf("Incorrect Usage.\n\n")
-			cli.ShowCommandHelp(context, "create")
+			containerUsage(context)
 			return fmt.Errorf("runc: \"create\" requires exactly one argument")
 		}
 		spec, err := setupSpec(context)

--- a/pause.go
+++ b/pause.go
@@ -22,6 +22,7 @@ Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
 		hasError := false
 		if !context.Args().Present() {
+			containerUsage(context)
 			return fmt.Errorf("runc: \"pause\" requires a minimum of 1 argument")
 		}
 
@@ -63,6 +64,7 @@ Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
 		hasError := false
 		if !context.Args().Present() {
+			containerUsage(context)
 			return fmt.Errorf("runc: \"resume\" requires a minimum of 1 argument")
 		}
 

--- a/restore.go
+++ b/restore.go
@@ -86,6 +86,7 @@ using the runc checkpoint command.`,
 		imagePath := context.String("image-path")
 		id := context.Args().First()
 		if id == "" {
+			containerUsage(context)
 			return errEmptyID
 		}
 		if imagePath == "" {

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -46,6 +46,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 func getContainer(context *cli.Context) (libcontainer.Container, error) {
 	id := context.Args().First()
 	if id == "" {
+		containerUsage(context)
 		return nil, errEmptyID
 	}
 	factory, err := loadFactory(context)
@@ -282,6 +283,7 @@ func validateProcessSpec(spec *specs.Process) error {
 func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, error) {
 	id := context.Args().First()
 	if id == "" {
+		containerUsage(context)
 		return -1, errEmptyID
 	}
 	container, err := createContainer(context, id, spec)
@@ -304,4 +306,8 @@ func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, e
 		create:          create,
 	}
 	return r.run(&spec.Process)
+}
+func containerUsage(context *cli.Context) {
+	command := context.Command.FullName()
+	cli.ShowCommandHelp(context, command)
 }


### PR DESCRIPTION
Unify to show the usage when the arguments are missing while start/create/pause/resume  the container 
It shows  the command help/usage when args are missing ( along with real error)

Signed-off-by: rajasec <rajasec79@gmail.com>