### PR TITLE
Handle non-devices correctly in DeviceFromPath

### DIFF
--- a/libcontainer/devices/devices_linux.go
+++ b/libcontainer/devices/devices_linux.go
@@ -28,6 +28,15 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	var (
+		devNumber = int(stat.Rdev)
+		major     = Major(devNumber)
+	)
+	if major == 0 {
+		return nil, ErrNotADevice
+	}
+
 	var (
 		devType rune
 		mode    = stat.Mode
@@ -37,21 +46,16 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 		devType = 'b'
 	case mode&unix.S_IFCHR == unix.S_IFCHR:
 		devType = 'c'
-	default:
-		return nil, ErrNotADevice
 	}
-	devNumber := int(stat.Rdev)
-	uid := stat.Uid
-	gid := stat.Gid
 	return &configs.Device{
 		Type:        devType,
 		Path:        path,
-		Major:       Major(devNumber),
+		Major:       major,
 		Minor:       Minor(devNumber),
 		Permissions: permissions,
 		FileMode:    os.FileMode(mode),
-		Uid:         uid,
-		Gid:         gid,
+		Uid:         stat.Uid,
+		Gid:         stat.Gid,
 	}, nil
 }
 


### PR DESCRIPTION
Before this change, some file type would be treated as char devices
(e.g. symlinks).

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

In my previous PR #1544 I had forgotten to commit a piece of code before pushing :man_facepalming:. Since I had it in a dirty vendor on my docker PR I didn't realize it was missing from here. 

This PR should fix this issue once and for all hopefully :sweat_smile: 

ping @crosbymichael @mrunalp 