### PR TITLE
Backward compatability for InitProcessStartTime and Swappiness

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -187,7 +187,7 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.Resources.MemorySwappiness == nil || int64(*cgroup.Resources.MemorySwappiness) == -1 {
 		return nil
 	} else if *cgroup.Resources.MemorySwappiness <= 100 {
-		if err := writeFile(path, "memory.swappiness", strconv.FormatUint(*cgroup.Resources.MemorySwappiness, 10)); err != nil {
+		if err := writeFile(path, "memory.swappiness", strconv.FormatUint(*(*uint64)(cgroup.Resources.MemorySwappiness), 10)); err != nil {
 			return err
 		}
 	} else {

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -236,7 +237,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	defer helper.cleanup()
 
 	swappinessBefore := 60 //default is 60
-	swappinessAfter := uint64(0)
+	swappinessAfter := configs.Swappiness(0)
 
 	helper.writeFileContents(map[string]string{
 		"memory.swappiness": strconv.Itoa(swappinessBefore),
@@ -252,7 +253,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse memory.swappiness - %s", err)
 	}
-	if value != swappinessAfter {
+	if value != uint64(swappinessAfter) {
 		t.Fatalf("Got the wrong value (%d), set memory.swappiness = %d failed.", value, swappinessAfter)
 	}
 }

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -1,5 +1,9 @@
 package configs
 
+import (
+	"encoding/json"
+)
+
 type FreezerState string
 
 const (
@@ -30,6 +34,26 @@ type Cgroup struct {
 	// Resources contains various cgroups settings to apply
 	*Resources
 }
+type Swappiness uint64
+
+func (a *Swappiness) UnmarshalJSON(b []byte) error {
+	var s uint64
+	if err := json.Unmarshal(b, &s); err != nil {
+		var s2 int64
+		if err2 := json.Unmarshal(b, &s2); err2 != nil {
+			return err
+		} else if s2 == -1 {
+			// swappiness equivalent of all versions including v1.0.0-v3
+			*a = 60
+			return nil
+		} else {
+			return err
+		}
+	}
+	*a = Swappiness(s)
+	return nil
+}
+
 
 type Resources struct {
 	// If this is true allow access to any kind of device within the container.  If false, allow access only to devices explicitly listed in the allowed_devices list.
@@ -112,7 +136,7 @@ type Resources struct {
 	OomKillDisable bool `json:"oom_kill_disable"`
 
 	// Tuning swappiness behaviour per cgroup
-	MemorySwappiness *uint64 `json:"memory_swappiness"`
+	MemorySwappiness *Swappiness `json:"memory_swappiness"`
 
 	// Set priority of network traffic for container
 	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap"`

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -54,7 +54,6 @@ func (a *Swappiness) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-
 type Resources struct {
 	// If this is true allow access to any kind of device within the container.  If false, allow access only to devices explicitly listed in the allowed_devices list.
 	// Deprecated

--- a/libcontainer/configs/cgroup_linux_test.go
+++ b/libcontainer/configs/cgroup_linux_test.go
@@ -1,0 +1,43 @@
+// +build linux
+
+package configs
+
+import (
+	"testing"
+	"encoding/json"
+)
+
+func TestSwappinessType(t *testing.T) {
+
+	test := []byte(`{"swappiness":-1}`)
+	test2 := []byte(`{"swappiness":29}`)
+
+	x := struct{ AA Swappiness `json:"swappiness"` }{AA: 6, }
+	// over
+	err := json.Unmarshal(test, &x)
+	if err != nil {
+		t.Fatalf("Can't unmarshal %v", err)
+	}
+	// default set to 60 in Swappiness when -1 used
+	if x.AA != 60 {
+		t.Fatalf("Expected linux swappiness default of 60 when -1 used.  Got %v", x)
+	}
+	// over
+	err = json.Unmarshal(test2, &x)
+	if err != nil {
+		t.Fatalf("Can't unmarshal %v", err)
+	}
+	if x.AA != 29 {
+		t.Fatalf("Normal Uint64 function failed %v ",x)
+	}
+	// now marshal back out.  Do not emit
+	bb, marshalErr := json.Marshal(x)
+	if marshalErr != nil {
+		t.Fatalf("Marshal err %v swappiness failed",marshalErr)
+	}
+	if string(bb) != string(test2) {
+		t.Fatalf("Marshal swappiness failed got >%s< want >%s<",string(bb),string(test2))
+
+	}
+}
+

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -274,7 +274,7 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 		if err != nil {
 			return err
 		}
-		c.initProcessStartTime = state.InitProcessStartTime
+		c.initProcessStartTime = uint64(state.InitProcessStartTime)
 
 		if c.config.Hooks != nil {
 			s := configs.HookState{
@@ -1498,7 +1498,7 @@ func (c *linuxContainer) currentState() (*State, error) {
 			ID:                   c.ID(),
 			Config:               *c.config,
 			InitProcessPid:       pid,
-			InitProcessStartTime: startTime,
+			InitProcessStartTime: Uint64Compat(startTime),
 			Created:              c.created,
 		},
 		Rootless:            c.config.Rootless,

--- a/libcontainer/container_test.go
+++ b/libcontainer/container_test.go
@@ -1,19 +1,17 @@
-// +build linux
-
-package configs
+package libcontainer
 
 import (
 	"encoding/json"
 	"testing"
 )
 
-func TestSwappinessType(t *testing.T) {
+func TestUint64CompatType(t *testing.T) {
 
-	test := []byte(`{"swappiness":-1}`)
-	test2 := []byte(`{"swappiness":29}`)
+	test := []byte(`{"rc3":"9999999999999999999"}`)
+	test2 := []byte(`{"rc3":9999999999999999998}`)
 
 	x := struct {
-		AA Swappiness `json:"swappiness"`
+		AA Uint64Compat `json:"rc3"`
 	}{AA: 6}
 	// over
 	err := json.Unmarshal(test, &x)
@@ -21,24 +19,24 @@ func TestSwappinessType(t *testing.T) {
 		t.Fatalf("Can't unmarshal %v", err)
 	}
 	// default set to 60 in Swappiness when -1 used
-	if x.AA != 60 {
-		t.Fatalf("Expected linux swappiness default of 60 when -1 used.  Got %v", x)
+	if x.AA != 9999999999999999999 {
+		t.Fatalf("Expected linux 9999999999999999999.  Got %v", x)
 	}
-	// over
+	// straight large number
 	err = json.Unmarshal(test2, &x)
 	if err != nil {
 		t.Fatalf("Can't unmarshal %v", err)
 	}
-	if x.AA != 29 {
+	if x.AA != 9999999999999999998 {
 		t.Fatalf("Normal Uint64 function failed %v ", x)
 	}
 	// now marshal back out.  Do not emit
 	bb, marshalErr := json.Marshal(x)
 	if marshalErr != nil {
-		t.Fatalf("Marshal err %v swappiness failed", marshalErr)
+		t.Fatalf("Marshal err %v Uint64Compatfailed", marshalErr)
 	}
 	if string(bb) != string(test2) {
-		t.Fatalf("Marshal swappiness failed got >%s< want >%s<", string(bb), string(test2))
+		t.Fatalf("Marshal Uint64Compat failed got >%s< want >%s<", string(bb), string(test2))
 
 	}
 }

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -200,7 +200,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	}
 	r := &nonChildProcess{
 		processPid:       state.InitProcessPid,
-		processStartTime: state.InitProcessStartTime,
+		processStartTime: uint64(state.InitProcessStartTime),
 		fds:              state.ExternalDescriptors,
 	}
 	// We have to use the RootlessManager.
@@ -209,7 +209,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	}
 	c := &linuxContainer{
 		initProcess:          r,
-		initProcessStartTime: state.InitProcessStartTime,
+		initProcessStartTime: uint64(state.InitProcessStartTime),
 		id:                   id,
 		config:               &state.Config,
 		initArgs:             l.InitArgs,

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -378,7 +378,8 @@ func createCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
 			c.Resources.KernelMemoryTCP = *r.Memory.KernelTCP
 		}
 		if r.Memory.Swappiness != nil {
-			c.Resources.MemorySwappiness = r.Memory.Swappiness
+			xx := configs.Swappiness(  *r.Memory.Swappiness )
+			c.Resources.MemorySwappiness = &xx
 		}
 		if r.Memory.DisableOOMKiller != nil {
 			c.Resources.OomKillDisable = *r.Memory.DisableOOMKiller

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -378,7 +378,7 @@ func createCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
 			c.Resources.KernelMemoryTCP = *r.Memory.KernelTCP
 		}
 		if r.Memory.Swappiness != nil {
-			xx := configs.Swappiness(  *r.Memory.Swappiness )
+			xx := configs.Swappiness(*r.Memory.Swappiness)
 			c.Resources.MemorySwappiness = &xx
 		}
 		if r.Memory.DisableOOMKiller != nil {


### PR DESCRIPTION
We have a project that embeds runc as a library.

Recent commits post v1.0.0-rc3 broke the ability to read 1000s of CoreOS and Ubuntu hosts we have that rely on earlier versions of runc by way of Docker.  

This is a simple PR which allow the older default values '-1' for swappiness, and a string rep of a uint64 to be read using mainline runc.

Docker on CoreOS and Ubuntu all use either runc v1.0.0-rc2 or v1.0.0-rc3. 

I've provided tests of course.

