### PR TITLE
List: remove dup root check

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -90,7 +90,7 @@ func CriuPath(criupath string) func(*LinuxFactory) error {
 
 // New returns a linux based container factory based in the root directory and
 // configures the factory with the provided option funcs.
-func New(root string, options ...func(*LinuxFactory) error) (Factory, error) {
+func New(root string, options ...func(*LinuxFactory) error) (*LinuxFactory, error) {
 	if root != "" {
 		if err := os.MkdirAll(root, 0700); err != nil {
 			return nil, newGenericError(err, SystemError)

--- a/list.go
+++ b/list.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"text/tabwriter"
 	"time"
 
@@ -110,12 +109,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 	if err != nil {
 		return nil, err
 	}
-	root := context.GlobalString("root")
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		return nil, err
-	}
-	list, err := ioutil.ReadDir(absRoot)
+	list, err := ioutil.ReadDir(factory.Root)
 	if err != nil {
 		fatal(err)
 	}

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -24,8 +24,8 @@ var errEmptyID = errors.New("container id cannot be empty")
 
 var container libcontainer.Container
 
-// loadFactory returns the configured factory instance for execing containers.
-func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
+// loadFactory returns the configured LinuxFactory instance for execing containers.
+func loadFactory(context *cli.Context) (*libcontainer.LinuxFactory, error) {
 	root := context.GlobalString("root")
 	abs, err := filepath.Abs(root)
 	if err != nil {


### PR DESCRIPTION
There is no need to do duplicate root check.
factory.Root is checked and valid value.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>