### PR TITLE
remove `-i` option to avoid failure of jenkins in non-interactive mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ localtest:
 	make localunittest localintegration
 
 unittest: runcimage
-	docker run -e TESTFLAGS -ti --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) make localunittest
+	docker run -e TESTFLAGS -t --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) make localunittest
 
 localunittest: all
 	go test -timeout 3m -tags "$(BUILDTAGS)" ${TESTFLAGS} -v ./...


### PR DESCRIPTION
Signed-off-by: Fengtu Wang <wangfengtu@huawei.com>