### PR TITLE
libcontainer: create Cwd when it does not exist

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -68,7 +68,7 @@ func (l *linuxStandardInit) Init() error {
 
 	// prepareRootfs() can be executed only for a new mount namespace.
 	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
-		if err := prepareRootfs(l.pipe, l.config.Config); err != nil {
+		if err := prepareRootfs(l.pipe, l.config); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The benefit for doing this within runc is that it works well with
userns.
Actually, runc already does the same thing for mount points.

discussed in https://github.com/containerd/containerd/pull/1585 (cc @crosbymichael @estesp )

If this change is fine, I'll open a PR to runtime-spec correspondingly.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>