### PR TITLE
libcontainer: handler errors from terminate 

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1782,12 +1782,10 @@ func ignoreTerminateErrors(err error) error {
 	if err == nil {
 		return nil
 	}
-
-	// TODO(steve): Update these to none string checks if the runtime exports them.
-	switch err.Error() {
-	case "os: process already finished", "exec: Wait was already called":
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "process already finished"), strings.Contains(s, "Wait was already called"):
 		return nil
-	default:
-		return err
 	}
+	return err
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -289,7 +289,7 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 	}
 	if err := parent.start(); err != nil {
 		// terminate the process to ensure that it properly is reaped.
-		if err := parent.terminate(); err != nil {
+		if err := ignoreTerminateErrors(parent.terminate()); err != nil {
 			logrus.Warn(err)
 		}
 		return newSystemErrorWithCause(err, "starting container process")
@@ -315,7 +315,7 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 			}
 			for i, hook := range c.config.Hooks.Poststart {
 				if err := hook.Run(s); err != nil {
-					if err := parent.terminate(); err != nil {
+					if err := ignoreTerminateErrors(parent.terminate()); err != nil {
 						logrus.Warn(err)
 					}
 					return newSystemErrorWithCausef(err, "running poststart hook %d", i)
@@ -1773,4 +1773,21 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 	})
 
 	return bytes.NewReader(r.Serialize()), nil
+}
+
+// ignoreTerminateErrors returns nil if the given err matches an error known
+// to indicate that the terminate occurred successfully or err was nil, otherwise
+// err is returned unaltered.
+func ignoreTerminateErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// TODO(steve): Update these to none string checks if the runtime exports them.
+	switch err.Error() {
+	case "os: process already finished", "exec: Wait was already called":
+		return nil
+	default:
+		return err
+	}
 }


### PR DESCRIPTION
Closes #1295


This is a carry of #1295 to run on the new tests again. 