### PR TITLE
Revert memory fields to signed integers

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -332,8 +332,8 @@ func removePath(p string, err error) error {
 	return nil
 }
 
-func CheckCpushares(path string, c uint64) error {
-	var cpuShares uint64
+func CheckCpushares(path string, c int64) error {
+	var cpuShares int64
 
 	if c == 0 {
 		return nil

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -55,7 +55,7 @@ func (s *CpuGroup) ApplyDir(path string, cgroup *configs.Cgroup, pid int) error 
 
 func (s *CpuGroup) SetRtSched(path string, cgroup *configs.Cgroup) error {
 	if cgroup.Resources.CpuRtPeriod != 0 {
-		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatUint(cgroup.Resources.CpuRtPeriod, 10)); err != nil {
+		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatInt(cgroup.Resources.CpuRtPeriod, 10)); err != nil {
 			return err
 		}
 	}
@@ -69,12 +69,12 @@ func (s *CpuGroup) SetRtSched(path string, cgroup *configs.Cgroup) error {
 
 func (s *CpuGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.Resources.CpuShares != 0 {
-		if err := writeFile(path, "cpu.shares", strconv.FormatUint(cgroup.Resources.CpuShares, 10)); err != nil {
+		if err := writeFile(path, "cpu.shares", strconv.FormatInt(cgroup.Resources.CpuShares, 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.Resources.CpuPeriod != 0 {
-		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatUint(cgroup.Resources.CpuPeriod, 10)); err != nil {
+		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(cgroup.Resources.CpuPeriod, 10)); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -73,14 +73,14 @@ func EnableKernelMemoryAccounting(path string) error {
 	// until a limit is set on the cgroup and limit cannot be set once the
 	// cgroup has children, or if there are already tasks in the cgroup.
 	for _, i := range []int64{1, -1} {
-		if err := setKernelMemory(path, uint64(i)); err != nil {
+		if err := setKernelMemory(path, i); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func setKernelMemory(path string, kernelMemoryLimit uint64) error {
+func setKernelMemory(path string, kernelMemoryLimit int64) error {
 	if path == "" {
 		return fmt.Errorf("no such directory for %s", cgroupKernelMemoryLimit)
 	}
@@ -88,7 +88,7 @@ func setKernelMemory(path string, kernelMemoryLimit uint64) error {
 		// kernel memory is not enabled on the system so we should do nothing
 		return nil
 	}
-	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatUint(kernelMemoryLimit, 10)), 0700); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatInt(kernelMemoryLimit, 10)), 0700); err != nil {
 		// Check if the error number returned by the syscall is "EBUSY"
 		// The EBUSY signal is returned on attempts to write to the
 		// memory.kmem.limit_in_bytes file if the cgroup has children or
@@ -106,14 +106,12 @@ func setKernelMemory(path string, kernelMemoryLimit uint64) error {
 }
 
 func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {
-	ulimited := -1
-
-	// If the memory update is set to uint64(-1) we should also
-	// set swap to uint64(-1), it means unlimited memory.
-	if cgroup.Resources.Memory == uint64(ulimited) {
+	// If the memory update is set to -1 we should also set swap to -1
+	// -1 means unlimited memory
+	if cgroup.Resources.Memory == -1 {
 		// Only set swap if it's enbled in kernel
 		if cgroups.PathExists(filepath.Join(path, cgroupMemorySwapLimit)) {
-			cgroup.Resources.MemorySwap = uint64(ulimited)
+			cgroup.Resources.MemorySwap = -1
 		}
 	}
 
@@ -128,29 +126,29 @@ func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {
 		// When update memory limit, we should adapt the write sequence
 		// for memory and swap memory, so it won't fail because the new
 		// value and the old value don't fit kernel's validation.
-		if cgroup.Resources.MemorySwap == uint64(ulimited) || memoryUsage.Limit < cgroup.Resources.MemorySwap {
-			if err := writeFile(path, cgroupMemorySwapLimit, strconv.FormatUint(cgroup.Resources.MemorySwap, 10)); err != nil {
+		if cgroup.Resources.MemorySwap == -1 || memoryUsage.Limit < uint64(cgroup.Resources.MemorySwap) {
+			if err := writeFile(path, cgroupMemorySwapLimit, strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
 				return err
 			}
-			if err := writeFile(path, cgroupMemoryLimit, strconv.FormatUint(cgroup.Resources.Memory, 10)); err != nil {
+			if err := writeFile(path, cgroupMemoryLimit, strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
 				return err
 			}
 		} else {
-			if err := writeFile(path, cgroupMemoryLimit, strconv.FormatUint(cgroup.Resources.Memory, 10)); err != nil {
+			if err := writeFile(path, cgroupMemoryLimit, strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
 				return err
 			}
-			if err := writeFile(path, cgroupMemorySwapLimit, strconv.FormatUint(cgroup.Resources.MemorySwap, 10)); err != nil {
+			if err := writeFile(path, cgroupMemorySwapLimit, strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
 				return err
 			}
 		}
 	} else {
 		if cgroup.Resources.Memory != 0 {
-			if err := writeFile(path, cgroupMemoryLimit, strconv.FormatUint(cgroup.Resources.Memory, 10)); err != nil {
+			if err := writeFile(path, cgroupMemoryLimit, strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
 				return err
 			}
 		}
 		if cgroup.Resources.MemorySwap != 0 {
-			if err := writeFile(path, cgroupMemorySwapLimit, strconv.FormatUint(cgroup.Resources.MemorySwap, 10)); err != nil {
+			if err := writeFile(path, cgroupMemorySwapLimit, strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
 				return err
 			}
 		}
@@ -171,13 +169,13 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 	}
 
 	if cgroup.Resources.MemoryReservation != 0 {
-		if err := writeFile(path, "memory.soft_limit_in_bytes", strconv.FormatUint(cgroup.Resources.MemoryReservation, 10)); err != nil {
+		if err := writeFile(path, "memory.soft_limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemoryReservation, 10)); err != nil {
 			return err
 		}
 	}
 
 	if cgroup.Resources.KernelMemoryTCP != 0 {
-		if err := writeFile(path, "memory.kmem.tcp.limit_in_bytes", strconv.FormatUint(cgroup.Resources.KernelMemoryTCP, 10)); err != nil {
+		if err := writeFile(path, "memory.kmem.tcp.limit_in_bytes", strconv.FormatInt(cgroup.Resources.KernelMemoryTCP, 10)); err != nil {
 			return err
 		}
 	}
@@ -188,12 +186,12 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 	}
 	if cgroup.Resources.MemorySwappiness == nil || int64(*cgroup.Resources.MemorySwappiness) == -1 {
 		return nil
-	} else if *cgroup.Resources.MemorySwappiness <= 100 {
-		if err := writeFile(path, "memory.swappiness", strconv.FormatUint(*cgroup.Resources.MemorySwappiness, 10)); err != nil {
+	} else if int64(*cgroup.Resources.MemorySwappiness) >= 0 && int64(*cgroup.Resources.MemorySwappiness) <= 100 {
+		if err := writeFile(path, "memory.swappiness", strconv.FormatInt(*cgroup.Resources.MemorySwappiness, 10)); err != nil {
 			return err
 		}
 	} else {
-		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", *cgroup.Resources.MemorySwappiness)
+		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", int64(*cgroup.Resources.MemorySwappiness))
 	}
 
 	return nil
@@ -255,7 +253,7 @@ func memoryAssigned(cgroup *configs.Cgroup) bool {
 		cgroup.Resources.KernelMemory > 0 ||
 		cgroup.Resources.KernelMemoryTCP > 0 ||
 		cgroup.Resources.OomKillDisable ||
-		(cgroup.Resources.MemorySwappiness != nil && int64(*cgroup.Resources.MemorySwappiness) != -1)
+		(cgroup.Resources.MemorySwappiness != nil && *cgroup.Resources.MemorySwappiness != -1)
 }
 
 func getMemoryData(path, name string) (cgroups.MemoryData, error) {

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -235,7 +235,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	defer helper.cleanup()
 
 	swappinessBefore := 60 //default is 60
-	swappinessAfter := uint64(0)
+	swappinessAfter := int64(0)
 
 	helper.writeFileContents(map[string]string{
 		"memory.swappiness": strconv.Itoa(swappinessBefore),
@@ -251,7 +251,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse memory.swappiness - %s", err)
 	}
-	if value != swappinessAfter {
+	if int64(value) != swappinessAfter {
 		t.Fatalf("Got the wrong value (%d), set memory.swappiness = %d failed.", value, swappinessAfter)
 	}
 }

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -260,19 +260,19 @@ func (m *Manager) Apply(pid int) error {
 
 	if c.Resources.Memory != 0 {
 		properties = append(properties,
-			newProp("MemoryLimit", c.Resources.Memory))
+			newProp("MemoryLimit", uint64(c.Resources.Memory)))
 	}
 
 	if c.Resources.CpuShares != 0 {
 		properties = append(properties,
-			newProp("CPUShares", c.Resources.CpuShares))
+			newProp("CPUShares", uint64(c.Resources.CpuShares)))
 	}
 
 	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
 	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
-		cpuQuotaPerSecUSec := uint64(c.Resources.CpuQuota*1000000) / c.Resources.CpuPeriod
+		cpuQuotaPerSecUSec := c.Resources.CpuQuota * 1000000 / c.Resources.CpuPeriod
 		properties = append(properties,
-			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
+			newProp("CPUQuotaPerSecUSec", uint64(cpuQuotaPerSecUSec)))
 	}
 
 	if c.Resources.BlkioWeight != 0 {

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -43,34 +43,34 @@ type Resources struct {
 	Devices []*Device `json:"devices"`
 
 	// Memory limit (in bytes)
-	Memory uint64 `json:"memory"`
+	Memory int64 `json:"memory"`
 
 	// Memory reservation or soft_limit (in bytes)
-	MemoryReservation uint64 `json:"memory_reservation"`
+	MemoryReservation int64 `json:"memory_reservation"`
 
 	// Total memory usage (memory + swap); set `-1` to enable unlimited swap
-	MemorySwap uint64 `json:"memory_swap"`
+	MemorySwap int64 `json:"memory_swap"`
 
 	// Kernel memory limit (in bytes)
-	KernelMemory uint64 `json:"kernel_memory"`
+	KernelMemory int64 `json:"kernel_memory"`
 
 	// Kernel memory limit for TCP use (in bytes)
-	KernelMemoryTCP uint64 `json:"kernel_memory_tcp"`
+	KernelMemoryTCP int64 `json:"kernel_memory_tcp"`
 
 	// CPU shares (relative weight vs. other containers)
-	CpuShares uint64 `json:"cpu_shares"`
+	CpuShares int64 `json:"cpu_shares"`
 
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
 	CpuQuota int64 `json:"cpu_quota"`
 
 	// CPU period to be used for hardcapping (in usecs). 0 to use system default.
-	CpuPeriod uint64 `json:"cpu_period"`
+	CpuPeriod int64 `json:"cpu_period"`
 
 	// How many time CPU will use in realtime scheduling (in usecs).
 	CpuRtRuntime int64 `json:"cpu_rt_quota"`
 
 	// CPU period to be used for realtime scheduling (in usecs).
-	CpuRtPeriod uint64 `json:"cpu_rt_period"`
+	CpuRtPeriod int64 `json:"cpu_rt_period"`
 
 	// CPU to use
 	CpusetCpus string `json:"cpuset_cpus"`
@@ -112,7 +112,7 @@ type Resources struct {
 	OomKillDisable bool `json:"oom_kill_disable"`
 
 	// Tuning swappiness behaviour per cgroup
-	MemorySwappiness *uint64 `json:"memory_swappiness"`
+	MemorySwappiness *int64 `json:"memory_swappiness"`
 
 	// Set priority of network traffic for container
 	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap"`

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -360,39 +360,40 @@ func createCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
 	}
 	if r.Memory != nil {
 		if r.Memory.Limit != nil {
-			c.Resources.Memory = *r.Memory.Limit
+			c.Resources.Memory = int64(*r.Memory.Limit)
 		}
 		if r.Memory.Reservation != nil {
-			c.Resources.MemoryReservation = *r.Memory.Reservation
+			c.Resources.MemoryReservation = int64(*r.Memory.Reservation)
 		}
 		if r.Memory.Swap != nil {
-			c.Resources.MemorySwap = *r.Memory.Swap
+			c.Resources.MemorySwap = int64(*r.Memory.Swap)
 		}
 		if r.Memory.Kernel != nil {
-			c.Resources.KernelMemory = *r.Memory.Kernel
+			c.Resources.KernelMemory = int64(*r.Memory.Kernel)
 		}
 		if r.Memory.KernelTCP != nil {
-			c.Resources.KernelMemoryTCP = *r.Memory.KernelTCP
+			c.Resources.KernelMemoryTCP = int64(*r.Memory.KernelTCP)
 		}
 		if r.Memory.Swappiness != nil {
-			c.Resources.MemorySwappiness = r.Memory.Swappiness
+			swappiness := int64(*r.Memory.Swappiness)
+			c.Resources.MemorySwappiness = &swappiness
 		}
 	}
 	if r.CPU != nil {
 		if r.CPU.Shares != nil {
-			c.Resources.CpuShares = *r.CPU.Shares
+			c.Resources.CpuShares = int64(*r.CPU.Shares)
 		}
 		if r.CPU.Quota != nil {
-			c.Resources.CpuQuota = *r.CPU.Quota
+			c.Resources.CpuQuota = int64(*r.CPU.Quota)
 		}
 		if r.CPU.Period != nil {
-			c.Resources.CpuPeriod = *r.CPU.Period
+			c.Resources.CpuPeriod = int64(*r.CPU.Period)
 		}
 		if r.CPU.RealtimeRuntime != nil {
-			c.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
+			c.Resources.CpuRtRuntime = int64(*r.CPU.RealtimeRuntime)
 		}
 		if r.CPU.RealtimePeriod != nil {
-			c.Resources.CpuRtPeriod = *r.CPU.RealtimePeriod
+			c.Resources.CpuRtPeriod = int64(*r.CPU.RealtimePeriod)
 		}
 		if r.CPU.Cpus != "" {
 			c.Resources.CpusetCpus = r.CPU.Cpus

--- a/update.go
+++ b/update.go
@@ -240,18 +240,18 @@ other options are ignored.
 
 		// Update the value
 		config.Cgroups.Resources.BlkioWeight = *r.BlockIO.Weight
-		config.Cgroups.Resources.CpuPeriod = *r.CPU.Period
-		config.Cgroups.Resources.CpuQuota = *r.CPU.Quota
-		config.Cgroups.Resources.CpuShares = *r.CPU.Shares
-		config.Cgroups.Resources.CpuRtPeriod = *r.CPU.RealtimePeriod
-		config.Cgroups.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
+		config.Cgroups.Resources.CpuPeriod = int64(*r.CPU.Period)
+		config.Cgroups.Resources.CpuQuota = int64(*r.CPU.Quota)
+		config.Cgroups.Resources.CpuShares = int64(*r.CPU.Shares)
+		config.Cgroups.Resources.CpuRtPeriod = int64(*r.CPU.RealtimePeriod)
+		config.Cgroups.Resources.CpuRtRuntime = int64(*r.CPU.RealtimeRuntime)
 		config.Cgroups.Resources.CpusetCpus = r.CPU.Cpus
 		config.Cgroups.Resources.CpusetMems = r.CPU.Mems
-		config.Cgroups.Resources.KernelMemory = *r.Memory.Kernel
-		config.Cgroups.Resources.KernelMemoryTCP = *r.Memory.KernelTCP
-		config.Cgroups.Resources.Memory = *r.Memory.Limit
-		config.Cgroups.Resources.MemoryReservation = *r.Memory.Reservation
-		config.Cgroups.Resources.MemorySwap = *r.Memory.Swap
+		config.Cgroups.Resources.KernelMemory = int64(*r.Memory.Kernel)
+		config.Cgroups.Resources.KernelMemoryTCP = int64(*r.Memory.KernelTCP)
+		config.Cgroups.Resources.Memory = int64(*r.Memory.Limit)
+		config.Cgroups.Resources.MemoryReservation = int64(*r.Memory.Reservation)
+		config.Cgroups.Resources.MemorySwap = int64(*r.Memory.Swap)
 		config.Cgroups.Resources.PidsLimit = r.Pids.Limit
 
 		return container.Set(config)


### PR DESCRIPTION
Reverts commit 8430cc4f488f1925df01e517358c2a4cce8de176

Conflicted with commits 4f9cb13b644285c39c077feb20a254f3074d2d77
and 1e7e276aff03893ccb243311e2cbeb9edeae8198

The kernel specifically accepts -1 in its parser, using
page_counter_memparse(args, "-1",...) but we no longer allow this since
this change, so it no longer matches the kernel behaviour, even if it is
a "sort of" uint64 it is a special one that also accepts -1.

In addition the maximum meaningful value is 2^63 due to the kernel/user
memory split.

In addition some older kernels (RHEL 7.2 at least) will set the limits
to 0 if they are larger than 2^63, and then immediately crash, so
setting them to 2^64-1 makes them crash, while the previous -1 worked
correctly.

Signed-off-by: Tibor Vass <tibor@docker.com>
Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Fixes #1421
Closes #1422
Reverts #1375

Related to https://github.com/opencontainers/runtime-spec/commit/ec9449187bc752ef728727bd479e547d66fade44

In fact, that spec change seems incorrect for the reasons detailed above. I think we should also revert the spec.

cc @hqhq @crosbymichael @tonistiigi @justincormack 