### PR TITLE
travis: drop shfmt install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
   - sudo apt-get install -y libseccomp-dev libapparmor-dev
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/vbatts/git-validation
-  - go get -u github.com/mvdan/sh/cmd/shfmt
   - env | grep TRAVIS_
 
 script:


### PR DESCRIPTION
It looks like we missed this in 5930d5b42728 ("Remove shfmt"), which was
causing CI to break (since it looks like the repo has moved or something
like that). Since we're no longer using shfmt, drop it completely from
the repo.

Signed-off-by: Aleksa Sarai <asarai@suse.de>