### PR TITLE
 recvtty socket file replaced by pid-file during creation of container

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -171,6 +171,9 @@ func createPidFile(path string, process *libcontainer.Process) error {
 	if err != nil {
 		return err
 	}
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("file %s already exists", path)
+	}
 	var (
 		tmpDir  = filepath.Dir(path)
 		tmpName = filepath.Join(tmpDir, fmt.Sprintf(".%s", filepath.Base(path)))


### PR DESCRIPTION
Opened the socket by 
sudo ./contrib/cmd/recvtty/recvtty -m null /tmp/testfilesock

ls -ltr /tmp/filesock
srwxr-xr-x 1 root root 0 Aug  1 22:02 /tmp/testfilesock

In another terminal, created the container using the following command.
sudo ./runc create --console-socket /tmp/testfilesock --pid-file /tmp/testfilesock test
ls -ltr /tmp/filesock

Since os.Rename called at last, it replaces the socket file with pid-file
So when we try to use this socket for second container, socket file has been replaced by normal file, so it throws out an error saying "address in in use"
This problem comes when we pass the same name for both console-socket and pid-file.

Added the condition, so it will error out if the file exists.

Signed-off-by: rajasec <rajasec79@gmail.com>