### PR TITLE
Fix unlimited memory issue on old kernel

### DIFF
--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -1,5 +1,9 @@
 package configs
 
+import (
+	"math"
+)
+
 type FreezerState string
 
 const (
@@ -7,6 +11,8 @@ const (
 	Frozen    FreezerState = "FROZEN"
 	Thawed    FreezerState = "THAWED"
 )
+
+const MemoryUnlimited = math.MaxUint64
 
 type Cgroup struct {
 	// Deprecated, use Path instead
@@ -48,7 +54,7 @@ type Resources struct {
 	// Memory reservation or soft_limit (in bytes)
 	MemoryReservation uint64 `json:"memory_reservation"`
 
-	// Total memory usage (memory + swap); set `-1` to enable unlimited swap
+	// Total memory usage (memory + swap); set MemoryUnlimited to enable unlimited swap
 	MemorySwap uint64 `json:"memory_swap"`
 
 	// Kernel memory limit (in bytes)

--- a/update.go
+++ b/update.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/docker/go-units"
+	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
@@ -229,10 +230,10 @@ other options are ignored.
 						if err != nil {
 							return fmt.Errorf("invalid value for %s: %s", pair.opt, err)
 						}
+						*pair.dest = uint64(v)
 					} else {
-						v = -1
+						*pair.dest = configs.MemoryUnlimited
 					}
-					*pair.dest = uint64(v)
 				}
 			}
 			r.Pids.Limit = int64(context.Int("pids-limit"))


### PR DESCRIPTION
Fixes #1421

On old kernels (before 3.11), max memory limit is
LLONG_MAX, which is 2^63-1 on most platforms, so we
should not use uint64(-1) for unlimited memory.

Keep using `-1` for cgroup API when people want to
set memory unlimited to fix this.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>