### PR TITLE
Add timeout while waiting for StartTransinetUnit completion signal

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/sirupsen/logrus"
 )
 
 type Manager struct {
@@ -300,7 +301,11 @@ func (m *Manager) Apply(pid int) error {
 		return err
 	}
 
-	<-statusChan
+	select {
+	case <-statusChan:
+	case <-time.After(time.Second):
+		logrus.Warnf("Timed out while waiting for StartTransientUnit completion signal from dbus. Continuing...")
+	}
 
 	if err := joinCgroups(c, pid); err != nil {
 		return err


### PR DESCRIPTION
This PR adds one second timeout for waiting on channel for `StartTransientUnit` completion signal.

This channel was introduced to avoid a rare race between systemd and runc where systemd could delete pids cgroup created by runc. https://github.com/opencontainers/runc/pull/1683

If for some reason signal is not received like the case [here](https://bugzilla.redhat.com/show_bug.cgi?id=1548358#c22), runc will hang forever. Adding a timeout will help recover in such a case.

In the timeout handling, we have two options either return Error or continue. Since originally purpose of introducing channel was to avoid the race mentioned above, one second time duration should be enough in ensuring the same and to continue seems a better option of the two.

/cc @derekwaynecarr @sjenning 



