### PR TITLE
Add integration for update rt period and runtime

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -3,7 +3,7 @@
 load helpers
 
 TEST_CGROUP_NAME="runc-cgroups-integration-test"
-CGROUP_MEMORY="${CGROUP_BASE_PATH}/${TEST_CGROUP_NAME}"
+CGROUP_MEMORY="${CGROUP_MEMORY_BASE_PATH}/${TEST_CGROUP_NAME}"
 
 function teardown() {
     rm -f $BATS_TMPDIR/runc-update-integration-test.json


### PR DESCRIPTION
Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

Add missing integration test for https://github.com/opencontainers/runc/pull/1173 with "requires" support, because our test machine doesn't have a kernel supporting RT Cgroup yet.

/cc @cyphar 