### PR TITLE
Add --preserve-file-descriptors=N to create

### DIFF
--- a/create.go
+++ b/create.go
@@ -46,6 +46,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "no-new-keyring",
 			Usage: "do not create a new session keyring for the container.  This will cause the container to inherit the calling processes session key",
 		},
+		cli.IntFlag{
+			Name:  "preserve-fds",
+			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {

--- a/run.go
+++ b/run.go
@@ -57,6 +57,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "no-new-keyring",
 			Usage: "do not create a new session keyring for the container.  This will cause the container to inherit the calling processes session key",
 		},
+		cli.IntFlag{
+			Name:  "preserve-fds",
+			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {


### PR DESCRIPTION
This preserves the given number of file descriptors on top of the 3 stdio, that
is, fds [3..3+N) will be passed through.

Since Socket Activation (via $LISTEN_FDS) also claims fd 3 onwards the use of
this new flag is incompatible with socket activation.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>