### PR TITLE
travis: add travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: go
+go:
+  - 1.6.x
+  - 1.7.x
+# - master
+
+# `make ci` uses Docker.
+sudo: required
+services:
+  - docker
+
+env:
+  global:
+    - BUILDTAGS="seccomp apparmor selinux ambient"
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libseccomp-dev libapparmor-dev
+  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/vbatts/git-validation
+  - go get -u github.com/mvdan/sh/cmd/shfmt
+
+script:
+  - git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}
+  - make BUILDTAGS="${BUILDTAGS}"
+  - make BUILDTAGS="${BUILDTAGS}" clean validate test


### PR DESCRIPTION
This sets up a working Travis CI configuration, that runs all of our
integration and unit tests (and also checks a simple raw-build on the
Travis server).

Closes #1241 (this is a carry).
Signed-off-by: Aleksa Sarai <asarai@suse.de>