### PR TITLE
Fix condition to detect device type in DeviceFromPath

### DIFF
--- a/libcontainer/devices/devices_linux.go
+++ b/libcontainer/devices/devices_linux.go
@@ -33,9 +33,9 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 		mode    = stat.Mode
 	)
 	switch {
-	case mode&unix.S_IFBLK != 0:
+	case mode&unix.S_IFBLK == unix.S_IFBLK:
 		devType = 'b'
-	case mode&unix.S_IFCHR != 0:
+	case mode&unix.S_IFCHR == unix.S_IFCHR:
 		devType = 'c'
 	default:
 		return nil, ErrNotADevice


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--

Before this fix, `/dev/fuse` is created as a block device, and `docker` tries to create `/dev/fd` as a `0,0` device.