### PR TITLE
libcontainer: intelrdt: add update command support

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -213,8 +213,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		newgidmapPath: l.NewgidmapPath,
 		cgroupManager: l.NewCgroupsManager(config.Cgroups, nil),
 	}
-	c.intelRdtManager = nil
-	if intelrdt.IsEnabled() && c.config.IntelRdt != nil {
+	if intelrdt.IsEnabled() {
 		c.intelRdtManager = l.NewIntelRdtManager(config, id, "")
 	}
 	c.state = &stoppedState{c: c}
@@ -256,8 +255,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	if err := c.refreshState(); err != nil {
 		return nil, err
 	}
-	c.intelRdtManager = nil
-	if intelrdt.IsEnabled() && c.config.IntelRdt != nil {
+	if intelrdt.IsEnabled() {
 		c.intelRdtManager = l.NewIntelRdtManager(&state.Config, id, state.IntelRdtPath)
 	}
 	return c, nil

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -401,6 +401,10 @@ func GetIntelRdtPath(id string) (string, error) {
 
 // Applies Intel RDT configuration to the process with the specified pid
 func (m *IntelRdtManager) Apply(pid int) (err error) {
+	// If intelRdt is not specified in config, we do nothing
+	if m.Config.IntelRdt == nil {
+		return nil
+	}
 	d, err := getIntelRdtData(m.Config, pid)
 	if err != nil && !IsNotFound(err) {
 		return err


### PR DESCRIPTION
Add runc update command support for Intel RDT/CAT.

for example:
runc update --l3-cache-schema "L3:0=f;1=f" container-id

For more information about Intel Resource Director Technology (RDT)
and Cache Allocation Technology (CAT), please refer to #1279 

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>