### PR TITLE
libcontainer: setupUserNamespace is always called

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -192,9 +192,6 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	if err := createDevices(spec, config); err != nil {
 		return nil, err
 	}
-	if err := setupUserNamespace(spec, config); err != nil {
-		return nil, err
-	}
 	c, err := createCgroupConfig(opts)
 	if err != nil {
 		return nil, err
@@ -224,6 +221,11 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				{
 					Type: "loopback",
 				},
+			}
+		}
+		if config.Namespaces.Contains(configs.NEWUSER) {
+			if err := setupUserNamespace(spec, config); err != nil {
+				return nil, err
 			}
 		}
 		config.MaskPaths = spec.Linux.MaskedPaths


### PR DESCRIPTION
The setupUserNamespace is always called even if the usernamespace is not set. This results having wrong uid/gid set on devices.

This fix add a test to check if usernamespace is set befor calling
setupUserNamespace.

Fixes #1742

Signed-off-by: Julien Lavesque <julien.lavesque@gmail.com>