### PR TITLE
libcontainer/configs/config: Clear hook environ variables on empty Env

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -480,6 +480,9 @@ func (c Command) Run(s *specs.State) error {
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
+	if cmd.Env == nil {
+		cmd.Env = []string{}
+	}
 	if err := cmd.Start(); err != nil {
 		return err
 	}


### PR DESCRIPTION
The runtime spec [has][1]:

> * env (array of strings, OPTIONAL) with the same semantics as IEEE Std 1003.1-2008's environ.

And running `execle` or similar with `NULL` `env` results in an empty environent:

```console
$ cat test.c
#include <unistd.h>

int main()
{
  return execle("/usr/bin/env", "env", NULL, NULL);
}
$ cc -o test test.c
$ ./test
…no output…
```

[Go's `Cmd.Env`][2], on the other hand, has:

> If Env is nil, the new process uses the current process's environment.

This commit works around that by setting ~~a single dummy environment variable~~ `[]string{}` in those cases to avoid leaking the runtime environment into the hooks.

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#posix-platform-hooks
[2]: https://golang.org/pkg/os/exec/#Cmd