### PR TITLE
*: Avoid creation panics when 'process' and 'linux' are unset

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -257,7 +257,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	}
 	createHooks(spec, config)
 	config.Version = specs.Version
-	if spec.Linux.IntelRdt != nil {
+	if spec.Linux != nil && spec.Linux.IntelRdt != nil {
 		config.IntelRdt = &configs.IntelRdt{}
 		if spec.Linux.IntelRdt.L3CacheSchema != "" {
 			config.IntelRdt.L3CacheSchema = spec.Linux.IntelRdt.L3CacheSchema

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -238,19 +238,21 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 			config.Seccomp = seccomp
 		}
 	}
-	if spec.Process.SelinuxLabel != "" {
-		config.ProcessLabel = spec.Process.SelinuxLabel
-	}
-	if spec.Process != nil && spec.Process.OOMScoreAdj != nil {
-		config.OomScoreAdj = *spec.Process.OOMScoreAdj
-	}
-	if spec.Process.Capabilities != nil {
-		config.Capabilities = &configs.Capabilities{
-			Bounding:    spec.Process.Capabilities.Bounding,
-			Effective:   spec.Process.Capabilities.Effective,
-			Permitted:   spec.Process.Capabilities.Permitted,
-			Inheritable: spec.Process.Capabilities.Inheritable,
-			Ambient:     spec.Process.Capabilities.Ambient,
+	if spec.Process != nil {
+		if spec.Process.SelinuxLabel != "" {
+			config.ProcessLabel = spec.Process.SelinuxLabel
+		}
+		if spec.Process.OOMScoreAdj != nil {
+			config.OomScoreAdj = *spec.Process.OOMScoreAdj
+		}
+		if spec.Process.Capabilities != nil {
+			config.Capabilities = &configs.Capabilities{
+				Bounding:    spec.Process.Capabilities.Bounding,
+				Effective:   spec.Process.Capabilities.Effective,
+				Permitted:   spec.Process.Capabilities.Permitted,
+				Inheritable: spec.Process.Capabilities.Inheritable,
+				Ambient:     spec.Process.Capabilities.Ambient,
+			}
 		}
 	}
 	createHooks(spec, config)


### PR DESCRIPTION
`process` has been optional since opencontainers/runtime-spec#701, and `linux` has been optional since at least opencontainers/runtime-spec#414.  This pull-request makes a few pivots so runc can handle something like the spec's [minimal config][1].  I actually tested with:

```
{
  "ociVersion": "1.0.0",
  "root": {
    "path": "/"
  }
}
```

because the runtime crashes without access to a container-side `/proc` (I have syndtr/gocapability#14 open to address part of this, but [other][2] [parts][3] would take more work).  With the changes in this PR, `runc create test` succeeded with that configuration.  It also mucked up my local terminal creation (although I rebooted without digging into exactly why), so take care when testing this yourself.

There's some previous discussion on moving the `LookPath` call starting [here][4].

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/schema/test/config/good/minimal.json
[2]: https://github.com/opencontainers/runc/blob/595bea022f077a9e17d7473b34fbaf1adaed9e43/libcontainer/utils/utils_unix.go#L14
[3]: https://github.com/opencontainers/runc/blob/595bea022f077a9e17d7473b34fbaf1adaed9e43/libcontainer/standard_init_linux.go#L163-L167
[4]: https://github.com/opencontainers/runc/pull/827#discussion_r63464201