### PR TITLE
fix panic regression when config doesnt have caps

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -119,9 +119,11 @@ func finalizeNamespace(config *initConfig) error {
 		return err
 	}
 
-	capabilities := config.Config.Capabilities
+	capabilities := &configs.Capabilities{}
 	if config.Capabilities != nil {
 		capabilities = config.Capabilities
+	} else if config.Config.Capabilities != nil {
+		capabilities = config.Config.Capabilities
 	}
 	w, err := newContainerCapList(capabilities)
 	if err != nil {


### PR DESCRIPTION
When process config doesnt specify capabilities anywhere, we should not panic because setting capabilities are optional.

Without this, process without configured caps will panic with:

```
utils_test.go:51: exec_test.go:370: unexpected error: container_linux.go:259: starting container process caused "panic from initialization: runtime error: invalid memory address or nil pointer dereference, goroutine 1 [running, locked to thread]:
runtime/debug.Stack(0xc4200bf878, 0x704700, 0xabedd0)
\t/usr/local/go/src/runtime/debug/stack.go:24 +0x79
github.com/opencontainers/runc/libcontainer.(*LinuxFactory).StartInitialization.func2(0xc4200bfee0)
\t/go/src/github.com/opencontainers/runc/libcontainer/factory_linux.go:278 +0x60
panic(0x704700, 0xabedd0)
\t/usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/opencontainers/runc/libcontainer.newContainerCapList(0x0, 0x0, 0x0, 0x7486a0)
\t/go/src/github.com/opencontainers/runc/libcontainer/capabilities_linux.go:36 +0x4f
github.com/opencontainers/runc/libcontainer.finalizeNamespace(0xc4200ec000, 0xc42000e0e8, 0x0)
\t/go/src/github.com/opencontainers/runc/libcontainer/init_linux.go:132 +0x7c
github.com/opencontainers/runc/libcontainer.(*linuxStandardInit).Init(0xc4200c4e40, 0x8, 0xc42000e0e8)
\t/go/src/github.com/opencontainers/runc/libcontainer/standard_init_linux.go:147 +0x40a
github.com/opencontainers/runc/libcontainer.(*LinuxFactory).StartInitialization(0xc420050b90, 0x0, 0x0)
\t/go/src/github.com/opencontainers/runc/libcontainer/factory_linux.go:288 +0x3fb
github.com/opencontainers/runc/libcontainer/integration.init.1()
\t/go/src/github.com/opencontainers/runc/libcontainer/integration/init_test.go:26 +0x1bd
github.com/opencontainers/runc/libcontainer/integration.init()
\t/go/src/github.com/opencontainers/runc/libcontainer/integration/utils_test.go:171 +0xc0
main.init()
\tgithub.com/opencontainers/runc/libcontainer/integration/_test/_testmain.go:136 +0x4e
"
```