### PR TITLE
Remove a compiler warning in some environments

### DIFF
--- a/libcontainer/utils/cmsg.c
+++ b/libcontainer/utils/cmsg.c
@@ -131,7 +131,7 @@ struct file_t recvfd(int sockfd)
 	if (cmsg->cmsg_type != SCM_RIGHTS)
 		error("recvfd: expected SCM_RIGHTS in cmsg: %d", cmsg->cmsg_type);
 	if (cmsg->cmsg_len != CMSG_LEN(sizeof(int)))
-		error("recvfd: expected correct CMSG_LEN in cmsg: %lu", cmsg->cmsg_len);
+		error("recvfd: expected correct CMSG_LEN in cmsg: %lu", (unsigned long)cmsg->cmsg_len);
 
 	fdptr = (int *) CMSG_DATA(cmsg);
 	if (!fdptr || *fdptr < 0)


### PR DESCRIPTION
POSIX mandates that `cmsg_len` in `struct cmsghdr` is a `socklen_t`,
which is an `unsigned int`. Musl libc as used in Alpine implements
this; Glibc ignores the spec and makes it a `size_t` ie `unsigned long`.
To avoid the `-Wformat=` warning from the `%lu` on Alpine, cast this
to an `unsigned long` always.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>