### PR TITLE
Add timeout for syscall.Openat

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -166,15 +167,32 @@ func (l *linuxStandardInit) Init() error {
 	}
 	// close the pipe to signal that we have completed our init.
 	l.pipe.Close()
+
 	// wait for the fifo to be opened on the other side before
 	// exec'ing the users process.
-	fd, err := syscall.Openat(l.stateDirFD, execFifoFilename, os.O_WRONLY|syscall.O_CLOEXEC, 0)
-	if err != nil {
-		return newSystemErrorWithCause(err, "openat exec fifo")
+	ch := make(chan Error, 1)
+	go func() {
+		fd, err := syscall.Openat(l.stateDirFD, execFifoFilename, os.O_WRONLY|syscall.O_CLOEXEC, 0)
+		if err != nil {
+			ch <- newSystemErrorWithCause(err, "openat exec fifo")
+			return
+		}
+		if _, err := syscall.Write(fd, []byte("0")); err != nil {
+			ch <- newSystemErrorWithCause(err, "write 0 exec fifo")
+			return
+		}
+		ch <- nil
+	}()
+
+	select {
+	case chErr := <-ch:
+		if chErr != nil {
+			return chErr
+		}
+	case <-time.After(120 * time.Second):
+		return newSystemErrorWithCause(fmt.Errorf("timeout"), "wait for the fifo to be opened on the other side ")
 	}
-	if _, err := syscall.Write(fd, []byte("0")); err != nil {
-		return newSystemErrorWithCause(err, "write 0 exec fifo")
-	}
+
 	if l.config.Config.Seccomp != nil && l.config.NoNewPrivileges {
 		if err := seccomp.InitSeccomp(l.config.Config.Seccomp); err != nil {
 			return newSystemErrorWithCause(err, "init seccomp")


### PR DESCRIPTION
Openat will be blocked until the fifo on the other side is  opened, but in some
abnomal scenario(e.g. containerd is killed), Openat maybe be blocked all the time.

Signed-off-by: yangshukui <yangshukui@huawei.com>