### PR TITLE
Put container's stdin behind TTY waitgroup.

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -54,11 +54,12 @@ func setupProcessPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, err
 			t.postStart = append(t.postStart, c)
 		}
 	}
+	t.wg.Add(3)
 	go func() {
+		defer t.wg.Done()
 		io.Copy(i.Stdin, os.Stdin)
 		i.Stdin.Close()
 	}()
-	t.wg.Add(2)
 	go t.copyIO(os.Stdout, i.Stdout)
 	go t.copyIO(os.Stderr, i.Stderr)
 	return t, nil


### PR DESCRIPTION
This fixes a race between `runc run` closing stdin on exit and TTY copier goroutine also trying to close it because of EOF on the console:

<details>
```
Read at 0x00c4200b8060 by main goroutine:
  os.(*file).close()
      /usr/local/go1.8/src/os/file_unix.go:136 +0xa4
  os.(*File).Close()
      /usr/local/go1.8/src/os/file_unix.go:132 +0x55
  main.(*tty).Close()
      go/src/github.com/opencontainers/runc/tty.go:120 +0x114
  main.(*runner).run()
      go/src/github.com/opencontainers/runc/utils_linux.go:310 +0x966
  main.startContainer()
      go/src/github.com/opencontainers/runc/utils_linux.go:395 +0x4ff
  main.glob..func13()
      go/src/github.com/opencontainers/runc/run.go:76 +0xe3
  runtime.call32()
      /usr/local/go1.8/src/runtime/asm_amd64.s:514 +0x47
  reflect.Value.Call()
      /usr/local/go1.8/src/reflect/value.go:302 +0xc0
  github.com/urfave/cli.HandleAction()
      go/src/github.com/urfave/cli/app.go:487 +0x22d
  github.com/urfave/cli.Command.Run()
      go/src/github.com/urfave/cli/command.go:191 +0xdee
  github.com/urfave/cli.(*App).Run()
      go/src/github.com/urfave/cli/app.go:240 +0x8eb
  main.main()
      go/src/github.com/opencontainers/runc/main.go:138 +0x1249

Previous write at 0x00c4200b8060 by goroutine 9:
  os.(*file).close()
      /usr/local/go1.8/src/os/file_unix.go:143 +0x10a
  os.(*File).Close()
      /usr/local/go1.8/src/os/file_unix.go:132 +0x55
  main.setupProcessPipes.func1()
      go/src/github.com/opencontainers/runc/tty.go:57 +0xcc

Goroutine 9 (finished) created at:
  main.setupProcessPipes()
      go/src/github.com/opencontainers/runc/tty.go:58 +0x510
  main.setupIO()
      go/src/github.com/opencontainers/runc/utils_linux.go:163 +0x26e
  main.(*runner).run()
      go/src/github.com/opencontainers/runc/utils_linux.go:264 +0x6b5
  main.startContainer()
      go/src/github.com/opencontainers/runc/utils_linux.go:395 +0x4ff
  main.glob..func13()
      go/src/github.com/opencontainers/runc/run.go:76 +0xe3
  runtime.call32()
      /usr/local/go1.8/src/runtime/asm_amd64.s:514 +0x47
  reflect.Value.Call()
      /usr/local/go1.8/src/reflect/value.go:302 +0xc0
  github.com/urfave/cli.HandleAction()
      go/src/github.com/urfave/cli/app.go:487 +0x22d
  github.com/urfave/cli.Command.Run()
      go/src/github.com/urfave/cli/command.go:191 +0xdee
  github.com/urfave/cli.(*App).Run()
      go/src/github.com/urfave/cli/app.go:240 +0x8eb
  main.main()
      go/src/github.com/opencontainers/runc/main.go:138 +0x1249
```
</details>