### PR TITLE
Ensure container tests do not write on the host

### DIFF
--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -4,6 +4,7 @@ package libcontainer
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -281,8 +282,16 @@ func TestGetContainerStateAfterUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	rootDir, err := ioutil.TempDir("", "TestGetContainerStateAfterUpdate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(rootDir)
+
 	container := &linuxContainer{
-		id: "myid",
+		root: rootDir,
+		id:   "myid",
 		config: &configs.Config{
 			Namespaces: []configs.Namespace{
 				{Type: configs.NEWPID},


### PR DESCRIPTION
TestGetContainerStateAfterUpdate creates its state.json file on the current
directory which turns out to be the host runc directory. Thus whenever
the test completes it leaves the state.json file behind thus
a) poluting the local git repository
b) changing the host file system violating the principle of doing
everything in an isolated container environment

This change would create a new temporary (in-container) directory and use it as
linuxContainer.root

Signed-off-by: Tom Godkin <tgodkin@pivotal.io>