### PR TITLE
Cleanup: remove redundant code

### DIFF
--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -343,7 +343,7 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 			if len(groups) > 0 {
 				// First match wins, even if there's more than one matching entry.
 				user.Gid = groups[0].Gid
-			} else if groupArg != "" {
+			} else {
 				// If we can't find a group with the given name, the only other valid
 				// option is if it's a numeric group name with no associated entry in group.
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

Has `if groupArg != ""` before enter the `if ... else if groupArg != ""`, check `if groupArg != ""` is redundant here. 