### PR TITLE
Make the setupSeccomp function public.

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -233,7 +233,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		config.MountLabel = spec.Linux.MountLabel
 		config.Sysctl = spec.Linux.Sysctl
 		if spec.Linux.Seccomp != nil {
-			seccomp, err := setupSeccomp(spec.Linux.Seccomp)
+			seccomp, err := SetupSeccomp(spec.Linux.Seccomp)
 			if err != nil {
 				return nil, err
 			}
@@ -736,7 +736,7 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 	return flag, pgflag, strings.Join(data, ","), extFlags
 }
 
-func setupSeccomp(config *specs.LinuxSeccomp) (*configs.Seccomp, error) {
+func SetupSeccomp(config *specs.LinuxSeccomp) (*configs.Seccomp, error) {
 	if config == nil {
 		return nil, nil
 	}

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -123,7 +123,7 @@ func TestSetupSeccomp(t *testing.T) {
 			},
 		},
 	}
-	seccomp, err := setupSeccomp(conf)
+	seccomp, err := SetupSeccomp(conf)
 
 	if err != nil {
 		t.Errorf("Couldn't create Seccomp config: %v", err)


### PR DESCRIPTION
This function is useful for converting from the OCI spec format to the one used by runC/libcontainer.

Signed-off-by: dlorenc <lorenc.d@gmail.com>