### PR TITLE
Only configure networking when creating a net ns

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -219,7 +219,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 			}
 			config.Namespaces.Add(t, ns.Path)
 		}
-		if config.Namespaces.Contains(configs.NEWNET) {
+		if config.Namespaces.Contains(configs.NEWNET) && config.Namespaces.PathOf(configs.NEWNET) == "" {
 			config.Networks = []*configs.Network{
 				{
 					Type: "loopback",


### PR DESCRIPTION
When joining an existing namespace, don't default to configuring a loopback interface in that namespace.

Its creator should have done that, and we don't want to fail to create the container when we don't have sufficient privileges to configure the network namespace.