### PR TITLE
Warning message if 'go-md2man' is not yet installed

### DIFF
--- a/man/md2man-all.sh
+++ b/man/md2man-all.sh
@@ -9,6 +9,11 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 	pwd
 }
 
+if ! ( which go-md2man &>/dev/null ); then
+	echo "To install man pages, please install 'go-md2man'."
+	exit 0
+fi
+
 for FILE in *.md; do
 	base="$(basename "$FILE")"
 	name="${base%.md}"


### PR DESCRIPTION
If 'go-md2man' is not installed,
an error can occur when running md2man-all.sh like below:

```
  $ ./man/md2man-all.sh -q
  ./man/md2man-all.sh: line 21: go-md2man: command not found
```
So fix it.
  