### PR TITLE
unix.SOCK_CLOEXEC is not available for darwin

### DIFF
--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 package utils
 


### PR DESCRIPTION
unix.SOCK_CLOEXEC is not available for darwin. So this file is not compatible on Darwin. Add this constraints in build details.