### PR TITLE
Add CFS data to libcontainer cgroups

### DIFF
--- a/events.go
+++ b/events.go
@@ -74,8 +74,14 @@ type cpuUsage struct {
 	User   uint64   `json:"user"`
 }
 
+type cfs struct {
+	Period uint64 `json:"period,omitempty"`
+	Quota  int64  `json:"quota,omitempty"`
+}
+
 type cpu struct {
 	Usage      cpuUsage   `json:"usage,omitempty"`
+	CFS        cfs        `json:"cfs,omitempty"`
 	Throttling throttling `json:"throttling,omitempty"`
 }
 
@@ -205,6 +211,8 @@ func convertLibcontainerStats(ls *libcontainer.Stats) *stats {
 	s.CPU.Throttling.Periods = cg.CpuStats.ThrottlingData.Periods
 	s.CPU.Throttling.ThrottledPeriods = cg.CpuStats.ThrottlingData.ThrottledPeriods
 	s.CPU.Throttling.ThrottledTime = cg.CpuStats.ThrottlingData.ThrottledTime
+	s.CPU.CFS.Period = cg.CpuStats.CFS.Period
+	s.CPU.CFS.Quota = cg.CpuStats.CFS.Quota
 
 	s.Memory.Cache = cg.MemoryStats.Cache
 	s.Memory.Kernel = convertMemoryEntry(cg.MemoryStats.KernelUsage)

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -109,12 +109,21 @@ func TestCpuStats(t *testing.T) {
 		nrPeriods     = 2000
 		nrThrottled   = 200
 		throttledTime = uint64(18446744073709551615)
+
+		cfsPeriod = 10000
+		cfsQuota  = -1
 	)
 
 	cpuStatContent := fmt.Sprintf("nr_periods %d\n nr_throttled %d\n throttled_time %d\n",
 		nrPeriods, nrThrottled, throttledTime)
 	helper.writeFileContents(map[string]string{
 		"cpu.stat": cpuStatContent,
+	})
+	helper.writeFileContents(map[string]string{
+		"cpu.cfs_period_us": fmt.Sprintf("%d\n", cfsPeriod),
+	})
+	helper.writeFileContents(map[string]string{
+		"cpu.cfs_quota_us": fmt.Sprintf("%d\n", cfsQuota),
 	})
 
 	cpu := &CpuGroup{}

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -28,8 +28,16 @@ type CpuUsage struct {
 	UsageInUsermode uint64 `json:"usage_in_usermode"`
 }
 
+type CpuCfs struct {
+	// CPU time in microseconds that can be consumed (quota) out of a given total (period)
+	// If the Quota is -1, there is not limit for the given period
+	Period uint64 `json:"cfs_period"`
+	Quota  int64  `json:"cfs_usage"`
+}
+
 type CpuStats struct {
 	CpuUsage       CpuUsage       `json:"cpu_usage,omitempty"`
+	CFS            CpuCfs         `json:"cpu_cfs"`
 	ThrottlingData ThrottlingData `json:"throttling_data,omitempty"`
 }
 


### PR DESCRIPTION
Add information about the completely fair scheduler in cpu cgroups to libcontainer/cgroups. and report the information as a part of `runc events`