### PR TITLE
Move user pkg unix specific calls to unix file

### DIFF
--- a/libcontainer/user/lookup.go
+++ b/libcontainer/user/lookup.go
@@ -2,8 +2,6 @@ package user
 
 import (
 	"errors"
-
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -35,13 +33,6 @@ func lookupUser(filter func(u User) bool) (User, error) {
 
 	// Assume the first entry is the "correct" one.
 	return users[0], nil
-}
-
-// CurrentUser looks up the current user by their user id in /etc/passwd. If the
-// user cannot be found (or there is no /etc/passwd file on the filesystem),
-// then CurrentUser returns an error.
-func CurrentUser() (User, error) {
-	return LookupUid(unix.Getuid())
 }
 
 // LookupUser looks up a user by their username in /etc/passwd. If the user
@@ -83,13 +74,6 @@ func lookupGroup(filter func(g Group) bool) (Group, error) {
 
 	// Assume the first entry is the "correct" one.
 	return groups[0], nil
-}
-
-// CurrentGroup looks up the current user's group by their primary group id's
-// entry in /etc/passwd. If the group cannot be found (or there is no
-// /etc/group file on the filesystem), then CurrentGroup returns an error.
-func CurrentGroup() (Group, error) {
-	return LookupGid(unix.Getgid())
 }
 
 // LookupGroup looks up a group by its name in /etc/group. If the group cannot

--- a/libcontainer/user/lookup_unix.go
+++ b/libcontainer/user/lookup_unix.go
@@ -5,6 +5,8 @@ package user
 import (
 	"io"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 // Unix-specific path to the passwd and group formatted files.
@@ -27,4 +29,18 @@ func GetGroupPath() (string, error) {
 
 func GetGroup() (io.ReadCloser, error) {
 	return os.Open(unixGroupPath)
+}
+
+// CurrentUser looks up the current user by their user id in /etc/passwd. If the
+// user cannot be found (or there is no /etc/passwd file on the filesystem),
+// then CurrentUser returns an error.
+func CurrentUser() (User, error) {
+	return LookupUid(unix.Getuid())
+}
+
+// CurrentGroup looks up the current user's group by their primary group id's
+// entry in /etc/passwd. If the group cannot be found (or there is no
+// /etc/group file on the filesystem), then CurrentGroup returns an error.
+func CurrentGroup() (Group, error) {
+	return LookupGid(unix.Getgid())
 }

--- a/libcontainer/user/lookup_unsupported.go
+++ b/libcontainer/user/lookup_unsupported.go
@@ -2,7 +2,10 @@
 
 package user
 
-import "io"
+import (
+	"io"
+	"syscall"
+)
 
 func GetPasswdPath() (string, error) {
 	return "", ErrUnsupported
@@ -18,4 +21,18 @@ func GetGroupPath() (string, error) {
 
 func GetGroup() (io.ReadCloser, error) {
 	return nil, ErrUnsupported
+}
+
+// CurrentUser looks up the current user by their user id in /etc/passwd. If the
+// user cannot be found (or there is no /etc/passwd file on the filesystem),
+// then CurrentUser returns an error.
+func CurrentUser() (User, error) {
+	return LookupUid(syscall.Getuid())
+}
+
+// CurrentGroup looks up the current user's group by their primary group id's
+// entry in /etc/passwd. If the group cannot be found (or there is no
+// /etc/group file on the filesystem), then CurrentGroup returns an error.
+func CurrentGroup() (Group, error) {
+	return LookupGid(syscall.Getgid())
 }


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

This fix a compile error on systems that import the user package (e.g. `Docker` on `Windows`)