### PR TITLE
update criu to 2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libaio-dev \
     libcap-dev \
+    libnet-dev \
+    libnl-3-dev \
     libprotobuf-dev \
     libprotobuf-c0-dev \
     libseccomp2/jessie-backports \
@@ -31,7 +33,7 @@ RUN cd /tmp \
     && rm -rf /tmp/bats
 
 # install criu
-ENV CRIU_VERSION 1.7
+ENV CRIU_VERSION 2.10
 RUN mkdir -p /usr/src/criu \
     && curl -sSL https://github.com/xemul/criu/archive/v${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \


### PR DESCRIPTION
When running the tests under overlay2, criu failed to parse mountinfo
and return the following log

```
(00.009971)      1:     type overlay source overlay mnt_id 309 s_dev
0x32 / @ ./ flags 0x200000 options
seclabel,lowerdir=/var/lib/docker/overlay2/l/PYTCIQRNYY5T6DD3YV4F6URSNN:/var/lib/docker/overlay2/l/GQ7SZUXXXIO46JPSD3JCYRWTRL:/var/lib/docker/overlay2/l/P4PLTJCCERJJEXJ32J7B5CQXFM:/var/lib/docker/overlay2/l/5UCCLJKJMBUWOHZJUF4WWRKYL2:/var/lib/docker/overlay2/l/GSTVOU3X2AMMLQMLVB2QGQK6PA:/var/lib/docker/overlay2/l/SNMSZYAVJDXHZFGA2Q5KEO3EFQ:/var/lib/docker/overlay2/l/O2SK4T6N5OQAIRWOUJ5TR6BZUW:/var/lib/docker/overlay2/l/YCB5Z54JCI2KIRV4EAIYL6YVYW:/var/lib/docker/overlay2/l/OECEHKQA6DB5EBAHKFANECBPYQ:/var/lib/docker/overlay2/l/VGJYCB3U4FU3Z7YEVSAL42IJAS:/var/lib/docker/overlay2/l/4G6XUVDRFZ6YYMUH66TQQDXNWO:/var/lib/docker/overlay2/l/KD62VJNIAIA2IIAL6WPOEXBRWA:/var/lib/docker/overlay2/l/QCMHENA34ODPEO3ZAPH3FK2OCD:/var/lib/docker/overlay2/l/RRDTDKVUR2V25YTJOLHR3TLBTD:/var/lib/docker/overlay2/l/7226SNFBM2R6XOQ2WAMSBKZSBI:/var/lib/docker/overlay2/l/J5EWEIFPTC66NOKTXHHVVRT43C:/var/lib/docker/overlay2/l/D53SRXCVRCCIGQWD7MOAUIPDRF,upperdir=/var/lib/docker/overlay2/87e
(00.010001)      1: Error (proc_parse.c:1151): Bad format in 0
mountinfo:
'739dac4ad853b7873c725664d89b423c08db81e903c21815d0fda4b29fc85/diff,workdir=/var/lib/docker/overlay2/87e739dac4ad853b7873c725664d89b423c08db81e903c21815d0fda4b29fc85/work
'
(00.010009)      1: Error (mount.c:1642): Can't parse 0's mountinfo
(00.025661) Error (cr-restore.c:1933): Restoring FAILED.
```

criu upstream added a workaround https://github.com/xemul/criu/commit/fb4f28f00af0f2d8c6fafdbafc74951f0caea925
This upgrades out current criu in test to the latest version.

Fixes: https://github.com/opencontainers/runc/issues/1070