### PR TITLE
Fix checkpoint/restore tests with newer kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN cd /tmp \
     && rm -rf /tmp/bats
 
 # install criu
-ENV CRIU_VERSION 2.12
+ENV CRIU_VERSION 3.1
 RUN mkdir -p /usr/src/criu \
     && curl -sSL https://github.com/xemul/criu/archive/v${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,9 @@ RUN cd /tmp \
     && rm -rf /tmp/bats
 
 # install criu
-ENV CRIU_VERSION 3.1
+ENV CRIU_VERSION 3ca8e575b49763030d3ddfec4af190a4c9f9deef
 RUN mkdir -p /usr/src/criu \
-    && curl -sSL https://github.com/xemul/criu/archive/v${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
+    && curl -sSL https://github.com/xemul/criu/archive/${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \
     && make install-criu \
     && rm -rf /usr/src/criu

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -24,22 +24,26 @@ function teardown() {
   testcontainer test_busybox running
 
   for i in `seq 2`; do
-	  # checkpoint the running container
-	  runc --criu "$CRIU" checkpoint test_busybox
-	  # if you are having problems getting criu to work uncomment the following dump:
-	  #cat /run/opencontainer/containers/test_busybox/criu.work/dump.log
-	  [ "$status" -eq 0 ]
+    # checkpoint the running container
+    runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
+    ret=$?
+    # if you are having problems getting criu to work uncomment the following dump:
+    #cat /run/opencontainer/containers/test_busybox/criu.work/dump.log
+    cat ./work-dir/dump.log | grep -B 5 Error || true
+    [ "$ret" -eq 0 ]
 
-	  # after checkpoint busybox is no longer running
-	  runc state test_busybox
-	  [ "$status" -ne 0 ]
+    # after checkpoint busybox is no longer running
+    runc state test_busybox
+    [ "$status" -ne 0 ]
 
-	  # restore from checkpoint
-	  runc --criu "$CRIU" restore -d --console-socket $CONSOLE_SOCKET test_busybox
-	  [ "$status" -eq 0 ]
+    # restore from checkpoint
+    runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket $CONSOLE_SOCKET test_busybox
+    ret=$?
+    cat ./work-dir/restore.log | grep -B 5 Error || true
+    [ "$ret" -eq 0 ]
 
-	  # busybox should be back up and running
-          testcontainer test_busybox running
+    # busybox should be back up and running
+    testcontainer test_busybox running
   done
 }
 


### PR DESCRIPTION
Story for the stack gap problem: https://github.com/xemul/criu/issues/322

This upgrades criu to a testing commit to fix our test failures. We should upgrade again when criu does a release but this commit seems to fix the tests for now.