### PR TITLE
Add definitions for cgroup namespaces

### DIFF
--- a/libcontainer/configs/namespaces_linux.go
+++ b/libcontainer/configs/namespaces_linux.go
@@ -7,12 +7,13 @@ import (
 )
 
 const (
-	NEWNET  NamespaceType = "NEWNET"
-	NEWPID  NamespaceType = "NEWPID"
-	NEWNS   NamespaceType = "NEWNS"
-	NEWUTS  NamespaceType = "NEWUTS"
-	NEWIPC  NamespaceType = "NEWIPC"
-	NEWUSER NamespaceType = "NEWUSER"
+	NEWNET    NamespaceType = "NEWNET"
+	NEWPID    NamespaceType = "NEWPID"
+	NEWNS     NamespaceType = "NEWNS"
+	NEWUTS    NamespaceType = "NEWUTS"
+	NEWIPC    NamespaceType = "NEWIPC"
+	NEWUSER   NamespaceType = "NEWUSER"
+	NEWCGROUP NamespaceType = "NEWCGROUP"
 )
 
 var (
@@ -35,6 +36,8 @@ func NsName(ns NamespaceType) string {
 		return "user"
 	case NEWUTS:
 		return "uts"
+	case NEWCGROUP:
+		return "cgroup"
 	}
 	return ""
 }
@@ -68,6 +71,7 @@ func NamespaceTypes() []NamespaceType {
 		NEWNET,
 		NEWPID,
 		NEWNS,
+		NEWCGROUP,
 	}
 }
 

--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -9,12 +9,13 @@ func (n *Namespace) Syscall() int {
 }
 
 var namespaceInfo = map[NamespaceType]int{
-	NEWNET:  unix.CLONE_NEWNET,
-	NEWNS:   unix.CLONE_NEWNS,
-	NEWUSER: unix.CLONE_NEWUSER,
-	NEWIPC:  unix.CLONE_NEWIPC,
-	NEWUTS:  unix.CLONE_NEWUTS,
-	NEWPID:  unix.CLONE_NEWPID,
+	NEWNET:    unix.CLONE_NEWNET,
+	NEWNS:     unix.CLONE_NEWNS,
+	NEWUSER:   unix.CLONE_NEWUSER,
+	NEWIPC:    unix.CLONE_NEWIPC,
+	NEWUTS:    unix.CLONE_NEWUTS,
+	NEWPID:    unix.CLONE_NEWPID,
+	NEWCGROUP: unix.CLONE_NEWCGROUP,
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -186,6 +186,7 @@ func TestGetContainerState(t *testing.T) {
 				{Type: configs.NEWNS},
 				{Type: configs.NEWNET, Path: expectedNetworkPath},
 				{Type: configs.NEWUTS},
+				{Type: configs.NEWCGROUP},
 				// emulate host for IPC
 				//{Type: configs.NEWIPC},
 			},
@@ -265,6 +266,8 @@ func TestGetContainerState(t *testing.T) {
 				file = "user"
 			case configs.NEWUTS:
 				file = "uts"
+			case configs.NEWCGROUP:
+				file = "cgroup"
 			}
 			expected := fmt.Sprintf("/proc/%d/ns/%s", pid, file)
 			if expected != path {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -28,6 +28,7 @@ var namespaceMapping = map[specs.LinuxNamespaceType]configs.NamespaceType{
 	specs.UserNamespace:    configs.NEWUSER,
 	specs.IPCNamespace:     configs.NEWIPC,
 	specs.UTSNamespace:     configs.NEWUTS,
+	specs.CgroupNamespace:  configs.NEWCGROUP,
 }
 
 var mountPropagationMapping = map[string]int{


### PR DESCRIPTION
This adds support for cgroup namespaces, which were
added in Linux v4.6. The primary benefit is that it makes
/proc/self/cgroup's paths consistent with what's seen
under /sys/fs/cgroup.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>