### PR TITLE
libcontainer: one more switch from syscall to x/sys/unix

### DIFF
--- a/libcontainer/devices/devices_linux.go
+++ b/libcontainer/devices/devices_linux.go
@@ -2,11 +2,9 @@ package devices
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall" //only for Stat_t
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 
@@ -19,45 +17,41 @@ var (
 
 // Testing dependencies
 var (
-	osLstat       = os.Lstat
+	unixLstat     = unix.Lstat
 	ioutilReadDir = ioutil.ReadDir
 )
 
 // Given the path to a device and its cgroup_permissions(which cannot be easily queried) look up the information about a linux device and return that information as a Device struct.
 func DeviceFromPath(path, permissions string) (*configs.Device, error) {
-	fileInfo, err := osLstat(path)
+	var stat unix.Stat_t
+	err := unixLstat(path, &stat)
 	if err != nil {
 		return nil, err
 	}
 	var (
-		devType                rune
-		mode                   = fileInfo.Mode()
-		fileModePermissionBits = os.FileMode.Perm(mode)
+		devType rune
+		mode    = stat.Mode
 	)
 	switch {
-	case mode&os.ModeDevice == 0:
-		return nil, ErrNotADevice
-	case mode&os.ModeCharDevice != 0:
-		fileModePermissionBits |= unix.S_IFCHR
+	case mode&unix.S_IFBLK != 0:
+		devType = 'b'
+	case mode&unix.S_IFCHR != 0:
 		devType = 'c'
 	default:
-		fileModePermissionBits |= unix.S_IFBLK
-		devType = 'b'
+		return nil, ErrNotADevice
 	}
-	stat_t, ok := fileInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		return nil, fmt.Errorf("cannot determine the device number for device %s", path)
-	}
-	devNumber := int(stat_t.Rdev)
+	devNumber := int(stat.Rdev)
+	uid := stat.Uid
+	gid := stat.Gid
 	return &configs.Device{
 		Type:        devType,
 		Path:        path,
 		Major:       Major(devNumber),
 		Minor:       Minor(devNumber),
 		Permissions: permissions,
-		FileMode:    fileModePermissionBits,
-		Uid:         stat_t.Uid,
-		Gid:         stat_t.Gid,
+		FileMode:    os.FileMode(mode),
+		Uid:         uid,
+		Gid:         gid,
 	}, nil
 }
 

--- a/libcontainer/devices/devices_test.go
+++ b/libcontainer/devices/devices_test.go
@@ -6,14 +6,16 @@ import (
 	"errors"
 	"os"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestDeviceFromPathLstatFailure(t *testing.T) {
 	testError := errors.New("test error")
 
-	// Override os.Lstat to inject error.
-	osLstat = func(path string) (os.FileInfo, error) {
-		return nil, testError
+	// Override unix.Lstat to inject error.
+	unixLstat = func(path string, stat *unix.Stat_t) error {
+		return testError
 	}
 
 	_, err := DeviceFromPath("", "")


### PR DESCRIPTION
Refactor DeviceFromPath in order to get rid of package syscall and
directly use the functions from x/sys/unix. This also allows to get rid
of the conversion from the OS-independent file mode values (from the os
package) to Linux specific values and instead let's us use the raw
file mode value directly.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>