### PR TITLE
man: Fix manpages related to console

### DIFF
--- a/man/runc-create.8.md
+++ b/man/runc-create.8.md
@@ -20,7 +20,8 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 
 # OPTIONS
    --bundle value, -b value  path to the root of the bundle directory, defaults to the current directory
-   --console value           specify the pty slave path for use with the container
+   --console-socket value    path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal
    --pid-file value          specify the file to write the process id to
    --no-pivot                do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk
    --no-new-keyring          do not create a new session keyring for the container.  This will cause the container to inherit the calling processes session key
+   --preserve-fds value      Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total) (default: 0)

--- a/man/runc-run.8.md
+++ b/man/runc-run.8.md
@@ -20,9 +20,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 
 # OPTIONS
    --bundle value, -b value  path to the root of the bundle directory, defaults to the current directory
-   --console value           specify the pty slave path for use with the container
+   --console-socket value    path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal
    --detach, -d              detach from the container's process
    --pid-file value          specify the file to write the process id to
    --no-subreaper            disable the use of the subreaper used to reap reparented processes
    --no-pivot                do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk
    --no-new-keyring          do not create a new session keyring for the container.  This will cause the container to inherit the calling processes session key
+   --preserve-fds value      Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total) (default: 0)


### PR DESCRIPTION
The commit 244c9fc ("*: console rewrite")
removed the --console option and the commit 7df64f8
("runc: implement --console-socket") create new option
--console-socket. However, the old --console option
still exists so fix it.

In addtion, add missing --preserve-fds option to
create and run manpages.