### PR TITLE
Update state after update

### DIFF
--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/system"
 )
 
 type mockCgroupManager struct {
@@ -214,5 +215,67 @@ func TestGetContainerState(t *testing.T) {
 				t.Fatalf("expected path %q but received %q", expected, path)
 			}
 		}
+	}
+}
+
+func TestGetContainerStateAfterUpdate(t *testing.T) {
+	var (
+		pid = os.Getpid()
+	)
+	stat, err := system.Stat(pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	container := &linuxContainer{
+		id: "myid",
+		config: &configs.Config{
+			Namespaces: []configs.Namespace{
+				{Type: configs.NEWPID},
+				{Type: configs.NEWNS},
+				{Type: configs.NEWNET},
+				{Type: configs.NEWUTS},
+				{Type: configs.NEWIPC},
+			},
+			Cgroups: &configs.Cgroup{
+				Resources: &configs.Resources{
+					Memory: 1024,
+				},
+			},
+		},
+		initProcess: &mockProcess{
+			_pid:    pid,
+			started: stat.StartTime,
+		},
+		cgroupManager: &mockCgroupManager{},
+	}
+	container.state = &createdState{c: container}
+	state, err := container.State()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.InitProcessPid != pid {
+		t.Fatalf("expected pid %d but received %d", pid, state.InitProcessPid)
+	}
+	if state.InitProcessStartTime != stat.StartTime {
+		t.Fatalf("expected process start time %d but received %d", stat.StartTime, state.InitProcessStartTime)
+	}
+	if state.Config.Cgroups.Resources.Memory != 1024 {
+		t.Fatalf("expected Memory to be 1024 but received %q", state.Config.Cgroups.Memory)
+	}
+
+	// Set initProcessStartTime so we fake to be running
+	container.initProcessStartTime = state.InitProcessStartTime
+	container.state = &runningState{c: container}
+	newConfig := container.Config()
+	newConfig.Cgroups.Resources.Memory = 2048
+	if err := container.Set(newConfig); err != nil {
+		t.Fatal(err)
+	}
+	state, err = container.State()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Config.Cgroups.Resources.Memory != 2048 {
+		t.Fatalf("expected Memory to be 2048 but received %q", state.Config.Cgroups.Memory)
 	}
 }


### PR DESCRIPTION
state.json should be a reflection of the container's
realtime state, including resource configurations,
so we should update state.json after updating container
resources.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>