### PR TITLE
specconv: avoid skipping gidmappings applied when uidmappings is empty

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -618,9 +618,6 @@ func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
 		}
 	}
 	if spec.Linux != nil {
-		if len(spec.Linux.UIDMappings) == 0 {
-			return nil
-		}
 		for _, m := range spec.Linux.UIDMappings {
 			config.UidMappings = append(config.UidMappings, create(m))
 		}


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>