### PR TITLE
rootless: set sticky bit if using XDG_RUNTIME_DIR

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,15 @@ func main() {
 		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
 		if runtimeDir != "" {
 			root = runtimeDir + "/runc"
+			// According to the XDG specification, we need to set anything in
+			// XDG_RUNTIME_DIR to have a sticky bit if we don't want it to get
+			// auto-pruned.
+			if err := os.MkdirAll(root, 0700); err != nil {
+				fatal(err)
+			}
+			if err := os.Chmod(root, 0700|os.ModeSticky); err != nil {
+				fatal(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
According to the XDG specification[1], in order to avoid the possibility of
our container states being auto-pruned every 6 hours we need to set the
sticky bit. Rather than handling all of the users of --root, we just
create the directory and set the sticky bit during detection, as it's
not expensive.

[1]: https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

Fixes #1694
Signed-off-by: Aleksa Sarai <asarai@suse.de>