### PR TITLE
user: fix the parameter error

### DIFF
--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -199,18 +199,16 @@ type ExecUser struct {
 // files cannot be opened for any reason, the error is ignored and a nil
 // io.Reader is passed instead.
 func GetExecUserPath(userSpec string, defaults *ExecUser, passwdPath, groupPath string) (*ExecUser, error) {
-	passwd, err := os.Open(passwdPath)
-	if err != nil {
-		passwd = nil
-	} else {
-		defer passwd.Close()
+	var passwd, group io.Reader
+
+	if passwdFile, err := os.Open(passwdPath); err == nil {
+		passwd = passwdFile
+		defer passwdFile.Close()
 	}
 
-	group, err := os.Open(groupPath)
-	if err != nil {
-		group = nil
-	} else {
-		defer group.Close()
+	if groupFile, err := os.Open(groupPath); err == nil {
+		group = groupFile
+		defer groupFile.Close()
 	}
 
 	return GetExecUser(userSpec, defaults, passwd, group)
@@ -433,9 +431,11 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 // that opens the groupPath given and gives it as an argument to
 // GetAdditionalGroups.
 func GetAdditionalGroupsPath(additionalGroups []string, groupPath string) ([]int, error) {
-	group, err := os.Open(groupPath)
-	if err == nil {
-		defer group.Close()
+	var group io.Reader
+
+	if groupFile, err := os.Open(groupPath); err == nil {
+		group = groupFile
+		defer groupFile.Close()
 	}
 	return GetAdditionalGroups(additionalGroups, group)
 }


### PR DESCRIPTION
The parameters passed to `GetExecUser` is not correct.
Consider the following code:

```
package main

import (
	"fmt"
	"io"
	"os"
)

func main() {
	passwd, err := os.Open("/etc/passwd1")
	if err != nil {
		passwd = nil
	} else {
		defer passwd.Close()
	}

	err = GetUserPasswd(passwd)
	if err != nil {
		fmt.Printf("%#v\n", err)
	}
}

func GetUserPasswd(r io.Reader) error {
	if r == nil {
		return fmt.Errorf("nil source for passwd-formatted
data")
	} else {
		fmt.Printf("r = %#v\n", r)
	}
	return nil
}
```

If the file `/etc/passwd1` is not exist, we expect to return
`nil source for passwd-formatted data` error, and in fact, the func
`GetUserPasswd` return nil.

The same logic exists in runc code. this patch fix it.

Signed-off-by: Wang Long <long.wanglong@huawei.com>