### PR TITLE
add gitignore line for supporting goland IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/pkg
 contrib/cmd/recvtty/recvtty
 man/man8
 release
+.idea


### PR DESCRIPTION
I added gitignore option `.idea` for supporting Jetbrain goland IDE.