### PR TITLE
fix systemd slice expansion so that it could be consumed by cAdvisor

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -390,7 +390,7 @@ func joinCgroups(c *configs.Cgroup, pid int) error {
 
 // systemd represents slice hierarchy using `-`, so we need to follow suit when
 // generating the path of slice. Essentially, test-a-b.slice becomes
-// test.slice/test-a.slice/test-a-b.slice.
+// /test.slice/test-a.slice/test-a-b.slice.
 func ExpandSlice(slice string) (string, error) {
 	suffix := ".slice"
 	// Name has to end with ".slice", but can't be just ".slice".
@@ -416,10 +416,9 @@ func ExpandSlice(slice string) (string, error) {
 		}
 
 		// Append the component to the path and to the prefix.
-		path += prefix + component + suffix + "/"
+		path += "/" + prefix + component + suffix
 		prefix += component + "-"
 	}
-
 	return path, nil
 }
 


### PR DESCRIPTION
As of now systemd slice expansion would result in strings with a suffix  "/" but we want "/" to be prefixed in kubernetes so that cAdvisor can read stats.

The only call to ExpandSlice function in runc seems to be happening from 

https://github.com/opencontainers/runc/blob/master/libcontainer/cgroups/systemd/apply_systemd.go#L449

which uses filepath.Join, so shouldn't cause a behavioural change.

xref: https://github.com/kubernetes/kubernetes/issues/59993

/cc @derekwaynecarr @sjenning 

Signed-off-by: ravisantoshgudimetla <ravisantoshgudimetla@gmail.com>