### PR TITLE
Update state JSON encoding fields to match spec

### DIFF
--- a/list.go
+++ b/list.go
@@ -31,9 +31,9 @@ type containerState struct {
 	// Status is the current status of the container, running, paused, ...
 	Status string `json:"status"`
 	// Bundle is the path on the filesystem to the bundle
-	Bundle string `json:"bundle"`
+	Bundle string `json:"bundlePath"`
 	// Rootfs is a path to a directory containing the container's root filesystem.
-	Rootfs string `json:"rootfs"`
+	Rootfs string `json:"rootfsPath"`
 	// Created is the unix timestamp for the creation time of the container in UTC
 	Created time.Time `json:"created"`
 	// Annotations is the user defined annotations added to the config.

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -53,7 +53,7 @@ function teardown() {
 
   ROOT=$HELLO_BUNDLE runc list --format json
   [ "$status" -eq 0 ]
-  [[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-  [[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-  [[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
+  [[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundlePath\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfsPath\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
+  [[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundlePath\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfsPath\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
+  [[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundlePath\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfsPath\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
 }


### PR DESCRIPTION
In #1048 the `cState` struct was consolidated into the `containerState`
struct which inadvertently changed the `bundlePath` and `rootfsPath`
fields in the JSON to `bundle` and `rootfs` respectively.

https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#state
requires that the bundle path field be named `bundlePath` so reinstate
that name.

The specification does not cover the rootfs field name, but revert it
too for consistency.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

/cc @crosbymichael 