### PR TITLE
Sync HookState struct with OCI spec

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type Rlimit struct {
@@ -243,13 +244,7 @@ func (hooks Hooks) MarshalJSON() ([]byte, error) {
 }
 
 // HookState is the payload provided to a hook on execution.
-type HookState struct {
-	Version    string `json:"ociVersion"`
-	ID         string `json:"id"`
-	Pid        int    `json:"pid"`
-	Root       string `json:"root"`
-	BundlePath string `json:"bundlePath"`
-}
+type HookState specs.State
 
 type Hook interface {
 	// Run executes the hook with the provided state.

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -120,10 +120,10 @@ func TestMarshalHooksWithUnexpectedType(t *testing.T) {
 
 func TestFuncHookRun(t *testing.T) {
 	state := configs.HookState{
-		Version: "1",
-		ID:      "1",
-		Pid:     1,
-		Root:    "root",
+		Version:    "1",
+		ID:         "1",
+		Pid:        1,
+		BundlePath: "/bundle",
 	}
 
 	fHook := configs.NewFunctionHook(func(s configs.HookState) error {
@@ -138,10 +138,10 @@ func TestFuncHookRun(t *testing.T) {
 
 func TestCommandHookRun(t *testing.T) {
 	state := configs.HookState{
-		Version: "1",
-		ID:      "1",
-		Pid:     1,
-		Root:    "root",
+		Version:    "1",
+		ID:         "1",
+		Pid:        1,
+		BundlePath: "/bundle",
 	}
 	timeout := time.Second
 
@@ -161,10 +161,10 @@ func TestCommandHookRun(t *testing.T) {
 
 func TestCommandHookRunTimeout(t *testing.T) {
 	state := configs.HookState{
-		Version: "1",
-		ID:      "1",
-		Pid:     1,
-		Root:    "root",
+		Version:    "1",
+		ID:         "1",
+		Pid:        1,
+		BundlePath: "/bundle",
 	}
 	timeout := (10 * time.Millisecond)
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -266,7 +266,6 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 				Version:    c.config.Version,
 				ID:         c.id,
 				Pid:        parent.pid(),
-				Root:       c.config.Rootfs,
 				BundlePath: utils.SearchLabels(c.config.Labels, "bundle"),
 			}
 			for i, hook := range c.config.Hooks.Poststart {
@@ -1038,10 +1037,10 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 	case notify.GetScript() == "setup-namespaces":
 		if c.config.Hooks != nil {
 			s := configs.HookState{
-				Version: c.config.Version,
-				ID:      c.id,
-				Pid:     int(notify.GetPid()),
-				Root:    c.config.Rootfs,
+				Version:    c.config.Version,
+				ID:         c.id,
+				Pid:        int(notify.GetPid()),
+				BundlePath: utils.SearchLabels(c.config.Labels, "bundle"),
 			}
 			for i, hook := range c.config.Hooks.Prestart {
 				if err := hook.Run(s); err != nil {

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -76,6 +76,17 @@ func newTestRoot() (string, error) {
 	return dir, nil
 }
 
+func newTestBundle() (string, error) {
+	dir, err := ioutil.TempDir("", "bundle")
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
 // newRootfs creates a new tmp directory and copies the busybox root filesystem
 func newRootfs() (string, error) {
 	dir, err := ioutil.TempDir("", "")

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -339,10 +339,10 @@ func (p *initProcess) start() error {
 			if !p.config.Config.Namespaces.Contains(configs.NEWNS) {
 				if p.config.Config.Hooks != nil {
 					s := configs.HookState{
-						Version: p.container.config.Version,
-						ID:      p.container.id,
-						Pid:     p.pid(),
-						Root:    p.config.Config.Rootfs,
+						Version:    p.container.config.Version,
+						ID:         p.container.id,
+						Pid:        p.pid(),
+						BundlePath: utils.SearchLabels(p.config.Config.Labels, "bundle"),
 					}
 					for i, hook := range p.config.Config.Hooks.Prestart {
 						if err := hook.Run(s); err != nil {
@@ -362,7 +362,6 @@ func (p *initProcess) start() error {
 					Version:    p.container.config.Version,
 					ID:         p.container.id,
 					Pid:        p.pid(),
-					Root:       p.config.Config.Rootfs,
 					BundlePath: utils.SearchLabels(p.config.Config.Labels, "bundle"),
 				}
 				for i, hook := range p.config.Config.Hooks.Prestart {

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -60,7 +60,6 @@ func runPoststopHooks(c *linuxContainer) error {
 		s := configs.HookState{
 			Version:    c.config.Version,
 			ID:         c.id,
-			Root:       c.config.Rootfs,
 			BundlePath: utils.SearchLabels(c.config.Labels, "bundle"),
 		}
 		for _, hook := range c.config.Hooks.Poststop {


### PR DESCRIPTION
<del>* modify json name of `ociVersion` to `version`
<del>* Add missing `Status` and `Annotations` field

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

Edit:

`HookState` struct should follow definition of `State` in runtime-spec:
    
* Remove redundant `Rootfs` field as rootfs can be retrived from
 `bundlePath/config.json`

