### PR TITLE
libcontainer: Don't set container state to running when exec'ing

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -377,10 +377,6 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 				}
 			}
 		}
-	} else {
-		c.state = &runningState{
-			c: c,
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
There is no reason to set the container state to "running" as a
temporary value when exec'ing a process on a container in "created"
state. The problem doing this is that consumers of the libcontainer
library might use it by keeping pointers in memory. In this case,
the container state will indicate that the container is running, which
is wrong, and this will end up with a failure on the next action
because the check for the container state transition will complain.

Fixes #1767

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>