### PR TITLE
vendor: clean up to be better written

### DIFF
--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -72,7 +72,7 @@ function teardown() {
   run git clone https://github.com/opencontainers/runtime-spec.git src/runtime-spec
   [ "$status" -eq 0 ]
 
-  SPEC_COMMIT=$(grep runtime-spec ${TESTDIR}/../../vendor.conf | cut -d ' ' -f 2)
+  SPEC_COMMIT=$(grep '^github.com/opencontainers/runtime-spec' ${TESTDIR}/../../vendor.conf | cut -d ' ' -f 2)
   run git -C src/runtime-spec reset --hard "${SPEC_COMMIT}"
 
   [ "$status" -eq 0 ]

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,15 +1,21 @@
-github.com/Sirupsen/logrus 26709e2714106fb8ad40b773b711ebce25b78914
-github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/coreos/pkg/dlopen 3ac0863d7acf3bc44daf49afef8919af12f704ef
-github.com/docker/docker 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
-github.com/docker/go-units 9b001659dd36225e356b4467c465d732e745f53d
-github.com/godbus/dbus c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
-github.com/golang/protobuf/proto f7137ae6b19afbfd61a94b746fda3b3fe0491874
+# OCI runtime-spec. When updating this, make sure you use a version tag rather
+# than a commit ID so it's much more obvious what version of the spec we are
+# using.
+github.com/opencontainers/runtime-spec v1.0.0-rc5
+# Core libcontainer functionality.
 github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
-github.com/opencontainers/runtime-spec/specs-go 035da1dca3dfbb00d752eb58b0b158d6129f3776
-github.com/opencontainers/selinux ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d
+github.com/opencontainers/selinux v1.0.0-rc1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
-github.com/syndtr/gocapability/capability e7cb7fa329f456b3855136a2642b197bad7366ba
-github.com/urfave/cli d53eb991652b1d438abdd34ce4bfa3ef1539108e
+github.com/Sirupsen/logrus 26709e2714106fb8ad40b773b711ebce25b78914
+github.com/syndtr/gocapability e7cb7fa329f456b3855136a2642b197bad7366ba
 github.com/vishvananda/netlink 1e2e08e8a2dcdacaae3f14ac44c5cfa31361f270
+# systemd integration.
+github.com/coreos/go-systemd v14
+github.com/coreos/pkg v3
+github.com/godbus/dbus v3
+github.com/golang/protobuf f7137ae6b19afbfd61a94b746fda3b3fe0491874
+# Command-line interface.
+github.com/docker/docker 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
+github.com/docker/go-units v0.2.0
+github.com/urfave/cli d53eb991652b1d438abdd34ce4bfa3ef1539108e
 golang.org/x/sys 9a7256cb28ed514b4e1e5f68959914c4c28a92e0 https://github.com/golang/sys


### PR DESCRIPTION
vndr doesn't support non-top-level imports, and in addition we really
should be using tagged releases far more than we currently are
(*especially* when it come to the OCI specs).

Signed-off-by: Aleksa Sarai <asarai@suse.de>