### PR TITLE
define MemoryUnlimited const for users

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -104,14 +104,12 @@ func setKernelMemory(path string, kernelMemoryLimit uint64) error {
 }
 
 func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {
-	ulimited := -1
-
-	// If the memory update is set to uint64(-1) we should also
-	// set swap to uint64(-1), it means unlimited memory.
-	if cgroup.Resources.Memory == uint64(ulimited) {
+	// If the memory update is set to MemoryUnlimited we should also
+	// set swap to MemoryUnlimited.
+	if cgroup.Resources.Memory == configs.MemoryUnlimited {
 		// Only set swap if it's enbled in kernel
 		if cgroups.PathExists(filepath.Join(path, cgroupMemorySwapLimit)) {
-			cgroup.Resources.MemorySwap = uint64(ulimited)
+			cgroup.Resources.MemorySwap = uint64(configs.MemoryUnlimited)
 		}
 	}
 
@@ -126,7 +124,7 @@ func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {
 		// When update memory limit, we should adapt the write sequence
 		// for memory and swap memory, so it won't fail because the new
 		// value and the old value don't fit kernel's validation.
-		if cgroup.Resources.MemorySwap == uint64(ulimited) || memoryUsage.Limit < cgroup.Resources.MemorySwap {
+		if cgroup.Resources.MemorySwap == uint64(configs.MemoryUnlimited) || memoryUsage.Limit < cgroup.Resources.MemorySwap {
 			if err := writeFile(path, cgroupMemorySwapLimit, strconv.FormatUint(cgroup.Resources.MemorySwap, 10)); err != nil {
 				return err
 			}

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -2,6 +2,10 @@
 
 package configs
 
+import (
+	"math"
+)
+
 type FreezerState string
 
 const (
@@ -33,6 +37,8 @@ type Cgroup struct {
 	*Resources
 }
 
+const MemoryUnlimited = math.MaxUint64
+
 type Resources struct {
 	// If this is true allow access to any kind of device within the container.  If false, allow access only to devices explicitly listed in the allowed_devices list.
 	// Deprecated
@@ -50,7 +56,7 @@ type Resources struct {
 	// Memory reservation or soft_limit (in bytes)
 	MemoryReservation uint64 `json:"memory_reservation"`
 
-	// Total memory usage (memory + swap); set `-1` to enable unlimited swap
+	// Total memory usage (memory + swap); set MemoryUnlimited to enable unlimited swap
 	MemorySwap uint64 `json:"memory_swap"`
 
 	// Kernel memory limit (in bytes)

--- a/update.go
+++ b/update.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/docker/go-units"
+	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
@@ -222,10 +223,10 @@ other options are ignored.
 						if err != nil {
 							return fmt.Errorf("invalid value for %s: %s", pair.opt, err)
 						}
+						*pair.dest = uint64(v)
 					} else {
-						v = -1
+						*pair.dest = configs.MemoryUnlimited
 					}
-					*pair.dest = uint64(v)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/opencontainers/runc/issues/1421

Currently, a user wanting to set `MemorySwap` to unlimited has to do a messy trick:
```
unlimited := -1
res.MemorySwap = uint64(unlimited)
```
as `uint64(-1)` doesn't compile.

This PR defines a `MemoryUnlimited` constant to make this cleaner.

@derekwaynecarr @mrunalp 