### PR TITLE
Revert "DupSecOpt needs to match InitLabels"

### DIFF
--- a/libcontainer/label/label_selinux.go
+++ b/libcontainer/label/label_selinux.go
@@ -33,19 +33,15 @@ func InitLabels(options []string) (string, string, error) {
 		pcon := selinux.NewContext(processLabel)
 		mcon := selinux.NewContext(mountLabel)
 		for _, opt := range options {
-			val := strings.SplitN(opt, "=", 2)
-			if val[0] != "label" {
-				continue
-			}
-			if len(val) < 2 {
-				return "", "", fmt.Errorf("bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
-			}
-			if val[1] == "disable" {
+			if opt == "disable" {
 				return "", "", nil
 			}
-			con := strings.SplitN(val[1], ":", 2)
-			if len(con) < 2 || !validOptions[con[0]] {
-				return "", "", fmt.Errorf("bad label option %q, valid options 'disable, user, role, level, type'", con[0])
+			if i := strings.Index(opt, ":"); i == -1 {
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
+			}
+			con := strings.SplitN(opt, ":", 2)
+			if !validOptions[con[0]] {
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type'", con[0])
 
 			}
 			pcon[con[0]] = con[1]

--- a/libcontainer/label/label_selinux_test.go
+++ b/libcontainer/label/label_selinux_test.go
@@ -18,7 +18,7 @@ func TestInit(t *testing.T) {
 			t.Log("InitLabels Failed")
 			t.Fatal(err)
 		}
-		testDisabled := []string{"label=disable"}
+		testDisabled := []string{"disable"}
 		roMountLabel := GetROMountLabel()
 		if roMountLabel == "" {
 			t.Errorf("GetROMountLabel Failed")
@@ -32,7 +32,7 @@ func TestInit(t *testing.T) {
 			t.Log("InitLabels Disabled Failed")
 			t.FailNow()
 		}
-		testUser := []string{"label=user:user_u", "label=role:user_r", "label=type:user_t", "label=level:s0:c1,c15"}
+		testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
 		plabel, mlabel, err = InitLabels(testUser)
 		if err != nil {
 			t.Log("InitLabels User Failed")
@@ -44,7 +44,7 @@ func TestInit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testBadData := []string{"label=user", "label=role:user_r", "label=type:user_t", "label=level:s0:c1,c15"}
+		testBadData := []string{"user", "role:user_r", "type:user_t", "level:s0:c1,c15"}
 		if _, _, err = InitLabels(testBadData); err == nil {
 			t.Log("InitLabels Bad Failed")
 			t.Fatal(err)


### PR DESCRIPTION
This reverts commit 491cadac9260de4886d2d4df680de065ccdffec1.

@rhatdan PTAL as per discussion in https://github.com/opencontainers/runc/pull/1109#issuecomment-275868464 and https://github.com/docker/docker/pull/30532#issuecomment-275864816