### PR TITLE
Don't add device to list if it doesn't exist anymore

### DIFF
--- a/libcontainer/devices/devices_unix.go
+++ b/libcontainer/devices/devices_unix.go
@@ -94,6 +94,9 @@ func getDevices(path string) ([]*configs.Device, error) {
 			if err == ErrNotADevice {
 				continue
 			}
+			if os.IsNotExist(err) {
+				continue
+			}
 			return nil, err
 		}
 		out = append(out, device)


### PR DESCRIPTION
Fix a race where a device is first seen while walking /dev but has disappeared by the time we stat it. This is seen in environments where lots of privileged containers are launched/deleted rapidly with devicemapper as storage driver as lots of device mapper devices are created/deleted.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>