### PR TITLE
Add runtime-tools' validation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,5 @@ before_install:
 script:
   - git-validation -run DCO,short-subject -v
   - make BUILDTAGS="${BUILDTAGS}"
+  - make BUILDTAGS="${BUILDTAGS}" oci-runtime-validation
   - make BUILDTAGS="${BUILDTAGS}" clean ci cross

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ validate:
 	script/validate-c
 	$(GO) vet $(allpackages)
 
+oci-runtime-validation:
+	RUNTIME=$(CURDIR)/runc script/oci-runtime-validation
+
 ci: validate test release
 
 cross: runcimage

--- a/script/oci-runtime-validation
+++ b/script/oci-runtime-validation
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Install and run runtime-tools' validation tests
+npm install -g tap
+go get -d -u github.com/opencontainers/runtime-tools || true
+
+cd $GOPATH/src/github.com/opencontainers/runtime-tools
+make
+sudo PATH="$PATH:$(dirname $(which node))" TAP="$(which tap)" RUNTIME="${RUNTIME}" make localvalidation \
+ || true # All tests don't pass yet. For now, only display results without returning an error.
+


### PR DESCRIPTION
For now, the results of the tests are printed without returning an error.

Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

This is superseding https://github.com/opencontainers/runc/pull/1757: trying to use Travis CI instead of CircleCI.

I see the following in the logs: https://travis-ci.org/kinvolk/runc/jobs/353911723
```
  348 passing (57s)
  82 pending
  13 failing
```