### PR TITLE
Set initial console size based on process spec

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -522,6 +522,8 @@ func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 		cfg.Rlimits = process.Rlimits
 	}
 	cfg.CreateConsole = process.ConsoleSocket != nil
+	cfg.ConsoleWidth = process.ConsoleWidth
+	cfg.ConsoleHeight = process.ConsoleHeight
 	return cfg
 }
 

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -47,6 +47,10 @@ type Process struct {
 	// ExtraFiles specifies additional open files to be inherited by the container
 	ExtraFiles []*os.File
 
+	// Initial sizings for the console
+	ConsoleWidth  uint16
+	ConsoleHeight uint16
+
 	// Capabilities specify the capabilities to keep when executing the process inside the container
 	// All capabilities not specified will be dropped from the processes capability mask
 	Capabilities *configs.Capabilities

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -108,6 +108,12 @@ func newProcess(p specs.Process) (*libcontainer.Process, error) {
 		NoNewPrivileges: &p.NoNewPrivileges,
 		AppArmorProfile: p.ApparmorProfile,
 	}
+
+	if p.ConsoleSize != nil {
+		lp.ConsoleWidth = uint16(p.ConsoleSize.Width)
+		lp.ConsoleHeight = uint16(p.ConsoleSize.Height)
+	}
+
 	if p.Capabilities != nil {
 		lp.Capabilities = &configs.Capabilities{}
 		lp.Capabilities.Bounding = p.Capabilities.Bounding


### PR DESCRIPTION
Signed-off-by: Petar Petrov <pppepito86@gmail.com>

This commit hopefully resolves issue #1269, setting the initial console size for TTYs based on the ConsoleSize properties in the process spec.

Two thoughts about this PR that would be good to get feedback on: Firstly, the height and width are passed through as separate primitives and turned into a `term.WinSize` right before use. We weren't sure of the pros and cons of this approach vs the `term` package all the way up the stack, or the runtime-spec `Box` or even whether we should define another process config struct.

Secondly, the bats test would ideally read the master fd from the `$CONSOLE_SOCKET` and read output directly from a `runc exec` invocation calling `stty -a` but there seems to be no convention for doing this and working around the existing `recvtty` infrastructure to allow these kind of tests seemed like a fairly sizable change, that might be best as its own PR.