### PR TITLE
Correct runc command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The first way is to use the convenience command `run` that will handle creating,
 ```bash
 cd /mycontainer
 
-runc run mycontainerid
+runc start mycontainerid
 ```
 
 If you used the unmodified `runc spec` template this should give you a `sh` session inside the container.
@@ -152,12 +152,7 @@ Now we can go though the lifecycle operations in your shell.
 ```bash
 cd /mycontainer
 
-runc create mycontainerid
-
-# view the container is created and in the "created" state
-runc list
-
-# start the process inside the container
+# create and start the process inside the container
 runc start mycontainerid
 
 # after 5 seconds view that the container has exited and is now in the stopped state


### PR DESCRIPTION
I build the runc command and found that 
```
COMMANDS:
   checkpoint	checkpoint a running container
   delete	delete any resources held by the container often used with detached containers
   events	display container events such as OOM notifications, cpu, memory, IO and network stats
   exec		execute new process inside the container
   kill		kill sends the specified signal (default: SIGTERM) to the container's init process
   list		lists containers started by runc with the given root
   pause	pause suspends all processes inside the container
   restore	restore a container from a previous checkpoint
   resume	resumes all processes that have been previously paused
   spec		create a new specification file
   start	create and run a container
   help, h	Shows a list of commands or help for one command
```

runc hasn't `create` command. We can use start to replace it.
