### PR TITLE
kill: make second argument optional

### DIFF
--- a/kill.go
+++ b/kill.go
@@ -52,10 +52,10 @@ var signalMap = map[string]syscall.Signal{
 var killCommand = cli.Command{
 	Name:  "kill",
 	Usage: "kill sends the specified signal (default: SIGTERM) to the container's init process",
-	ArgsUsage: `<container-id> <signal>
+	ArgsUsage: `<container-id> [signal]
 
 Where "<container-id>" is the name for the instance of the container and
-"<signal>" is the signal to be sent to the init process.
+"[signal]" is the signal to be sent to the init process.
 
 EXAMPLE:
 For example, if the container id is "ubuntu01" the following will send a "KILL"
@@ -69,7 +69,7 @@ signal to the init process of the "ubuntu01" container:
 		},
 	},
 	Action: func(context *cli.Context) error {
-		if err := checkArgs(context, 2, exactArgs); err != nil {
+		if err := checkArgs(context, 1, minArgs); err != nil {
 			return err
 		}
 		container, err := getContainer(context)


### PR DESCRIPTION
commit b517076907b7c1 added a check that kill accepts two arguments.
Since the second argument is optional, change it back to accept the
shorter form "kill CONTAINER".

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>