### PR TITLE
Fix breaking change in Seccomp profile behavior

### DIFF
--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -22,6 +22,11 @@ var (
 	actErrno = libseccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
 )
 
+const (
+	// Linux system calls can have at most 6 arguments
+	syscallMaxArguments int = 6
+)
+
 // Filters given syscalls in a container, preventing them from being used
 // Started in the container init process, and carried over to all child processes
 // Setns calls, however, require a separate invocation, as they are not children
@@ -45,11 +50,11 @@ func InitSeccomp(config *configs.Seccomp) error {
 	for _, arch := range config.Architectures {
 		scmpArch, err := libseccomp.GetArchFromString(arch)
 		if err != nil {
-			return err
+			return fmt.Errorf("error validating Seccomp architecture: %s", err)
 		}
 
 		if err := filter.AddArch(scmpArch); err != nil {
-			return err
+			return fmt.Errorf("error adding architecture to seccomp filter: %s", err)
 		}
 	}
 
@@ -170,29 +175,55 @@ func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall) error {
 	// Convert the call's action to the libseccomp equivalent
 	callAct, err := getAction(call.Action)
 	if err != nil {
-		return err
+		return fmt.Errorf("action in seccomp profile is invalid: %s", err)
 	}
 
 	// Unconditional match - just add the rule
 	if len(call.Args) == 0 {
 		if err = filter.AddRule(callNum, callAct); err != nil {
-			return err
+			return fmt.Errorf("error adding seccomp filter rule for syscall %s: %s", call.Name, err)
 		}
 	} else {
-		// Conditional match - convert the per-arg rules into library format
+		// If two or more arguments have the same condition,
+		// Revert to old behavior, adding each condition as a separate rule
+		argCounts := make([]uint, syscallMaxArguments)
 		conditions := []libseccomp.ScmpCondition{}
 
 		for _, cond := range call.Args {
 			newCond, err := getCondition(cond)
 			if err != nil {
-				return err
+				return fmt.Errorf("error creating seccomp syscall condition for syscall %s: %s", call.Name, err)
 			}
+
+			argCounts[cond.Index] += 1
 
 			conditions = append(conditions, newCond)
 		}
 
-		if err = filter.AddRuleConditional(callNum, callAct, conditions); err != nil {
-			return err
+		hasMultipleArgs := false
+		for _, count := range argCounts {
+			if count > 1 {
+				hasMultipleArgs = true
+				break
+			}
+		}
+
+		if hasMultipleArgs {
+			// Revert to old behavior
+			// Add each condition attached to a separate rule
+			for _, cond := range conditions {
+				condArr := []libseccomp.ScmpCondition{cond}
+
+				if err = filter.AddRuleConditional(callNum, callAct, condArr); err != nil {
+					return fmt.Errorf("error adding seccomp rule for syscall %s: %s", call.Name, err)
+				}
+			}
+		} else {
+			// No conditions share same argument
+			// Use new, proper behavior
+			if err = filter.AddRuleConditional(callNum, callAct, conditions); err != nil {
+				return fmt.Errorf("error adding seccomp rule for syscall %s: %s", call.Name, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Multiple conditions were previously allowed to be placed upon the same syscall argument. My earlier patch #1424 fixed an issue in the Libseccomp bindings with conditional syscall matching, but this broke multiple conditions being placed upon the same argument. This patch restores the old behavior for rules which would be broken by the prior change.

Note that the prior behavior here is still not correct behavior - the conditions for these rules will still be logical-OR instead of logical-AND as they should be. I looked into generating rules that would act correctly, but that proved to be unreasonably complex in some cases.

I haven't added a warning for the badly-behaved profiles, though I am open to doing so.