### PR TITLE
Add build 1.9 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.7.x
   - 1.8.x
+  - 1.9.x
   - tip
 
 matrix:


### PR DESCRIPTION
`tip` should point to 1.10 already ? (or soon-ish)

/cc @cyphar @crosbymichael @dqminh

Signed-off-by: Vincent Demeester <vincent@sbr.pm>