### PR TITLE
Clean up unix vs linux usage

### DIFF
--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -1,5 +1,3 @@
-// +build linux freebsd
-
 package configs
 
 type FreezerState string

--- a/libcontainer/configs/config_linux.go
+++ b/libcontainer/configs/config_linux.go
@@ -1,5 +1,3 @@
-// +build freebsd linux
-
 package configs
 
 import "fmt"

--- a/libcontainer/configs/config_linux_test.go
+++ b/libcontainer/configs/config_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux freebsd
-
 package configs
 
 import (

--- a/libcontainer/configs/namespaces_linux.go
+++ b/libcontainer/configs/namespaces_linux.go
@@ -1,5 +1,3 @@
-// +build linux freebsd
-
 package configs
 
 import (

--- a/libcontainer/configs/namespaces_unsupported.go
+++ b/libcontainer/configs/namespaces_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!freebsd
+// +build !linux
 
 package configs
 

--- a/libcontainer/criu_opts_linux.go
+++ b/libcontainer/criu_opts_linux.go
@@ -1,5 +1,3 @@
-// +build linux freebsd
-
 package libcontainer
 
 // cgroup restoring strategy provided by criu

--- a/libcontainer/devices/devices_linux.go
+++ b/libcontainer/devices/devices_linux.go
@@ -1,5 +1,3 @@
-// +build linux freebsd
-
 package devices
 
 import (

--- a/libcontainer/devices/devices_unsupported.go
+++ b/libcontainer/devices/devices_unsupported.go
@@ -1,3 +1,3 @@
-// +build windows
+// +build !linux
 
 package devices

--- a/main_linux.go
+++ b/main_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package main
 
 import (

--- a/main_solaris.go
+++ b/main_solaris.go
@@ -1,5 +1,3 @@
-// +build solaris
-
 package main
 
 import "github.com/urfave/cli"


### PR DESCRIPTION
FreeBSD does not support cgroups or namespaces, which the code suggested, and is not supported
in runc anyway right now. So clean up the file naming to use `_linux` where appropriate.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>