### PR TITLE
libcontainer: selinux: fix DupSecOpt and DisableSecOpt

### DIFF
--- a/libcontainer/selinux/selinux.go
+++ b/libcontainer/selinux/selinux.go
@@ -536,14 +536,14 @@ func DupSecOpt(src string) []string {
 		con["level"] == "" {
 		return nil
 	}
-	return []string{"label=user:" + con["user"],
-		"label=role:" + con["role"],
-		"label=type:" + con["type"],
-		"label=level:" + con["level"]}
+	return []string{"user:" + con["user"],
+		"role:" + con["role"],
+		"type:" + con["type"],
+		"level:" + con["level"]}
 }
 
 // DisableSecOpt returns a security opt that can be used to disabling SELinux
 // labeling support for future container processes
 func DisableSecOpt() []string {
-	return []string{"label=disable"}
+	return []string{"disable"}
 }


### PR DESCRIPTION
`label.InitLabels` takes options as a string slice in the form of:

    user:system_u
    role:system_r
    type:container_t
    level:s0:c4,c5

However, `DupSecOpt` and `DisableSecOpt` were still adding a docker
specifc `label=` in front of every option. That leads to `InitLabels`
not being able to correctly init selinux labels in this scenario for
instance:

    label.InitLabels(DupSecOpt([%OPTIONS%]))

if `%OPTIONS` has options prefixed with `label=`, that's going to fail.
Fix this by removing that docker specific `label=` prefix.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>