### PR TITLE
 rootless: allow setgroups if `--force-mapping-tool` is set

### DIFF
--- a/create.go
+++ b/create.go
@@ -50,6 +50,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "preserve-fds",
 			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
 		},
+		cli.BoolFlag{
+			Name:  "force-mapping-tool",
+			Usage: "forcibly use newuidmap/newgidmap tool. This is useful for rootless mode to keep /proc/PID/setgroups \"allow\"",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -47,6 +47,7 @@ type linuxContainer struct {
 	criuPath             string
 	newuidmapPath        string
 	newgidmapPath        string
+	forceMappingTool     bool
 	m                    sync.Mutex
 	criuVersion          int
 	state                containerState
@@ -1749,8 +1750,9 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 					Value: []byte(c.newgidmapPath),
 				})
 			}
-			// The following only applies if we are root.
-			if !c.config.Rootless {
+			// The following only applies if we are root, unless we are
+			// advised to use the mapping tool.
+			if !(c.config.Rootless && !c.forceMappingTool) {
 				// check if we have CAP_SETGID to setgroup properly
 				pid, err := capability.NewPid(os.Getpid())
 				if err != nil {
@@ -1763,6 +1765,12 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 					})
 				}
 			}
+		}
+		if c.forceMappingTool {
+			r.AddData(&Boolmsg{
+				Type:  ForceMappingToolAttr,
+				Value: true,
+			})
 		}
 	}
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -158,6 +158,9 @@ type LinuxFactory struct {
 	NewuidmapPath string
 	NewgidmapPath string
 
+	// ForceMappingTool forcibly enables newuidmap/newgidmap tool.
+	ForceMappingTool bool
+
 	// Validator provides validation to container configurations.
 	Validator validate.Validator
 
@@ -191,15 +194,16 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		return nil, newGenericError(err, SystemError)
 	}
 	c := &linuxContainer{
-		id:            id,
-		root:          containerRoot,
-		config:        config,
-		initPath:      l.InitPath,
-		initArgs:      l.InitArgs,
-		criuPath:      l.CriuPath,
-		newuidmapPath: l.NewuidmapPath,
-		newgidmapPath: l.NewgidmapPath,
-		cgroupManager: l.NewCgroupsManager(config.Cgroups, nil),
+		id:               id,
+		root:             containerRoot,
+		config:           config,
+		initPath:         l.InitPath,
+		initArgs:         l.InitArgs,
+		criuPath:         l.CriuPath,
+		newuidmapPath:    l.NewuidmapPath,
+		newgidmapPath:    l.NewgidmapPath,
+		forceMappingTool: l.ForceMappingTool,
+		cgroupManager:    l.NewCgroupsManager(config.Cgroups, nil),
 	}
 	if intelrdt.IsEnabled() {
 		c.intelRdtManager = l.NewIntelRdtManager(config, id, "")
@@ -359,6 +363,15 @@ func NewuidmapPath(newuidmapPath string) func(*LinuxFactory) error {
 func NewgidmapPath(newgidmapPath string) func(*LinuxFactory) error {
 	return func(l *LinuxFactory) error {
 		l.NewgidmapPath = newgidmapPath
+		return nil
+	}
+}
+
+// ForceMappingTool returns an option func to configure a LinuxFactory with the
+// provided ..
+func ForceMappingTool(flag bool) func(*LinuxFactory) error {
+	return func(l *LinuxFactory) error {
+		l.ForceMappingTool = flag
 		return nil
 	}
 }

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -77,13 +77,13 @@ func (msg *Boolmsg) Serialize() []byte {
 	native.PutUint16(buf[0:2], uint16(msg.Len()))
 	native.PutUint16(buf[2:4], msg.Type)
 	if msg.Value {
-		buf[4] = 1
+		native.PutUint32(buf[4:8], uint32(1))
 	} else {
-		buf[4] = 0
+		native.PutUint32(buf[4:8], uint32(0))
 	}
 	return buf
 }
 
 func (msg *Boolmsg) Len() int {
-	return unix.NLA_HDRLEN + 1
+	return unix.NLA_HDRLEN + 4 // alignment
 }

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -10,16 +10,17 @@ import (
 // list of known message types we want to send to bootstrap program
 // The number is randomly chosen to not conflict with known netlink types
 const (
-	InitMsg         uint16 = 62000
-	CloneFlagsAttr  uint16 = 27281
-	NsPathsAttr     uint16 = 27282
-	UidmapAttr      uint16 = 27283
-	GidmapAttr      uint16 = 27284
-	SetgroupAttr    uint16 = 27285
-	OomScoreAdjAttr uint16 = 27286
-	RootlessAttr    uint16 = 27287
-	UidmapPathAttr  uint16 = 27288
-	GidmapPathAttr  uint16 = 27289
+	InitMsg              uint16 = 62000
+	CloneFlagsAttr       uint16 = 27281
+	NsPathsAttr          uint16 = 27282
+	UidmapAttr           uint16 = 27283
+	GidmapAttr           uint16 = 27284
+	SetgroupAttr         uint16 = 27285
+	OomScoreAdjAttr      uint16 = 27286
+	RootlessAttr         uint16 = 27287
+	UidmapPathAttr       uint16 = 27288
+	GidmapPathAttr       uint16 = 27289
+	ForceMappingToolAttr uint16 = 27290
 )
 
 type Int32msg struct {

--- a/run.go
+++ b/run.go
@@ -61,6 +61,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "preserve-fds",
 			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
 		},
+		cli.BoolFlag{
+			Name:  "force-mapping-tool",
+			Usage: "forcibly use newuidmap/newgidmap tool. This is useful for rootless mode to keep /proc/PID/setgroups \"allow\"",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -62,11 +62,16 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	if err != nil {
 		newgidmap = ""
 	}
+	forceMappingTool := context.Bool("force-mapping-tool")
+	if forceMappingTool && (newuidmap == "" || newgidmap == "") {
+		return nil, errors.New("force mapping tool flag passed, but newuidmap/newgidmap tool is not available")
+	}
 
 	return libcontainer.New(abs, cgroupManager, intelRdtManager,
 		libcontainer.CriuPath(context.GlobalString("criu")),
 		libcontainer.NewuidmapPath(newuidmap),
-		libcontainer.NewgidmapPath(newgidmap))
+		libcontainer.NewgidmapPath(newgidmap),
+		libcontainer.ForceMappingTool(forceMappingTool))
 }
 
 // getContainer returns the specified container instance by loading it from state


### PR DESCRIPTION
Previously, `/proc/PID/setgroups` was always set to `"deny"` in rootless mode, as recent Linux kernel does not allow unprivileged users to update `/proc/PID/uid_map` without doing so.

However, we can mitigate this limitation by using `newuidmap(1)` and `newgidmap(1)`, although it requires these binaries (not `runc` itself) to have suid bit.

This PR adds a new flag `--force-mapping-tool` to use these binaries compulsory.

Now `apt` works within a rootless container, without ptrace hack:

Example config.json: https://gist.github.com/AkihiroSuda/0a46ad9ba6f392b27ac4c8d372721207

Demo (Tested on Ubuntu 17.10, kernel 4.13.0-25-generic x86_64):
```
$ mkdir rootfs
$ wget -O /tmp/ubuntu-base-17.10-base-amd64.tar.gz http://cdimage.ubuntu.com/ubuntu-base/releases/17.10/release/ubuntu-base-17.10-base-amd64.tar.gz
$ tar xzf /tmp/ubuntu-base-17.10-base-amd64.tar.gz -C ./rootfs || echo "mknod error were ignored"
$ cp /etc/resolv.conf rootfs/etc
$ vi config.json
(you need to set your own uidMappings and gidMappings)
$ runc run --force-mapping-tool foo
root@runc:/# chmod 1777 /tmp
root@runc:/# apt update
root@runc:/# apt install cowsay
root@runc:/# /usr/games/cowsay hello rootless apt
 ____________________
< hello rootless apt >
 --------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```


If depending on the mapping tool is problem, we can use `ptrace(2)` hacks instead: https://github.com/AkihiroSuda/runrootless
