### PR TITLE
specconv.Example(): add /proc/scsi to masked paths

### DIFF
--- a/libcontainer/specconv/example.go
+++ b/libcontainer/specconv/example.go
@@ -116,6 +116,7 @@ func Example() *specs.Spec {
 				"/proc/timer_stats",
 				"/proc/sched_debug",
 				"/sys/firmware",
+				"/proc/scsi",
 			},
 			ReadonlyPaths: []string{
 				"/proc/asound",


### PR DESCRIPTION
Port over https://github.com/moby/moby/pull/35399

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>