### PR TITLE
WIP: libcontainer/specconv/spec_linux: defaults should not be a no-op

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -641,7 +641,7 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 		"async":         {true, syscall.MS_SYNCHRONOUS},
 		"atime":         {true, syscall.MS_NOATIME},
 		"bind":          {false, syscall.MS_BIND},
-		"defaults":      {false, 0},
+		"defaults":      {true, syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_NOSUID | syscall.MS_RDONLY | syscall.MS_SYNCHRONOUS},
 		"dev":           {true, syscall.MS_NODEV},
 		"diratime":      {true, syscall.MS_NODIRATIME},
 		"dirsync":       {false, syscall.MS_DIRSYNC},


### PR DESCRIPTION
It has been since it landed in 9fac1832, but [the spec currently references mount(8) for these options][1] and [mount(8) has][2]:

> * defaults
>
>     Use the default options: rw, suid, dev, exec, auto, nouser, and async.
>
>     Note that the real set of all default mount options depends on kernel and filesystem type.  See the beginning of this section for more details.

I exepect that “real set” paragraph applies to:

> Note that filesystems also have per-filesystem specific default mount options (see for example tune2fs -l output for extN filesystems).

For what its worth, util-linux 2.28.2 seems to ignore `defaults` instead of clearing bits:

    # strace -o /tmp/trace mount -t tmpfs -o ro,defaults - /tmp/a
    # grep 'mount(' /tmp/trace
    mount("-", "/tmp/a", "tmpfs", MS_MGC_VAL|MS_RDONLY, NULL) = 0

While a single-bit clear option does unset an earlier bit:

    # strace -o /tmp/trace mount -t tmpfs -o ro,rw - /tmp/a
    # grep 'mount(' /tmp/trace
    mount("-", "/tmp/a", "tmpfs", MS_MGC_VAL, NULL) = 0

but the spec is currnently punting to the util-linux mount(8) page and not to the util-linux implementation.

Related to opencontainers/runtime-spec#771.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/config.md#L68
[2]: http://man7.org/linux/man-pages/man8/mount.8.html#FILESYSTEM-INDEPENDENT_MOUNT%20OPTIONS