### PR TITLE
Fix misspelling of "properties" in various places

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -33,7 +33,7 @@ checkpointed.`,
 		cli.BoolFlag{Name: "file-locks", Usage: "handle file locks, for safety"},
 		cli.BoolFlag{Name: "pre-dump", Usage: "dump container's memory information only, leave the container running after this"},
 		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'"},
-		cli.StringSliceFlag{Name: "empty-ns", Usage: "create a namespace, but don't restore its properies"},
+		cli.StringSliceFlag{Name: "empty-ns", Usage: "create a namespace, but don't restore its properties"},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {

--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -22,4 +22,4 @@ checkpointed.
    --file-locks                 handle file locks, for safety
    --pre-dump                   dump container's memory information only, leave the container running after this
    --manage-cgroups-mode value  cgroups mode: 'soft' (default), 'full' and 'strict'
-   --empty-ns value             create a namespace, but don't restore its properies
+   --empty-ns value             create a namespace, but don't restore its properties

--- a/restore.go
+++ b/restore.go
@@ -80,7 +80,7 @@ using the runc checkpoint command.`,
 		},
 		cli.StringSliceFlag{
 			Name:  "empty-ns",
-			Usage: "create a namespace, but don't restore its properies",
+			Usage: "create a namespace, but don't restore its properties",
 		},
 	},
 	Action: func(context *cli.Context) error {


### PR DESCRIPTION
Hi there.  Here's a very small patch to fix the word "properties" where it has been misspelled in various places.

(Resubmitted after adding Signed-off-by to certify DCO).