### PR TITLE
Add --additional-gids to runc exec.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -50,9 +50,9 @@ following will output a list of processes running in the container:
 			Name:  "user, u",
 			Usage: "UID (format: <uid>[:<gid>])",
 		},
-		cli.StringFlag{
+		cli.Int64SliceFlag{
 			Name:  "additional-gids, g",
-			Usage: "additional gids separated by comma",
+			Usage: "additional gids",
 		},
 		cli.StringFlag{
 			Name:  "process, p",
@@ -208,14 +208,8 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 		}
 		p.User.UID = uint32(uid)
 	}
-	if context.String("additional-gids") != "" {
-		for _, i := range strings.Split(context.String("additional-gids"), ",") {
-			gid, err := strconv.Atoi(i)
-			if err != nil {
-				return nil, fmt.Errorf("parsing %s as int for gid failed: %v", i, err)
-			}
-			p.User.AdditionalGids = append(p.User.AdditionalGids, uint32(gid))
-		}
+	for _, gid := range context.Int64Slice("additional-gids") {
+		p.User.AdditionalGids = append(p.User.AdditionalGids, uint32(gid))
 	}
 	return &p, nil
 }

--- a/exec.go
+++ b/exec.go
@@ -51,6 +51,10 @@ following will output a list of processes running in the container:
 			Usage: "UID (format: <uid>[:<gid>])",
 		},
 		cli.StringFlag{
+			Name:  "additional-gids, g",
+			Usage: "additional gids separated by comma",
+		},
+		cli.StringFlag{
 			Name:  "process, p",
 			Usage: "path to the process.json",
 		},
@@ -203,6 +207,15 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 			return nil, fmt.Errorf("parsing %s as int for uid failed: %v", u[0], err)
 		}
 		p.User.UID = uint32(uid)
+	}
+	if context.String("additional-gids") != "" {
+		for _, i := range strings.Split(context.String("additional-gids"), ",") {
+			gid, err := strconv.Atoi(i)
+			if err != nil {
+				return nil, fmt.Errorf("parsing %s as int for gid failed: %v", i, err)
+			}
+			p.User.AdditionalGids = append(p.User.AdditionalGids, uint32(gid))
+		}
 	}
 	return &p, nil
 }

--- a/man/runc-exec.8.md
+++ b/man/runc-exec.8.md
@@ -14,16 +14,17 @@ following will output a list of processes running in the container:
        # runc exec <container-id> ps
 
 # OPTIONS
-   --console value              specify the pty slave path for use with the container
-   --cwd value                  current working directory in the container
-   --env value, -e value        set environment variables
-   --tty, -t                    allocate a pseudo-TTY
-   --user value, -u value       UID (format: <uid>[:<gid>])
-   --process value, -p value    path to the process.json
-   --detach, -d                 detach from the container's process
-   --pid-file value             specify the file to write the process id to
-   --process-label value        set the asm process label for the process commonly used with selinux
-   --apparmor value             set the apparmor profile for the process
-   --no-new-privs               set the no new privileges value for the process
-   --cap value, -c value        add a capability to the bounding set for the process
-   --no-subreaper               disable the use of the subreaper used to reap reparented processes
+   --console value                          specify the pty slave path for use with the container
+   --cwd value                              current working directory in the container
+   --env value, -e value                    set environment variables
+   --tty, -t                                allocate a pseudo-TTY
+   --user value, -u value                   UID (format: <uid>[:<gid>])
+   --additional-gids value, -g value        additional gids separated by comma
+   --process value, -p value                path to the process.json
+   --detach, -d                             detach from the container's process
+   --pid-file value                         specify the file to write the process id to
+   --process-label value                    set the asm process label for the process commonly used with selinux
+   --apparmor value                         set the apparmor profile for the process
+   --no-new-privs                           set the no new privileges value for the process
+   --cap value, -c value                    add a capability to the bounding set for the process
+   --no-subreaper                           disable the use of the subreaper used to reap reparented processes

--- a/man/runc-exec.8.md
+++ b/man/runc-exec.8.md
@@ -19,7 +19,7 @@ following will output a list of processes running in the container:
    --env value, -e value                    set environment variables
    --tty, -t                                allocate a pseudo-TTY
    --user value, -u value                   UID (format: <uid>[:<gid>])
-   --additional-gids value, -g value        additional gids separated by comma
+   --additional-gids value, -g value        additional gids
    --process value, -p value                path to the process.json
    --detach, -d                             detach from the container's process
    --pid-file value                         specify the file to write the process id to

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -131,8 +131,8 @@ function teardown() {
 
   wait_for_container 15 1 test_busybox
 
-  runc exec --user 1000:1000 --additional-gids 100 test_busybox id
+  runc exec --user 1000:1000 --additional-gids 100 --additional-gids 99 test_busybox id 
   [ "$status" -eq 0 ]
 
-  [[ ${output} == "uid=1000 gid=1000 groups=100(users)" ]]
+  [[ ${output} == "uid=1000 gid=1000 groups=99(nogroup),100(users)" ]]
 }

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -123,3 +123,16 @@ function teardown() {
 
   [[ ${output} == "uid=1000 gid=1000" ]]
 }
+
+@test "runc exec --additional-gids" {
+  # run busybox detached
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  [ "$status" -eq 0 ]
+
+  wait_for_container 15 1 test_busybox
+
+  runc exec --user 1000:1000 --additional-gids 100 test_busybox id
+  [ "$status" -eq 0 ]
+
+  [[ ${output} == "uid=1000 gid=1000 groups=100(users)" ]]
+}


### PR DESCRIPTION
This flag allows specifying additional gids for the process.
Without this flag, the user will have to provide process.json which allows additional gids.
Closes #1306

Signed-off-by: Sumit Sanghrajka <sumit.sanghrajka@gmail.com>