### PR TITLE
libcontainer: Set 'status' in hook stdin

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -272,26 +272,23 @@ func (hooks Hooks) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// HookState is the payload provided to a hook on execution.
-type HookState specs.State
-
 type Hook interface {
 	// Run executes the hook with the provided state.
-	Run(HookState) error
+	Run(*specs.State) error
 }
 
 // NewFunctionHook will call the provided function when the hook is run.
-func NewFunctionHook(f func(HookState) error) FuncHook {
+func NewFunctionHook(f func(*specs.State) error) FuncHook {
 	return FuncHook{
 		run: f,
 	}
 }
 
 type FuncHook struct {
-	run func(HookState) error
+	run func(*specs.State) error
 }
 
-func (f FuncHook) Run(s HookState) error {
+func (f FuncHook) Run(s *specs.State) error {
 	return f.run(s)
 }
 
@@ -314,7 +311,7 @@ type CommandHook struct {
 	Command
 }
 
-func (c Command) Run(s HookState) error {
+func (c Command) Run(s *specs.State) error {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return err

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestUnmarshalHooks(t *testing.T) {
@@ -101,7 +102,7 @@ func TestMarshalUnmarshalHooks(t *testing.T) {
 }
 
 func TestMarshalHooksWithUnexpectedType(t *testing.T) {
-	fHook := configs.NewFunctionHook(func(configs.HookState) error {
+	fHook := configs.NewFunctionHook(func(*specs.State) error {
 		return nil
 	})
 	hook := configs.Hooks{
@@ -119,14 +120,15 @@ func TestMarshalHooksWithUnexpectedType(t *testing.T) {
 }
 
 func TestFuncHookRun(t *testing.T) {
-	state := configs.HookState{
+	state := &specs.State{
 		Version: "1",
 		ID:      "1",
+		Status:  "created",
 		Pid:     1,
 		Bundle:  "/bundle",
 	}
 
-	fHook := configs.NewFunctionHook(func(s configs.HookState) error {
+	fHook := configs.NewFunctionHook(func(s *specs.State) error {
 		if !reflect.DeepEqual(state, s) {
 			t.Errorf("Expected state %+v to equal %+v", state, s)
 		}
@@ -137,9 +139,10 @@ func TestFuncHookRun(t *testing.T) {
 }
 
 func TestCommandHookRun(t *testing.T) {
-	state := configs.HookState{
+	state := &specs.State{
 		Version: "1",
 		ID:      "1",
+		Status:  "created",
 		Pid:     1,
 		Bundle:  "/bundle",
 	}
@@ -160,9 +163,10 @@ func TestCommandHookRun(t *testing.T) {
 }
 
 func TestCommandHookRunTimeout(t *testing.T) {
-	state := configs.HookState{
+	state := &specs.State{
 		Version: "1",
 		ID:      "1",
+		Status:  "created",
 		Pid:     1,
 		Bundle:  "/bundle",
 	}

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Status is the status of a container.
@@ -84,6 +85,12 @@ type BaseContainer interface {
 	// errors:
 	// SystemError - System error.
 	State() (*State, error)
+
+	// OCIState returns the current container's state information.
+	//
+	// errors:
+	// SystemError - System error.
+	OCIState() (*specs.State, error)
 
 	// Returns the current config of the container.
 	Config() configs.Config

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/mount"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"golang.org/x/sys/unix"
 )
@@ -229,6 +230,6 @@ func marshal(path string, v interface{}) error {
 
 type unserializableHook struct{}
 
-func (unserializableHook) Run(configs.HookState) error {
+func (unserializableHook) Run(*specs.State) error {
 	return nil
 }

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"golang.org/x/sys/unix"
 )
@@ -1148,7 +1149,7 @@ func TestHook(t *testing.T) {
 
 	config.Hooks = &configs.Hooks{
 		Prestart: []configs.Hook{
-			configs.NewFunctionHook(func(s configs.HookState) error {
+			configs.NewFunctionHook(func(s *specs.State) error {
 				if s.Bundle != expectedBundle {
 					t.Fatalf("Expected prestart hook bundlePath '%s'; got '%s'", expectedBundle, s.Bundle)
 				}
@@ -1165,7 +1166,7 @@ func TestHook(t *testing.T) {
 			}),
 		},
 		Poststart: []configs.Hook{
-			configs.NewFunctionHook(func(s configs.HookState) error {
+			configs.NewFunctionHook(func(s *specs.State) error {
 				if s.Bundle != expectedBundle {
 					t.Fatalf("Expected poststart hook bundlePath '%s'; got '%s'", expectedBundle, s.Bundle)
 				}
@@ -1178,7 +1179,7 @@ func TestHook(t *testing.T) {
 			}),
 		},
 		Poststop: []configs.Hook{
-			configs.NewFunctionHook(func(s configs.HookState) error {
+			configs.NewFunctionHook(func(s *specs.State) error {
 				if s.Bundle != expectedBundle {
 					t.Fatalf("Expected poststop hook bundlePath '%s'; got '%s'", expectedBundle, s.Bundle)
 				}

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -365,14 +365,13 @@ func (p *initProcess) start() error {
 				}
 
 				if p.config.Config.Hooks != nil {
-					bundle, annotations := utils.Annotations(p.container.config.Labels)
-					s := configs.HookState{
-						Version:     p.container.config.Version,
-						ID:          p.container.id,
-						Pid:         p.pid(),
-						Bundle:      bundle,
-						Annotations: annotations,
+					s, err := p.container.currentOCIState()
+					if err != nil {
+						return err
 					}
+					// initProcessStartTime hasn't been set yet.
+					s.Pid = p.cmd.Process.Pid
+					s.Status = "creating"
 					for i, hook := range p.config.Config.Hooks.Prestart {
 						if err := hook.Run(s); err != nil {
 							return newSystemErrorWithCausef(err, "running prestart hook %d", i)
@@ -396,14 +395,13 @@ func (p *initProcess) start() error {
 				}
 			}
 			if p.config.Config.Hooks != nil {
-				bundle, annotations := utils.Annotations(p.container.config.Labels)
-				s := configs.HookState{
-					Version:     p.container.config.Version,
-					ID:          p.container.id,
-					Pid:         p.pid(),
-					Bundle:      bundle,
-					Annotations: annotations,
+				s, err := p.container.currentOCIState()
+				if err != nil {
+					return err
 				}
+				// initProcessStartTime hasn't been set yet.
+				s.Pid = p.cmd.Process.Pid
+				s.Status = "creating"
 				for i, hook := range p.config.Config.Hooks.Prestart {
 					if err := hook.Run(s); err != nil {
 						return newSystemErrorWithCausef(err, "running prestart hook %d", i)

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/utils"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -63,12 +62,9 @@ func destroy(c *linuxContainer) error {
 
 func runPoststopHooks(c *linuxContainer) error {
 	if c.config.Hooks != nil {
-		bundle, annotations := utils.Annotations(c.config.Labels)
-		s := configs.HookState{
-			Version:     c.config.Version,
-			ID:          c.id,
-			Bundle:      bundle,
-			Annotations: annotations,
+		s, err := c.currentOCIState()
+		if err != nil {
+			return err
 		}
 		for _, hook := range c.config.Hooks.Poststop {
 			if err := hook.Run(s); err != nil {


### PR DESCRIPTION
Finish off the work started in #1201 to bring hook stdin into compliance with runtime-spec.

Also:

* Drop `HookState`, since there's no need for a local alias for `specs.State`.
* ~~Add `len` guards to avoid computing the state when `.Hooks` is non-`nil` but the particular phase we're looking at is empty.~~ I had to drop these to satisfy @cyphar [here][4].
* Also set `c.initProcess` in `newInitProcess` to support `OCIState` calls from within `initProcess.start()`.  I think the cyclic references between `linuxContainer` and `initProcess` are unfortunate, but didn't want to address that here.
* I've also left the timing of the `Prestart` hooks alone, although [the spec calls for them to happen before start][1] (not as part of creation, #1710).  Once the timing gets fixed we can drop the `initProcessStartTime` hacks which `initProcess.start` currently needs.

I'm not sure why we trigger the prestart hooks in response to both [`procReady`][2] and [`procHooks`][3].  But we've had two prestart rounds in `initProcess.start` since #568.  I've left that alone too.

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0/config.md#prestart
[2]: https://github.com/opencontainers/runc/blob/b50fa98d9e5ec3ff58028c46767129607067f961/libcontainer/process_linux.go#L343
[3]: https://github.com/opencontainers/runc/blob/b50fa98d9e5ec3ff58028c46767129607067f961/libcontainer/process_linux.go#L374
[4]: https://github.com/opencontainers/runc/pull/1741#discussion_r233331570