### PR TITLE
Set container state only once during start

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -263,9 +263,6 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 	}
 	// generate a timestamp indicating when the container was started
 	c.created = time.Now().UTC()
-	c.state = &runningState{
-		c: c,
-	}
 	if isInit {
 		c.state = &createdState{
 			c: c,
@@ -291,6 +288,10 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 					return newSystemErrorWithCausef(err, "running poststart hook %d", i)
 				}
 			}
+		}
+	} else {
+		c.state = &runningState{
+			c: c,
 		}
 	}
 	return nil


### PR DESCRIPTION
Irrespective of 'isInit' is set to true or false, set container state during start only once. 

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>