### PR TITLE
Don't fchown when inheriting io

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"sync"
-	"syscall"
 
 	"github.com/docker/docker/pkg/term"
 	"github.com/opencontainers/runc/libcontainer"
@@ -28,9 +27,9 @@ func (t *tty) copyIO(w io.Writer, r io.ReadCloser) {
 	r.Close()
 }
 
-// setup standard pipes so that the TTY of the calling runc process
-// is not inherited by the container.
-func createStdioPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, error) {
+// setup pipes for the process so that advanced features like c/r are able to easily checkpoint
+// and restore the process's IO without depending on a host specific path or device
+func setupProcessPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, error) {
 	i, err := p.InitializeIO(rootuid, rootgid)
 	if err != nil {
 		return nil, err
@@ -62,19 +61,10 @@ func createStdioPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, erro
 	return t, nil
 }
 
-func dupStdio(process *libcontainer.Process, rootuid, rootgid int) error {
+func inheritStdio(process *libcontainer.Process) error {
 	process.Stdin = os.Stdin
 	process.Stdout = os.Stdout
 	process.Stderr = os.Stderr
-	for _, fd := range []uintptr{
-		os.Stdin.Fd(),
-		os.Stdout.Fd(),
-		os.Stderr.Fd(),
-	} {
-		if err := syscall.Fchown(int(fd), rootuid, rootgid); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -110,19 +110,15 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, det
 		process.Stderr = nil
 		return &tty{}, nil
 	}
-
-	// When we detach, we just dup over stdio and call it a day. There's no
-	// requirement that we set up anything nice for our caller or the
-	// container.
+	// when runc will detach the caller provides the stdio to runc via runc's 0,1,2
+	// and the container's process inherits runc's stdio.
 	if detach {
-		if err := dupStdio(process, rootuid, rootgid); err != nil {
+		if err := inheritStdio(process); err != nil {
 			return nil, err
 		}
 		return &tty{}, nil
 	}
-
-	// XXX: This doesn't sit right with me. It's ugly.
-	return createStdioPipes(process, rootuid, rootgid)
+	return setupProcessPipes(process, rootuid, rootgid)
 }
 
 // createPidFile creates a file with the processes pid inside it atomically


### PR DESCRIPTION
This is a fix for rootless containers and general io handling.  The
higher level systems must preparte the IO for the container in the
detach case and make sure it is setup correctly for the container's
process.

Replacement for #1349

Fixes detached use case for #774 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>