### PR TITLE
stopped container can't be checkpoint

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -56,8 +56,8 @@ checkpointed.`,
 		if err != nil {
 			return err
 		}
-		if status == libcontainer.Created {
-			fatalf("Container cannot be checkpointed in created state")
+		if status == libcontainer.Created || status == libcontainer.Stopped {
+			fatalf("Container cannot be checkpointed in %s state", status.String())
 		}
 		defer destroy(container)
 		options := criuOptions(context)


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

Except created containers, stopped containers should also not be supported to be checkpointed