### PR TITLE
Update devices_unix.go for LXD

### DIFF
--- a/libcontainer/devices/devices_unix.go
+++ b/libcontainer/devices/devices_unix.go
@@ -75,7 +75,7 @@ func getDevices(path string) ([]*configs.Device, error) {
 		switch {
 		case f.IsDir():
 			switch f.Name() {
-			case "pts", "shm", "fd", "mqueue":
+			case "pts", "shm", "fd", "mqueue", ".lxc", ".lxd-mounts":
 				continue
 			default:
 				sub, err := getDevices(filepath.Join(path, f.Name()))

--- a/libcontainer/devices/devices_unix.go
+++ b/libcontainer/devices/devices_unix.go
@@ -75,6 +75,7 @@ func getDevices(path string) ([]*configs.Device, error) {
 		switch {
 		case f.IsDir():
 			switch f.Name() {
+			// ".lxc" & ".lxd-mounts" added to address https://github.com/lxc/lxd/issues/2825
 			case "pts", "shm", "fd", "mqueue", ".lxc", ".lxd-mounts":
 				continue
 			default:


### PR DESCRIPTION
getDevices() has been updated to skip `/dev/.lxc` and `/dev/.lxd-mounts`, which was breaking privileged Docker containers running on runC inside of LXD managed Linux Containers.

See https://github.com/lxc/lxd/issues/2825