### PR TITLE
Support multiple users/groups mapped for the rootless case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     protobuf-c-compiler \
     protobuf-compiler \
     python-minimal \
+    uidmap \
     --no-install-recommends \
     && apt-get clean
 

--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,10 @@ localintegration: all
 	bats -t tests/integration${TESTFLAGS}
 
 rootlessintegration: runcimage
-	docker run -e TESTFLAGS -t --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) --cap-drop=ALL -u rootless $(RUNC_IMAGE) make localintegration
+	docker run -e TESTFLAGS -t --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) make localrootlessintegration
 
-# FIXME: This should not be separate from rootlessintegration's method of running.
 localrootlessintegration: all
-	sudo -u rootless -H PATH="${PATH}" bats -t tests/integration${TESTFLAGS}
+	tests/rootless.sh
 
 shell: all
 	docker run -e TESTFLAGS -ti --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) bash

--- a/libcontainer/configs/validate/rootless.go
+++ b/libcontainer/configs/validate/rootless.go
@@ -36,37 +36,27 @@ func (v *ConfigValidator) rootless(config *configs.Config) error {
 	return nil
 }
 
-func rootlessMappings(config *configs.Config) error {
-	rootuid, err := config.HostRootUID()
-	if err != nil {
-		return fmt.Errorf("failed to get root uid from uidMappings: %v", err)
+func hasIDMapping(id int, mappings []configs.IDMap) bool {
+	for _, m := range mappings {
+		if id >= m.ContainerID && id < m.ContainerID+m.Size {
+			return true
+		}
 	}
+	return false
+}
+
+func rootlessMappings(config *configs.Config) error {
 	if euid := geteuid(); euid != 0 {
 		if !config.Namespaces.Contains(configs.NEWUSER) {
 			return fmt.Errorf("rootless containers require user namespaces")
 		}
-		if rootuid != euid {
-			return fmt.Errorf("rootless containers cannot map container root to a different host user")
-		}
 	}
 
-	rootgid, err := config.HostRootGID()
-	if err != nil {
-		return fmt.Errorf("failed to get root gid from gidMappings: %v", err)
+	if len(config.UidMappings) == 0 {
+		return fmt.Errorf("rootless containers requires at least one UID mapping")
 	}
-
-	// Similar to the above test, we need to make sure that we aren't trying to
-	// map to a group ID that we don't have the right to be.
-	if rootgid != getegid() {
-		return fmt.Errorf("rootless containers cannot map container root to a different host group")
-	}
-
-	// We can only map one user and group inside a container (our own).
-	if len(config.UidMappings) != 1 || config.UidMappings[0].Size != 1 {
-		return fmt.Errorf("rootless containers cannot map more than one user")
-	}
-	if len(config.GidMappings) != 1 || config.GidMappings[0].Size != 1 {
-		return fmt.Errorf("rootless containers cannot map more than one group")
+	if len(config.GidMappings) == 0 {
+		return fmt.Errorf("rootless containers requires at least one UID mapping")
 	}
 
 	return nil
@@ -104,11 +94,28 @@ func rootlessMount(config *configs.Config) error {
 		// Check that the options list doesn't contain any uid= or gid= entries
 		// that don't resolve to root.
 		for _, opt := range strings.Split(mount.Data, ",") {
-			if strings.HasPrefix(opt, "uid=") && opt != "uid=0" {
-				return fmt.Errorf("cannot specify uid= mount options in rootless containers where argument isn't 0")
+			if strings.HasPrefix(opt, "uid=") {
+				var uid int
+				n, err := fmt.Sscanf(opt, "uid=%d", &uid)
+				if n != 1 || err != nil {
+					// Ignore unknown mount options.
+					continue
+				}
+				if !hasIDMapping(uid, config.UidMappings) {
+					return fmt.Errorf("cannot specify uid= mount options for unmapped uid in rootless containers")
+				}
 			}
-			if strings.HasPrefix(opt, "gid=") && opt != "gid=0" {
-				return fmt.Errorf("cannot specify gid= mount options in rootless containers where argument isn't 0")
+
+			if strings.HasPrefix(opt, "gid=") {
+				var gid int
+				n, err := fmt.Sscanf(opt, "gid=%d", &gid)
+				if n != 1 || err != nil {
+					// Ignore unknown mount options.
+					continue
+				}
+				if !hasIDMapping(gid, config.GidMappings) {
+					return fmt.Errorf("cannot specify gid= mount options for unmapped gid in rootless containers")
+				}
 			}
 		}
 	}

--- a/libcontainer/configs/validate/rootless_test.go
+++ b/libcontainer/configs/validate/rootless_test.go
@@ -66,28 +66,6 @@ func TestValidateRootlessMappingUid(t *testing.T) {
 	if err := validator.Validate(config); err == nil {
 		t.Errorf("Expected error to occur if no uid mappings provided")
 	}
-
-	config = rootlessConfig()
-	config.UidMappings[0].HostID = geteuid() + 1
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if geteuid() != mapped uid")
-	}
-
-	config = rootlessConfig()
-	config.UidMappings[0].Size = 1024
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one uid mapped")
-	}
-
-	config = rootlessConfig()
-	config.UidMappings = append(config.UidMappings, configs.IDMap{
-		HostID:      geteuid() + 1,
-		ContainerID: 0,
-		Size:        1,
-	})
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one uid extent mapped")
-	}
 }
 
 func TestValidateRootlessMappingGid(t *testing.T) {
@@ -97,28 +75,6 @@ func TestValidateRootlessMappingGid(t *testing.T) {
 	config.GidMappings = nil
 	if err := validator.Validate(config); err == nil {
 		t.Errorf("Expected error to occur if no gid mappings provided")
-	}
-
-	config = rootlessConfig()
-	config.GidMappings[0].HostID = getegid() + 1
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if getegid() != mapped gid")
-	}
-
-	config = rootlessConfig()
-	config.GidMappings[0].Size = 1024
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one gid mapped")
-	}
-
-	config = rootlessConfig()
-	config.GidMappings = append(config.GidMappings, configs.IDMap{
-		HostID:      getegid() + 1,
-		ContainerID: 0,
-		Size:        1,
-	})
-	if err := validator.Validate(config); err == nil {
-		t.Errorf("Expected error to occur if more than one gid extent mapped")
 	}
 }
 
@@ -149,6 +105,18 @@ func TestValidateRootlessMountUid(t *testing.T) {
 	if err := validator.Validate(config); err != nil {
 		t.Errorf("Expected error to not occur when setting uid=0 in mount options: %+v", err)
 	}
+
+	config.Mounts[0].Data = "uid=2"
+	config.UidMappings[0].Size = 10
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur when setting uid=2 in mount options and UidMapping[0].size is 10")
+	}
+
+	config.Mounts[0].Data = "uid=20"
+	config.UidMappings[0].Size = 10
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur when setting uid=20 in mount options and UidMapping[0].size is 10")
+	}
 }
 
 func TestValidateRootlessMountGid(t *testing.T) {
@@ -175,6 +143,18 @@ func TestValidateRootlessMountGid(t *testing.T) {
 	config.Mounts[0].Data = "gid=0"
 	if err := validator.Validate(config); err != nil {
 		t.Errorf("Expected error to not occur when setting gid=0 in mount options: %+v", err)
+	}
+
+	config.Mounts[0].Data = "gid=5"
+	config.GidMappings[0].Size = 10
+	if err := validator.Validate(config); err != nil {
+		t.Errorf("Expected error to not occur when setting gid=5 in mount options and GidMapping[0].size is 10")
+	}
+
+	config.Mounts[0].Data = "gid=11"
+	config.GidMappings[0].Size = 10
+	if err := validator.Validate(config); err == nil {
+		t.Errorf("Expected error to occur when setting gid=11 in mount options and GidMapping[0].size is 10")
 	}
 }
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -44,6 +44,8 @@ type linuxContainer struct {
 	initProcess          parentProcess
 	initProcessStartTime uint64
 	criuPath             string
+	newuidmapPath        string
+	newgidmapPath        string
 	m                    sync.Mutex
 	criuVersion          int
 	state                containerState
@@ -1707,6 +1709,10 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 	if !joinExistingUser {
 		// write uid mappings
 		if len(c.config.UidMappings) > 0 {
+			r.AddData(&Bytemsg{
+				Type:  UidmapPathAttr,
+				Value: []byte(c.newuidmapPath),
+			})
 			b, err := encodeIDMapping(c.config.UidMappings)
 			if err != nil {
 				return nil, err
@@ -1729,6 +1735,10 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 			})
 			// The following only applies if we are root.
 			if !c.config.Rootless {
+				r.AddData(&Bytemsg{
+					Type:  GidmapPathAttr,
+					Value: []byte(c.newgidmapPath),
+				})
 				// check if we have CAP_SETGID to setgroup properly
 				pid, err := capability.NewPid(os.Getpid())
 				if err != nil {

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -18,6 +18,8 @@ const (
 	SetgroupAttr    uint16 = 27285
 	OomScoreAdjAttr uint16 = 27286
 	RootlessAttr    uint16 = 27287
+	UidmapPathAttr  uint16 = 27288
+	GidmapPathAttr  uint16 = 27289
 )
 
 type Int32msg struct {

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -211,7 +211,7 @@ static int try_mapping_tool(const char *app, int pid, char *map, size_t map_len)
 	int child;
 
 	/*
-	 * If @app is NULL, execvp will segfault. Just check it here and bail (if
+	 * If @app is NULL, execve will segfault. Just check it here and bail (if
 	 * we're in this path, the caller is already getting desparate and there
 	 * isn't a backup to this failing). This usually would be a configuration
 	 * or programming issue.
@@ -226,6 +226,7 @@ static int try_mapping_tool(const char *app, int pid, char *map, size_t map_len)
 	if (!child) {
 #define MAX_ARGV 20
 		char *argv[MAX_ARGV];
+		char *envp[] = {NULL};
 		char pid_fmt[16];
 		int argc = 0;
 		char *next;
@@ -252,8 +253,8 @@ static int try_mapping_tool(const char *app, int pid, char *map, size_t map_len)
 			map = next + strspn(next, "\n ");
 		}
 
-		execvp(app, argv);
-		bail("failed to execvp");
+		execve(app, argv, envp);
+		bail("failed to execv");
 	} else {
 		int status;
 

--- a/main.go
+++ b/main.go
@@ -61,6 +61,15 @@ func main() {
 	}
 	v = append(v, fmt.Sprintf("spec: %s", specs.Version))
 	app.Version = strings.Join(v, "\n")
+
+	root := "/run/runc"
+	if os.Geteuid() != 0 {
+		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+		if runtimeDir != "" {
+			root = runtimeDir + "/runc"
+		}
+	}
+
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "debug",
@@ -78,7 +87,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "root",
-			Value: "/run/runc",
+			Value: root,
 			Usage: "root directory for storage of container state (this should be located in tmpfs)",
 		},
 		cli.StringFlag{

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -50,7 +50,7 @@ value for "bundle" is the current directory.
    --debug              enable debug output for logging
    --log value          set the log file path where internal debug information is written (default: "/dev/null")
    --log-format value   set the format used by logs ('text' (default), or 'json') (default: "text")
-   --root value         root directory for storage of container state (this should be located in tmpfs) (default: "/run/runc")
+   --root value         root directory for storage of container state (this should be located in tmpfs) (default: "/run/runc" or $XDG_RUNTIME_DIR/runc for rootless containers)
    --criu value         path to the criu binary used for checkpoint and restore (default: "criu")
    --systemd-cgroup     enable systemd cgroup support, expects cgroupsPath to be of form "slice:prefix:name" for e.g. "system.slice:runc:434234"
    --help, -h           show help

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -100,8 +100,8 @@ function teardown() {
 }
 
 @test "runc exec --user" {
-  # --user can't work in rootless containers
-  requires root
+  # --user can't work in rootless containers that don't have idmap.
+  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
@@ -110,5 +110,5 @@ function teardown() {
   runc exec --user 1000:1000 test_busybox id
   [ "$status" -eq 0 ]
 
-  [[ ${output} == "uid=1000 gid=1000" ]]
+  [[ "${output}" == "uid=1000 gid=1000"* ]]
 }

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -51,7 +51,7 @@ function teardown() {
   [ ! -e "$HELLO_BUNDLE"/config.json ]
 
   # test generation of spec does not return an error
-  runc_spec --bundle "$HELLO_BUNDLE"
+  runc_spec "$HELLO_BUNDLE"
   [ "$status" -eq 0 ]
 
   # test generation of spec created our config.json (spec)

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -21,8 +21,8 @@ function teardown() {
 }
 
 @test "runc run detached ({u,g}id != 0)" {
-  # cannot start containers as another user in rootless setup
-  requires root
+  # cannot start containers as another user in rootless setup without idmap
+  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -21,8 +21,8 @@ function teardown() {
 }
 
 @test "runc run ({u,g}id != 0)" {
-  # cannot start containers as another user in rootless setup
-  requires root
+  # cannot start containers as another user in rootless setup without idmap
+  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -24,9 +24,9 @@ function teardown() {
 }
 
 @test "runc run [tty owner]" {
-	# tty chmod is not doable in rootless containers.
+	# tty chmod is not doable in rootless containers without idmap.
 	# TODO: this can be made as a change to the gid test.
-	requires root
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
 	# Replace sh script with stat.
 	sed -i 's/"sh"/"sh", "-c", "stat -c %u:%g $(tty) | tr : \\\\\\\\n"/' config.json
@@ -40,8 +40,8 @@ function teardown() {
 }
 
 @test "runc run [tty owner] ({u,g}id != 0)" {
-	# tty chmod is not doable in rootless containers.
-	requires root
+	# tty chmod is not doable in rootless containers without idmap.
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
@@ -76,9 +76,9 @@ function teardown() {
 }
 
 @test "runc exec [tty owner]" {
-	# tty chmod is not doable in rootless containers.
+	# tty chmod is not doable in rootless containers without idmap.
 	# TODO: this can be made as a change to the gid test.
-	requires root
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
 	# run busybox detached
 	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
@@ -95,8 +95,8 @@ function teardown() {
 }
 
 @test "runc exec [tty owner] ({u,g}id != 0)" {
-	# tty chmod is not doable in rootless containers.
-	requires root
+	# tty chmod is not doable in rootless containers without idmap.
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright (C) 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# rootless.sh -- Runner for rootless container tests. The purpose of this
+# script is to allow for the addition (and testing) of "opportunistic" features
+# to rootless containers while still testing the base features. In order to add
+# a new feature, please match the existing style. Add an entry to $ALL_FEATURES,
+# and add an enable_* and disable_* hook.
+
+ALL_FEATURES=()
+ROOT="$(readlink -f "$(dirname "${BASH_SOURCE}")/..")"
+
+# Create a powerset of $ALL_FEATURES (the set of all subsets of $ALL_FEATURES).
+# We test all of the possible combinations (as long as we don't add too many
+# feature knobs this shouldn't take too long -- but the number of tested
+# combinations is O(2^n)).
+function powerset() {
+	eval printf '%s' $(printf '{,%s+}' "$@"):
+}
+features_powerset="$(powerset "${ALL_FEATURES[@]}")"
+
+# Iterate over the powerset of all features.
+IFS=:
+for enabled_features in $features_powerset
+do
+	idx="$(($idx+1))"
+	echo "[$(printf '%.2d' "$idx")] run rootless tests ... (${enabled_features%%+})"
+
+	unset IFS
+	for feature in "${ALL_FEATURES[@]}"
+	do
+		hook_func="disable_$feature"
+		grep -E "(^|\+)$feature(\+|$)" <<<$enabled_features &>/dev/null && hook_func="enable_$feature"
+		"$hook_func"
+	done
+
+	# Run the test suite!
+	set -e
+	echo path: $PATH
+	export ROOTLESS_FEATURES="$enabled_features"
+	sudo -HE -u rootless PATH="$PATH" bats -t "$ROOT/tests/integration"
+	set +e
+done

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 
@@ -35,6 +36,9 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// We default to cgroupfs, and can only use systemd if the system is a
+	// systemd box.
 	cgroupManager := libcontainer.Cgroupfs
 	if context.GlobalBool("systemd-cgroup") {
 		if systemd.UseSystemd() {
@@ -49,10 +53,22 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 		intelRdtManager = nil
 	}
 
+	// We resolve the paths for {newuidmap,newgidmap} from the context of runc,
+	// to avoid doing a path lookup in the nsexec context. TODO: The binary
+	// names are not currently configurable.
+	newuidmap, err := exec.LookPath("newuidmap")
+	if err != nil {
+		newuidmap = ""
+	}
+	newgidmap, err := exec.LookPath("newgidmap")
+	if err != nil {
+		newgidmap = ""
+	}
+
 	return libcontainer.New(abs, cgroupManager, intelRdtManager,
 		libcontainer.CriuPath(context.GlobalString("criu")),
-		libcontainer.NewuidmapPath("newuidmap"),
-		libcontainer.NewgidmapPath("newgidmap"))
+		libcontainer.NewuidmapPath(newuidmap),
+		libcontainer.NewgidmapPath(newgidmap))
 }
 
 // getContainer returns the specified container instance by loading it from state

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -43,11 +43,16 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 			return nil, fmt.Errorf("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
 		}
 	}
-	if intelrdt.IsEnabled() {
-		intelRdtManager := libcontainer.IntelRdtFs
-		return libcontainer.New(abs, cgroupManager, intelRdtManager, libcontainer.CriuPath(context.GlobalString("criu")))
+
+	intelRdtManager := libcontainer.IntelRdtFs
+	if !intelrdt.IsEnabled() {
+		intelRdtManager = nil
 	}
-	return libcontainer.New(abs, cgroupManager, libcontainer.CriuPath(context.GlobalString("criu")))
+
+	return libcontainer.New(abs, cgroupManager, intelRdtManager,
+		libcontainer.CriuPath(context.GlobalString("criu")),
+		libcontainer.NewuidmapPath("newuidmap"),
+		libcontainer.NewgidmapPath("newgidmap"))
 }
 
 // getContainer returns the specified container instance by loading it from state


### PR DESCRIPTION
Take advantage of the newuidmap/newgidmap tools to allow multiple users/groups to be mapped into the new user namespace in the rootless case.

This is what I've tried here (only the relevant bits showed for config.json):

```json
	"args": [
	    "cat", "/proc/self/uid_map"
	],
...
        "uidMappings": [
            {
                "hostID": 1000,
                "containerID": 0,
                "size": 1
            },
            {
                "hostID": 110000,
                "containerID": 1,
                "size": 255
            }
        ],
        "gidMappings": [
            {
                "hostID": 1000,
                "containerID": 0,
                "size": 1
            }
        ],
```

```bash
$ whoami
gscrivano

$ grep ^gscrivano /etc/subuid
gscrivano:110000:65536

$ runc run foo
         0       1000          1
         1     110000        255
```