### PR TITLE
cgroups: support udpate nested cpuset cgroup

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -367,6 +368,53 @@ func CheckCpushares(path string, c uint64) error {
 		return fmt.Errorf("The maximum allowed cpu-shares is %d", cpuShares)
 	} else if c < cpuShares {
 		return fmt.Errorf("The minimum allowed cpu-shares is %d", cpuShares)
+	}
+
+	return nil
+}
+
+// writeNestedFile writes data into nested cgroup file, note that the function
+// only apply in cpuset cgroup currently, cause child cpusets contain a subset
+// of the parents CPU and Memory resources.
+func writeNestedFile(dir, file, data string) error {
+	oldData, err := readFile(dir, file)
+	if err != nil {
+		return err
+	}
+
+	oldData = strings.TrimRightFunc(oldData, func(c rune) bool {
+		return c == '\n' || c == '\r'
+	})
+	// oldData will never be null
+	mergedData := oldData + "," + data
+
+	return walk(dir, file, mergedData, data)
+}
+
+// recurse directory, first set mergedData in current cgroup file, then set newData
+// for the file after function return.
+func walk(dir, file, mergedData, newData string) error {
+	if err := writeFile(dir, file, mergedData); err != nil {
+		return err
+	}
+
+	items, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range items {
+		if !item.IsDir() {
+			continue
+		}
+
+		if err := walk(filepath.Join(dir, item.Name()), file, mergedData, newData); err != nil {
+			return err
+		}
+	}
+
+	if err := writeFile(dir, file, newData); err != nil {
+		return err
 	}
 
 	return nil

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -31,12 +31,12 @@ func (s *CpusetGroup) Apply(d *cgroupData) error {
 
 func (s *CpusetGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.Resources.CpusetCpus != "" {
-		if err := writeFile(path, "cpuset.cpus", cgroup.Resources.CpusetCpus); err != nil {
+		if err := writeNestedFile(path, "cpuset.cpus", cgroup.Resources.CpusetCpus); err != nil {
 			return err
 		}
 	}
 	if cgroup.Resources.CpusetMems != "" {
-		if err := writeFile(path, "cpuset.mems", cgroup.Resources.CpusetMems); err != nil {
+		if err := writeNestedFile(path, "cpuset.mems", cgroup.Resources.CpusetMems); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
cpuset cgroup form a nested hierarchy visible in a virtual
file system, and child cpusets must contain a subset of the
parents CPU and Memory resources. When root user get permission
to make nested cpuset cgroup, this patch will allow update
operation in this case.

Fixes: #1635

Signed-off-by: Ace-Tang <aceapril@126.com>