### PR TITLE
Add AutoDedup option to CriuOpts

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -35,6 +35,7 @@ checkpointed.`,
 		cli.BoolFlag{Name: "pre-dump", Usage: "dump container's memory information only, leave the container running after this"},
 		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'"},
 		cli.StringSliceFlag{Name: "empty-ns", Usage: "create a namespace, but don't restore its properties"},
+		cli.BoolFlag{Name: "auto-dedup", Usage: "enable auto deduplication of memory images"},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -811,6 +811,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 		FileLocks:       proto.Bool(criuOpts.FileLocks),
 		EmptyNs:         proto.Uint32(criuOpts.EmptyNs),
 		OrphanPtsMaster: proto.Bool(true),
+		AutoDedup:       proto.Bool(criuOpts.AutoDedup),
 	}
 
 	fcg := c.cgroupManager.GetPaths()["freezer"]
@@ -1012,6 +1013,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 			FileLocks:       proto.Bool(criuOpts.FileLocks),
 			EmptyNs:         proto.Uint32(criuOpts.EmptyNs),
 			OrphanPtsMaster: proto.Bool(true),
+			AutoDedup:       proto.Bool(criuOpts.AutoDedup),
 		},
 	}
 

--- a/libcontainer/criu_opts_linux.go
+++ b/libcontainer/criu_opts_linux.go
@@ -34,4 +34,5 @@ type CriuOpts struct {
 	VethPairs               []VethPairName     // pass the veth to criu when restore
 	ManageCgroupsMode       cgMode             // dump or restore cgroup mode
 	EmptyNs                 uint32             // don't c/r properties for namespace from this mask
+	AutoDedup               bool               // auto deduplication for incremental dumps
 }

--- a/restore.go
+++ b/restore.go
@@ -82,6 +82,10 @@ using the runc checkpoint command.`,
 			Name:  "empty-ns",
 			Usage: "create a namespace, but don't restore its properties",
 		},
+		cli.BoolFlag{
+			Name:  "auto-dedup",
+			Usage: "enable auto deduplication of memory images",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {
@@ -123,5 +127,6 @@ func criuOptions(context *cli.Context) *libcontainer.CriuOpts {
 		ShellJob:                context.Bool("shell-job"),
 		FileLocks:               context.Bool("file-locks"),
 		PreDump:                 context.Bool("pre-dump"),
+		AutoDedup:               context.Bool("auto-dedup"),
 	}
 }


### PR DESCRIPTION
Memory image deduplication, very useful for incremental dumps.

See: https://criu.org/Memory_images_deduplication

Signed-off-by: Nikolas Sepos <nikolas.sepos@gmail.com>