### PR TITLE
Fix go_vet errors

### DIFF
--- a/libcontainer/configs/namespaces_syscall_unsupported.go
+++ b/libcontainer/configs/namespaces_syscall_unsupported.go
@@ -4,12 +4,10 @@ package configs
 
 func (n *Namespace) Syscall() int {
 	panic("No namespace syscall support")
-	return 0
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct
 // flags on clone, unshare. This function returns flags only for new namespaces.
 func (n *Namespaces) CloneFlags() uintptr {
 	panic("No namespace syscall support")
-	return uintptr(0)
 }


### PR DESCRIPTION
runc/libcontainer/configs/namespaces_syscall_unsupported.go
Line 7: error: unreachable code (vet)
Line 14: error: unreachable code (vet)

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>