### PR TITLE
Always save own namespace paths

### DIFF
--- a/libcontainer/configs/namespaces_linux.go
+++ b/libcontainer/configs/namespaces_linux.go
@@ -79,9 +79,6 @@ type Namespace struct {
 }
 
 func (n *Namespace) GetPath(pid int) string {
-	if n.Path != "" {
-		return n.Path
-	}
 	return fmt.Sprintf("/proc/%d/ns/%s", pid, NsName(n.Type))
 }
 

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -134,7 +134,7 @@ func TestGetContainerState(t *testing.T) {
 	var (
 		pid                 = os.Getpid()
 		expectedMemoryPath  = "/sys/fs/cgroup/memory/myid"
-		expectedNetworkPath = "/networks/fd"
+		expectedNetworkPath = fmt.Sprintf("/proc/%d/ns/net", pid)
 	)
 	container := &linuxContainer{
 		id: "myid",


### PR DESCRIPTION
fix #1476

If containerA shares namespace, say ipc namespace, with containerB, then
its ipc namespace path would be the same as containerB and be stored in
`state.json`. Exec into containerA will just read the namespace paths
stored in this file and join these namespaces. So, if containerB has
already been stopped, `docker exec containerA` will fail.

To address this issue, we should always save own namespace paths no
matter if we share namespaces with other containers.

Signed-off-by: Yuanhong Peng <pengyuanhong@huawei.com>