### PR TITLE
libcontainer/console_linux.go: Make SaneTerminal public

### DIFF
--- a/contrib/cmd/recvtty/recvtty.go
+++ b/contrib/cmd/recvtty/recvtty.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/urfave/cli"
 )
@@ -98,6 +99,9 @@ func handleSingle(path string) error {
 	// Get the master file descriptor from runC.
 	master, err := utils.RecvFd(socket)
 	if err != nil {
+		return err
+	}
+	if err = libcontainer.SaneTerminal(master); err != nil {
 		return err
 	}
 

--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -21,9 +21,6 @@ func newConsole() (Console, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := saneTerminal(master); err != nil {
-		return nil, err
-	}
 	console, err := ptsname(master)
 	if err != nil {
 		return nil, err
@@ -133,12 +130,12 @@ func ptsname(f *os.File) (string, error) {
 	return fmt.Sprintf("/dev/pts/%d", n), nil
 }
 
-// saneTerminal sets the necessary tty_ioctl(4)s to ensure that a pty pair
+// SaneTerminal sets the necessary tty_ioctl(4)s to ensure that a pty pair
 // created by us acts normally. In particular, a not-very-well-known default of
 // Linux unix98 ptys is that they have +onlcr by default. While this isn't a
 // problem for terminal emulators, because we relay data from the terminal we
 // also relay that funky line discipline.
-func saneTerminal(terminal *os.File) error {
+func SaneTerminal(terminal *os.File) error {
 	// Go doesn't have a wrapper for any of the termios ioctls.
 	var termios unix.Termios
 

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -300,6 +300,7 @@ func TestExecInTTY(t *testing.T) {
 				err: err,
 			}
 		}
+		libcontainer.SaneTerminal(f)
 		dc <- &cdata{
 			c: libcontainer.ConsoleFromFile(f),
 		}

--- a/tty.go
+++ b/tty.go
@@ -74,6 +74,9 @@ func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) error {
 	if err != nil {
 		return err
 	}
+	if err = libcontainer.SaneTerminal(f); err != nil {
+		return err
+	}
 	console := libcontainer.ConsoleFromFile(f)
 	go io.Copy(console, os.Stdin)
 	t.wg.Add(1)


### PR DESCRIPTION
And use it only in local tooling that is forwarding the pseudoterminal master.  That way runC no longer has an opinion on the `onlcr` setting for folks who are creating a terminal and detaching.  They'll use `--console-socket` and can setup the pseudoterminal however they like without runC having an opinion.  With this commit, the only cases where runC still applies SaneTerminal is when *it* is the process consuming the master descriptor.

Previous discussion in #1146 (which landed `saneTerminal` in the first place) and also [on IRC earlier today][1].  From that IRC discussion, this PR takes the “whoever gets the master descriptor can set it up as they see fit” approach.  And alternative floated by @crosbymichael was to [expose some subset of the termios structure in the config][2] which had later [support][3] from @mrunalp.  After further discussion, both @cyphar ([here][4]) and @crosbymichael ([here][5]) seem ok with the “setup the master descriptor as you see fit” approach I've taken here (although that doesn't mean they'll approve of the way I've implemented that approach).

[1]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-06-07.log.html#t2017-06-07T17:17:44
[2]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-06-07.log.html#t2017-06-07T20:47:27
[3]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-06-07.log.html#t2017-06-07T21:03:25
[4]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-06-07.log.html#t2017-06-07T23:17:56
[5]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-06-07.log.html#t2017-06-07T23:22:26