### PR TITLE
libcontainer: cgroups: Write freezer state after every state check

### DIFF
--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -29,11 +29,15 @@ func (s *FreezerGroup) Apply(d *cgroupData) error {
 func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {
 	switch cgroup.Resources.Freezer {
 	case configs.Frozen, configs.Thawed:
-		if err := writeFile(path, "freezer.state", string(cgroup.Resources.Freezer)); err != nil {
-			return err
-		}
-
 		for {
+			// In case this loop does not exit because it doesn't get the expected
+			// state, let's write again this state, hoping it's going to be properly
+			// set this time. Otherwise, this loop could run infinitely, waiting for
+			// a state change that would never happen.
+			if err := writeFile(path, "freezer.state", string(cgroup.Resources.Freezer)); err != nil {
+				return err
+			}
+
 			state, err := readFile(path, "freezer.state")
 			if err != nil {
 				return err
@@ -41,6 +45,7 @@ func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {
 			if strings.TrimSpace(state) == string(cgroup.Resources.Freezer) {
 				break
 			}
+
 			time.Sleep(1 * time.Millisecond)
 		}
 	case configs.Undefined:


### PR DESCRIPTION
This commit ensures we write the expected freezer cgroup state after
every state check, in case the state check does not give the expected
result. This can happen when a new task is created and prevents the
whole cgroup to be FROZEN, leaving the state into FREEZING instead.

This patch prevents the case of an infinite loop to happen.

Fixes https://github.com/opencontainers/runc/issues/1609