### PR TITLE
Use NLA_* constants from x/sys/unix instead of syscall

### DIFF
--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -3,9 +3,8 @@
 package libcontainer
 
 import (
-	"syscall"
-
 	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 )
 
 // list of known message types we want to send to bootstrap program
@@ -19,9 +18,6 @@ const (
 	SetgroupAttr    uint16 = 27285
 	OomScoreAdjAttr uint16 = 27286
 	RootlessAttr    uint16 = 27287
-
-	// When syscall.NLA_HDRLEN is in gccgo, take this out.
-	syscall_NLA_HDRLEN = (syscall.SizeofNlAttr + syscall.NLA_ALIGNTO - 1) & ^(syscall.NLA_ALIGNTO - 1)
 )
 
 type Int32msg struct {
@@ -43,7 +39,7 @@ func (msg *Int32msg) Serialize() []byte {
 }
 
 func (msg *Int32msg) Len() int {
-	return syscall_NLA_HDRLEN + 4
+	return unix.NLA_HDRLEN + 4
 }
 
 // Bytemsg has the following representation
@@ -56,7 +52,7 @@ type Bytemsg struct {
 
 func (msg *Bytemsg) Serialize() []byte {
 	l := msg.Len()
-	buf := make([]byte, (l+syscall.NLA_ALIGNTO-1) & ^(syscall.NLA_ALIGNTO-1))
+	buf := make([]byte, (l+unix.NLA_ALIGNTO-1) & ^(unix.NLA_ALIGNTO-1))
 	native := nl.NativeEndian()
 	native.PutUint16(buf[0:2], uint16(l))
 	native.PutUint16(buf[2:4], msg.Type)
@@ -65,7 +61,7 @@ func (msg *Bytemsg) Serialize() []byte {
 }
 
 func (msg *Bytemsg) Len() int {
-	return syscall_NLA_HDRLEN + len(msg.Value) + 1 // null-terminated
+	return unix.NLA_HDRLEN + len(msg.Value) + 1 // null-terminated
 }
 
 type Boolmsg struct {
@@ -87,5 +83,5 @@ func (msg *Boolmsg) Serialize() []byte {
 }
 
 func (msg *Boolmsg) Len() int {
-	return syscall_NLA_HDRLEN + 1
+	return unix.NLA_HDRLEN + 1
 }


### PR DESCRIPTION
Use the NLA_ALIGNTO and NLA_HDRLEN constants from x/sys/unix instead of
syscall, as the syscall package shouldn't be used anymore (except for a
few exceptions).

This also makes the syscall_NLA_HDRLEN workaround for gccgo unnecessary.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>