### PR TITLE
Create the xattr test file in user's home dir

### DIFF
--- a/libcontainer/xattr/xattr_test.go
+++ b/libcontainer/xattr/xattr_test.go
@@ -4,13 +4,19 @@ package xattr_test
 
 import (
 	"os"
+	"os/user"
+	"path/filepath"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/xattr"
 )
 
 func TestXattr(t *testing.T) {
-	tmp := "xattr_test"
+	u, err := user.Current()
+	if err != nil {
+		t.Fatal("failed")
+	}
+	tmp := filepath.Join(u.HomeDir, "xattr_test")
 	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE, 0)
 	if err != nil {
 		t.Fatal("failed")


### PR DESCRIPTION
Running tests on a Mac with a VirtualBox Linux docker host we see TestXattr fail because the test is unable to set the extended attributes on /go/src/github.com/opencontainers/runc. Extended attributes do not seem to work on VBox shared file systems (which is what
VirtualBox mounts the runc directory as).

We propose creating the test file in the user's home directory which is more likely to be a file system that supports extended attributes

We think this change is uncontroversial because of this statement in the README: https://github.com/opencontainers/runc/blame/10dc96bb9e7e3b07511efdc830560c1384d92f79/README.md#L72

Signed-off-by: Danail Branekov <danailster@gmail.com>