### PR TITLE
Fix cgroup: add check task exists after writing freezer.state

### DIFF
--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -43,6 +43,14 @@ func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {
 			}
 			time.Sleep(1 * time.Millisecond)
 		}
+		tasks, err := readFile(path, "tasks")
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(tasks) == "" {
+			return fmt.Errorf("Error: no tasks running in freeze cgroup")
+		}
+
 	case configs.Undefined:
 		return nil
 	default:


### PR DESCRIPTION
Description:
  Example: we start a container which just run `sleep 3` command in
container. After 3 seconds, if we try to pause it (container exit
process in shim/containerd is not finished), the cgroup file exists.

So we could update the cgroup file successfully, but the container
process `sleep 3` has already exited.

Then we got an 'Exited' container with paused state in docker.

So I think we should check if the `tasks` is empty or not after update
`freezer.state`.

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>