### PR TITLE
tests: don't call wait_for_container after synchronous operations

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -47,7 +47,6 @@ EOF
     # run a detached busybox to work with
     runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_kmem
     [ "$status" -eq 0 ]
-    wait_for_container 15 1 test_cgroups_kmem
 
     # update kernel memory limit
     runc update test_cgroups_kmem --kernel-memory 50331648
@@ -67,7 +66,6 @@ EOF
     # run a detached busybox to work with
     runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_kmem
     [ "$status" -eq 0 ]
-    wait_for_container 15 1 test_cgroups_kmem
 
     # update kernel memory limit
     runc update test_cgroups_kmem --kernel-memory 50331648

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -67,21 +67,33 @@ function teardown() {
   # setting terminal and root:readonly: to false
   sed -i 's;"terminal": true;"terminal": false;' config.json
   sed -i 's;"readonly": true;"readonly": false;' config.json
-  sed -i 's/"sh"/"sh","-c","while :; do date; sleep 1; done"/' config.json
+  sed -i 's/"sh"/"sh","-c","for i in `seq 10`; do read xxx || continue; echo ponG $xxx; done"/' config.json
 
-  (
+  # The following code creates pipes for stdin and stdout.
+  # CRIU can't handle fifo-s, so we need all these tricks.
+  fifo=`mktemp -u /tmp/runc-fifo-XXXXXX`
+  mkfifo $fifo
+
+  # stdout
+  cat $fifo | cat $fifo &
+  pid=$!
+  exec 50</proc/$pid/fd/0
+  exec 51>/proc/$pid/fd/0
+
+  # stdin
+  cat $fifo | cat $fifo &
+  pid=$!
+  exec 60</proc/$pid/fd/0
+  exec 61>/proc/$pid/fd/0
+
+  echo -n > $fifo
+  unlink $fifo
+
     # run busybox (not detached)
-    runc run test_busybox
-    [ "$status" -eq 0 ]
-  ) &
+  __runc run -d test_busybox <&60 >&51 2>&51
+  [ $? -eq 0 ]
 
-  # check state
-  wait_for_container 15 1 test_busybox
-
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
-
+  testcontainer test_busybox running
 
   #test checkpoint pre-dump
   mkdir parent-dir
@@ -95,7 +107,9 @@ function teardown() {
 
   # checkpoint the running container
   mkdir image-dir
-  runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --image-path ./image-dir test_busybox
+  mkdir work-dir
+  runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
+  cat ./work-dir/dump.log | grep -B 5 Error || true
   [ "$status" -eq 0 ]
 
   # after checkpoint busybox is no longer running
@@ -103,16 +117,22 @@ function teardown() {
   [ "$status" -ne 0 ]
 
   # restore from checkpoint
-  (
-    runc --criu "$CRIU" restore --image-path ./image-dir test_busybox
-    [ "$status" -eq 0 ]
-  ) &
-
-  # check state
-  wait_for_container 15 1 test_busybox
+  __runc --criu "$CRIU" restore -d --work-path ./work-dir --image-path ./image-dir test_busybox <&60 >&51 2>&51
+  ret=$?
+  cat ./work-dir/restore.log | grep -B 5 Error || true
+  [ $ret -eq 0 ]
 
   # busybox should be back up and running
-  runc state test_busybox
+  testcontainer test_busybox running
+
+  runc exec --cwd /bin test_busybox echo ok
   [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
+  [[ ${output} == "ok" ]]
+
+  echo Ping >&61
+  exec 61>&-
+  exec 51>&-
+  run cat <&50
+  [ "$status" -eq 0 ]
+  [[ "${output}" == *"ponG Ping"* ]]
 }

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -17,8 +17,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   runc kill test_busybox KILL
@@ -40,8 +38,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   # force delete test_busybox

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -19,9 +19,6 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  # check state
-  wait_for_container 15 1 test_busybox
-
   # generate stats
   runc events --stats test_busybox
   [ "$status" -eq 0 ]
@@ -36,9 +33,6 @@ function teardown() {
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
-
-  # check state
-  wait_for_container 15 1 test_busybox
 
   # spawn two sub processes (shells)
   # the first sub process is an event logger that sends stats events to events.log
@@ -67,9 +61,6 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  # check state
-  wait_for_container 15 1 test_busybox
-
   # spawn two sub processes (shells)
   # the first sub process is an event logger that sends stats events to events.log once a second
   # the second sub process tries 3 times for an event that incudes test_busybox
@@ -95,9 +86,6 @@ function teardown() {
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
-
-  # check state
-  wait_for_container 15 1 test_busybox
 
   #prove there is no carry over of events.log from a prior test
   [ ! -e events.log ]

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -16,8 +16,6 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  wait_for_container 15 1 test_busybox
-
   runc exec test_busybox echo Hello from exec
   [ "$status" -eq 0 ]
   echo text echoed = "'""${output}""'"
@@ -28,8 +26,6 @@ function teardown() {
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
-
-  wait_for_container 15 1 test_busybox
 
   runc exec --pid-file pid.txt test_busybox echo Hello from exec
   [ "$status" -eq 0 ]
@@ -56,8 +52,6 @@ function teardown() {
   runc run -d -b $BUSYBOX_BUNDLE --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  wait_for_container 15 1 test_busybox
-
   runc exec --pid-file pid.txt test_busybox echo Hello from exec
   [ "$status" -eq 0 ]
   echo text echoed = "'""${output}""'"
@@ -77,8 +71,6 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  wait_for_container 15 1 test_busybox
-
   runc exec test_busybox ls -la
   [ "$status" -eq 0 ]
   [[ ${lines[0]} == *"total"* ]]
@@ -91,8 +83,6 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  wait_for_container 15 1 test_busybox
-
   runc exec --cwd /bin test_busybox pwd
   [ "$status" -eq 0 ]
   [[ ${output} == "/bin" ]]
@@ -102,8 +92,6 @@ function teardown() {
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
-
-  wait_for_container 15 1 test_busybox
 
   runc exec --env RUNC_EXEC_TEST=true test_busybox env
   [ "$status" -eq 0 ]
@@ -118,8 +106,6 @@ function teardown() {
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
-
-  wait_for_container 15 1 test_busybox
 
   runc exec --user 1000:1000 test_busybox id
   [ "$status" -eq 0 ]

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -18,8 +18,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   runc kill test_busybox KILL

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -21,15 +21,12 @@ function teardown() {
   # run a few busyboxes detached
   ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box1
   [ "$status" -eq 0 ]
-  wait_for_container_inroot 15 1 test_box1 $HELLO_BUNDLE
 
   ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box2
   [ "$status" -eq 0 ]
-  wait_for_container_inroot 15 1 test_box2 $HELLO_BUNDLE
 
   ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box3
   [ "$status" -eq 0 ]
-  wait_for_container_inroot 15 1 test_box3 $HELLO_BUNDLE
 
   ROOT=$HELLO_BUNDLE runc list
   [ "$status" -eq 0 ]

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -23,8 +23,6 @@ function teardown() {
 	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
 
-	wait_for_container 15 1 test_busybox
-
 	runc exec test_busybox cat /testfile
 	[ "$status" -eq 0 ]
 	[[ "${output}" == "" ]]
@@ -42,8 +40,6 @@ function teardown() {
 	# run busybox detached
 	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
-
-	wait_for_container 15 1 test_busybox
 
 	runc exec test_busybox ls /testdir
 	[ "$status" -eq 0 ]

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -19,7 +19,7 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  wait_for_container 15 1 test_busybox
+  testcontainer test_busybox running
 
   # pause busybox
   runc pause test_busybox
@@ -44,7 +44,7 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  wait_for_container 15 1 test_busybox
+  testcontainer test_busybox running
 
   # pause test_busybox and nonexistent container
   runc pause test_busybox

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -20,8 +20,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   runc ps test_busybox
@@ -39,8 +37,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   runc ps -f json test_busybox
@@ -57,8 +53,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   runc ps test_busybox -e -x

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -22,10 +22,6 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  # check state of the busyboxes are only in their respective root path
-  wait_for_container 15 1 test_busybox
-  wait_for_container_inroot 15 1 test_dotbox $HELLO_BUNDLE
-
   runc state test_busybox
   [ "$status" -eq 0 ]
   [[ "${output}" == *"running"* ]]

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -17,8 +17,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 }
 
@@ -36,8 +34,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 }
 
@@ -47,8 +43,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   # check pid.txt was generated
@@ -71,8 +65,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   # check pid.txt was generated

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -20,8 +20,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   runc kill test_busybox KILL
@@ -50,8 +48,6 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # check state
-  wait_for_container 15 1 test_busybox
-
   testcontainer test_busybox running
 
   # pause busybox

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -64,9 +64,6 @@ function teardown() {
 	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
-	wait_for_container 15 1 test_busybox
-
 	# make sure we're running
 	testcontainer test_busybox running
 
@@ -86,9 +83,6 @@ function teardown() {
 	# run busybox detached
 	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
-
-	# check state
-	wait_for_container 15 1 test_busybox
 
 	# make sure we're running
 	testcontainer test_busybox running
@@ -112,9 +106,6 @@ function teardown() {
 	# run busybox detached
 	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
 	[ "$status" -eq 0 ]
-
-	# check state
-	wait_for_container 15 1 test_busybox
 
 	# make sure we're running
 	testcontainer test_busybox running

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -61,7 +61,6 @@ function check_cgroup_value() {
     # run a few busyboxes detached
     runc run -d --console-socket $CONSOLE_SOCKET test_update
     [ "$status" -eq 0 ]
-    wait_for_container 15 1 test_update
 
     # get the cgroup paths
     for g in MEMORY CPUSET CPU BLKIO PIDS; do
@@ -266,7 +265,6 @@ EOF
     # run a detached busybox
     runc run -d --console-socket $CONSOLE_SOCKET test_update_rt
     [ "$status" -eq 0 ]
-    wait_for_container 15 1 test_update_rt
 
     # get the cgroup paths
     eval CGROUP_CPU="${CGROUP_CPU_BASE_PATH}/runc-update-integration-test"


### PR DESCRIPTION
It is useless and potentially we can skip bugs.

Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>