### PR TITLE
libcontainer: Use gocapability's NewPid2

### DIFF
--- a/libcontainer/capabilities_linux.go
+++ b/libcontainer/capabilities_linux.go
@@ -71,7 +71,7 @@ func newContainerCapList(capConfig *configs.Capabilities) (*containerCapabilitie
 		}
 		ambient = append(ambient, v)
 	}
-	pid, err := capability.NewPid(0)
+	pid, err := capability.NewPid2(0)
 	if err != nil {
 		return nil, err
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1804,8 +1804,12 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 			// The following only applies if we are root.
 			if !c.config.Rootless {
 				// check if we have CAP_SETGID to setgroup properly
-				pid, err := capability.NewPid(0)
+				pid, err := capability.NewPid2(0)
 				if err != nil {
+					return nil, err
+				}
+				err = pid.Load()
+				if err != nil && !os.IsNotExist(err) {
 					return nil, err
 				}
 				if !pid.Get(capability.EFFECTIVE, capability.CAP_SETGID) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
 github.com/opencontainers/selinux v1.0.0-rc1
 github.com/seccomp/libseccomp-golang 84e90a91acea0f4e51e62bc1a75de18b1fc0790f
 github.com/sirupsen/logrus a3f95b5c423586578a4e099b11a46c2479628cac
-github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
+github.com/syndtr/gocapability 33e07d32887e1e06b7c025f27ce52f62c7990bc0
 github.com/vishvananda/netlink 1e2e08e8a2dcdacaae3f14ac44c5cfa31361f270
 # systemd integration.
 github.com/coreos/go-systemd v14

--- a/vendor/github.com/syndtr/gocapability/capability/capability.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability.go
@@ -60,13 +60,74 @@ type Capabilities interface {
 	Apply(kind CapType) error
 }
 
-// NewPid create new initialized Capabilities object for given pid when it
-// is nonzero, or for the current pid if pid is 0
+// NewPid initializes a new Capabilities object for given pid when
+// it is nonzero, or for the current process if pid is 0.
+//
+// Deprecated: Replace with NewPid2.  For example, replace:
+//
+//    c, err := NewPid(0)
+//    if err != nil {
+//      return err
+//    }
+//
+// with:
+//
+//    c, err := NewPid2(0)
+//    if err != nil {
+//      return err
+//    }
+//    err = c.Load()
+//    if err != nil {
+//      return err
+//    }
 func NewPid(pid int) (Capabilities, error) {
+	c, err := newPid(pid)
+	if err != nil {
+		return c, err
+	}
+	err = c.Load()
+	return c, err
+}
+
+// NewPid2 initializes a new Capabilities object for given pid when
+// it is nonzero, or for the current process if pid is 0.  This
+// does not load the process's current capabilities; to do that you
+// must call Load explicitly.
+func NewPid2(pid int) (Capabilities, error) {
 	return newPid(pid)
 }
 
-// NewFile create new initialized Capabilities object for given named file.
-func NewFile(name string) (Capabilities, error) {
-	return newFile(name)
+// NewFile initializes a new Capabilities object for given file path.
+//
+// Deprecated: Replace with NewFile2.  For example, replace:
+//
+//    c, err := NewFile(path)
+//    if err != nil {
+//      return err
+//    }
+//
+// with:
+//
+//    c, err := NewFile2(path)
+//    if err != nil {
+//      return err
+//    }
+//    err = c.Load()
+//    if err != nil {
+//      return err
+//    }
+func NewFile(path string) (Capabilities, error) {
+	c, err := newFile(path)
+	if err != nil {
+		return c, err
+	}
+	err = c.Load()
+	return c, err
+}
+
+// NewFile2 creates a new initialized Capabilities object for given
+// file path.  This does not load the process's current capabilities;
+// to do that you must call Load explicitly.
+func NewFile2(path string) (Capabilities, error) {
+	return newFile(path)
 }

--- a/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -114,10 +114,6 @@ func newPid(pid int) (c Capabilities, err error) {
 		err = errUnknownVers
 		return
 	}
-	err = c.Load()
-	if err != nil {
-		c = nil
-	}
 	return
 }
 
@@ -492,10 +488,6 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 
 func newFile(path string) (c Capabilities, err error) {
 	c = &capsFile{path: path}
-	err = c.Load()
-	if err != nil {
-		c = nil
-	}
 	return
 }
 


### PR DESCRIPTION
For `newContainerCapList`, we don't care what the current values are.  Using `NewPid2` saves us a few syscalls at no cost.

For `bootstrapData`, this avoids crashing when there is no container-side `/proc`.  Previously you'd get:

    container_linux.go:… starting container process caused "open /proc/self/status: no such file or directory"

The `IsNotExist` check is because we do need to load the effective set.  But [`capsV3`'s `Load()` does that first with the `capget()` call][1].  After the `capget` call [it hits `/proc` for bounding and ambient capabilities][2].  We don't need those, so a not-exist error isn't a problem.  This is a fairly tight binding to the current gocapability implementation, but we vendor gocapability, so I'm not too worried about it.  If it becomes an issue we can follow up with a `LoadType(which CapType)` so we can explicitly ask to only load the effective set.

Part of #1734.

[1]: https://github.com/syndtr/gocapability/blob/33e07d32887e1e06b7c025f27ce52f62c7990bc0/capability/capability_linux.go#L399
[2]: https://github.com/syndtr/gocapability/blob/33e07d32887e1e06b7c025f27ce52f62c7990bc0/capability/capability_linux.go#L406-L434