### PR TITLE
kill: add an option --signal to specify a signal

### DIFF
--- a/kill.go
+++ b/kill.go
@@ -14,7 +14,7 @@ import (
 var killCommand = cli.Command{
 	Name:  "kill",
 	Usage: "kill sends the specified signal (default: SIGTERM) to the container's init process",
-	ArgsUsage: `<container-id> [signal]
+	ArgsUsage: `<container-id>
 
 Where "<container-id>" is the name for the instance of the container and
 "[signal]" is the signal to be sent to the init process.
@@ -23,18 +23,22 @@ EXAMPLE:
 For example, if the container id is "ubuntu01" the following will send a "KILL"
 signal to the init process of the "ubuntu01" container:
 	 
-       # runc kill ubuntu01 KILL`,
+       # runc kill --signal KILL ubuntu01`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "all, a",
 			Usage: "send the specified signal to all processes inside the container",
+		},
+		cli.StringFlag{
+			Name:  "signal",
+			Usage: "specify a signal to be sent to processes",
 		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, minArgs); err != nil {
 			return err
 		}
-		if err := checkArgs(context, 2, maxArgs); err != nil {
+		if err := checkArgs(context, 1, maxArgs); err != nil {
 			return err
 		}
 		container, err := getContainer(context)
@@ -42,7 +46,7 @@ signal to the init process of the "ubuntu01" container:
 			return err
 		}
 
-		sigstr := context.Args().Get(1)
+		sigstr := context.String("signal")
 		if sigstr == "" {
 			sigstr = "SIGTERM"
 		}

--- a/man/runc-kill.8.md
+++ b/man/runc-kill.8.md
@@ -9,10 +9,11 @@ Where "<container-id>" is the name for the instance of the container and
 
 # OPTIONS
    --all, -a  send the specified signal to all processes inside the container
+   --signal   specify a signal to be sent to processes
 
 # EXAMPLE
 
 For example, if the container id is "ubuntu01" the following will send a "KILL"
 signal to the init process of the "ubuntu01" container:
 
-       # runc kill ubuntu01 KILL
+       # runc kill --signal KILL ubuntu01

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -19,7 +19,7 @@ function teardown() {
   # check state
   testcontainer test_busybox running
 
-  runc kill test_busybox KILL
+  runc kill --signal KILL test_busybox
   [ "$status" -eq 0 ]
   # wait for busybox to be in the destroyed state
   retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -297,7 +297,7 @@ function teardown_running_container() {
 	# here we detect "test_busybox "(with one extra blank) to avoid conflict prefix
 	# e.g. "test_busybox" and "test_busybox_update"
 	if [[ "${output}" == *"$1 "* ]]; then
-		runc kill $1 KILL
+		runc kill --signal KILL $1
 		retry 10 1 eval "__runc state '$1' | grep -q 'stopped'"
 		runc delete $1
 	fi
@@ -309,7 +309,7 @@ function teardown_running_container_inroot() {
 	# here we detect "test_busybox "(with one extra blank) to avoid conflict prefix
 	# e.g. "test_busybox" and "test_busybox_update"
 	if [[ "${output}" == *"$1 "* ]]; then
-		ROOT=$2 runc kill $1 KILL
+		ROOT=$2 runc kill --signal KILL $1
 		retry 10 1 eval "ROOT='$2' __runc state '$1' | grep -q 'stopped'"
 		ROOT=$2 runc delete $1
 	fi

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -20,7 +20,7 @@ function teardown() {
   # check state
   testcontainer test_busybox running
 
-  runc kill test_busybox KILL
+  runc kill --signal KILL test_busybox
   [ "$status" -eq 0 ]
 
   retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -36,13 +36,13 @@ function teardown() {
   runc state test_dotbox
   [ "$status" -ne 0 ]
 
-  runc kill test_busybox KILL
+  runc kill --signal KILL test_busybox
   [ "$status" -eq 0 ]
   retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
   runc delete test_busybox
   [ "$status" -eq 0 ]
 
-  ROOT=$HELLO_BUNDLE runc kill test_dotbox KILL
+  ROOT=$HELLO_BUNDLE runc kill --signal KILL test_dotbox
   [ "$status" -eq 0 ]
   retry 10 1 eval "ROOT='$HELLO_BUNDLE' __runc state test_dotbox | grep -q 'stopped'"
   ROOT=$HELLO_BUNDLE runc delete test_dotbox

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -22,7 +22,7 @@ function teardown() {
   # check state
   testcontainer test_busybox running
 
-  runc kill test_busybox KILL
+  runc kill --signal KILL test_busybox
   [ "$status" -eq 0 ]
 
   # wait for busybox to be in the destroyed state

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -190,7 +190,7 @@ EOF
 	testcontainer test_busybox running
 
 	# Kill the container.
-	runc kill test_busybox KILL
+	runc kill --signal KILL test_busybox
 	[ "$status" -eq 0 ]
 }
 
@@ -209,7 +209,7 @@ EOF
 	testcontainer test_busybox running
 
 	# Kill the container.
-	runc kill test_busybox KILL
+	runc kill --signal KILL test_busybox
 	[ "$status" -eq 0 ]
 }
 
@@ -225,6 +225,6 @@ EOF
 	testcontainer test_busybox running
 
 	# Kill the container.
-	runc kill test_busybox KILL
+	runc kill --signal KILL test_busybox
 	[ "$status" -eq 0 ]
 }


### PR DESCRIPTION
According to the command line interface of [runtime-tools](https://github.com/opencontainers/runtime-tools/blob/master/docs/command-line-interface.md#kill), signal needs to be set by an option `--signal`. However, `runc kill` does not have the option, but just takes the first argument as the signal.

Let's add a new option `--signal` to `runc kill`. Then we are able to make runtime-tools call simply a kill command with `--signal` in [the validation utils](https://github.com/opencontainers/runtime-tools/blob/master/validation/util/container.go#L172..L174).

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>