### PR TITLE
tests: redirect runc log messages to stderr

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -21,12 +21,7 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  # check state
-  wait_for_container 15 1 test_busybox
-
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
+  testcontainer test_busybox running
 
   for i in `seq 2`; do
 	  # checkpoint the running container
@@ -40,19 +35,12 @@ function teardown() {
 	  [ "$status" -ne 0 ]
 
 	  # restore from checkpoint
-	  (
-	    runc --criu "$CRIU" restore -d --console-socket $CONSOLE_SOCKET test_busybox
-	    [ "$status" -eq 0 ]
-	  ) &
+	  runc --criu "$CRIU" restore -d --console-socket $CONSOLE_SOCKET test_busybox
+	  [ "$status" -eq 0 ]
 
-	  # check state
-	  wait_for_container 15 1 test_busybox
+	  # busybox should be back up and running
+          testcontainer test_busybox running
   done
-
-  # busybox should be back up and running
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
 }
 
 @test "checkpoint --pre-dump and restore" {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -55,7 +55,7 @@ function runc() {
 
 # Raw wrapper for runc.
 function __runc() {
-	"$RUNC" --root "$ROOT" "$@"
+	"$RUNC" --log /proc/self/fd/2 --root "$ROOT" "$@"
 }
 
 # Wrapper for runc spec.


### PR DESCRIPTION
Currently we don't see these messages, but there may be useful information for understanding problems.