### PR TITLE
RFC: libcontainer: remove dependency on libapparmor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 before_install:
   - echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get -qq update
-  - sudo apt-get install -y libapparmor-dev libseccomp-dev/trusty-backports
+  - sudo apt-get install -y libseccomp-dev/trusty-backports
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/vbatts/git-validation
   - env | grep TRAVIS_

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ make BUILDTAGS='seccomp apparmor'
 |-----------|------------------------------------|-------------|
 | seccomp   | Syscall filtering                  | libseccomp  |
 | selinux   | selinux process and mount labeling | <none>      |
-| apparmor  | apparmor profile support           | libapparmor |
+| apparmor  | apparmor profile support           | <none>      |
 | ambient   | ambient capability support         | kernel 4.3  |
 
 


### PR DESCRIPTION
libapparmor is integrated in libcontainer using cgo but is only used to
call a single function: aa_change_onexec. It turns out this function is
simple enough (writing a string to a file in /proc/<n>/attr/...) to be
re-implemented locally in libcontainer in plain Go.

This allows to drop the dependency on libapparmor and the corresponding
cgo integration.

Fixes #1674

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>