### PR TITLE
kill: unix.SIGUNUSED removed from golang/x/sys

### DIFF
--- a/signalmap.go
+++ b/signalmap.go
@@ -37,7 +37,6 @@ var signalMap = map[string]syscall.Signal{
 	"TSTP":   unix.SIGTSTP,
 	"TTIN":   unix.SIGTTIN,
 	"TTOU":   unix.SIGTTOU,
-	"UNUSED": unix.SIGUNUSED,
 	"URG":    unix.SIGURG,
 	"USR1":   unix.SIGUSR1,
 	"USR2":   unix.SIGUSR2,


### PR DESCRIPTION
unix.SIGUNUSED has been removed from golang/x/sys upstream so building fails if not using the vendored deps bundled with runc. Causes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889704 in Debian. See http://paste.debian.net/hidden/3f64ef85/