### PR TITLE
Update man pages

### DIFF
--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -23,3 +23,4 @@ checkpointed.
    --pre-dump                   dump container's memory information only, leave the container running after this
    --manage-cgroups-mode value  cgroups mode: 'soft' (default), 'full' and 'strict'
    --empty-ns value             create a namespace, but don't restore its properties
+   --auto-dedup                 enable auto deduplication of memory images

--- a/man/runc-delete.8.md
+++ b/man/runc-delete.8.md
@@ -12,6 +12,6 @@ Where "<container-id>" is the name for the instance of the container.
 # EXAMPLE
 For example, if the container id is "ubuntu01" and runc list currently shows the
 status of "ubuntu01" as "stopped" the following will delete resources held for
-"ubuntu01" removing "ubuntu01" from the runc list of containers:  
+"ubuntu01" removing "ubuntu01" from the runc list of containers:
 
        # runc delete ubuntu01

--- a/man/runc-pause.8.md
+++ b/man/runc-pause.8.md
@@ -9,4 +9,4 @@ paused.
 
 # DESCRIPTION
    The pause command suspends all processes in the instance of the container.
-Use runc list to identiy instances of containers and their current status.
+Use runc list to identify instances of containers and their current status.

--- a/man/runc-pause.8.md
+++ b/man/runc-pause.8.md
@@ -5,7 +5,7 @@
    runc pause <container-id>
 
 Where "<container-id>" is the name for the instance of the container to be
-paused. 
+paused.
 
 # DESCRIPTION
    The pause command suspends all processes in the instance of the container.

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -12,6 +12,7 @@ restored.
 using the runc checkpoint command.
 
 # OPTIONS
+   --console-socket value       path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal
    --image-path value           path to criu image files for restoring
    --work-path value            path for saving work files and logs
    --tcp-established            allow open tcp connections
@@ -24,3 +25,6 @@ using the runc checkpoint command.
    --pid-file value             specify the file to write the process id to
    --no-subreaper               disable the use of the subreaper used to reap reparented processes
    --no-pivot                   do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk
+   --empty-ns value             create a namespace, but don't restore its properties
+   --auto-dedup                 enable auto deduplication of memory images
+   --lazy-pages                 use userfaultfd to lazily restore memory pages

--- a/man/runc-resume.8.md
+++ b/man/runc-resume.8.md
@@ -9,4 +9,4 @@ resumed.
 
 # DESCRIPTION
    The resume command resumes all processes in the instance of the container.
-Use runc list to identiy instances of containers and their current status.
+Use runc list to identify instances of containers and their current status.

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -26,7 +26,7 @@ accepted format is as follow (unchanged values can be omitted):
        "mems": ""
      },
      "blockIO": {
-       "blkioWeight": 0
+       "weight": 0
      }
    }
 

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -29,6 +29,7 @@ value for "bundle" is the current directory.
 
 # COMMANDS
    checkpoint   checkpoint a running container
+   create       create a container
    delete       delete any resources held by the container often used with detached containers
    events       display container events such as OOM notifications, cpu, memory, IO and network stats
    exec         execute new process inside the container

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -3,7 +3,7 @@
 
 # SYNOPSIS
    runc [global options] command [command options] [arguments...]
-   
+
 # DESCRIPTION
 runc is a command line client for running applications packaged according to
 the Open Container Initiative (OCI) format and is a compliant implementation of the
@@ -16,7 +16,7 @@ direct child of the process supervisor.
 
 Containers are configured using bundles. A bundle for a container is a directory
 that includes a specification file named "config.json" and a root filesystem.
-The root filesystem contains the contents of the container. 
+The root filesystem contains the contents of the container.
 
 To start a new instance of a container:
 
@@ -45,7 +45,7 @@ value for "bundle" is the current directory.
    state        output the state of a container
    update       update container resource constraints
    help, h      Shows a list of commands or help for one command
-   
+
 # GLOBAL OPTIONS
    --debug              enable debug output for logging
    --log value          set the log file path where internal debug information is written (default: "/dev/null")

--- a/pause.go
+++ b/pause.go
@@ -13,7 +13,7 @@ Where "<container-id>" is the name for the instance of the container to be
 paused. `,
 	Description: `The pause command suspends all processes in the instance of the container.
 
-Use runc list to identiy instances of containers and their current status.`,
+Use runc list to identify instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
@@ -39,7 +39,7 @@ Where "<container-id>" is the name for the instance of the container to be
 resumed.`,
 	Description: `The resume command resumes all processes in the instance of the container.
 
-Use runc list to identiy instances of containers and their current status.`,
+Use runc list to identify instances of containers and their current status.`,
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err


### PR DESCRIPTION
Hello,
This PR aims to add some missing options in the manual pages.

However, to avoid similar inconsistencies in future, we have to automate the process of generating the markdown files.

Here is a simple shell script which does that:
```bash
#!/bin/bash

# Get a list of all commands from runc --help
commands=$(runc --help | sed -n '/^COMMANDS:$/,/^ *$/p' | awk '{print $1;}' | sed '/^COMMANDS\|help/d')

# generate markdown page for each command
for cmd in $commands;
do
    runc $cmd --help | sed 's/^USAGE:$/SYNOPSIS:/g' | sed 's/^\([A-Z ]\+\):$/# \1/g' > runc-$cmd.8.md
done

# generate markdown page for runc
runc --help | sed 's/^USAGE:$/SYNOPSIS:/g' | sed 's/^\([A-Z ]\+\):$/# \1/g' > runc.8.md
```
Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>