### PR TITLE
kill.go: Remove unnecessary checks

### DIFF
--- a/kill.go
+++ b/kill.go
@@ -61,13 +61,7 @@ signal to the init process of the "ubuntu01" container:
 func parseSignal(rawSignal string) (syscall.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
-		sig := syscall.Signal(s)
-		for _, msig := range signalMap {
-			if sig == msig {
-				return sig, nil
-			}
-		}
-		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+		return syscall.Signal(s), nil
 	}
 	signal, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
 	if !ok {


### PR DESCRIPTION
... that prevent sending signals not mentioned in signal map.
Currently these are SIGRTMIN..SIGRTMAX.

Signed-off-by: Valentin Kulesh <valentin.kulesh@virtuozzo.com>