### PR TITLE
libcontainer/specconv/spec_linux: Support empty 'type' for bind mounts

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -269,13 +269,17 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	flags, pgflags, data, ext := parseMountOptions(m.Options)
 	source := m.Source
-	if m.Type == "bind" {
+	device := m.Type
+	if flags|unix.MS_BIND != 0 {
+		if device == "" {
+			device = "bind"
+		}
 		if !filepath.IsAbs(source) {
 			source = filepath.Join(cwd, m.Source)
 		}
 	}
 	return &configs.Mount{
-		Device:           m.Type,
+		Device:           device,
 		Source:           source,
 		Destination:      m.Destination,
 		Data:             data,

--- a/notify_socket.go
+++ b/notify_socket.go
@@ -44,7 +44,7 @@ func (ns *notifySocket) Close() error {
 // If systemd is supporting sd_notify protocol, this function will add support
 // for sd_notify protocol from within the container.
 func (s *notifySocket) setupSpec(context *cli.Context, spec *specs.Spec) {
-	mount := specs.Mount{Destination: s.host, Type: "bind", Source: s.socketPath, Options: []string{"bind"}}
+	mount := specs.Mount{Destination: s.host, Source: s.socketPath, Options: []string{"bind"}}
 	spec.Mounts = append(spec.Mounts, mount)
 	spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("NOTIFY_SOCKET=%s", s.host))
 }

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	teardown_busybox
+	setup_busybox
+}
+
+function teardown() {
+	teardown_busybox
+}
+
+@test "runc run [bind mount]" {
+	CONFIG=$(jq '.mounts |= . + [{"source": ".", "destination": "/tmp/bind", "options": ["bind"]}] | .process.args = ["ls", "/tmp/bind/config.json"]' config.json)
+	echo "${CONFIG}" >config.json
+
+	runc run test_bind_mount
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" =~ '/tmp/bind/config.json' ]]
+}


### PR DESCRIPTION
From the “Creating a bind mount” section of [`mount(2)`][1]:

> If mountflags includes MS_BIND (available since Linux 2.4), then perform a bind mount…
>
> The filesystemtype and data arguments are ignored.

This pull request adds support for configurations that leave the [OPTIONAL `type`][2] unset for bind mounts.  There's a related spec-example change in flight with opencontainers/runtime-spec#954, although my personal preference would be a more explicit spec for the whole mount structure (opencontainers/runtime-spec#771).

[1]: http://man7.org/linux/man-pages/man2/mount.2.html
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/config.md#L102