### PR TITLE
Use newuidmap to allow multiple ID mappings when running rootless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     protobuf-c-compiler \
     protobuf-compiler \
     python-minimal \
+    uidmap \
     --no-install-recommends \
     && apt-get clean
 

--- a/libcontainer/configs/validate/rootless.go
+++ b/libcontainer/configs/validate/rootless.go
@@ -61,14 +61,6 @@ func rootlessMappings(config *configs.Config) error {
 		return fmt.Errorf("rootless containers cannot map container root to a different host group")
 	}
 
-	// We can only map one user and group inside a container (our own).
-	if len(config.UidMappings) != 1 || config.UidMappings[0].Size != 1 {
-		return fmt.Errorf("rootless containers cannot map more than one user")
-	}
-	if len(config.GidMappings) != 1 || config.GidMappings[0].Size != 1 {
-		return fmt.Errorf("rootless containers cannot map more than one group")
-	}
-
 	return nil
 }
 

--- a/libcontainer/configs/validate/rootless_test.go
+++ b/libcontainer/configs/validate/rootless_test.go
@@ -75,8 +75,8 @@ func TestValidateRootlessMappingUid(t *testing.T) {
 
 	config = rootlessConfig()
 	config.UidMappings[0].Size = 1024
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one uid mapped")
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur if more than one uid mapped")
 	}
 
 	config = rootlessConfig()
@@ -85,8 +85,8 @@ func TestValidateRootlessMappingUid(t *testing.T) {
 		ContainerID: 0,
 		Size:        1,
 	})
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one uid extent mapped")
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur if more than one uid extent mapped")
 	}
 }
 
@@ -107,8 +107,8 @@ func TestValidateRootlessMappingGid(t *testing.T) {
 
 	config = rootlessConfig()
 	config.GidMappings[0].Size = 1024
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one gid mapped")
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur if more than one gid mapped")
 	}
 
 	config = rootlessConfig()
@@ -117,8 +117,8 @@ func TestValidateRootlessMappingGid(t *testing.T) {
 		ContainerID: 0,
 		Size:        1,
 	})
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one gid extent mapped")
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur if more than one gid extent mapped")
 	}
 }
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1479,11 +1479,17 @@ func (c *linuxContainer) orderNamespacePaths(namespaces map[configs.NamespaceTyp
 	return paths, nil
 }
 
-func encodeIDMapping(idMap []configs.IDMap) ([]byte, error) {
+func encodeIDMapping(idMap []configs.IDMap, rootless bool) ([]byte, error) {
 	data := bytes.NewBuffer(nil)
+	separator := "\n"
+	if rootless {
+		// pass IDs as args to new{u,g}idmap rather than writing them directly
+		separator = " "
+	}
+
 	for _, im := range idMap {
-		mapping := fmt.Sprintf("%d %d %d ", im.ContainerID, im.HostID, im.Size)
-		if _, err := data.WriteString(mapping); err != nil {
+		line := fmt.Sprintf("%d %d %d%s", im.ContainerID, im.HostID, im.Size, separator)
+		if _, err := data.WriteString(line); err != nil {
 			return nil, err
 		}
 	}
@@ -1523,7 +1529,7 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 	if !joinExistingUser {
 		// write uid mappings
 		if len(c.config.UidMappings) > 0 {
-			b, err := encodeIDMapping(c.config.UidMappings)
+			b, err := encodeIDMapping(c.config.UidMappings, c.config.Rootless)
 			if err != nil {
 				return nil, err
 			}
@@ -1539,7 +1545,7 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 
 		// write gid mappings
 		if len(c.config.GidMappings) > 0 {
-			b, err := encodeIDMapping(c.config.GidMappings)
+			b, err := encodeIDMapping(c.config.GidMappings, c.config.Rootless)
 			if err != nil {
 				return nil, err
 			}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -42,6 +42,8 @@ type linuxContainer struct {
 	initProcess          parentProcess
 	initProcessStartTime uint64
 	criuPath             string
+	newuidmapPath        string
+	newgidmapPath        string
 	m                    sync.Mutex
 	criuVersion          int
 	state                containerState
@@ -1529,6 +1531,10 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 				Type:  UidmapAttr,
 				Value: b,
 			})
+			r.AddData(&Bytemsg{
+				Type:  UidmapPathAttr,
+				Value: []byte(c.newuidmapPath),
+			})
 		}
 
 		// write gid mappings
@@ -1540,6 +1546,10 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 			r.AddData(&Bytemsg{
 				Type:  GidmapAttr,
 				Value: b,
+			})
+			r.AddData(&Bytemsg{
+				Type:  GidmapPathAttr,
+				Value: []byte(c.newgidmapPath),
 			})
 			// The following only applies if we are root.
 			if !c.config.Rootless {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1480,8 +1480,8 @@ func (c *linuxContainer) orderNamespacePaths(namespaces map[configs.NamespaceTyp
 func encodeIDMapping(idMap []configs.IDMap) ([]byte, error) {
 	data := bytes.NewBuffer(nil)
 	for _, im := range idMap {
-		line := fmt.Sprintf("%d %d %d\n", im.ContainerID, im.HostID, im.Size)
-		if _, err := data.WriteString(line); err != nil {
+		mapping := fmt.Sprintf("%d %d %d ", im.ContainerID, im.HostID, im.Size)
+		if _, err := data.WriteString(mapping); err != nil {
 			return nil, err
 		}
 	}

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -109,6 +109,24 @@ func CriuPath(criupath string) func(*LinuxFactory) error {
 	}
 }
 
+// NewuidmapPath returns an option func to configure a LinuxFactory with the
+// provided ..
+func NewuidmapPath(newuidmapPath string) func(*LinuxFactory) error {
+	return func(l *LinuxFactory) error {
+		l.NewuidmapPath = newuidmapPath
+		return nil
+	}
+}
+
+// NewgidmapPath returns an option func to configure a LinuxFactory with the
+// provided ..
+func NewgidmapPath(newgidmapPath string) func(*LinuxFactory) error {
+	return func(l *LinuxFactory) error {
+		l.NewgidmapPath = newgidmapPath
+		return nil
+	}
+}
+
 // New returns a linux based container factory based in the root directory and
 // configures the factory with the provided option funcs.
 func New(root string, options ...func(*LinuxFactory) error) (Factory, error) {
@@ -144,6 +162,11 @@ type LinuxFactory struct {
 	// CriuPath is the path to the criu binary used for checkpoint and restore of
 	// containers.
 	CriuPath string
+
+	// New{u,g}uidmapPath is the path to the binaries used for mapping with
+	// rootless containers.
+	NewuidmapPath string
+	NewgidmapPath string
 
 	// Validator provides validation to container configurations.
 	Validator validate.Validator
@@ -183,6 +206,8 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		config:        config,
 		initArgs:      l.InitArgs,
 		criuPath:      l.CriuPath,
+		newuidmapPath: l.NewuidmapPath,
+		newgidmapPath: l.NewgidmapPath,
 		cgroupManager: l.NewCgroupsManager(config.Cgroups, nil),
 	}
 	c.state = &stoppedState{c: c}
@@ -214,6 +239,8 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		config:               &state.Config,
 		initArgs:             l.InitArgs,
 		criuPath:             l.CriuPath,
+		newuidmapPath:        l.NewuidmapPath,
+		newgidmapPath:        l.NewgidmapPath,
 		cgroupManager:        l.NewCgroupsManager(state.Config.Cgroups, state.CgroupPaths),
 		root:                 containerRoot,
 		created:              state.Created,

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -261,14 +261,6 @@ func setupUser(config *initConfig) error {
 	}
 
 	if config.Rootless {
-		if execUser.Uid != 0 {
-			return fmt.Errorf("cannot run as a non-root user in a rootless container")
-		}
-
-		if execUser.Gid != 0 {
-			return fmt.Errorf("cannot run as a non-root group in a rootless container")
-		}
-
 		// We cannot set any additional groups in a rootless container and thus we
 		// bail if the user asked us to do so. TODO: We currently can't do this
 		// earlier, but if libcontainer.Process.User was typesafe this might work.

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -3,6 +3,8 @@
 package libcontainer
 
 import (
+	"syscall"
+
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
@@ -18,6 +20,12 @@ const (
 	SetgroupAttr    uint16 = 27285
 	OomScoreAdjAttr uint16 = 27286
 	RootlessAttr    uint16 = 27287
+
+	UidmapPathAttr uint16 = 27288
+	GidmapPathAttr uint16 = 27289
+
+	// When syscall.NLA_HDRLEN is in gccgo, take this out.
+	syscall_NLA_HDRLEN = (syscall.SizeofNlAttr + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)
 )
 
 type Int32msg struct {

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -69,6 +69,10 @@ struct nlconfig_t {
 	size_t uidmap_len;
 	char *gidmap;
 	size_t gidmap_len;
+	char *uidmappath;
+	size_t uidmappath_len;
+	char *gidmappath;
+	size_t gidmappath_len;
 	char *namespaces;
 	size_t namespaces_len;
 	uint8_t is_setgroup;
@@ -89,6 +93,8 @@ struct nlconfig_t {
 #define SETGROUP_ATTR		27285
 #define OOM_SCORE_ADJ_ATTR	27286
 #define ROOTLESS_ATTR	    27287
+#define UIDMAPPATH_ATTR	    27288
+#define GIDMAPPATH_ATTR	    27289
 
 /*
  * Use the raw syscall for versions of glibc which don't include a function for
@@ -333,6 +339,14 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 		case NS_PATHS_ATTR:
 			config->namespaces = current;
 			config->namespaces_len = payload_len;
+			break;
+		case UIDMAPPATH_ATTR:
+			config->uidmappath = current;
+			config->uidmappath_len = payload_len;
+			break;
+		case GIDMAPPATH_ATTR:
+			config->gidmappath = current;
+			config->gidmappath_len = payload_len;
 			break;
 		case UIDMAP_ATTR:
 			config->uidmap = current;
@@ -588,8 +602,8 @@ void nsexec(void)
 						update_setgroups(child, SETGROUPS_DENY);
 
 					/* Set up mappings. */
-					update_mappings("newuidmap", child, config.uidmap, config.uidmap_len);
-					update_mappings("newgidmap", child, config.gidmap, config.gidmap_len);
+					update_mappings(config.uidmappath, child, config.uidmap, config.uidmap_len);
+					update_mappings(config.gidmappath, child, config.gidmap, config.gidmap_len);
 
 					s = SYNC_USERMAP_ACK;
 					if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -620,11 +620,14 @@ void nsexec(void)
 						update_setgroups(child, SETGROUPS_DENY);
 
 					/* Set up mappings. */
-					if (config.is_rootless) {
+					if (config.uidmappath_len > 0) {
 						update_mappings(config.uidmappath, child, config.uidmap, config.uidmap_len);
-						update_mappings(config.gidmappath, child, config.gidmap, config.gidmap_len);
 					} else {
 						update_uidmap(child, config.uidmap, config.uidmap_len);
+					}
+					if (config.gidmappath_len > 0) {
+						update_mappings(config.gidmappath, child, config.gidmap, config.gidmap_len);
+					} else {
 						update_gidmap(child, config.gidmap, config.gidmap_len);
 					}
 

--- a/main.go
+++ b/main.go
@@ -85,6 +85,16 @@ func main() {
 			Value: "criu",
 			Usage: "path to the criu binary used for checkpoint and restore",
 		},
+		cli.StringFlag{
+			Name:  "newuidmap",
+			Value: "newuidmap",
+			Usage: "path to the newuidmap binary used for uid mapping with rootless containers",
+		},
+		cli.StringFlag{
+			Name:  "newgidmap",
+			Value: "newgidmap",
+			Usage: "path to the newgidmap binary used for gid mapping with rootless containers",
+		},
 		cli.BoolFlag{
 			Name:  "systemd-cgroup",
 			Usage: "enable systemd cgroup support, expects cgroupsPath to be of form \"slice:prefix:name\" for e.g. \"system.slice:runc:434234\"",

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -100,8 +100,9 @@ function teardown() {
 }
 
 @test "runc exec --user" {
-  # --user can't work in rootless containers
-  requires root
+  if [ "$ROOTLESS" -ne 0 ]; then
+    runc_spec_additional_mappings
+  fi
 
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -111,5 +111,5 @@ function teardown() {
   runc exec --user 1000:1000 test_busybox id
   [ "$status" -eq 0 ]
 
-  [[ ${output} == "uid=1000 gid=1000" ]]
+  [[ ${output} == *"uid=1000 gid=1000"* ]]
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -69,6 +69,15 @@ function runc_spec() {
 	runc spec $args "$@"
 }
 
+function runc_spec_additional_mappings() {
+	cat config.json | \
+		jq '.linux.uidMappings |= .+ [{"hostID": 362144, "containerID": 1000, "size": 1}]' | \
+		jq '.linux.gidMappings |= .+ [{"hostID": 362144, "containerID": 100, "size": 1}]' | \
+		jq '.linux.gidMappings |= .+ [{"hostID": 362145, "containerID": 1000, "size": 1}]' \
+		> config.json.tmp
+	mv config.json.tmp config.json
+}
+
 # Fails the current test, providing the error given.
 function fail() {
 	echo "$@" >&2

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -70,11 +70,11 @@ function runc_spec() {
 }
 
 function runc_spec_additional_mappings() {
-	cat config.json | \
-		jq '.linux.uidMappings |= .+ [{"hostID": 362144, "containerID": 1000, "size": 1}]' | \
-		jq '.linux.gidMappings |= .+ [{"hostID": 362144, "containerID": 100, "size": 1}]' | \
-		jq '.linux.gidMappings |= .+ [{"hostID": 362145, "containerID": 1000, "size": 1}]' \
-		> config.json.tmp
+	cat config.json \
+		| jq '.linux.uidMappings |= .+ [{"hostID": 362144, "containerID": 1000, "size": 1}]' \
+		| jq '.linux.gidMappings |= .+ [{"hostID": 362144, "containerID": 100, "size": 1}]' \
+		| jq '.linux.gidMappings |= .+ [{"hostID": 362145, "containerID": 1000, "size": 1}]' \
+			>config.json.tmp
 	mv config.json.tmp config.json
 }
 

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -21,8 +21,9 @@ function teardown() {
 }
 
 @test "runc run detached ({u,g}id != 0)" {
-  # cannot start containers as another user in rootless setup
-  requires root
+  if [ "$ROOTLESS" -ne 0 ]; then
+    runc_spec_additional_mappings
+  fi
 
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -21,8 +21,9 @@ function teardown() {
 }
 
 @test "runc run ({u,g}id != 0)" {
-  # cannot start containers as another user in rootless setup
-  requires root
+  if [ "$ROOTLESS" -ne 0 ]; then
+    runc_spec_additional_mappings
+  fi
 
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -42,7 +42,12 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 			return nil, fmt.Errorf("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
 		}
 	}
-	return libcontainer.New(abs, cgroupManager, libcontainer.CriuPath(context.GlobalString("criu")))
+	return libcontainer.New(abs,
+		cgroupManager,
+		libcontainer.CriuPath(context.GlobalString("criu")),
+		libcontainer.NewuidmapPath(context.GlobalString("newuidmap")),
+		libcontainer.NewgidmapPath(context.GlobalString("newgidmap")),
+	)
 }
 
 // getContainer returns the specified container instance by loading it from state


### PR DESCRIPTION
Opening this PR to start a discussion Re: multiple ID mappings for rootless containers.
The approach suggested here makes use of `newuidmap` and `newgidmap` binaries in order to provide the desired functionality.
We've been experimenting with this approach on the Cloud Foundry Garden team and after some initial testing it seems to provide what we're after.

A possible downside to this approach is that it introduces a dependency on external binaries. However the binaries are available on most major distros, and are only ever used when opted in to and in cases where runc would have failed anyway if the binaries were not available.

Any feedback appreciated.

Cheers,
Ed