### PR TITLE
Fix make shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ rootlessintegration: runcimage
 localrootlessintegration: all
 	tests/rootless.sh
 
-shell: all
+shell: runcimage
 	docker run -e TESTFLAGS -ti --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) bash
 
 install:


### PR DESCRIPTION
The "shell" rule in the Makefile uses docker to run a bash session,
however it was depending on the "all" rule which assumes non-docker local
development. This commit fixes it by making it depend on the "runcimage" rule.