### PR TITLE
Fix integration when missing criu

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -18,7 +18,7 @@ HELLO_IMAGE="$TESTDATA/hello-world.tar"
 HELLO_BUNDLE="$BATS_TMPDIR/hello-world"
 
 # CRIU PATH
-CRIU="$(which criu)"
+CRIU="$(which criu || true)"
 
 # Kernel version
 KERNEL_VERSION="$(uname -r)"


### PR DESCRIPTION
If criu isn't installed in the host, integration tests won't be able
to go on, it should skip checkpoint/restore tests instead of interrupt.

Output before:

```
$ make localintegration
bats -t tests/integration
/usr/lib/bats/bats-exec-suite: line 20: let: count+=: syntax error:
operand expected (error token is "+=")
Makefile:103: recipe for target 'localintegration' failed
```

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>