### PR TITLE
Makefile: add manpage cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ clean:
 	rm -f $(RUNC_LINK)
 	rm -rf $(GOPATH)/pkg
 	rm -rf $(RELEASE_DIR)
+	rm -rf $(MAN_DIR)
 
 validate:
 	script/validate-gofmt


### PR DESCRIPTION
I think generated manpages should also need cleanup

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>