### PR TITLE
nsexec.c: fix GCC 8 warning

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -505,7 +505,8 @@ void join_namespaces(char *nslist)
 
 		ns->fd = fd;
 		ns->ns = nsflag(namespace);
-		strncpy(ns->path, path, PATH_MAX);
+		strncpy(ns->path, path, PATH_MAX - 1);
+		ns->path[PATH_MAX - 1] = '\0';
 	} while ((namespace = strtok_r(NULL, ",", &saveptr)) != NULL);
 
 	/*


### PR DESCRIPTION
```
$ make BUILDTAGS="seccomp selinux"
go build -buildmode=pie  -ldflags "-X main.gitCommit="0e16bd9b53eb3c57ea6fe59fc6d9385c2edb9fd9" -X main.version=1.0.0-rc5+dev " -tags "seccomp selinux" -o runc .
# github.com/opencontainers/runc/libcontainer/nsenter
nsexec.c: In function ‘join_namespaces’:
nsexec.c:508:3: warning: ‘strncpy’ specified bound 4096 equals destination size [-Wstringop-truncation]
   strncpy(ns->path, path, PATH_MAX);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>