### PR TITLE
Add support for IO redirection on runc exec

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -84,6 +84,18 @@ following will output a list of processes running in the container:
 			Usage:  "disable the use of the subreaper used to reap reparented processes",
 			Hidden: true,
 		},
+		cli.StringFlag{
+			Name:  "stdin",
+			Usage: "redirect process stdin to given filepath",
+		},
+		cli.StringFlag{
+			Name:  "stdout",
+			Usage: "redirect process stdout to given filepath",
+		},
+		cli.StringFlag{
+			Name:  "stderr",
+			Usage: "redirect process stderr to given filepath",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 2, minArgs); err != nil {
@@ -136,6 +148,9 @@ func execProcess(context *cli.Context) (int, error) {
 		container:       container,
 		consoleSocket:   context.String("console-socket"),
 		detach:          detach,
+		stdin:           context.String("stdin"),
+		stdout:          context.String("stdout"),
+		stderr:          context.String("stderr"),
 		pidFile:         context.String("pid-file"),
 	}
 	return r.run(p)

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -426,3 +426,47 @@ func signalAllProcesses(m cgroups.Manager, s os.Signal) error {
 	}
 	return nil
 }
+
+func setupStdio() error {
+	stdinFD := os.Getenv("STDIN_FD")
+	stdoutFD := os.Getenv("STDOUT_FD")
+	stderrFD := os.Getenv("STDERR_FD")
+
+	if len(stdinFD) > 0 {
+		stdinFD, err := strconv.Atoi(stdinFD)
+		if err != nil {
+			return err
+		}
+
+		err = syscall.Dup2(stdinFD, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(stdoutFD) > 0 {
+		stdoutFD, err := strconv.Atoi(stdoutFD)
+		if err != nil {
+			return err
+		}
+
+		err = syscall.Dup2(stdoutFD, 1)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(stderrFD) > 0 {
+		stderrFD, err := strconv.Atoi(stderrFD)
+		if err != nil {
+			return err
+		}
+
+		err = syscall.Dup2(stderrFD, 2)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -58,5 +58,9 @@ func (l *linuxSetnsInit) Init() error {
 	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
 		return err
 	}
+	if err := setupStdio(); err != nil {
+		return err
+	}
+
 	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -231,3 +231,11 @@ function teardown_hello() {
 	teardown_running_container test_hello
 	run rm -f -r "$HELLO_BUNDLE"
 }
+
+function setup_fifos() {
+	mkfifo stdinfifo stdoutfifo stderrfifo
+}
+
+function teardown_fifos() {
+	rm -f stdinfifo stdoutfifo stderrfifo
+}


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/opencontainers/runc/issues/349), separating the stdout/err streams of `runc exec/init` and the container is not possible because the streams of runc get inherited by the container process. This is not ideal for Garden because we don't want runc errors appearing in the "user's" application logs.

This PR attempts to separate the standard streams of runc from those of the container by adding 3 flags - one for stdin, stdout and stderr. If you pass one of these flags this essentially redirects the corresponding standard stream to the given file just before exec-ing the container process. After this redirection it is safe to assume that runc's streams are not written to by the container process and vice versa, the container's streams are not written to by runc.

This is a first stab at this behaviour but it seemed consistent with how the LISTEN_FDS behaved. 

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>