### PR TITLE
Fix leftover cgroup directory issue

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -114,8 +114,8 @@ func (m *Manager) Apply(pid int) (err error) {
 		return err
 	}
 
+	m.Paths = make(map[string]string)
 	if c.Paths != nil {
-		paths := make(map[string]string)
 		for name, path := range c.Paths {
 			_, err := d.path(name)
 			if err != nil {
@@ -124,17 +124,12 @@ func (m *Manager) Apply(pid int) (err error) {
 				}
 				return err
 			}
-			paths[name] = path
+			m.Paths[name] = path
 		}
-		m.Paths = paths
 		return cgroups.EnterPid(m.Paths, pid)
 	}
 
-	paths := make(map[string]string)
 	for _, sys := range subsystems {
-		if err := sys.Apply(d); err != nil {
-			return err
-		}
 		// TODO: Apply should, ideally, be reentrant or be broken up into a separate
 		// create and join phase so that the cgroup hierarchy for a container can be
 		// created then join consists of writing the process pids to cgroup.procs
@@ -147,9 +142,12 @@ func (m *Manager) Apply(pid int) (err error) {
 			}
 			return err
 		}
-		paths[sys.Name()] = p
+		m.Paths[sys.Name()] = p
+
+		if err := sys.Apply(d); err != nil {
+			return err
+		}
 	}
-	m.Paths = paths
 	return nil
 }
 


### PR DESCRIPTION
In the cases that we got failure on a subsystem's Apply,
we'll get some subsystems' cgroup directories leftover.

On Docker's point of view, start a container failed, use
`docker rm` to remove the container, but some cgroup files
are leftover.

Sometimes we don't want to clean everyting up when something
went wrong, because we need these inter situation
information to debug what's going on, but cgroup directories
are not useful information we want to keep.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>