### PR TITLE
enable unit test on arm64 platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.0
+FROM golang:1.8
 
 # libseccomp in jessie is not _quite_ new enough -- need backports version
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list


### PR DESCRIPTION
Currently, unit test can't be done on arm64 platform
due to multi-arch issue.

Fix points:
golang:1.8.0 doesn't support arm64.
We use golang:1.8 to replace it.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>