### PR TITLE
move error check out of the for loop

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -189,9 +189,6 @@ func GetAllSubsystems() ([]string, error) {
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
 		text := s.Text()
 		if text[0] != '#' {
 			parts := strings.Fields(text)
@@ -199,6 +196,9 @@ func GetAllSubsystems() ([]string, error) {
 				subsystems = append(subsystems, parts[0])
 			}
 		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
 	}
 	return subsystems, nil
 }
@@ -265,10 +265,6 @@ func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
 	cgroups := make(map[string]string)
 
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
-
 		text := s.Text()
 		// from cgroups(7):
 		// /proc/[pid]/cgroup
@@ -285,6 +281,10 @@ func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
 			cgroups[subs] = parts[2]
 		}
 	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
 	return cgroups, nil
 }
 

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -212,10 +212,6 @@ func parseStatusFile(path string) (map[string]string, error) {
 	status := make(map[string]string)
 
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
-
 		text := s.Text()
 		parts := strings.Split(text, ":")
 
@@ -225,5 +221,9 @@ func parseStatusFile(path string) (map[string]string, error) {
 
 		status[parts[0]] = parts[1]
 	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
 	return status, nil
 }


### PR DESCRIPTION
The `bufio.Scanner.Scan` method returns false either by reaching the
end of the input or an error. After Scan returns false, the Err method
will return any error that occurred during scanning, except that if it
was io.EOF, Err will return nil.

We should check the error when Scan return false(out of the for loop).

refer: [https://golang.org/pkg/bufio/#Scanner.Scan](https://golang.org/pkg/bufio/#Scanner.Scan)

Signed-off-by: Wang Long <long.wanglong@huawei.com>