### PR TITLE
Fixing error message in nsexec

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -394,7 +394,7 @@ void join_namespaces(char *nslist)
 
 		fd = open(path, O_RDONLY);
 		if (fd < 0)
-			bail("failed to open %s", namespace);
+			bail("failed to open %s", path);
 
 		ns->fd = fd;
 		ns->ns = nsflag(namespace);


### PR DESCRIPTION
Small update to error message when open calls fails on path
Signed-off-by: rajasec <rajasec79@gmail.com>