### PR TITLE
libcontainer: use additional functions and constants from x/sys/unix

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1290,11 +1290,11 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 			}
 		}
 	case notify.GetScript() == "orphan-pts-master":
-		scm, err := syscall.ParseSocketControlMessage(oob)
+		scm, err := unix.ParseSocketControlMessage(oob)
 		if err != nil {
 			return err
 		}
-		fds, err := syscall.ParseUnixRights(&scm[0])
+		fds, err := unix.ParseUnixRights(&scm[0])
 
 		master := os.NewFile(uintptr(fds[0]), "orphan-pts-master")
 		defer master.Close()

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -43,7 +43,7 @@ func (l *linuxSetnsInit) Init() error {
 		}
 	}
 	if l.config.NoNewPrivileges {
-		if err := unix.Prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -42,10 +42,6 @@ func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
 	return fmt.Sprintf("_ses.%s", l.config.ContainerId), 0xffffffff, newperms
 }
 
-// PR_SET_NO_NEW_PRIVS isn't exposed in Golang so we define it ourselves copying the value
-// the kernel
-const PR_SET_NO_NEW_PRIVS = 0x26
-
 func (l *linuxStandardInit) Init() error {
 	if !l.config.Config.NoNewKeyring {
 		ringname, keepperms, newperms := l.getSessionRingParams()
@@ -128,7 +124,7 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 	if l.config.NoNewPrivileges {
-		if err := unix.Prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Use ParseSocketControlMessage and ParseUnixRights from
golang.org/x/sys/unix instead of their syscall equivalent.

Use PR_SET_NO_NEW_PRIVS defined in golang.org/x/sys/unix instead of
manually defining it.