### PR TITLE
We should not mount /dev read-only

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -127,18 +127,6 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 // finalizeRootfs sets anything to ro if necessary. You must call
 // prepareRootfs first.
 func finalizeRootfs(config *configs.Config) (err error) {
-	// remount dev as ro if specified
-	for _, m := range config.Mounts {
-		if libcontainerUtils.CleanPath(m.Destination) == "/dev" {
-			if m.Flags&unix.MS_RDONLY == unix.MS_RDONLY {
-				if err := remountReadonly(m); err != nil {
-					return newSystemErrorWithCausef(err, "remounting %q as readonly", m.Destination)
-				}
-			}
-			break
-		}
-	}
-
 	// set rootfs ( / ) as readonly
 	if config.Readonlyfs {
 		if err := setReadonly(); err != nil {


### PR DESCRIPTION
/dev is on a tmpfs.  It is not part of the host file system, so it should not be read-only.

This stops certain containers from creating device nodes in /dev as well as /dev/log.

Breaks systemd, which wants to create /dev/log for the journal.  Also will also break any
tool that creates a tty device or any of the other devices allowed to be created by the device cgroup.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>