### PR TITLE
*: fix shfmt

### DIFF
--- a/script/check-config.sh
+++ b/script/check-config.sh
@@ -202,7 +202,7 @@ flags=(
 	NF_NAT_IPV4 IP_NF_FILTER IP_NF_TARGET_MASQUERADE
 	NETFILTER_XT_MATCH_{ADDRTYPE,CONNTRACK}
 	NF_NAT NF_NAT_NEEDED
-
+	
 	# required for bind-mounting /dev/mqueue into containers
 	POSIX_MQUEUE
 )


### PR DESCRIPTION
Recent changes in upstream shfmt have started causing our scripts to no
longer be "correctly formatted". Fix up with `shfmt -w`.

Signed-off-by: Aleksa Sarai <asarai@suse.de>