### PR TITLE
libcontainer/user: add supplementary groups only for non-numeric users

### DIFF
--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -358,8 +358,8 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 
 				// Okay, so it's numeric. We can just roll with this.
 			}
-		} else if len(groups) > 0 {
-			// Supplementary group ids only make sense if in the implicit form.
+		} else if len(groups) > 0 && uidErr != nil {
+			// Supplementary group ids only make sense if in the implicit form for non-numeric users.
 			user.Sgids = make([]int, len(groups))
 			for i, group := range groups {
 				user.Sgids[i] = group.Gid


### PR DESCRIPTION
As described in [opencontainers/image-spec#492](https://github.com/opencontainers/image-spec/pull/492) by @cyphar 

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>