### PR TITLE
Provide install instruction that uses "go get"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ make
 sudo make install
 ```
 
+You can also use `go get` to install to your `GOPATH`, assuming that you have a `github.com` parent folder already created under `src`:
+
+```bash
+go get github.com/opencontainers/runc
+cd $GOPATH/src/github.com/opencontainers/runc
+make
+sudo make install
+```
+
 `runc` will be installed to `/usr/local/sbin/runc` on your system.
 
 #### Build Tags

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ sudo make install
 
 `runc` will be installed to `/usr/local/sbin/runc` on your system.
 
+
 #### Build Tags
 
 `runc` supports optional build tags for compiling support of various features.


### PR DESCRIPTION
Is there any substantial difference to using go get instead of git clone? I first did the git clone (and of course) cloned one directory level off, resulting in the wrong paths and a bunch of errors. This is of course user error, but given that Go is a dependency anyway, would it make sense to control this clone step to prevent the user (me<--) from messing it  up?