### PR TITLE
chroot when no mount namespaces is provided

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -100,8 +100,10 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 
 	if config.NoPivotRoot {
 		err = msMoveRoot(config.Rootfs)
-	} else {
+	} else if config.Namespaces.Contains(configs.NEWNS) {
 		err = pivotRoot(config.Rootfs)
+	} else {
+		err = chroot(config.Rootfs)
 	}
 	if err != nil {
 		return newSystemErrorWithCause(err, "jailing process inside rootfs")
@@ -702,6 +704,10 @@ func msMoveRoot(rootfs string) error {
 	if err := unix.Mount(rootfs, "/", "", unix.MS_MOVE, ""); err != nil {
 		return err
 	}
+	return chroot(rootfs)
+}
+
+func chroot(rootfs string) error {
 	if err := unix.Chroot("."); err != nil {
 		return err
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -65,14 +65,9 @@ func (l *linuxStandardInit) Init() error {
 	}
 
 	label.Init()
-
-	// prepareRootfs() can be executed only for a new mount namespace.
-	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
-		if err := prepareRootfs(l.pipe, l.config); err != nil {
-			return err
-		}
+	if err := prepareRootfs(l.pipe, l.config); err != nil {
+		return err
 	}
-
 	// Set up the console. This has to be done *before* we finalize the rootfs,
 	// but *after* we've given the user the chance to set up all of the mounts
 	// they wanted.


### PR DESCRIPTION
We shouldn't skip the rootfs code when NEWNS is not specified because it will place the process in the host's `/`, instead, perform a simple `chroot` so that the process is still placed inside the specified rootfs. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>