### PR TITLE
.travis.yml: Don't require FETCH_HEAD (partial fix for failing master tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ before_install:
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/vbatts/git-validation
   - go get -u github.com/mvdan/sh/cmd/shfmt
+  - env | grep TRAVIS_
 
 script:
-  - git-validation -run DCO,short-subject -v -range ${TRAVIS_BRANCH}..FETCH_HEAD
+  - git-validation -run DCO,short-subject -v
   - make BUILDTAGS="${BUILDTAGS}"
   - make BUILDTAGS="${BUILDTAGS}" clean validate test


### PR DESCRIPTION
Master builds [only have a `git clone …`][1] so `FETCH_HEAD` isn't defined and [git-validation crashes][2].  We don't want to be hard-coding a range here, and should update git-validation to handle these cases automatically.

Also echo `TRAVIS_*` variables during testing to make debugging git-validation easier.

[1]: https://travis-ci.org/opencontainers/runc/jobs/213508696#L243
[2]: https://travis-ci.org/opencontainers/runc/jobs/213508696#L347