### PR TITLE
Remove the code that close negative descriptor

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -143,8 +143,7 @@ static int write_file(char *data, size_t data_len, char *pathfmt, ...)
 
 	fd = open(path, O_RDWR);
 	if (fd < 0) {
-		ret = -1;
-		goto out;
+		return -1;
 	}
 
 	len = write(fd, data, data_len);


### PR DESCRIPTION
There is a possibility that  the code close negative descriptor,  it don't lead to a issue, but the code is ugly.

Signed-off-by: yangshukui <yangshukui@huawei.com>