### PR TITLE
libcontainer: expose annotations in hooks

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -308,11 +308,13 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 		c.initProcessStartTime = state.InitProcessStartTime
 
 		if c.config.Hooks != nil {
+			bundle, annotations := utils.Annotations(c.config.Labels)
 			s := configs.HookState{
-				Version: c.config.Version,
-				ID:      c.id,
-				Pid:     parent.pid(),
-				Bundle:  utils.SearchLabels(c.config.Labels, "bundle"),
+				Version:     c.config.Version,
+				ID:          c.id,
+				Pid:         parent.pid(),
+				Bundle:      bundle,
+				Annotations: annotations,
 			}
 			for i, hook := range c.config.Hooks.Poststart {
 				if err := hook.Run(s); err != nil {
@@ -1436,11 +1438,13 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 		}
 	case notify.GetScript() == "setup-namespaces":
 		if c.config.Hooks != nil {
+			bundle, annotations := utils.Annotations(c.config.Labels)
 			s := configs.HookState{
-				Version: c.config.Version,
-				ID:      c.id,
-				Pid:     int(notify.GetPid()),
-				Bundle:  utils.SearchLabels(c.config.Labels, "bundle"),
+				Version:     c.config.Version,
+				ID:          c.id,
+				Pid:         int(notify.GetPid()),
+				Bundle:      bundle,
+				Annotations: annotations,
 			}
 			for i, hook := range c.config.Hooks.Prestart {
 				if err := hook.Run(s); err != nil {

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -341,11 +341,13 @@ func (p *initProcess) start() error {
 				}
 
 				if p.config.Config.Hooks != nil {
+					bundle, annotations := utils.Annotations(p.container.config.Labels)
 					s := configs.HookState{
-						Version: p.container.config.Version,
-						ID:      p.container.id,
-						Pid:     p.pid(),
-						Bundle:  utils.SearchLabels(p.config.Config.Labels, "bundle"),
+						Version:     p.container.config.Version,
+						ID:          p.container.id,
+						Pid:         p.pid(),
+						Bundle:      bundle,
+						Annotations: annotations,
 					}
 					for i, hook := range p.config.Config.Hooks.Prestart {
 						if err := hook.Run(s); err != nil {
@@ -370,11 +372,13 @@ func (p *initProcess) start() error {
 				}
 			}
 			if p.config.Config.Hooks != nil {
+				bundle, annotations := utils.Annotations(p.container.config.Labels)
 				s := configs.HookState{
-					Version: p.container.config.Version,
-					ID:      p.container.id,
-					Pid:     p.pid(),
-					Bundle:  utils.SearchLabels(p.config.Config.Labels, "bundle"),
+					Version:     p.container.config.Version,
+					ID:          p.container.id,
+					Pid:         p.pid(),
+					Bundle:      bundle,
+					Annotations: annotations,
 				}
 				for i, hook := range p.config.Config.Hooks.Prestart {
 					if err := hook.Run(s); err != nil {

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -63,10 +63,12 @@ func destroy(c *linuxContainer) error {
 
 func runPoststopHooks(c *linuxContainer) error {
 	if c.config.Hooks != nil {
+		bundle, annotations := utils.Annotations(c.config.Labels)
 		s := configs.HookState{
-			Version: c.config.Version,
-			ID:      c.id,
-			Bundle:  utils.SearchLabels(c.config.Labels, "bundle"),
+			Version:     c.config.Version,
+			ID:          c.id,
+			Bundle:      bundle,
+			Annotations: annotations,
 		}
 		for _, hook := range c.config.Hooks.Poststop {
 			if err := hook.Run(s); err != nil {


### PR DESCRIPTION
Annotations weren't passed to hooks. This patch fixes that by passing
annotations to stdin for hooks.

Fix https://github.com/opencontainers/runc/issues/1686

/cc @mrunalp @FlorianOtel

Signed-off-by: Antonio Murdaca <runcom@redhat.com>