### PR TITLE
list: fix various problems with owner field

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -162,14 +162,6 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	if err := l.Validator.Validate(config); err != nil {
 		return nil, newGenericError(err, ConfigInvalid)
 	}
-	uid, err := config.HostRootUID()
-	if err != nil {
-		return nil, newGenericError(err, SystemError)
-	}
-	gid, err := config.HostRootGID()
-	if err != nil {
-		return nil, newGenericError(err, SystemError)
-	}
 	containerRoot := filepath.Join(l.Root, id)
 	if _, err := os.Stat(containerRoot); err == nil {
 		return nil, newGenericError(fmt.Errorf("container with id exists: %v", id), IdInUse)
@@ -179,7 +171,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	if err := os.MkdirAll(containerRoot, 0711); err != nil {
 		return nil, newGenericError(err, SystemError)
 	}
-	if err := os.Chown(containerRoot, uid, gid); err != nil {
+	if err := os.Chown(containerRoot, unix.Geteuid(), unix.Getegid()); err != nil {
 		return nil, newGenericError(err, SystemError)
 	}
 	if config.Rootless {

--- a/list.go
+++ b/list.go
@@ -135,7 +135,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 			stat := item.Sys().(*syscall.Stat_t)
 			owner, err := user.LookupUid(int(stat.Uid))
 			if err != nil {
-				owner.Name = string(stat.Uid)
+				owner.Name = fmt.Sprintf("#%d", stat.Uid)
 			}
 
 			container, err := factory.Load(item.Name())


### PR DESCRIPTION
If a container is owned by a UID that is not listed in /etc/passwd,
previously we would cast the UID to a string which contained a character
with the unicode value of the UID. This is clearly wrong, switch to
using fmt.Sprintf as intended.

In addition, notate unknown users with a leading '#' in the column. This
is necessary to ensure that a user is not under the impression that the
UID is the same as a numeric username.

It appears as though these semantics were not fully thought out when
implementing them for rootless containers. It is not necessary (and
could be potentially dangerous) to set the owner of /run/ctr/$id to be
the root inside the container (if user namespaces are being used).

Instead, just use the e{g,u}id of runc to determine the owner.

Fixes #1515 
Signed-off-by: Aleksa Sarai <asarai@suse.de>