### PR TITLE
fix lint error in specconv

### DIFF
--- a/libcontainer/specconv/example.go
+++ b/libcontainer/specconv/example.go
@@ -155,9 +155,9 @@ func Example() *specs.Spec {
 	}
 }
 
-// ExampleRootless returns an example spec file that works with rootless
-// containers. It's essentially a modified version of the specfile from
-// Example().
+// ToRootless converts the given spec file into one that should work with
+// rootless containers, by removing incompatible options and adding others that
+// are needed.
 func ToRootless(spec *specs.Spec) {
 	var namespaces []specs.LinuxNamespace
 


### PR DESCRIPTION
When I open runC project with my vs code, the IDE automatically reports this error:

```
comment on exported function ToRootless should be the form of `ToRootless`...
```

Try to fix this lint error.

Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>