### PR TITLE
Add missing lock in Apply()

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -295,6 +295,8 @@ func (m *Manager) Apply(pid int) error {
 		}
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if _, err := theConn.StartTransientUnit(unitName, "replace", properties, nil); err != nil && !isUnitExists(err) {
 		return err
 	}


### PR DESCRIPTION
Cgroups joins and local variable 'path' updation should be
done under lock protection. Lock protection absence can lead
to race conditions and errors [1].

[1] https://ci.openshift.redhat.com/jenkins/job/test_pull_request_crio_e2e_rhel/433/consoleFull#199861745056cbb9a5e4b02b88ae8c2f77
/cc @sjenning 
Signed-off-by: vikaschoudhary16 <vichoudh@redhat.com>