### PR TITLE
tests: add missing cgroups_kmem requirement

### DIFF
--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -260,7 +260,7 @@ EOF
 
 @test "update rt period and runtime" {
     [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    requires cgroups_rt
+    requires cgroups_kmem cgroups_rt
 
     # run a detached busybox
     runc run -d --console-socket $CONSOLE_SOCKET test_update_rt


### PR DESCRIPTION
Since the defined config.json contains kmem settings, the test will try
writing to memory.kmem.* and fail. Therefore, it needs to require
cgroups_kmem.

Signed-off-by: Thomas Hipp <thipp@suse.de>