### PR TITLE
Check error return values

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -75,11 +75,15 @@ func (h *signalHandler) forward(process *libcontainer.Process, tty *tty, detach 
 	}
 
 	// perform the initial tty resize.
-	tty.resize()
+	if err := tty.resize(); err != nil {
+		logrus.Error(err)
+	}
 	for s := range h.signals {
 		switch s {
 		case unix.SIGWINCH:
-			tty.resize()
+			if err := tty.resize(); err != nil {
+				logrus.Error(err)
+			}
 		case unix.SIGCHLD:
 			exits, err := h.reap()
 			if err != nil {

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -371,7 +371,10 @@ func startContainer(context *cli.Context, spec *specs.Spec, action CtAct, criuOp
 	}
 
 	if notifySocket != nil {
-		notifySocket.setupSocket()
+		err := notifySocket.setupSocket()
+		if err != nil {
+			return -1, err
+		}
 	}
 
 	// Support on-demand socket activation by passing file descriptors into the container init process.


### PR DESCRIPTION
Both tty.resize and notifySocket.setupSocket return an error which isn't
handled in the caller. Fix this and either log or propagate the errors.

Found using https://github.com/mvdan/unparam

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>