### PR TITLE
libcontainer/sync: Drop procConsole transaction from comments

### DIFF
--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -19,11 +19,6 @@ type syncType string
 // procHooks   --> [run hooks]
 //             <-- procResume
 //
-// procConsole -->
-//             <-- procConsoleReq
-//  [send(fd)] --> [recv(fd)]
-//             <-- procConsoleAck
-//
 // procReady   --> [final setup]
 //             <-- procRun
 const (


### PR DESCRIPTION
These were added in 244c9fc4 (#1018) alongside `procConsole` and the associated handling.  `procConsole` and that handling were removed in 00a0ecf5 (#1356), but 00a0ecf5 missed this comment.