### PR TITLE
Fix regression of exec command

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -18,10 +18,11 @@ import (
 var execCommand = cli.Command{
 	Name:  "exec",
 	Usage: "execute new process inside the container",
-	ArgsUsage: `<container-id> <container command> [command options]
+	ArgsUsage: `<container-id> <command> [command options]  || -p process.json <container-id>
 
 Where "<container-id>" is the name for the instance of the container and
-"<container command>" is the command to be executed in the container.
+"<command>" is the command to be executed in the container.
+"<command>" can't be empty unless a "-p" flag provided.
 
 EXAMPLE:
 For example, if the container is configured to run the linux ps command the
@@ -86,7 +87,7 @@ following will output a list of processes running in the container:
 		},
 	},
 	Action: func(context *cli.Context) error {
-		if err := checkArgs(context, 2, minArgs); err != nil {
+		if err := checkArgs(context, 1, minArgs); err != nil {
 			return err
 		}
 		if os.Geteuid() != 0 {


### PR DESCRIPTION
Fixes #1264

Set minimal required args to 1 for `exec` command to roll back to
previous behavior, also modify help message a little bit.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>