### PR TITLE
Revert "fix minor issue"

### DIFF
--- a/libcontainer/network_linux.go
+++ b/libcontainer/network_linux.go
@@ -171,7 +171,7 @@ func (v *veth) create(n *network, nspid int) (err error) {
 			netlink.LinkDel(veth)
 		}
 	}()
-	if err = v.attach(&n.Network); err != nil {
+	if err := v.attach(&n.Network); err != nil {
 		return err
 	}
 	child, err := netlink.LinkByName(n.TempVethPeerName)


### PR DESCRIPTION
This reverts commit d4091ef151f33ecc000a4c9fe91a9ca043fc683f.

d4091ef151f3 ("fix minor issue") doesn't actually make any sense, and
actually makes the code more confusing.

Signed-off-by: Aleksa Sarai <asarai@suse.de>