### PR TITLE
libcontainer: Add support for the "pausing" status

### DIFF
--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -13,6 +13,7 @@ const (
 
 	// Container errors
 	ContainerNotExists
+	ContainerPausing
 	ContainerPaused
 	ContainerNotStopped
 	ContainerNotRunning
@@ -33,6 +34,8 @@ func (c ErrorCode) String() string {
 		return "Id already in use"
 	case InvalidIdFormat:
 		return "Invalid format"
+	case ContainerPausing:
+		return "Container pausing"
 	case ContainerPaused:
 		return "Container paused"
 	case ConfigInvalid:

--- a/libcontainer/state_linux_test.go
+++ b/libcontainer/state_linux_test.go
@@ -11,6 +11,7 @@ var states = map[containerState]Status{
 	&createdState{}:          Created,
 	&runningState{}:          Running,
 	&restoredState{}:         Running,
+	&pausingState{}:          Pausing,
 	&pausedState{}:           Paused,
 	&stoppedState{}:          Stopped,
 	&loadedState{s: Running}: Running,
@@ -67,6 +68,19 @@ func TestStoppedStateTransition(t *testing.T) {
 	)
 }
 
+func TestPausingStateTransition(t *testing.T) {
+	testTransitions(
+		t,
+		&pausingState{c: &linuxContainer{}},
+		[]containerState{
+			&pausingState{},
+			&pausedState{},
+			&runningState{},
+			&stoppedState{},
+		},
+	)
+}
+
 func TestPausedStateTransition(t *testing.T) {
 	testTransitions(
 		t,
@@ -96,6 +110,7 @@ func TestRunningStateTransition(t *testing.T) {
 		&runningState{c: &linuxContainer{}},
 		[]containerState{
 			&stoppedState{},
+			&pausingState{},
 			&pausedState{},
 			&runningState{},
 		},
@@ -108,6 +123,7 @@ func TestCreatedStateTransition(t *testing.T) {
 		&createdState{c: &linuxContainer{}},
 		[]containerState{
 			&stoppedState{},
+			&pausingState{},
 			&pausedState{},
 			&runningState{},
 			&createdState{},


### PR DESCRIPTION
Builds on #1703; review that first.

The freezer controller [distinguishes between freezing and frozen][1]. We've had a `Pausing` since dbb515f0 (2014-07-08), but had [never implemented it][2].  This pull-request adds the missing implementation.

I haven't updated `libcontainer/cgroups`, which has used a blocking freeze change since 3e8849fa (2014-06-04). The cgroups interface doesn't distinguish between blocking and non-blocking sets, so there's no way to say “I want to start freezing, but don't need to block until completion”.

I haven't added integration tests either.  All of our current tests (`state.bats` and `pause.bats`) assume a complete transition to `paused`.  That makes sense because `runc pause …` is based on the blocking `libcontainer/cgroups` implementation.  The only way to see `pausing` would be to have a parallel state call during the pause call.  Here's how the timing could work out:

1. Call `pause`.
2. Call `state`, which reads `THAWED` and outputs `running` (or `created`, or whatever).
3. `pause` starts freezing the controller.
4. Call `state`, which reads `FREEZING` and outputs `pausing`.
5. `pause` finishes freezing the controller.
6. Call `state`, which reads `FROZEN` and outputs `paused`.
7. `pause` exits.

I'm not sure how to get a test where the `state` call consistently fires at 4 and not at 2 or 6.

[1]: https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt
[2]: https://github.com/opencontainers/runc/pull/218/files#r38837239