### PR TITLE
container.Processes(): make sure the container is not stopped

### DIFF
--- a/ps.go
+++ b/ps.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/opencontainers/runc/libcontainer"
 	"github.com/urfave/cli"
 )
 
@@ -31,6 +32,13 @@ var psCommand = cli.Command{
 		container, err := getContainer(context)
 		if err != nil {
 			return err
+		}
+		status, err := container.Status()
+		if err != nil {
+			return err
+		}
+		if status == libcontainer.Stopped {
+			return fmt.Errorf("cannot ps a container that has run and stopped")
 		}
 
 		pids, err := container.Processes()


### PR DESCRIPTION
Stopped is the status that denotes the container does not have a created or running process.
it seems that `runc ps` a stopped container is useless.

Signed-off-by: CuiHaozhi <cuihaozhi@chinacloud.com.cn>