### PR TITLE
libcontainer/capabilities_linux: Drop os.Getpid() call

### DIFF
--- a/libcontainer/capabilities_linux.go
+++ b/libcontainer/capabilities_linux.go
@@ -4,7 +4,6 @@ package libcontainer
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -72,7 +71,7 @@ func newContainerCapList(capConfig *configs.Capabilities) (*containerCapabilitie
 		}
 		ambient = append(ambient, v)
 	}
-	pid, err := capability.NewPid(os.Getpid())
+	pid, err := capability.NewPid(0)
 	if err != nil {
 		return nil, err
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1804,7 +1804,7 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 			// The following only applies if we are root.
 			if !c.config.Rootless {
 				// check if we have CAP_SETGID to setgroup properly
-				pid, err := capability.NewPid(os.Getpid())
+				pid, err := capability.NewPid(0)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
gocapability has supported 0 as “the current PID” since syndtr/gocapability#2.  libcontainer was ported to that approach in 444cc298 (docker/libcontainer#358), but the change was clobbered by 22df5551 which landed via 5b73860e (docker/libcontainer#388).  This pull-request restores the changes from 444cc298.