### PR TITLE
travis: set go_import_path to github.com/opencontainers/runc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
   allow_failures:
     - go: tip
 
+go_import_path: github.com/opencontainers/runc
+
 # `make ci` uses Docker.
 sudo: required
 services:


### PR DESCRIPTION
If someone forks runc and wants to check changes in travis, he will find
that the command 'make BUILDTAGS="${BUILDTAGS}"' fails, because
github.com/opencontainers/runc/ is used in many places to import
packages (e.g. libcontainer).

Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>