### PR TITLE
Remove redundant declaration of namespace slice

### DIFF
--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -64,12 +64,12 @@ func IsNamespaceSupported(ns NamespaceType) bool {
 
 func NamespaceTypes() []NamespaceType {
 	return []NamespaceType{
+		NEWUSER, // Keep user NS always first, don't move it.
+		NEWIPC,
+		NEWUTS,
 		NEWNET,
 		NEWPID,
 		NEWNS,
-		NEWUTS,
-		NEWIPC,
-		NEWUSER,
 	}
 }
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1444,17 +1444,8 @@ func (c *linuxContainer) currentState() (*State, error) {
 // can setns in order.
 func (c *linuxContainer) orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
 	paths := []string{}
-	order := []configs.NamespaceType{
-		// The user namespace *must* be done first.
-		configs.NEWUSER,
-		configs.NEWIPC,
-		configs.NEWUTS,
-		configs.NEWNET,
-		configs.NEWPID,
-		configs.NEWNS,
-	}
 
-	for _, ns := range order {
+	for _, ns := range configs.NamespaceTypes() {
 
 		// Remove namespaces that we don't need to join.
 		if !c.config.Namespaces.Contains(ns) {


### PR DESCRIPTION
Namespaces slice is declared twice. Let's keep list 
namespaces at one place instead of duplicating it. Should
there be any change in future in the number of namespaces
or anything like that, we just have to change in one 
location.

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>