### PR TITLE
signal: ignore tty.resize errors

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -74,16 +74,15 @@ func (h *signalHandler) forward(process *libcontainer.Process, tty *tty, detach 
 		}
 	}
 
-	// perform the initial tty resize.
-	if err := tty.resize(); err != nil {
-		logrus.Error(err)
-	}
+	// Perform the initial tty resize. Always ignore errors resizing because
+	// stdout might have disappeared (due to races with when SIGHUP is sent).
+	_ = tty.resize()
+	// Handle and forward signals.
 	for s := range h.signals {
 		switch s {
 		case unix.SIGWINCH:
-			if err := tty.resize(); err != nil {
-				logrus.Error(err)
-			}
+			// Ignore errors resizing, as above.
+			_ = tty.resize()
 		case unix.SIGCHLD:
 			exits, err := h.reap()
 			if err != nil {


### PR DESCRIPTION
Fixes a race that occurred very frequently in testing where the tty of
the container may be closed by the time that runc gets to sending
SIGWINCH. This failure mode is not fatal, but it would cause test
failures due to expected outputs not matching. On further review it
appears that the original addition of these checks in 4c5bf649d01e
("Check error return values") was actually not necessary, so partially
revert that change.

The particular failure mode this resolves would manifest as error logs
of the form:

  time="2017-08-24T07:59:50Z" level=error msg="bad file descriptor"

Fixes: 4c5bf649d01e ("Check error return values")
Fixes #1571
Signed-off-by: Aleksa Sarai <asarai@suse.de>