### PR TITLE
tty: dup /dev/null over stdio for (detach && !terminal)

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -3,114 +3,121 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
+}
+
+function __test_checkpoint_and_restore() {
+	requires criu
+
+	opt_detach=""
+	opt_predump=""
+	while getopts "td" optch; do
+		case "$optch" in
+			d)
+				opt_detach="1"
+				;;
+			p)
+				opt_predump="1"
+				;;
+		esac
+	done
+
+	# criu does not work with external terminals so..
+	# setting terminal and root:readonly: to false
+	sed -i 's;"terminal": true;"terminal": false;' config.json
+	sed -i 's;"readonly": true;"readonly": false;' config.json
+	sed -i 's/"sh"/"sh","-c","while :; do date; sleep 1; done"/' config.json
+
+	run_args=()
+	if [[ "$opt_detach" ]]; then
+		run_args+=("-d")
+	fi
+
+	# run busybox
+	if [[ "$opt_detach" ]]; then
+		runc run "${run_args[@]}" test_busybox
+		[ "$status" -eq 0 ]
+	else
+		(
+			runc run "${run_args[@]}" test_busybox
+			[ "$status" -eq 0 ]
+		) &
+	fi
+
+	# check state
+	wait_for_container 15 1 test_busybox
+
+	runc state test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"running"* ]]
+
+	# if you are having problems getting criu to work uncomment the following dump:
+	#cat /run/opencontainer/containers/test_busybox/criu.work/dump.log
+
+	restore_args=()
+	checkpoint_args=()
+	if [[ "$opt_predump" ]]; then
+		mkdir parent-dir
+		restore_args=("--image-path" "./image-dir")
+		checkpoint_args=("--image-path" "./image-dir" "--parent-path" "./parent-dir")
+
+		# do a pre-dump checkpoint
+		runc --criu "$CRIU" checkpoint --pre-dump --image-path ./parent-dir test_busybox
+		[ "$status" -eq 0 ]
+
+		# busybox should still be running
+		runc state test_busybox
+		[ "$status" -eq 0 ]
+		[[ "${output}" == *"running"* ]]
+	fi
+
+	# checkpoint the running container
+	mkdir image-dir
+	runc --criu "$CRIU" checkpoint "${checkpoint_args[@]}" test_busybox
+	[ "$status" -eq 0 ]
+
+	# after checkpoint busybox is no longer running
+	runc state test_busybox
+	[ "$status" -ne 0 ]
+
+	# restore from checkpoint
+	if [[ "$opt_detach" ]]; then
+		runc --criu "$CRIU" restore "${restore_args[@]}" "${run_args[@]}" test_busybox
+		[ "$status" -eq 0 ]
+	else
+		(
+			runc --criu "$CRIU" restore "${restore_args[@]}" "${run_args[@]}" test_busybox
+			[ "$status" -eq 0 ]
+		) &
+	fi
+
+	# check state
+	wait_for_container 15 1 test_busybox
+
+	# busybox should be back up and running
+	runc state test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"running"* ]]
+
 }
 
 @test "checkpoint and restore" {
-  requires criu
-
-  # criu does not work with external terminals so..
-  # setting terminal and root:readonly: to false
-  sed -i 's;"terminal": true;"terminal": false;' config.json
-  sed -i 's;"readonly": true;"readonly": false;' config.json
-  sed -i 's/"sh"/"sh","-c","while :; do date; sleep 1; done"/' config.json
-
-  (
-    # run busybox (not detached)
-    runc run test_busybox
-    [ "$status" -eq 0 ]
-  ) &
-
-  # check state
-  wait_for_container 15 1 test_busybox
-
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
-
-  # checkpoint the running container
-  runc --criu "$CRIU" checkpoint test_busybox
-  # if you are having problems getting criu to work uncomment the following dump:
-  #cat /run/opencontainer/containers/test_busybox/criu.work/dump.log
-  [ "$status" -eq 0 ]
-
-  # after checkpoint busybox is no longer running
-  runc state test_busybox
-  [ "$status" -ne 0 ]
-
-  # restore from checkpoint
-  (
-    runc --criu "$CRIU" restore test_busybox
-    [ "$status" -eq 0 ]
-  ) &
-
-  # check state
-  wait_for_container 15 1 test_busybox
-
-  # busybox should be back up and running
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
+	__test_checkpoint_and_restore
 }
 
-@test "checkpoint(pre-dump) and restore" {
-  requires criu
+@test "checkpoint and restore [detach]" {
+	__test_checkpoint_and_restore -d
+}
 
-  # criu does not work with external terminals so..
-  # setting terminal and root:readonly: to false
-  sed -i 's;"terminal": true;"terminal": false;' config.json
-  sed -i 's;"readonly": true;"readonly": false;' config.json
-  sed -i 's/"sh"/"sh","-c","while :; do date; sleep 1; done"/' config.json
+@test "checkpoint --pre-dump and restore" {
+	__test_checkpoint_and_restore -p
+}
 
-  (
-    # run busybox (not detached)
-    runc run test_busybox
-    [ "$status" -eq 0 ]
-  ) &
-
-  # check state
-  wait_for_container 15 1 test_busybox
-
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
-
-
-  #test checkpoint pre-dump
-  mkdir parent-dir
-  runc --criu "$CRIU" checkpoint --pre-dump --image-path ./parent-dir test_busybox
-  [ "$status" -eq 0 ]
-
-  # busybox should still be running
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
-
-  # checkpoint the running container
-  mkdir image-dir
-  runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --image-path ./image-dir test_busybox
-  [ "$status" -eq 0 ]
-
-  # after checkpoint busybox is no longer running
-  runc state test_busybox
-  [ "$status" -ne 0 ]
-
-  # restore from checkpoint
-  (
-    runc --criu "$CRIU" restore --image-path ./image-dir test_busybox
-    [ "$status" -eq 0 ]
-  ) &
-
-  # check state
-  wait_for_container 15 1 test_busybox
-
-  # busybox should be back up and running
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
+@test "checkpoint --pre-dump and restore [detach]" {
+	__test_checkpoint_and_restore -d -p
 }

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -115,7 +115,7 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, det
 	// requirement that we set up anything nice for our caller or the
 	// container.
 	if detach {
-		if err := dupStdio(process, rootuid, rootgid); err != nil {
+		if err := nullStdio(process); err != nil {
 			return nil, err
 		}
 		return &tty{}, nil


### PR DESCRIPTION
This cleans up some of the terminal=false semantics for detached
containers. One of the biggest issues with running `runc create` inside
a terminal is that it gave the container process access to a host tty.
While this is not a security issue in of itself, it is quite concerning
(and similar bugs have caused security issues in LXC in the past). Not
to mention that this meant that the user's shell was borked -- something
which should be fixed anyway.

Signed-off-by: Aleksa Sarai <asarai@suse.de>