### PR TITLE
Handle container creation when cgroups have already been mounted in another location

### DIFF
--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -57,10 +57,11 @@ func (s *CpusetGroup) ApplyDir(dir string, cgroup *configs.Cgroup, pid int) erro
 	if dir == "" {
 		return nil
 	}
-	root, err := getCgroupRoot()
+	mountInfo, err := ioutil.ReadFile("/proc/self/mountinfo")
 	if err != nil {
 		return err
 	}
+	root := filepath.Dir(cgroups.GetClosestMountpointAncestor(dir, string(mountInfo)))
 	// 'ensureParent' start with parent because we don't want to
 	// explicitly inherit from parent, it could conflict with
 	// 'cpuset.cpu_exclusive'.

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -66,6 +66,21 @@ func isSubsystemAvailable(subsystem string) bool {
 	return avail
 }
 
+func GetClosestMountpointAncestor(dir, mountinfo string) string {
+	deepestMountPoint := ""
+	for _, mountInfoEntry := range strings.Split(mountinfo, "\n") {
+		mountInfoParts := strings.Fields(mountInfoEntry)
+		if len(mountInfoParts) < 5 {
+			continue
+		}
+		mountPoint := mountInfoParts[4]
+		if strings.HasPrefix(mountPoint, deepestMountPoint) && strings.HasPrefix(dir, mountPoint) {
+			deepestMountPoint = mountPoint
+		}
+	}
+	return deepestMountPoint
+}
+
 func FindCgroupMountpointDir() (string, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -300,3 +300,34 @@ func TestIgnoreCgroup2Mount(t *testing.T) {
 		}
 	}
 }
+
+const fakeMountInfo = ` 18 24 0:17 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw
+100 99 1:31 / /foo/bar rw,relatime - fake fake rw,fake
+100 99 1:31 / /foo/bar/baz2 rw,relatime - fake fake rw,fake
+100 99 1:31 / /foo/bar/baz rw,relatime - fake fake rw,fake
+100 99 1:31 / /foo/bar/bazza rw,relatime - fake fake rw,fake
+100 99 1:31 / /foo/bar/baz3 rw,relatime - fake fake rw,fake
+100 99 1:31 / /foo rw,relatime - fake fake rw,fake
+100 99 1:31 / /unrelated rw,relatime - fake fake rw,fake
+100 99 1:31 / / rw,relatime - fake fake rw,fake
+`
+
+func TestGetClosestMountpointAncestor(t *testing.T) {
+	testCases := []struct {
+		input      string
+		mountinfos string
+		output     string
+	}{
+		{input: "/foo/bar/baz/a/b/c", mountinfos: fakeMountInfo, output: "/foo/bar/baz"},
+		{input: "/foo/bar/baz", mountinfos: fakeMountInfo, output: "/foo/bar/baz"},
+		{input: "/foo/bar/bazza", mountinfos: fakeMountInfo, output: "/foo/bar/bazza"},
+		{input: "/a/b/c/d", mountinfos: fakeMountInfo, output: "/"},
+	}
+
+	for _, c := range testCases {
+		mountpoint := GetClosestMountpointAncestor(c.input, c.mountinfos)
+		if mountpoint != c.output {
+			t.Errorf("expected %s, got %s", c.output, mountpoint)
+		}
+	}
+}


### PR DESCRIPTION
As described in https://github.com/opencontainers/runc/issues/1367, if a non-cpuset subsystem has been been mounted earlier in the mount table at a disjoint location to the rest of the hierarchy (e.g. `/sys/fs/cgroup/{cpuset,cpu,memory...}`) then `runc create` will fail with:

```
container_linux.go:259: starting container process caused "process_linux.go:283: applying cgroup configuration for process caused \"open /sys/fs/cpuset.cpus: no such file or directory\""
```

To replicate this behaviour, using Ubuntu 14.04 with a 4.4 kernel (linux-generic-lts-xenial package), create a mount table that looks like this:

```
cgroup /cgroup cgroup rw,relatime,cpu 0 0
none /sys/fs/cgroup tmpfs rw,relatime 0 0
cgroup /sys/fs/cgroup/cpuset cgroup rw,relatime,cpuset 0 0
cgroup /sys/fs/cgroup/cpu cgroup rw,relatime,cpu 0 0
cgroup /sys/fs/cgroup/cpuacct cgroup rw,relatime,cpuacct 0 0
cgroup /sys/fs/cgroup/blkio cgroup rw,relatime,blkio 0 0
cgroup /sys/fs/cgroup/memory cgroup rw,relatime,memory 0 0
cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
cgroup /sys/fs/cgroup/freezer cgroup rw,relatime,freezer 0 0
cgroup /sys/fs/cgroup/net_cls cgroup rw,relatime,net_cls 0 0
cgroup /sys/fs/cgroup/perf_event cgroup rw,relatime,perf_event 0 0
cgroup /sys/fs/cgroup/net_prio cgroup rw,relatime,net_prio 0 0
cgroup /sys/fs/cgroup/hugetlb cgroup rw,relatime,hugetlb 0 0
cgroup /sys/fs/cgroup/pids cgroup rw,relatime,pids 0 0
```

Note that /cgroup can't have subsystem cpuset, otherwise everything will be fine.

On runc master:

```
→ runc create test
container_linux.go:259: starting container process caused "process_linux.go:283: applying cgroup configuration for process caused \"open /sys/fs/cpuset.cpus: no such file or directory\""
```

Using this PR, creation completes successfully. It succeeds because we no longer use the "cgroup root" (the dir that is assumed to contain all cgroup subsystem mountpoints) to work out the highest cpuset subsystem dir. Instead we look for the closest mountpoint ancestor of the cgroup dir we are operating on.

The following shell functions may come in handy for setting up a mount table that looks like this:

```
function cmount() { mount -t cgroup -o cpu cgroup /cgroup && mount -t tmpfs none /sys/fs/cgroup && cgroups-mount; }

function cumount { cgroups-umount && umount /sys/fs/cgroup && umount /cgroup; }
```

We weren't sure how to integration test this, as providing a mount table like above seems to break the integration tests in docker, precisely due to this bug but if anyone has any ideas we are happy to update.

We think it would be ideal if runc took a "cgroup root" as configuration (it could be optional), but didn't want to change too much in this PR.

Cheers,
@williammartin and Craig