### PR TITLE
Update console dependency to fix runc exec on BE

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -21,5 +21,5 @@ github.com/urfave/cli d53eb991652b1d438abdd34ce4bfa3ef1539108e
 golang.org/x/sys 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce https://github.com/golang/sys
 
 # console dependencies
-github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
+github.com/containerd/console 2748ece16665b45a47f884001d5831ec79703880
 github.com/pkg/errors v0.8.0

--- a/vendor/github.com/containerd/console/tc_linux.go
+++ b/vendor/github.com/containerd/console/tc_linux.go
@@ -13,25 +13,21 @@ const (
 	cmdTcSet = unix.TCSETS
 )
 
-func ioctl(fd, flag, data uintptr) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return err
 	}
 	return nil
 }
 
-// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
-// unlockpt should be called before opening the slave side of a pty.
-func unlockpt(f *os.File) error {
-	var u int32
-	return ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
-}
-
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
-	if err != nil {
+	var u uint32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return "", err
 	}
-	return fmt.Sprintf("/dev/pts/%d", n), nil
+	return fmt.Sprintf("/dev/pts/%d", u), nil
 }


### PR DESCRIPTION
This fixes a bug in the console package for big-endian architectures.
When creating a new pty the returned path to the new pty slave was
wrong for the second und all subsequent ptys.
In runc the exec subcommand failed with an runtime error such as
`container_linux.go:265: starting container process caused "open
/dev/pts/4294967296: no such file or directory"`.
The number is shifted by 32.

Signed-off-by: Peter Morjan <peter.morjan@de.ibm.com>