### PR TITLE
*: fix go-vet failures

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -39,8 +39,8 @@ func testExecPS(t *testing.T, userns bool) {
 	defer remove(rootfs)
 	config := newTemplateConfig(rootfs)
 	if userns {
-		config.UidMappings = []configs.IDMap{{0, 0, 1000}}
-		config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
+		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
 	}
 
@@ -181,8 +181,8 @@ func testRlimit(t *testing.T, userns bool) {
 
 	config := newTemplateConfig(rootfs)
 	if userns {
-		config.UidMappings = []configs.IDMap{{0, 0, 1000}}
-		config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
+		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
 	}
 
@@ -1565,8 +1565,8 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 
 	// Execute a long-running container
 	config1 := newTemplateConfig(rootfs)
-	config1.UidMappings = []configs.IDMap{{0, 0, 1000}}
-	config1.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config1.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
+	config1.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config1.Namespaces = append(config1.Namespaces, configs.Namespace{Type: configs.NEWUSER})
 	container1, err := newContainer(config1)
 	ok(t, err)
@@ -1597,8 +1597,8 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 	defer remove(rootfs2)
 
 	config2 := newTemplateConfig(rootfs2)
-	config2.UidMappings = []configs.IDMap{{0, 0, 1000}}
-	config2.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config2.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
+	config2.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config2.Namespaces.Add(configs.NEWNET, netns1)
 	config2.Namespaces.Add(configs.NEWUSER, userns1)
 	config2.Cgroups.Path = "integration/test2"

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -89,8 +89,8 @@ func testExecInRlimit(t *testing.T, userns bool) {
 
 	config := newTemplateConfig(rootfs)
 	if userns {
-		config.UidMappings = []configs.IDMap{{0, 0, 1000}}
-		config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
+		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
 	}
 
@@ -503,8 +503,8 @@ func TestExecInUserns(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 	config := newTemplateConfig(rootfs)
-	config.UidMappings = []configs.IDMap{{0, 0, 1000}}
-	config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
+	config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
 	container, err := newContainer(config)
 	ok(t, err)


### PR DESCRIPTION
Previously, we would get failures with go-vet with test files.

```
% go vet ./...
libcontainer/integration/exec_test.go:42: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/exec_test.go:43: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/exec_test.go:184: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/exec_test.go:185: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/exec_test.go:1568: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/exec_test.go:1569: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/exec_test.go:1600: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/exec_test.go:1601: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/execin_test.go:92: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/execin_test.go:93: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/execin_test.go:506: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
libcontainer/integration/execin_test.go:507: github.com/opencontainers/runc/libcontainer/configs.IDMap composite literal uses unkeyed fields
```

Signed-off-by: Aleksa Sarai <asarai@suse.de>