### PR TITLE
Revert back to using /sbin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
 PREFIX := $(DESTDIR)/usr/local
-BINDIR := $(PREFIX)/bin
+BINDIR := $(PREFIX)/sbin
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))


### PR DESCRIPTION
This was changed in
https://github.com/opencontainers/runc/commit/d2f49696#diff-b67911656ef5d18c4ae36cb6741b7965R7
and is causing install problems for people building runc and having it
installed in /bin and /sbin.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>