### PR TITLE
run: implement --delete-if-stopped

### DIFF
--- a/man/runc-run.8.md
+++ b/man/runc-run.8.md
@@ -26,3 +26,4 @@ command(s) that get executed on start, edit the args parameter of the spec. See
    --no-subreaper            disable the use of the subreaper used to reap reparented processes
    --no-pivot                do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk
    --no-new-keyring          do not create a new session keyring for the container.  This will cause the container to inherit the calling processes session key
+   --delete-if-stopped       if a stopped container with the same id exists, delete it

--- a/run.go
+++ b/run.go
@@ -61,6 +61,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "preserve-fds",
 			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
 		},
+		cli.BoolFlag{
+			Name:  "delete-if-stopped",
+			Usage: "if a stopped container with the same id exists, delete it",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -161,6 +161,26 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcont
 	if err != nil {
 		return nil, err
 	}
+
+	if context.Bool("delete-if-stopped") {
+		containerRoot := filepath.Join(context.GlobalString("root"), id)
+		if _, err := os.Stat(containerRoot); err == nil {
+			container, err := factory.Load(id)
+			if err != nil {
+				return nil, err
+			}
+			status, err := container.Status()
+			if err != nil {
+				return nil, err
+			}
+			if status == libcontainer.Stopped {
+				if err = os.RemoveAll(containerRoot); err != nil {
+					fmt.Fprintf(os.Stderr, "remove %s: %v\n", containerRoot, err)
+				}
+			}
+		}
+	}
+
 	return factory.Create(id, config)
 }
 


### PR DESCRIPTION
"run -d container" and "run container" behave in different ways in
what they leave after the container exits, "run container" cleans up
the root directory while "run -d" requires an additional delete.

I'd like to have the possibility to run a container without caring if
there is already an existing one (stopped) with the same id.

In addition, the new option will simplify systemd services using runC
as it can be possible to have only one directive:

ExecStart=/usr/local/sbin/runc run --delete-if-stopped -d --pid-file /run/minecraft.pid minecraft-build-container

instead of requiring an additional ExecStopPost directive.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>