### PR TITLE
Pin version of gojsonschema in tests

### DIFF
--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -81,6 +81,9 @@ function teardown() {
   run bash -c "GOPATH='$GOPATH' go get github.com/xeipuuv/gojsonschema"
   [ "$status" -eq 0 ]
 
+  run git -C "${GOPATH}/src/github.com/xeipuuv/gojsonschema" reset --hard 6637feb73ee44cd4640bb3def285c29774234c7f
+  [ "$status" -eq 0 ]
+
   GOPATH="$GOPATH" go build src/runtime-spec/schema/validate.go
   [ -e ./validate ]
 


### PR DESCRIPTION
Fixes #1680 (partially). This is suggested as a temporary fix to runc so that CI can go green and development can continue.

We will detail a potential problem we've found with opencontainers json schema validation in a email to the mailing list.

Signed-off-by: Will Martin <wmartin@pivotal.io>
  