### PR TITLE
libcontainer: intelrdt: use init() to avoid race condition

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -159,7 +159,7 @@ func (v *ConfigValidator) sysctl(config *configs.Config) error {
 
 func (v *ConfigValidator) intelrdt(config *configs.Config) error {
 	if config.IntelRdt != nil {
-		if !intelrdt.IsIntelRdtEnabled() {
+		if !intelrdt.IsEnabled() {
 			return fmt.Errorf("intelRdt is specified in config, but Intel RDT feature is not supported or enabled")
 		}
 		if config.IntelRdt.L3CacheSchema == "" {

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -160,7 +160,7 @@ func TestGetContainerStats(t *testing.T) {
 	if stats.CgroupStats.MemoryStats.Usage.Usage != 1024 {
 		t.Fatalf("expected memory usage 1024 but recevied %d", stats.CgroupStats.MemoryStats.Usage.Usage)
 	}
-	if intelrdt.IsIntelRdtEnabled() {
+	if intelrdt.IsEnabled() {
 		if stats.IntelRdtStats == nil {
 			t.Fatal("intel rdt stats are nil")
 		}
@@ -231,7 +231,7 @@ func TestGetContainerState(t *testing.T) {
 	if memPath := paths["memory"]; memPath != expectedMemoryPath {
 		t.Fatalf("expected memory path %q but received %q", expectedMemoryPath, memPath)
 	}
-	if intelrdt.IsIntelRdtEnabled() {
+	if intelrdt.IsEnabled() {
 		intelRdtPath := state.IntelRdtPath
 		if intelRdtPath == "" {
 			t.Fatal("intel rdt path should not be empty")

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -204,7 +204,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		cgroupManager: l.NewCgroupsManager(config.Cgroups, nil),
 	}
 	c.intelRdtManager = nil
-	if intelrdt.IsIntelRdtEnabled() && c.config.IntelRdt != nil {
+	if intelrdt.IsEnabled() && c.config.IntelRdt != nil {
 		c.intelRdtManager = l.NewIntelRdtManager(config, id, "")
 	}
 	c.state = &stoppedState{c: c}
@@ -245,7 +245,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		return nil, err
 	}
 	c.intelRdtManager = nil
-	if intelrdt.IsIntelRdtEnabled() && c.config.IntelRdt != nil {
+	if intelrdt.IsEnabled() && c.config.IntelRdt != nil {
 		c.intelRdtManager = l.NewIntelRdtManager(&state.Config, id, state.IntelRdtPath)
 	}
 	return c, nil

--- a/libcontainer/intelrdt/intelrdt_test.go
+++ b/libcontainer/intelrdt/intelrdt_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIntelRdtSetL3CacheSchema(t *testing.T) {
-	if !IsIntelRdtEnabled() {
+	if !IsEnabled() {
 		return
 	}
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -43,7 +43,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 			return nil, fmt.Errorf("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
 		}
 	}
-	if intelrdt.IsIntelRdtEnabled() {
+	if intelrdt.IsEnabled() {
 		intelRdtManager := libcontainer.IntelRdtFs
 		return libcontainer.New(abs, cgroupManager, intelRdtManager, libcontainer.CriuPath(context.GlobalString("criu")))
 	}


### PR DESCRIPTION
This is the follow-up PR of #1279 to fix remaining issues:

Use init() to avoid race condition in IsIntelRdtEnabled().
Add also rename some variables and functions.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>