### PR TITLE
libcontainer/specconv/spec_linux: Add support for (no)lazytime

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -639,6 +639,7 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 		clear bool
 		flag  int
 	}{
+		"acl":           {false, unix.MS_POSIXACL},
 		"async":         {true, unix.MS_SYNCHRONOUS},
 		"atime":         {true, unix.MS_NOATIME},
 		"bind":          {false, unix.MS_BIND},
@@ -647,11 +648,17 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 		"diratime":      {true, unix.MS_NODIRATIME},
 		"dirsync":       {false, unix.MS_DIRSYNC},
 		"exec":          {true, unix.MS_NOEXEC},
+		"iversion":      {false, unix.MS_I_VERSION},
+		"lazytime":      {false, unix.MS_LAZYTIME},
+		"loud":          {true, unix.MS_SILENT},
 		"mand":          {false, unix.MS_MANDLOCK},
+		"noacl":         {true, unix.MS_POSIXACL},
 		"noatime":       {false, unix.MS_NOATIME},
 		"nodev":         {false, unix.MS_NODEV},
 		"nodiratime":    {false, unix.MS_NODIRATIME},
 		"noexec":        {false, unix.MS_NOEXEC},
+		"noiversion":    {true, unix.MS_I_VERSION},
+		"nolazytime":    {true, unix.MS_LAZYTIME},
 		"nomand":        {true, unix.MS_MANDLOCK},
 		"norelatime":    {true, unix.MS_RELATIME},
 		"nostrictatime": {true, unix.MS_STRICTATIME},
@@ -661,6 +668,7 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 		"remount":       {false, unix.MS_REMOUNT},
 		"ro":            {false, unix.MS_RDONLY},
 		"rw":            {true, unix.MS_RDONLY},
+		"silent":        {false, unix.MS_SILENT},
 		"strictatime":   {false, unix.MS_STRICTATIME},
 		"suid":          {true, unix.MS_NOSUID},
 		"sync":          {false, unix.MS_SYNCHRONOUS},


### PR DESCRIPTION
Part of catching runC up with the spec, which [punts valid options to `mount(8)`][1].  Part of opencontainers/runtime-spec#771.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/config.md#L68