### PR TITLE
fix minor issue

### DIFF
--- a/libcontainer/network_linux.go
+++ b/libcontainer/network_linux.go
@@ -171,7 +171,7 @@ func (v *veth) create(n *network, nspid int) (err error) {
 			netlink.LinkDel(veth)
 		}
 	}()
-	if err := v.attach(&n.Network); err != nil {
+	if err = v.attach(&n.Network); err != nil {
 		return err
 	}
 	child, err := netlink.LinkByName(n.TempVethPeerName)


### PR DESCRIPTION
When failed to attach veth pair, should remove the veth device

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>