### PR TITLE
libcontainer: add support for Intel RDT/CAT in runc

### DIFF
--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -311,6 +311,13 @@ type Network struct {
 	Priorities []InterfacePriority `json:"priorities,omitempty"`
 }
 
+// IntelRdt for Linux Intel RDT/CAT resource management (Linux 4.10)
+type IntelRdt struct {
+	// The schema for L3 cache id and capacity bitmask (CBM)
+	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+	L3CacheSchema *string `json:"l3CacheSchema,omitempty"`
+}
+
 // Resources has container runtime resource constraints
 type Resources struct {
 	// Devices configures the device whitelist.
@@ -331,6 +338,8 @@ type Resources struct {
 	HugepageLimits []HugepageLimit `json:"hugepageLimits,omitempty"`
 	// Network restriction configuration
 	Network *Network `json:"network,omitempty"`
+	// IntelRdt restriction configuration
+	IntelRdt *IntelRdt `json:"intelRdt,omitempty"`
 }
 
 // Device represents the mknod information for a Linux special device file

--- a/events.go
+++ b/events.go
@@ -24,11 +24,12 @@ type event struct {
 
 // stats is the runc specific stats structure for stability when encoding and decoding stats.
 type stats struct {
-	Cpu     cpu                `json:"cpu"`
-	Memory  memory             `json:"memory"`
-	Pids    pids               `json:"pids"`
-	Blkio   blkio              `json:"blkio"`
-	Hugetlb map[string]hugetlb `json:"hugetlb"`
+	Cpu      cpu                `json:"cpu"`
+	Memory   memory             `json:"memory"`
+	Pids     pids               `json:"pids"`
+	Blkio    blkio              `json:"blkio"`
+	Hugetlb  map[string]hugetlb `json:"hugetlb"`
+	IntelRdt intelRdt           `json:"intelRdt"`
 }
 
 type hugetlb struct {
@@ -93,6 +94,12 @@ type memory struct {
 	Kernel    memoryEntry       `json:"kernel,omitempty"`
 	KernelTCP memoryEntry       `json:"kernelTCP,omitempty"`
 	Raw       map[string]uint64 `json:"raw,omitempty"`
+}
+
+type intelRdt struct {
+	// The read-only default "schemas" in root, for reference
+	L3CacheSchemaRoot string `json:"l3CacheSchemaRoot,omitempty"`
+	L3CacheSchema     string `json:"l3CacheSchema,omitempty"`
 }
 
 var eventsCommand = cli.Command{
@@ -223,6 +230,10 @@ func convertLibcontainerStats(ls *libcontainer.Stats) *stats {
 	for k, v := range cg.HugetlbStats {
 		s.Hugetlb[k] = convertHugtlb(v)
 	}
+
+	is := cg.IntelRdtStats
+	s.IntelRdt.L3CacheSchemaRoot = is.IntelRdtRootStats.L3CacheSchema
+	s.IntelRdt.L3CacheSchema = is.IntelRdtGroupStats.L3CacheSchema
 	return &s
 }
 

--- a/libcontainer/SPEC.md
+++ b/libcontainer/SPEC.md
@@ -154,6 +154,93 @@ that no processes or threads escape the cgroups.  This sync is
 done via a pipe ( specified in the runtime section below ) that the container's
 init process will block waiting for the parent to finish setup.
 
+**intelRdt**:  
+Intel platforms with new Xeon CPU support Intel Resource Director Technology
+(RDT). Cache Allocation Technology (CAT) is a sub-feature of RDT, which
+currently supports L3 cache resource allocation.
+
+This feature provides a way for the software to restrict cache allocation to a
+defined 'subset' of L3 cache which may be overlapping with other 'subsets'.
+The different subsets are identified by class of service (CLOS) and each CLOS
+has a capacity bitmask (CBM).
+
+It can be used to handle L3 cache resource allocation for containers if
+hardware and kernel support Intel RDT/CAT.
+
+`intelRdt` is implemented as the `intel_rdt` cgroup subsystem in libcontainer
+even though the Linux kernel interface is not real cgroup. When intelRdt is
+joined, the statistics can be collected from intel_rdt cgroup subsystem.
+
+In Linux kernel, it is exposed via "resource control" filesystem, which is a
+"cgroup-like" interface.
+
+Comparing with cgroups, it has similar process management lifecycle and
+interfaces in a container. But unlike cgroups' hierarchy, it has single level
+filesystem layout.
+
+Intel RDT "resource control" filesystem hierarchy:
+```
+mount -t resctrl resctrl /sys/fs/resctrl
+tree /sys/fs/resctrl
+/sys/fs/resctrl/
+|-- info
+|   |-- L3
+|       |-- cbm_mask
+|       |-- num_closids
+|-- cpus
+|-- schemata
+|-- tasks
+|-- <container_id>
+    |-- cpus
+    |-- schemata
+    |-- tasks
+
+```
+
+For runc, we can make use of `tasks` and `schemata` configuration for L3 cache
+resource constraints.
+
+The file `tasks` has a list of tasks that belongs to this group (e.g.,
+<container_id>" group). Tasks can be added to a group by writing the task ID
+to the "tasks" file  (which will automatically remove them from the previous
+group to which they belonged). New tasks created by fork(2) and clone(2) are
+added to the same group as their parent. If a pid is not in any sub group, it
+is in root group.
+
+The file `schemata` has allocation masks/values for L3 cache on each socket,
+which contains L3 cache id and capacity bitmask (CBM).
+```
+	Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+```
+For example, on a two-socket machine, L3's schema line could be `L3:0=ff;1=c0`
+Which means L3 cache id 0's CBM is 0xff, and L3 cache id 1's CBM is 0xc0.
+
+The valid L3 cache CBM is a *contiguous bits set* and number of bits that can
+be set is less than the max bit. The max bits in the CBM is varied among
+supported Intel Xeon platforms. In Intel RDT "resource control" filesystem
+layout, the CBM in a group should be a subset of the CBM in root. Kernel will
+check if it is valid when writing. e.g., 0xfffff in root indicates the max bits
+of CBM is 20 bits, which mapping to entire L3 cache capacity. Some valid CBM
+values to set in a group: 0xf, 0xf0, 0x3ff, 0x1f00 and etc.
+
+For more information about Intel RDT/CAT kernel interface:  
+https://git.kernel.org/cgit/linux/kernel/git/tip/tip.git/commit/?h=x86/cache&id=f20e57892806ad244eaec7a7ae365e78fee53377
+
+An example for runc:
+```
+There are two L3 caches in the two-socket machine, the default CBM is 0xfffff
+and the max CBM length is 20 bits. This configuration assigns 4/5 of L3 cache
+id 0 and the whole L3 cache id 1 for the container:
+
+"linux": {
+	"resources": {
+		"intelRdt": {
+			"l3CacheSchema": "L3:0=ffff0;1=fffff"
+		}
+	}
+}
+```
+
 ### Security 
 
 The standard set of Linux capabilities that are set in a container

--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -39,6 +39,9 @@ type Manager interface {
 
 	// Sets the cgroup as configured.
 	Set(container *configs.Config) error
+
+	// Get non-cgroup resource path
+	GetResourcePath() string
 }
 
 type NotFoundError struct {

--- a/libcontainer/cgroups/fs/apply_raw_test.go
+++ b/libcontainer/cgroups/fs/apply_raw_test.go
@@ -20,7 +20,7 @@ func TestInvalidCgroupPath(t *testing.T) {
 		Path: "../../../../../../../../../../some/path",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestInvalidAbsoluteCgroupPath(t *testing.T) {
 		Path: "/../../../../../../../../../../some/path",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestInvalidCgroupParent(t *testing.T) {
 		Name:   "name",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestInvalidAbsoluteCgroupParent(t *testing.T) {
 		Name:   "name",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestInvalidCgroupName(t *testing.T) {
 		Name:   "../../../../../../../../../../some/path",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestInvalidAbsoluteCgroupName(t *testing.T) {
 		Name:   "/../../../../../../../../../../some/path",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestInvalidCgroupNameAndParent(t *testing.T) {
 		Name:   "../../../../../../../../../../some/path",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestInvalidAbsoluteCgroupNameAndParent(t *testing.T) {
 		Name:   "/../../../../../../../../../../some/path",
 	}
 
-	data, err := getCgroupData(config, 0)
+	data, err := getCgroupData(config, 0, "")
 	if err != nil {
 		t.Errorf("couldn't get cgroup data: %v", err)
 	}

--- a/libcontainer/cgroups/fs/intelrdt.go
+++ b/libcontainer/cgroups/fs/intelrdt.go
@@ -1,0 +1,395 @@
+// +build linux
+
+package fs
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+/*
+ * About Intel RDT/CAT feature:
+ * Intel platforms with new Xeon CPU support Resource Director Technology (RDT).
+ * Intel Cache Allocation Technology (CAT) is a sub-feature of RDT. Currently L3
+ * Cache is the only resource that is supported in RDT.
+ *
+ * This feature provides a way for the software to restrict cache allocation to a
+ * defined 'subset' of L3 cache which may be overlapping with other 'subsets'.
+ * The different subsets are identified by class of service (CLOS) and each CLOS
+ * has a capacity bitmask (CBM).
+ *
+ * For more information about Intel RDT/CAT can be found in the section 17.17
+ * of Intel Software Developer Manual.
+ *
+ * About Intel RDT/CAT kernel interface:
+ * In Linux kernel, the interface is defined and exposed via "resource control"
+ * filesystem, which is a "cgroup-like" interface.
+ *
+ * Comparing with cgroups, it has similar process management lifecycle and
+ * interfaces in a container. But unlike cgroups' hierarchy, it has single level
+ * filesystem layout.
+ *
+ * Intel RDT "resource control" filesystem hierarchy:
+ * mount -t resctrl resctrl /sys/fs/resctrl
+ * tree /sys/fs/resctrl
+ * /sys/fs/resctrl/
+ * |-- info
+ * |   |-- L3
+ * |       |-- cbm_mask
+ * |       |-- num_closids
+ * |-- cpus
+ * |-- schemata
+ * |-- tasks
+ * |-- <container_id>
+ *     |-- cpus
+ *     |-- schemata
+ *     |-- tasks
+ *
+ * For runc, we can make use of `tasks` and `schemata` configuration for L3 cache
+ * resource constraints.
+ *
+ *  The file `tasks` has a list of tasks that belongs to this group (e.g.,
+ * <container_id>" group). Tasks can be added to a group by writing the task ID
+ * to the "tasks" file  (which will automatically remove them from the previous
+ * group to which they belonged). New tasks created by fork(2) and clone(2) are
+ * added to the same group as their parent. If a pid is not in any sub group, it is
+ * in root group.
+ *
+ * The file `schemata` has allocation bitmasks/values for L3 cache on each socket,
+ * which contains L3 cache id and capacity bitmask (CBM).
+ * 	Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+ * For example, on a two-socket machine, L3's schema line could be `L3:0=ff;1=c0`
+ * which means L3 cache id 0's CBM is 0xff, and L3 cache id 1's CBM is 0xc0.
+ *
+ * The valid L3 cache CBM is a *contiguous bits set* and number of bits that can
+ * be set is less than the max bit. The max bits in the CBM is varied among
+ * supported Intel Xeon platforms. In Intel RDT "resource control" filesystem
+ * layout, the CBM in a group should be a subset of the CBM in root. Kernel will
+ * check if it is valid when writing. e.g., 0xfffff in root indicates the max bits
+ * of CBM is 20 bits, which mapping to entire L3 cache capacity. Some valid CBM
+ * values to set in a group: 0xf, 0xf0, 0x3ff, 0x1f00 and etc.
+ *
+ * For more information about Intel RDT/CAT kernel interface:
+ * https://git.kernel.org/cgit/linux/kernel/git/tip/tip.git/commit/?h=x86/cache&id=f20e57892806ad244eaec7a7ae365e78fee53377
+ *
+ * An example for runc:
+ * There are two L3 caches in the two-socket machine, the default CBM is 0xfffff
+ * and the max CBM length is 20 bits. This configuration assigns 4/5 of L3 cache
+ * id 0 and the whole L3 cache id 1 for the container:
+ *
+ * "linux": {
+ * 	"resources": {
+ * 		"intelRdt": {
+ * 			"l3CacheSchema": "L3:0=ffff0;1=fffff"
+ * 		}
+ * 	}
+ * }
+ */
+
+type IntelRdtGroup struct {
+}
+
+func (s *IntelRdtGroup) Name() string {
+	return "intel_rdt"
+}
+
+func (s *IntelRdtGroup) Apply(d *cgroupData) error {
+	data, err := getIntelRdtData(d.config, d.pid, d.containerId)
+	if err != nil && !cgroups.IsNotFound(err) {
+		return err
+	}
+
+	if _, err := data.join(data.containerId); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *IntelRdtGroup) Set(path string, cgroup *configs.Cgroup) error {
+	// About L3 cache schemata file:
+	// The schema has allocation masks/values for L3 cache on each socket,
+	// which contains L3 cache id and capacity bitmask (CBM).
+	//     Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+	// For example, on a two-socket machine, L3's schema line could be:
+	//     L3:0=ff;1=c0
+	// Which means L3 cache id 0's CBM is 0xff, and L3 cache id 1's CBM is 0xc0.
+	//
+	// About L3 cache CBM validity:
+	// The valid L3 cache CBM is a *contiguous bits set* and number of
+	// bits that can be set is less than the max bit. The max bits in the
+	// CBM is varied among supported Intel Xeon platforms. In Intel RDT
+	// "resource control" filesystem layout, the CBM in a group should
+	// be a subset of the CBM in root. Kernel will check if it is valid
+	// when writing.
+	// e.g., 0xfffff in root indicates the max bits of CBM is 20 bits,
+	// which mapping to entire L3 cache capacity. Some valid CBM values
+	// to set in a group: 0xf, 0xf0, 0x3ff, 0x1f00 and etc.
+	l3CacheSchema := cgroup.Resources.IntelRdtL3CacheSchema
+	if l3CacheSchema != "" {
+		if err := writeFile(path, "schemata", l3CacheSchema+"\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *IntelRdtGroup) Remove(d *cgroupData) error {
+	path, err := GetIntelRdtPath(d.containerId)
+	if err != nil {
+		return err
+	}
+	if err := removePath(path, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *IntelRdtGroup) GetStats(path string, stats *cgroups.Stats) error {
+	// The read-only default "schemata" in root
+	rootPath, err := getIntelRdtRoot()
+	if err != nil {
+		return err
+	}
+	schemaRoot, err := getCgroupParamString(rootPath, "schemata")
+	if err != nil {
+		return err
+	}
+	stats.IntelRdtStats.IntelRdtRootStats.L3CacheSchema = schemaRoot
+
+	// The stats in "container_id" group
+	schema, err := getCgroupParamString(path, "schemata")
+	if err != nil {
+		return err
+	}
+	stats.IntelRdtStats.IntelRdtGroupStats.L3CacheSchema = schema
+
+	return nil
+}
+
+const (
+	IntelRdtTasks = "tasks"
+)
+
+var (
+	ErrIntelRdtNotEnabled = errors.New("intelrdt: config provided but Intel RDT not supported")
+
+	// The root path of the Intel RDT "resource control" filesystem
+	intelRdtRoot string
+)
+
+type intelRdtData struct {
+	root        string
+	config      *configs.Cgroup
+	pid         int
+	containerId string
+}
+
+// The read-only Intel RDT related system information in root
+type IntelRdtInfo struct {
+	CbmMask   uint64 `json:"cbm_mask,omitempty"`
+	NumClosid uint64 `json:"num_closid,omitempty"`
+}
+
+// Return the mount point path of Intel RDT "resource control" filesysem
+func findIntelRdtMountpointDir() (string, error) {
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		text := s.Text()
+		fields := strings.Split(text, " ")
+		// Safe as mountinfo encodes mountpoints with spaces as \040.
+		index := strings.Index(text, " - ")
+		postSeparatorFields := strings.Fields(text[index+3:])
+		numPostFields := len(postSeparatorFields)
+
+		// This is an error as we can't detect if the mount is for "Intel RDT"
+		if numPostFields == 0 {
+			return "", fmt.Errorf("Found no fields post '-' in %q", text)
+		}
+
+		if postSeparatorFields[0] == "resctrl" {
+			// Check that the mount is properly formated.
+			if numPostFields < 3 {
+				return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
+			}
+
+			return fields[4], nil
+		}
+	}
+	if err := s.Err(); err != nil {
+		return "", err
+	}
+
+	return "", err
+}
+
+// Gets the root path of Intel RDT "resource control" filesystem
+func getIntelRdtRoot() (string, error) {
+	if intelRdtRoot != "" {
+		return intelRdtRoot, nil
+	}
+
+	root, err := findIntelRdtMountpointDir()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := os.Stat(root); err != nil {
+		return "", err
+	}
+
+	intelRdtRoot = root
+	return intelRdtRoot, nil
+}
+
+func getIntelRdtData(c *configs.Cgroup, pid int, containerId string) (*intelRdtData, error) {
+	rootPath, err := getIntelRdtRoot()
+	if err != nil {
+		return nil, err
+	}
+	return &intelRdtData{
+		root:        rootPath,
+		config:      c,
+		pid:         pid,
+		containerId: containerId,
+	}, nil
+}
+
+// WriteIntelRdtTasks writes the specified pid into the "tasks" file
+func WriteIntelRdtTasks(dir string, pid int) error {
+	if dir == "" {
+		return fmt.Errorf("no such directory for %s", IntelRdtTasks)
+	}
+
+	// Dont attach any pid if -1 is specified as a pid
+	if pid != -1 {
+		if err := ioutil.WriteFile(filepath.Join(dir, IntelRdtTasks), []byte(strconv.Itoa(pid)), 0700); err != nil {
+			return fmt.Errorf("failed to write %v to %v: %v", pid, IntelRdtTasks, err)
+		}
+	}
+	return nil
+}
+
+func (raw *intelRdtData) join(name string) (string, error) {
+	path := filepath.Join(raw.root, name)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return "", err
+	}
+
+	if err := WriteIntelRdtTasks(path, raw.pid); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func isIntelRdtMounted() bool {
+	_, err := getIntelRdtRoot()
+	if err != nil {
+		if !cgroups.IsNotFound(err) {
+			return false
+		}
+
+		// If not mounted, we try to mount again:
+		// mount -t resctrl resctrl /sys/fs/resctrl
+		if err := os.MkdirAll("/sys/fs/resctrl", 0755); err != nil {
+			return false
+		}
+		if err := exec.Command("mount", "-t", "resctrl", "resctrl", "/sys/fs/resctrl").Run(); err != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+func parseCpuInfoFile(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return false, err
+		}
+
+		text := s.Text()
+		flags := strings.Split(text, " ")
+
+		for _, flag := range flags {
+			if flag == "rdt_a" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// Check if Intel RDT is enabled
+func IsIntelRdtEnabled() bool {
+	// 1. check if hardware and kernel support Intel RDT feature
+	// "rdt" flag is set if supported
+	isFlagSet, err := parseCpuInfoFile("/proc/cpuinfo")
+	if err != nil {
+		return false
+	}
+
+	// 2. check if Intel RDT "resource control" filesystem is mounted
+	isMounted := isIntelRdtMounted()
+
+	return isFlagSet && isMounted
+}
+
+// Get Intel RDT "resource control" filesystem path
+func GetIntelRdtPath(id string) (string, error) {
+	rootPath, err := getIntelRdtRoot()
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(rootPath, id)
+	return path, nil
+}
+
+// Get read-only Intel RDT related system information
+func GetIntelRdtInfo() (*IntelRdtInfo, error) {
+	intelRdtInfo := &IntelRdtInfo{}
+
+	rootPath, err := getIntelRdtRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(rootPath, "info", "l3")
+	cbmMask, err := getCgroupParamUint(path, "cbm_mask")
+	if err != nil {
+		return nil, err
+	}
+	numClosid, err := getCgroupParamUint(path, "num_closid")
+	if err != nil {
+		return nil, err
+	}
+
+	intelRdtInfo.CbmMask = cbmMask
+	intelRdtInfo.NumClosid = numClosid
+
+	return intelRdtInfo, nil
+}

--- a/libcontainer/cgroups/fs/intelrdt_test.go
+++ b/libcontainer/cgroups/fs/intelrdt_test.go
@@ -1,0 +1,70 @@
+// +build linux
+
+package fs
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+func TestIntelRdtSetL3CacheSchema(t *testing.T) {
+	if !IsIntelRdtEnabled() {
+		return
+	}
+
+	helper := NewCgroupTestUtil("intel_rdt", t)
+	defer helper.cleanup()
+
+	const (
+		l3CacheSchemaBefore = "L3:0=f;1=f0"
+		l3CacheSchemeAfter  = "L3:0=f0;1=f"
+	)
+
+	helper.writeFileContents(map[string]string{
+		"schemata": l3CacheSchemaBefore + "\n",
+	})
+
+	helper.CgroupData.config.Resources.IntelRdtL3CacheSchema = l3CacheSchemeAfter
+	intelrdt := &IntelRdtGroup{}
+	if err := intelrdt.Set(helper.CgroupPath, helper.CgroupData.config); err != nil {
+		t.Fatal(err)
+	}
+
+	value, err := getCgroupParamString(helper.CgroupPath, "schemata")
+	if err != nil {
+		t.Fatalf("Failed to parse file 'schemata' - %s", err)
+	}
+
+	if value != l3CacheSchemeAfter {
+		t.Fatal("Got the wrong value, set 'schemata' failed.")
+	}
+}
+
+func TestIntelRdtStats(t *testing.T) {
+	if !IsIntelRdtEnabled() {
+		return
+	}
+
+	helper := NewCgroupTestUtil("intel_rdt", t)
+	defer helper.cleanup()
+
+	const (
+		l3CacheSchemaContent = "L3:0=ffff0;1=fff00"
+	)
+
+	helper.writeFileContents(map[string]string{
+		"schemata": l3CacheSchemaContent + "\n",
+	})
+
+	intelrdt := &IntelRdtGroup{}
+	stats := *cgroups.NewStats()
+	if err := intelrdt.GetStats(helper.CgroupPath, &stats); err != nil {
+		t.Fatal(err)
+	}
+
+	if stats.IntelRdtStats.IntelRdtGroupStats.L3CacheSchema != l3CacheSchemaContent {
+		t.Fatalf("Expected '%q', got '%q' for file 'schemata'",
+			l3CacheSchemaContent, stats.IntelRdtStats.IntelRdtGroupStats.L3CacheSchema)
+	}
+}

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -90,13 +90,27 @@ type HugetlbStats struct {
 	Failcnt uint64 `json:"failcnt"`
 }
 
+type IntelRdtRootStats struct {
+	L3CacheSchema string `json:"l3_cache_schema,omitempty"`
+}
+
+type IntelRdtGroupStats struct {
+	L3CacheSchema string `json:"l3_cache_schema,omitempty"`
+}
+
+type IntelRdtStats struct {
+	IntelRdtRootStats  IntelRdtRootStats  `json:"intel_rdt_root_stats,omitempty"`
+	IntelRdtGroupStats IntelRdtGroupStats `json:"intel_rdt_group_stats,omitempty"`
+}
+
 type Stats struct {
 	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 	PidsStats   PidsStats   `json:"pids_stats,omitempty"`
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
 	// the map is in the format "size of hugepage: stats of the hugepage"
-	HugetlbStats map[string]HugetlbStats `json:"hugetlb_stats,omitempty"`
+	HugetlbStats  map[string]HugetlbStats `json:"hugetlb_stats,omitempty"`
+	IntelRdtStats IntelRdtStats           `json:"intel_rdt_stats,omitempty"`
 }
 
 func NewStats() *Stats {

--- a/libcontainer/cgroups/systemd/apply_nosystemd.go
+++ b/libcontainer/cgroups/systemd/apply_nosystemd.go
@@ -10,8 +10,10 @@ import (
 )
 
 type Manager struct {
-	Cgroups *configs.Cgroup
-	Paths   map[string]string
+	Cgroups      *configs.Cgroup
+	Paths        map[string]string
+	ContainerId  string
+	ResourcePath string
 }
 
 func UseSystemd() bool {

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -121,4 +121,8 @@ type Resources struct {
 
 	// Set class identifier for container's network packets
 	NetClsClassid uint32 `json:"net_cls_classid_u"`
+
+	// Intel RDT: the schema for L3 cache id and capacity bitmask (CBM)
+	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+	IntelRdtL3CacheSchema string `json:"intel_rdt_l3_cache_schema"`
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -61,6 +61,9 @@ type State struct {
 
 	// Container's standard descriptors (std{in,out,err}), needed for checkpoint and restore
 	ExternalDescriptors []string `json:"external_descriptors,omitempty"`
+
+	// Intel RDT "resource control" filesystem path
+	IntelRdtPath string `json:"intel_rdt_path"`
 }
 
 // Container is a libcontainer container object.
@@ -376,6 +379,7 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 	return &setnsProcess{
 		cmd:           cmd,
 		cgroupPaths:   c.cgroupManager.GetPaths(),
+		intelRdtPath:  c.cgroupManager.GetResourcePath(),
 		childPipe:     childPipe,
 		parentPipe:    parentPipe,
 		config:        c.newInitConfig(p),
@@ -1202,6 +1206,7 @@ func (c *linuxContainer) currentState() (*State, error) {
 			Created:              c.created,
 		},
 		CgroupPaths:         c.cgroupManager.GetPaths(),
+		IntelRdtPath:        c.cgroupManager.GetResourcePath(),
 		NamespacePaths:      make(map[configs.NamespaceType]string),
 		ExternalDescriptors: externalDescriptors,
 	}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -464,6 +464,11 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 			})
 		}
 	}
+	if r.IntelRdt != nil {
+		if r.IntelRdt.L3CacheSchema != nil {
+			c.Resources.IntelRdtL3CacheSchema = *r.IntelRdt.L3CacheSchema
+		}
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
This PR fixes issue #433 

About Intel RDT/CAT feature:
Intel platforms with new Xeon CPU support Intel Resource Director Technology
(RDT). Cache Allocation Technology (CAT) is a sub-feature of RDT, which
currently supports L3 cache resource allocation.

This feature provides a way for the software to restrict cache allocation to a
defined 'subset' of L3 cache which may be overlapping with other 'subsets'.
The different subsets are identified by class of service (CLOS) and each CLOS
has a capacity bitmask (CBM).

For more information about Intel RDT/CAT can be found in the section 17.17
of Intel Software Developer Manual.

About Intel RDT/CAT kernel interface:
In Linux kernel, the interface is defined and exposed via "resource control"
filesystem, which is a "cgroup-like" interface.

Comparing with cgroups, it has similar process management lifecycle and
interfaces in a container. But unlike cgroups' hierarchy, it has single level
filesystem layout.

Intel RDT "resource control" filesystem hierarchy:
```
mount -t resctrl resctrl /sys/fs/resctrl
tree /sys/fs/resctrl
/sys/fs/resctrl/
|-- info
|   |-- L3
|       |-- cbm_mask
|       |-- num_closids
|-- cpus
|-- schemata
|-- tasks
|-- <container_id>
    |-- cpus
    |-- schemata
    |-- tasks
```
For runc, we can make use of `tasks` and `schemata` configuration for L3 cache
resource constraints.

The file `tasks` has a list of tasks that belongs to this group (e.g.,
<container_id>" group). Tasks can be added to a group by writing the task ID
to the "tasks" file  (which will automatically remove them from the previous
group to which they belonged). New tasks created by fork(2) and clone(2) are
added to the same group as their parent. If a pid is not in any sub group, it
Is in root group.

The file `schemata` has allocation bitmasks/values for L3 cache on each socket,
which contains L3 cache id and capacity bitmask (CBM).
```
	Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
```
For example, on a two-socket machine, L3's schema line could be `L3:0=ff;1=c0`
which means L3 cache id 0's CBM is 0xff, and L3 cache id 1's CBM is 0xc0.

The valid L3 cache CBM is a *contiguous bits set* and number of bits that can
be set is less than the max bit. The max bits in the CBM is varied among
supported Intel Xeon platforms. In Intel RDT "resource control" filesystem
layout, the CBM in a group should be a subset of the CBM in root. Kernel will
check if it is valid when writing. e.g., 0xfffff in root indicates the max bits
of CBM is 20 bits, which mapping to entire L3 cache capacity. Some valid CBM
values to set in a group: 0xf, 0xf0, 0x3ff, 0x1f00 and etc.

For more information about Intel RDT/CAT kernel interface:  
https://git.kernel.org/cgit/linux/kernel/git/tip/tip.git/commit/?h=x86/cache&id=f20e57892806ad244eaec7a7ae365e78fee53377

An example for runc:
```
There are two L3 caches in the two-socket machine, the default CBM is 0xfffff
and the max CBM length is 20 bits. This configuration assigns 4/5 of L3 cache
id 0 and the whole L3 cache id 1 for the container:

"linux": {
	"resources": {
		"intelRdt": {
			"l3CacheSchema": "L3:0=ffff0;1=fffff"
		}
	}
}
```
Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>