### PR TITLE
Resolve InitArgs to ensure init works

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -34,7 +34,15 @@ var (
 // InitArgs returns an options func to configure a LinuxFactory with the
 // provided init binary path and arguments.
 func InitArgs(args ...string) func(*LinuxFactory) error {
-	return func(l *LinuxFactory) error {
+	return func(l *LinuxFactory) (err error) {
+		if len(args) > 0 {
+			// Resolve relative paths to ensure that its available
+			// after directory changes.
+			if args[0], err = filepath.Abs(args[0]); err != nil {
+				return newGenericError(err, ConfigInvalid)
+			}
+		}
+
 		l.InitArgs = args
 		return nil
 	}


### PR DESCRIPTION
If a relative pathed exe is used for InitArgs init will fail to run if Cwd is not set the original path.

Prevent failure of init to run by ensuring that exe in InitArgs is an absolute path.

Signed-off-by: Steven Hartland <steven.hartland@multiplay.co.uk>