### PR TITLE
use conditional assignment for BUILDTAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
-BUILDTAGS := seccomp
+BUILDTAGS ?= seccomp
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 


### PR DESCRIPTION
This change would allow usage of additional BUILDTAGS while building
rpms. Like so:

BUILDTAGS="seccomp selinux" make all

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>