### PR TITLE
libcontainer: default mount propagation correctly

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -37,7 +37,7 @@ var mountPropagationMapping = map[string]int{
 	"slave":    unix.MS_SLAVE,
 	"rshared":  unix.MS_SHARED | unix.MS_REC,
 	"shared":   unix.MS_SHARED,
-	"":         unix.MS_PRIVATE | unix.MS_REC,
+	"":         0,
 }
 
 var allowedDevices = []*configs.Device{


### PR DESCRIPTION
The code in prepareRoot (https://github.com/opencontainers/runc/blob/e385f67a0e45fa1d8ef8154e2aea5128ea1d331b/libcontainer/rootfs_linux.go#L599-L605)
attempts to default the rootfs mount to `rslave`. However, since the spec
conversion has already defaulted it to `rprivate`, that code doesn't
actually ever do anything.

This changes the spec conversion code to accept "" and treat it as 0.

Implicitly, this makes rootfs propagation default to `rslave`, which is
a part of fixing the moby bug https://github.com/moby/moby/issues/34672

Alternate implementatoins include changing this defaulting to be
`rslave` and removing the defaulting code in prepareRoot, or skipping
the mapping entirely for "", but I think this change is the cleanest of
those options.

cc @cyphar, this is somewhat similar to #1500 and fixes a similar problem.