### PR TITLE
add type casting for uint64 parameter

### DIFF
--- a/libcontainer/devices/devices.go
+++ b/libcontainer/devices/devices.go
@@ -30,7 +30,7 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 	}
 
 	var (
-		devNumber = stat.Rdev
+		devNumber = uint64(stat.Rdev)
 		major     = unix.Major(devNumber)
 	)
 	if major == 0 {


### PR DESCRIPTION
Add type casting for major.unix method. Its input parameter is uint64, but the parameter in unix.Stat_t is int32. 