### PR TITLE
Don't format string if it's necessary

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -74,11 +75,11 @@ func setPageServer(context *cli.Context, options *libcontainer.CriuOpts) {
 	if psOpt := context.String("page-server"); psOpt != "" {
 		addressPort := strings.Split(psOpt, ":")
 		if len(addressPort) != 2 {
-			fatal(fmt.Errorf("Use --page-server ADDRESS:PORT to specify page server"))
+			fatal(errors.New("Use --page-server ADDRESS:PORT to specify page server"))
 		}
 		portInt, err := strconv.Atoi(addressPort[1])
 		if err != nil {
-			fatal(fmt.Errorf("Invalid port number"))
+			fatal(errors.New("Invalid port number"))
 		}
 		options.PageServer = libcontainer.CriuPageServerInfo{
 			Address: addressPort[0],
@@ -97,7 +98,7 @@ func setManageCgroupsMode(context *cli.Context, options *libcontainer.CriuOpts) 
 		case "strict":
 			options.ManageCgroupsMode = libcontainer.CRIU_CG_MODE_STRICT
 		default:
-			fatal(fmt.Errorf("Invalid manage cgroups mode"))
+			fatal(errors.New("Invalid manage cgroups mode"))
 		}
 	}
 }

--- a/create.go
+++ b/create.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -50,9 +51,9 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 	},
 	Action: func(context *cli.Context) error {
 		if context.NArg() != 1 {
-			fmt.Printf("Incorrect Usage.\n\n")
+			fmt.Print("Incorrect Usage.\n\n")
 			cli.ShowCommandHelp(context, "create")
-			return fmt.Errorf("runc: \"create\" requires exactly one argument")
+			return errors.New("runc: \"create\" requires exactly one argument")
 		}
 		if err := revisePidFile(context); err != nil {
 			return err

--- a/delete.go
+++ b/delete.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +23,7 @@ func killContainer(container libcontainer.Container) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("container init still running")
+	return errors.New("container init still running")
 }
 
 var deleteCommand = cli.Command{
@@ -47,7 +48,7 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 	Action: func(context *cli.Context) error {
 		hasError := false
 		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"delete\" requires a minimum of 1 argument")
+			return errors.New("runc: \"delete\" requires a minimum of 1 argument")
 		}
 
 		factory, err := loadFactory(context)
@@ -99,7 +100,7 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 		}
 
 		if hasError {
-			return fmt.Errorf("one or more of the container deletions failed")
+			return errors.New("one or more of the container deletions failed")
 		}
 		return nil
 	},

--- a/libcontainer/cgroups/systemd/apply_nosystemd.go
+++ b/libcontainer/cgroups/systemd/apply_nosystemd.go
@@ -3,7 +3,7 @@
 package systemd
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -19,19 +19,19 @@ func UseSystemd() bool {
 }
 
 func (m *Manager) Apply(pid int) error {
-	return fmt.Errorf("Systemd not supported")
+	return errors.New("Systemd not supported")
 }
 
 func (m *Manager) GetPids() ([]int, error) {
-	return nil, fmt.Errorf("Systemd not supported")
+	return nil, errors.New("Systemd not supported")
 }
 
 func (m *Manager) GetAllPids() ([]int, error) {
-	return nil, fmt.Errorf("Systemd not supported")
+	return nil, errors.New("Systemd not supported")
 }
 
 func (m *Manager) Destroy() error {
-	return fmt.Errorf("Systemd not supported")
+	return errors.New("Systemd not supported")
 }
 
 func (m *Manager) GetPaths() map[string]string {
@@ -39,17 +39,17 @@ func (m *Manager) GetPaths() map[string]string {
 }
 
 func (m *Manager) GetStats() (*cgroups.Stats, error) {
-	return nil, fmt.Errorf("Systemd not supported")
+	return nil, errors.New("Systemd not supported")
 }
 
 func (m *Manager) Set(container *configs.Config) error {
-	return nil, fmt.Errorf("Systemd not supported")
+	return nil, errors.New("Systemd not supported")
 }
 
 func (m *Manager) Freeze(state configs.FreezerState) error {
-	return fmt.Errorf("Systemd not supported")
+	return errors.New("Systemd not supported")
 }
 
 func Freeze(c *configs.Cgroup, state configs.FreezerState) error {
-	return fmt.Errorf("Systemd not supported")
+	return errors.New("Systemd not supported")
 }

--- a/libcontainer/configs/config_unix.go
+++ b/libcontainer/configs/config_unix.go
@@ -2,18 +2,20 @@
 
 package configs
 
-import "fmt"
+import (
+	"errors"
+)
 
 // HostUID gets the root uid for the process on host which could be non-zero
 // when user namespaces are enabled.
 func (c Config) HostUID() (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.UidMappings == nil {
-			return -1, fmt.Errorf("User namespaces enabled, but no user mappings found.")
+			return -1, errors.New("User namespaces enabled, but no user mappings found.")
 		}
 		id, found := c.hostIDFromMapping(0, c.UidMappings)
 		if !found {
-			return -1, fmt.Errorf("User namespaces enabled, but no root user mapping found.")
+			return -1, errors.New("User namespaces enabled, but no root user mapping found.")
 		}
 		return id, nil
 	}
@@ -26,11 +28,11 @@ func (c Config) HostUID() (int, error) {
 func (c Config) HostGID() (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.GidMappings == nil {
-			return -1, fmt.Errorf("User namespaces enabled, but no gid mappings found.")
+			return -1, errors.New("User namespaces enabled, but no gid mappings found.")
 		}
 		id, found := c.hostIDFromMapping(0, c.GidMappings)
 		if !found {
-			return -1, fmt.Errorf("User namespaces enabled, but no root group mapping found.")
+			return -1, errors.New("User namespaces enabled, but no root group mapping found.")
 		}
 		return id, nil
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -5,6 +5,7 @@ package libcontainer
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -178,7 +179,7 @@ func (c *linuxContainer) Set(config configs.Config) error {
 		return err
 	}
 	if status == Stopped {
-		return newGenericError(fmt.Errorf("container not running"), ContainerNotRunning)
+		return newGenericError(errors.New("container not running"), ContainerNotRunning)
 	}
 	c.config = &config
 	return c.cgroupManager.Set(c.config)
@@ -231,7 +232,7 @@ func (c *linuxContainer) exec() error {
 		os.Remove(path)
 		return nil
 	}
-	return fmt.Errorf("cannot start an already running container")
+	return errors.New("cannot start an already running container")
 }
 
 func (c *linuxContainer) start(process *Process, isInit bool) error {
@@ -459,7 +460,7 @@ func (c *linuxContainer) Resume() error {
 		return err
 	}
 	if status != Paused {
-		return newGenericError(fmt.Errorf("container not paused"), ContainerNotPaused)
+		return newGenericError(errors.New("container not paused"), ContainerNotPaused)
 	}
 	if err := c.cgroupManager.Freeze(configs.Thawed); err != nil {
 		return err
@@ -558,7 +559,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 	}
 
 	if criuOpts.ImagesDirectory == "" {
-		return fmt.Errorf("invalid directory to save checkpoint")
+		return errors.New("invalid directory to save checkpoint")
 	}
 
 	// Since a container can be C/R'ed multiple times,
@@ -717,7 +718,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 	}
 	defer workDir.Close()
 	if criuOpts.ImagesDirectory == "" {
-		return fmt.Errorf("invalid directory to restore checkpoint")
+		return errors.New("invalid directory to restore checkpoint")
 	}
 	imageDir, err := os.Open(criuOpts.ImagesDirectory)
 	if err != nil {
@@ -917,10 +918,10 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 			return err
 		}
 		if n == 0 {
-			return fmt.Errorf("unexpected EOF")
+			return errors.New("unexpected EOF")
 		}
 		if n == len(buf) {
-			return fmt.Errorf("buffer is too small")
+			return errors.New("buffer is too small")
 		}
 
 		resp := new(criurpc.CriuResp)

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -543,7 +543,7 @@ func testCpuShares(t *testing.T, systemd bool) {
 
 	_, _, err = runContainer(config, "", "ps")
 	if err == nil {
-		t.Fatalf("runContainer should failed with invalid CpuShares")
+		t.Fatal("runContainer should failed with invalid CpuShares")
 	}
 }
 
@@ -581,7 +581,7 @@ func testPids(t *testing.T, systemd bool) {
 	ok(t, err)
 
 	if ret != 0 {
-		t.Fatalf("expected fork() to succeed with no pids limit")
+		t.Fatal("expected fork() to succeed with no pids limit")
 	}
 
 	// Enforce a permissive limit. This needs to be fairly hand-wavey due to the
@@ -598,7 +598,7 @@ func testPids(t *testing.T, systemd bool) {
 	ok(t, err)
 
 	if ret != 0 {
-		t.Fatalf("expected fork() to succeed with permissive pids limit")
+		t.Fatal("expected fork() to succeed with permissive pids limit")
 	}
 
 	// Enforce a restrictive limit. 64 * /bin/true + 1 * shell should cause this
@@ -621,7 +621,7 @@ func testPids(t *testing.T, systemd bool) {
 	}
 
 	if err == nil {
-		t.Fatalf("expected fork() to fail with restrictive pids limit")
+		t.Fatal("expected fork() to fail with restrictive pids limit")
 	}
 
 	// Minimal restrictions are not really supported, due to quirks in using Go

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -1,7 +1,7 @@
 package libcontainer
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"math"
 	"os"
@@ -75,7 +75,7 @@ type Process struct {
 // Wait releases any resources associated with the Process
 func (p Process) Wait() (*os.ProcessState, error) {
 	if p.ops == nil {
-		return nil, newGenericError(fmt.Errorf("invalid process"), NoProcessOps)
+		return nil, newGenericError(errors.New("invalid process"), NoProcessOps)
 	}
 	return p.ops.wait()
 }
@@ -85,7 +85,7 @@ func (p Process) Pid() (int, error) {
 	// math.MinInt32 is returned here, because it's invalid value
 	// for the kill() system call.
 	if p.ops == nil {
-		return math.MinInt32, newGenericError(fmt.Errorf("invalid process"), NoProcessOps)
+		return math.MinInt32, newGenericError(errors.New("invalid process"), NoProcessOps)
 	}
 	return p.ops.pid(), nil
 }
@@ -93,7 +93,7 @@ func (p Process) Pid() (int, error) {
 // Signal sends a signal to the Process.
 func (p Process) Signal(sig os.Signal) error {
 	if p.ops == nil {
-		return newGenericError(fmt.Errorf("invalid process"), NoProcessOps)
+		return newGenericError(errors.New("invalid process"), NoProcessOps)
 	}
 	return p.ops.signal(sig)
 }
@@ -118,7 +118,7 @@ func (p *Process) NewConsole(rootuid, rootgid int) (Console, error) {
 // ConsoleFromPath sets the process's console with the path provided
 func (p *Process) ConsoleFromPath(path string) error {
 	if p.consolePath != "" {
-		return newGenericError(fmt.Errorf("console path already exists for process"), ConsoleExists)
+		return newGenericError(errors.New("console path already exists for process"), ConsoleExists)
 	}
 	p.consolePath = path
 	return nil

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -4,6 +4,7 @@ package seccomp
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -30,12 +31,12 @@ var (
 // of the init until they join the namespace
 func InitSeccomp(config *configs.Seccomp) error {
 	if config == nil {
-		return fmt.Errorf("cannot initialize Seccomp - nil config passed")
+		return errors.New("cannot initialize Seccomp - nil config passed")
 	}
 
 	defaultAction, err := getAction(config.DefaultAction)
 	if err != nil {
-		return fmt.Errorf("error initializing seccomp - invalid default action")
+		return errors.New("error initializing seccomp - invalid default action")
 	}
 
 	filter, err := libseccomp.NewFilter(defaultAction)
@@ -63,7 +64,7 @@ func InitSeccomp(config *configs.Seccomp) error {
 	// Add a rule for each syscall
 	for _, call := range config.Syscalls {
 		if call == nil {
-			return fmt.Errorf("encountered nil syscall while initializing Seccomp")
+			return errors.New("encountered nil syscall while initializing Seccomp")
 		}
 
 		if err = matchCall(filter, call); err != nil {
@@ -110,7 +111,7 @@ func getAction(act configs.Action) (libseccomp.ScmpAction, error) {
 	case configs.Trace:
 		return actTrace, nil
 	default:
-		return libseccomp.ActInvalid, fmt.Errorf("invalid action, cannot use in rule")
+		return libseccomp.ActInvalid, errors.New("invalid action, cannot use in rule")
 	}
 }
 
@@ -132,7 +133,7 @@ func getOperator(op configs.Operator) (libseccomp.ScmpCompareOp, error) {
 	case configs.MaskEqualTo:
 		return libseccomp.CompareMaskedEqual, nil
 	default:
-		return libseccomp.CompareInvalid, fmt.Errorf("invalid operator, cannot use in rule")
+		return libseccomp.CompareInvalid, errors.New("invalid operator, cannot use in rule")
 	}
 }
 
@@ -141,7 +142,7 @@ func getCondition(arg *configs.Arg) (libseccomp.ScmpCondition, error) {
 	cond := libseccomp.ScmpCondition{}
 
 	if arg == nil {
-		return cond, fmt.Errorf("cannot convert nil to syscall condition")
+		return cond, errors.New("cannot convert nil to syscall condition")
 	}
 
 	op, err := getOperator(arg.Op)
@@ -155,11 +156,11 @@ func getCondition(arg *configs.Arg) (libseccomp.ScmpCondition, error) {
 // Add a rule to match a single syscall
 func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall) error {
 	if call == nil || filter == nil {
-		return fmt.Errorf("cannot use nil as syscall to block")
+		return errors.New("cannot use nil as syscall to block")
 	}
 
 	if len(call.Name) == 0 {
-		return fmt.Errorf("empty string is not a valid syscall")
+		return errors.New("empty string is not a valid syscall")
 	}
 
 	// If we can't resolve the syscall, assume it's not supported on this kernel

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -94,7 +95,7 @@ func ParsePasswdFileFilter(path string, filter func(User) bool) ([]User, error) 
 
 func ParsePasswdFilter(r io.Reader, filter func(User) bool) ([]User, error) {
 	if r == nil {
-		return nil, fmt.Errorf("nil source for passwd-formatted data")
+		return nil, errors.New("nil source for passwd-formatted data")
 	}
 
 	var (
@@ -153,7 +154,7 @@ func ParseGroupFileFilter(path string, filter func(Group) bool) ([]Group, error)
 
 func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 	if r == nil {
-		return nil, fmt.Errorf("nil source for group-formatted data")
+		return nil, errors.New("nil source for group-formatted data")
 	}
 
 	var (

--- a/pause.go
+++ b/pause.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -22,7 +23,7 @@ Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
 		hasError := false
 		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"pause\" requires a minimum of 1 argument")
+			return errors.New("runc: \"pause\" requires a minimum of 1 argument")
 		}
 
 		factory, err := loadFactory(context)
@@ -44,7 +45,7 @@ Use runc list to identiy instances of containers and their current status.`,
 		}
 
 		if hasError {
-			return fmt.Errorf("one or more of container pause failed")
+			return errors.New("one or more of container pause failed")
 		}
 		return nil
 	},
@@ -63,7 +64,7 @@ Use runc list to identiy instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
 		hasError := false
 		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"resume\" requires a minimum of 1 argument")
+			return errors.New("runc: \"resume\" requires a minimum of 1 argument")
 		}
 
 		factory, err := loadFactory(context)
@@ -85,7 +86,7 @@ Use runc list to identiy instances of containers and their current status.`,
 		}
 
 		if hasError {
-			return fmt.Errorf("one or more of container resume failed")
+			return errors.New("one or more of container resume failed")
 		}
 		return nil
 	},

--- a/start.go
+++ b/start.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -20,7 +21,7 @@ your host.`,
 	Action: func(context *cli.Context) error {
 		hasError := false
 		if !context.Args().Present() {
-			return fmt.Errorf("runc: \"start\" requires a minimum of 1 argument")
+			return errors.New("runc: \"start\" requires a minimum of 1 argument")
 		}
 
 		factory, err := loadFactory(context)
@@ -60,7 +61,7 @@ your host.`,
 		}
 
 		if hasError {
-			return fmt.Errorf("one or more of container start failed")
+			return errors.New("one or more of container start failed")
 		}
 		return nil
 	},

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,7 +37,7 @@ func setupSpec(context *cli.Context) (*specs.Spec, error) {
 		setupSdNotify(spec, notifySocket)
 	}
 	if os.Geteuid() != 0 {
-		return nil, fmt.Errorf("runc should be run as root")
+		return nil, errors.New("runc should be run as root")
 	}
 	return spec, nil
 }

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -35,7 +35,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 		if systemd.UseSystemd() {
 			cgroupManager = libcontainer.SystemdCgroups
 		} else {
-			return nil, fmt.Errorf("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
+			return nil, errors.New("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
 		}
 	}
 	return libcontainer.New(abs, cgroupManager, libcontainer.CriuPath(context.GlobalString("criu")))
@@ -129,7 +129,7 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, console string
 	// detach and createTty will not work unless a console path is passed
 	// so error out here before changing any terminal settings
 	if createTTY && detach && console == "" {
-		return nil, fmt.Errorf("cannot allocate tty if runc will detach")
+		return nil, errors.New("cannot allocate tty if runc will detach")
 	}
 	if createTTY {
 		return createTty(process, rootuid, rootgid, console)
@@ -268,13 +268,13 @@ func (r *runner) terminate(p *libcontainer.Process) {
 
 func validateProcessSpec(spec *specs.Process) error {
 	if spec.Cwd == "" {
-		return fmt.Errorf("Cwd property must not be empty")
+		return errors.New("Cwd property must not be empty")
 	}
 	if !filepath.IsAbs(spec.Cwd) {
-		return fmt.Errorf("Cwd must be an absolute path")
+		return errors.New("Cwd must be an absolute path")
 	}
 	if len(spec.Args) == 0 {
-		return fmt.Errorf("args must not be empty")
+		return errors.New("args must not be empty")
 	}
 	return nil
 }


### PR DESCRIPTION
If the format of ```fmt.Errorf``` is unnecessary, replace it with ```errors.New``` because ```fmt.Errorf``` calls ```errors.New``` internally after the string been formated.