### PR TITLE
Fix non-Unix build of libcontainer/user

### DIFF
--- a/libcontainer/console_windows.go
+++ b/libcontainer/console_windows.go
@@ -1,5 +1,9 @@
 package libcontainer
 
+import (
+	"os"
+)
+
 // newConsole returns an initialized console that can be used within a container
 func newConsole() (Console, error) {
 	return &windowsConsole{}, nil
@@ -11,6 +15,10 @@ type windowsConsole struct {
 
 func (c *windowsConsole) Fd() uintptr {
 	return 0
+}
+
+func (c *windowsConsole) File() *os.File {
+	return nil
 }
 
 func (c *windowsConsole) Path() string {

--- a/libcontainer/user/lookup.go
+++ b/libcontainer/user/lookup.go
@@ -2,8 +2,6 @@ package user
 
 import (
 	"errors"
-
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -35,13 +33,6 @@ func lookupUser(filter func(u User) bool) (User, error) {
 
 	// Assume the first entry is the "correct" one.
 	return users[0], nil
-}
-
-// CurrentUser looks up the current user by their user id in /etc/passwd. If the
-// user cannot be found (or there is no /etc/passwd file on the filesystem),
-// then CurrentUser returns an error.
-func CurrentUser() (User, error) {
-	return LookupUid(unix.Getuid())
 }
 
 // LookupUser looks up a user by their username in /etc/passwd. If the user
@@ -83,13 +74,6 @@ func lookupGroup(filter func(g Group) bool) (Group, error) {
 
 	// Assume the first entry is the "correct" one.
 	return groups[0], nil
-}
-
-// CurrentGroup looks up the current user's group by their primary group id's
-// entry in /etc/passwd. If the group cannot be found (or there is no
-// /etc/group file on the filesystem), then CurrentGroup returns an error.
-func CurrentGroup() (Group, error) {
-	return LookupGid(unix.Getgid())
 }
 
 // LookupGroup looks up a group by its name in /etc/group. If the group cannot

--- a/libcontainer/user/lookup_unix.go
+++ b/libcontainer/user/lookup_unix.go
@@ -5,6 +5,8 @@ package user
 import (
 	"io"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 // Unix-specific path to the passwd and group formatted files.
@@ -27,4 +29,18 @@ func GetGroupPath() (string, error) {
 
 func GetGroup() (io.ReadCloser, error) {
 	return os.Open(unixGroupPath)
+}
+
+// CurrentUser looks up the current user by their user id in /etc/passwd. If the
+// user cannot be found (or there is no /etc/passwd file on the filesystem),
+// then CurrentUser returns an error.
+func CurrentUser() (User, error) {
+	return LookupUid(unix.Getuid())
+}
+
+// CurrentGroup looks up the current user's group by their primary group id's
+// entry in /etc/passwd. If the group cannot be found (or there is no
+// /etc/group file on the filesystem), then CurrentGroup returns an error.
+func CurrentGroup() (Group, error) {
+	return LookupGid(unix.Getgid())
 }

--- a/libcontainer/user/lookup_unsupported.go
+++ b/libcontainer/user/lookup_unsupported.go
@@ -19,3 +19,11 @@ func GetGroupPath() (string, error) {
 func GetGroup() (io.ReadCloser, error) {
 	return nil, ErrUnsupported
 }
+
+func CurrentUser() (User, error) {
+	return LookupUid(-1)
+}
+
+func CurrentGroup() (Group, error) {
+	return LookupGid(-1)
+}

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -38,15 +36,6 @@ func ResolveRootfs(uncleanRootfs string) (string, error) {
 		return "", err
 	}
 	return filepath.EvalSymlinks(rootfs)
-}
-
-// ExitStatus returns the correct exit status for a process based on if it
-// was signaled or exited cleanly
-func ExitStatus(status unix.WaitStatus) int {
-	if status.Signaled() {
-		return exitSignalOffset + int(status.Signal())
-	}
-	return status.ExitStatus()
 }
 
 // WriteJSON writes the provided struct v to w using standard json marshaling

--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -42,3 +42,12 @@ func NewSockPair(name string) (parent *os.File, child *os.File, err error) {
 	}
 	return os.NewFile(uintptr(fds[1]), name+"-p"), os.NewFile(uintptr(fds[0]), name+"-c"), nil
 }
+
+// ExitStatus returns the correct exit status for a process based on if it
+// was signaled or exited cleanly
+func ExitStatus(status unix.WaitStatus) int {
+	if status.Signaled() {
+		return exitSignalOffset + int(status.Signal())
+	}
+	return status.ExitStatus()
+}


### PR DESCRIPTION
Commit 3d7cb4293c15 ("Move libcontainer to x/sys/unix") switched from
`syscall.Get[ug]id` to `unix.Get[ug]id` where `unix.*` is (naturally) not
available on non-Unix platforms such as Windows.

Move the offending code into a Unix specific file and provide stubs in the
_unsupported.go case.

The stubs use `-1` for UID and GID which is what syscall_windows.go was
returning prior to 3d7cb4293c15, and these are laundered through `Lookup[GU]id`
to provide the same behaviour as before.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>