### PR TITLE
update go version at travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: go
 go:
-  - 1.6.x
   - 1.7.x
-# - master
+  - 1.8.x
+  - tip
+
+matrix:
+  allow_failures:
+    - go: tip
 
 # `make ci` uses Docker.
 sudo: required

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.4
+FROM golang:1.8.0
 
 # libseccomp in jessie is not _quite_ new enough -- need backports version
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list


### PR DESCRIPTION
Travis is testing against 1.6.x and 1.7.x if the intent is test againts the last two stable version we should remove the 1.6 and add the 1.8

Also the tool being use for the validation of bash scripts (https://github.com/mvdan/sh) is only compatible with 1.7>

Also I added tip as an allowed to fail version