### PR TITLE
cgroups/fs: fix NPE on Destroy than no cgroups are set

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -161,7 +161,7 @@ func (m *Manager) Apply(pid int) (err error) {
 }
 
 func (m *Manager) Destroy() error {
-	if m.Cgroups.Paths != nil {
+	if m.Cgroups == nil || m.Cgroups.Paths != nil {
 		return nil
 	}
 	m.mu.Lock()


### PR DESCRIPTION
Currently Manager accepts nil cgroups when calling Apply, but it will panic then trying to call Destroy with the same config.