### PR TITLE
libcontainer/container.go: Fix small marshaling error

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -54,7 +54,7 @@ type BaseState struct {
 	InitProcessPid int `json:"init_process_pid"`
 
 	// InitProcessStartTime is the init process start time in clock cycles since boot time.
-	InitProcessStartTime uint64 `json:"init_process_start"`
+	InitProcessStartTime uint64 `json:"init_process_start,string"`
 
 	// Created is the unix timestamp for the creation time of the container in UTC
 	Created time.Time `json:"created"`


### PR DESCRIPTION
When running runc kill <container> KILL, an error was always being throw like:

   json: cannot unmarshal string into Go struct field State.init_process_start of type uint64

Converting the uint64 to string for json output resolves the issue.