### PR TITLE
Add nsenter details to libcontainer README.md

### DIFF
--- a/libcontainer/README.md
+++ b/libcontainer/README.md
@@ -16,7 +16,14 @@ the current binary (/proc/self/exe) to be executed as the init process, and use
 arg "init", we call the first step process "bootstrap", so you always need a "init"
 function as the entry of "bootstrap".
 
+In addition to the go init function the early stage bootstrap is handled by importing
+[nsenter](https://github.com/opencontainers/runc/blob/master/libcontainer/nsenter/README.md).
+
 ```go
+import (
+	_ "github.com/opencontainers/runc/libcontainer/nsenter"
+)
+
 func init() {
 	if len(os.Args) > 1 && os.Args[1] == "init" {
 		runtime.GOMAXPROCS(1)


### PR DESCRIPTION
Add the import of nsenter to the example in libcontainer's README.md, as without it none of the example code works.

Signed-off-by: Steven Hartland <steven.hartland@multiplay.co.uk>