### PR TITLE
Allow update any resources in `spes.Resources`

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -208,7 +208,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	if err := setupUserNamespace(spec, config); err != nil {
 		return nil, err
 	}
-	c, err := createCgroupConfig(opts.CgroupName, opts.UseSystemdCgroup, spec)
+	c, err := CreateCgroupConfig(opts.CgroupName, opts.UseSystemdCgroup, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,8 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	}
 }
 
-func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*configs.Cgroup, error) {
+// CreateCgroupConfig convert specs.Spec to config.Cgroups
+func CreateCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*configs.Cgroup, error) {
 	var myCgroupPath string
 
 	c := &configs.Cgroup{

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -16,7 +16,7 @@ func TestLinuxCgroupsPathSpecified(t *testing.T) {
 		CgroupsPath: &cgroupsPath,
 	}
 
-	cgroup, err := createCgroupConfig("ContainerID", false, spec)
+	cgroup, err := CreateCgroupConfig("ContainerID", false, spec)
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestLinuxCgroupsPathSpecified(t *testing.T) {
 func TestLinuxCgroupsPathNotSpecified(t *testing.T) {
 	spec := &specs.Spec{}
 
-	cgroup, err := createCgroupConfig("ContainerID", false, spec)
+	cgroup, err := CreateCgroupConfig("ContainerID", false, spec)
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -9,6 +9,12 @@
 accepted format is as follow (unchanged values can be omitted):
 
    {
+     "devices": [
+       {
+         "allow": false,
+         "access": "rwm"
+       }
+     ],
      "memory": {
        "limit": 0,
        "reservation": 0,
@@ -25,9 +31,15 @@ accepted format is as follow (unchanged values can be omitted):
        "cpus": "",
        "mems": ""
      },
+     "pids": {
+       "limit": 0
+     },
      "blockIO": {
-       "blkioWeight": 0
-     }
+       "blkioWeight": 0,
+       "blkioLeafWeight": 0
+     },
+     "hugepageLimits": [],
+     "network": {}
    }
 
 Note: if data is to be read from a file or the standard input, all

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -2,21 +2,13 @@
 
 load helpers
 
-function teardown() {
-    rm -f $BATS_TMPDIR/runc-update-integration-test.json
-    teardown_running_container test_update
-    teardown_busybox
-}
+# get the cgroup paths
+for g in DEVICES MEMORY CPUSET CPU BLKIO; do
+	base_path=$(grep "cgroup"  /proc/self/mountinfo | gawk 'toupper($NF) ~ /\<'${g}'\>/ { print $5; exit }')
+	eval CGROUP_${g}="${base_path}/runc-update-integration-test"
+done
 
-function setup() {
-    teardown
-    setup_busybox
-
-    # Add cgroup path
-    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-update-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
-
-    # Set some initial known values
-    DATA=$(cat <<EOF
+DEFAULT_CGROUP_DATA=$(cat <<EOF
     "memory": {
         "limit": 33554432,
         "reservation": 25165824,
@@ -31,11 +23,27 @@ function setup() {
     },
     "blockio": {
         "blkioWeight": 1000
-    },
+    }
 EOF
     )
-    DATA=$(echo ${DATA} | sed 's/\n/\\n/g')
-    sed -i "s/\(\"resources\": {\)/\1\n${DATA}/" ${BUSYBOX_BUNDLE}/config.json
+
+
+function teardown() {
+    rm -f $BATS_TMPDIR/runc-update-integration-test.json
+    teardown_running_container test_update
+    teardown_busybox
+}
+
+function setup() {
+    teardown
+    setup_busybox
+
+    # Add cgroup path
+    sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-update-integration-test",/'  ${BUSYBOX_BUNDLE}/config.json
+
+    # Set some initial known values
+    DATA=$(echo ${DEFAULT_CGROUP_DATA} | sed 's/\n/\\n/g')
+    sed -i "s/\(\"resources\": {\)/\1\n${DATA},/" ${BUSYBOX_BUNDLE}/config.json
 }
 
 function check_cgroup_value() {
@@ -47,6 +55,15 @@ function check_cgroup_value() {
     [ "$current" -eq "$expected" ]
 }
 
+function contains_cgroup_value() {
+    cgroup=$1
+    source=$2
+    expected=$3
+
+    grep "$expected" $cgroup/$source
+    [[ ${line[0]} =~ "$expected" ]]
+}
+
 # TODO: test rt cgroup updating
 @test "update" {
     requires cgroups_kmem
@@ -54,12 +71,6 @@ function check_cgroup_value() {
     runc run -d --console /dev/pts/ptmx test_update
     [ "$status" -eq 0 ]
     wait_for_container 15 1 test_update
-
-    # get the cgroup paths
-    for g in MEMORY CPUSET CPU BLKIO; do
-        base_path=$(grep "cgroup"  /proc/self/mountinfo | gawk 'toupper($NF) ~ /\<'${g}'\>/ { print $5; exit }')
-        eval CGROUP_${g}="${base_path}/runc-update-integration-test"
-    done
 
     # check that initial values were properly set
     check_cgroup_value $CGROUP_BLKIO "blkio.weight" 1000
@@ -132,37 +143,6 @@ function check_cgroup_value() {
     [ "$status" -eq 0 ]
     check_cgroup_value $CGROUP_MEMORY "memory.kmem.tcp.limit_in_bytes" 41943040
 
-    # Revert to the test initial value via json on stding
-    runc update  -r - test_update <<EOF
-{
-  "memory": {
-    "limit": 33554432,
-    "reservation": 25165824,
-    "kernel": 16777216,
-    "kernelTCP": 11534336
-  },
-  "cpu": {
-    "shares": 100,
-    "quota": 500000,
-    "period": 1000000,
-    "cpus": "0"
-  },
-  "blockIO": {
-    "blkioWeight": 1000
-  }
-}
-EOF
-    [ "$status" -eq 0 ]
-    check_cgroup_value $CGROUP_BLKIO "blkio.weight" 1000
-    check_cgroup_value $CGROUP_CPU "cpu.cfs_period_us" 1000000
-    check_cgroup_value $CGROUP_CPU "cpu.cfs_quota_us" 500000
-    check_cgroup_value $CGROUP_CPU "cpu.shares" 100
-    check_cgroup_value $CGROUP_CPUSET "cpuset.cpus" 0
-    check_cgroup_value $CGROUP_MEMORY "memory.kmem.limit_in_bytes" 16777216
-    check_cgroup_value $CGROUP_MEMORY "memory.kmem.tcp.limit_in_bytes" 11534336
-    check_cgroup_value $CGROUP_MEMORY "memory.limit_in_bytes" 33554432
-    check_cgroup_value $CGROUP_MEMORY "memory.soft_limit_in_bytes" 25165824
-
     # redo all the changes at once
     runc update test_update --blkio-weight 500 \
         --cpu-period 900000 --cpu-quota 600000 --cpu-share 200 --memory 67108864 \
@@ -177,28 +157,64 @@ EOF
     check_cgroup_value $CGROUP_MEMORY "memory.limit_in_bytes" 67108864
     check_cgroup_value $CGROUP_MEMORY "memory.soft_limit_in_bytes" 33554432
 
-    # reset to initial test value via json file
-    DATA=$(cat <<"EOF"
+}
+
+@test "update from json file or stdin" {
+    requires cgroups_kmem
+    # run a few busyboxes detached
+    runc run -d --console /dev/pts/ptmx test_update
+    [ "$status" -eq 0 ]
+    wait_for_container 15 1 test_update
+
+    # Revert to the test initial value via json on stding
+    runc update  -r - test_update <<EOF
 {
+  "devices": [
+    {   
+      "major": 1,
+      "minor": 3, 
+      "type": "c",
+	  "allow": false,
+	  "access": "rwm"
+    }   
+  ],  
   "memory": {
-    "limit": 33554432,
-    "reservation": 25165824,
-    "kernel": 16777216,
-    "kernelTCP": 11534336
+    "limit": 29999104,
+    "reservation": 24158208,
+    "kernel": 12996608,
+    "kernelTCP": 12996608
   },
   "cpu": {
-    "shares": 100,
-    "quota": 500000,
-    "period": 1000000,
-    "cpus": "0"
+    "shares": 101,
+    "quota": 500001,
+    "period": 999999,
+    "cpus": "0",
+    "mems": "0"
   },
   "blockIO": {
-    "blkioWeight": 1000
-  }
+    "blkioWeight": 999,
+    "blkioLeafWeight": 801
+  },
+  "pids": {},
+  "hugepageLimits": [],
+  "network": {}
 }
 EOF
-)
-    echo $DATA > $BATS_TMPDIR/runc-update-integration-test.json
+    [ "$status" -eq 0 ]
+    ! contains_cgroup_value $CGROUP_DEVICES "devices.list" "c 1:3 rwm"
+    check_cgroup_value $CGROUP_BLKIO "blkio.weight" 999
+    check_cgroup_value $CGROUP_BLKIO "blkio.leaf_weight" 801
+    check_cgroup_value $CGROUP_CPU "cpu.cfs_period_us" 999999
+    check_cgroup_value $CGROUP_CPU "cpu.cfs_quota_us" 500001
+    check_cgroup_value $CGROUP_CPU "cpu.shares" 101
+    check_cgroup_value $CGROUP_CPUSET "cpuset.cpus" 0
+    check_cgroup_value $CGROUP_MEMORY "memory.kmem.limit_in_bytes" 12996608
+    check_cgroup_value $CGROUP_MEMORY "memory.kmem.tcp.limit_in_bytes" 12996608
+    check_cgroup_value $CGROUP_MEMORY "memory.limit_in_bytes" 29999104
+    check_cgroup_value $CGROUP_MEMORY "memory.soft_limit_in_bytes" 24158208
+
+    # reset to initial test value via json file
+    echo -e "{\n${DEFAULT_CGROUP_DATA}\n}" > $BATS_TMPDIR/runc-update-integration-test.json
 
     runc update  -r $BATS_TMPDIR/runc-update-integration-test.json test_update
     [ "$status" -eq 0 ]


### PR DESCRIPTION
The command `runc update -r file/-` accepts input from file or standard
input in JSON format, before this commit, runc can only update limited
fields in `specs.Resources`, this commit will enhance the update command
to make updating any field of `specs.Resources` possible.

The list of Cgroups resources newly supported to update includes:
* devices
* pids
* blockIO
* hugepageLimits
* network

In one word, this commit enables updating all the fields in
`spec.Resources` except `disableOOMKiller` and `oomScoreAdj`.

Note:
1. the enhanced fields can only be passed to runc via `update -r`
flag, this doesn't add extra flags for each resource, because it's a
long list and `-r` suffices and is easier for maintainance than endless
new flags.
2. This commit removes example in command help message because it takes
large space, instead this added a richer example in man page.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>