### PR TITLE
set unix.MS_BIND flag for bind mount

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -270,6 +270,11 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	flags, pgflags, data, ext := parseMountOptions(m.Options)
 	source := m.Source
 	device := m.Type
+
+	if m.Type == "bind" {
+		flags |= unix.MS_BIND
+	}
+
 	if flags|unix.MS_BIND != 0 {
 		if device == "" {
 			device = "bind"


### PR DESCRIPTION
always set unix.MS_BIND flag for bind mount, this fixs a error reporting
"no such device" with following  mount configration, which is similar to
mount --bind oldidr newdir

{
     "destination": "/host_dir",
     "type": "bind",
     "source": "host_dir"
}

Without this change, we always have to set the "options":
["rbind"], which will add the flag unix.MS_BIND in parseMountOptions.

Alternative fix is to add option "bind" to Mount.Options when it is bind
mount so the right flag can be set in parseMountOptions.

Signed-off-by: Bin Chen <nk@devicu.com>