### PR TITLE
libcontainer: call Prestart, Poststart hooks from correct places

### DIFF
--- a/create.go
+++ b/create.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/opencontainers/runc/libcontainer"
 	"github.com/urfave/cli"
 )
 
@@ -62,7 +63,7 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 		if err != nil {
 			return err
 		}
-		status, err := startContainer(context, spec, CT_ACT_CREATE, nil)
+		status, err := startContainer(context, spec, libcontainer.CT_ACT_CREATE, nil)
 		if err != nil {
 			return err
 		}

--- a/exec.go
+++ b/exec.go
@@ -149,7 +149,7 @@ func execProcess(context *cli.Context) (int, error) {
 		consoleSocket:   context.String("console-socket"),
 		detach:          detach,
 		pidFile:         context.String("pid-file"),
-		action:          CT_ACT_RUN,
+		action:          libcontainer.CT_ACT_RUN,
 		init:            false,
 		preserveFDs:     context.Int("preserve-fds"),
 		logLevel:        logLevel,

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -14,6 +14,13 @@ import (
 
 // Status is the status of a container.
 type Status int
+type CtAct uint8
+
+const (
+	CT_ACT_CREATE CtAct = iota + 1
+	CT_ACT_RUN
+	CT_ACT_RESTORE
+)
 
 const (
 	// Created is the status that denotes the container exists but has not been run yet.
@@ -128,7 +135,7 @@ type BaseContainer interface {
 	// ConfigInvalid - config is invalid,
 	// ContainerPaused - Container is paused,
 	// SystemError - System error.
-	Start(process *Process) (err error)
+	Start(process *Process, action CtAct) (err error)
 
 	// Run immediately starts the process inside the container.  Returns error if process
 	// fails to start.  It does not block waiting for the exec fifo  after start returns but
@@ -139,7 +146,7 @@ type BaseContainer interface {
 	// ConfigInvalid - config is invalid,
 	// ContainerPaused - Container is paused,
 	// SystemError - System error.
-	Run(process *Process) (err error)
+	Run(process *Process, action CtAct) (err error)
 
 	// Destroys the container, if its in a valid state, after killing any
 	// remaining running processes.

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -113,7 +113,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 		Init:   true,
 	}
 
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	if err != nil {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -231,7 +231,7 @@ func TestEnter(t *testing.T) {
 		Stdout: &stdout,
 		Init:   true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -249,7 +249,7 @@ func TestEnter(t *testing.T) {
 	pconfig2.Stdin = stdinR2
 	pconfig2.Stdout = &stdout2
 
-	err = container.Run(&pconfig2)
+	err = container.Run(&pconfig2, libcontainer.CT_ACT_RUN)
 	stdinR2.Close()
 	defer stdinW2.Close()
 	ok(t, err)
@@ -318,7 +318,7 @@ func TestProcessEnv(t *testing.T) {
 		Stdout: &stdout,
 		Init:   true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -362,7 +362,7 @@ func TestProcessEmptyCaps(t *testing.T) {
 		Stdout: &stdout,
 		Init:   true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -415,7 +415,7 @@ func TestProcessCaps(t *testing.T) {
 	pconfig.Capabilities.Permitted = append(config.Capabilities.Permitted, "CAP_NET_ADMIN")
 	pconfig.Capabilities.Effective = append(config.Capabilities.Effective, "CAP_NET_ADMIN")
 	pconfig.Capabilities.Inheritable = append(config.Capabilities.Inheritable, "CAP_NET_ADMIN")
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -479,7 +479,7 @@ func TestAdditionalGroups(t *testing.T) {
 		AdditionalGroups: []string{"plugdev", "audio"},
 		Init:             true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -532,7 +532,7 @@ func testFreeze(t *testing.T, systemd bool) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(pconfig)
+	err = container.Run(pconfig, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -739,7 +739,7 @@ func TestContainerState(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(p)
+	err = container.Run(p, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -799,7 +799,7 @@ func TestPassExtraFiles(t *testing.T) {
 		Stdout:     &stdout,
 		Init:       true,
 	}
-	err = container.Run(&process)
+	err = container.Run(&process, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -876,7 +876,7 @@ func TestMountCmds(t *testing.T) {
 		Env:  standardEnvironment,
 		Init: true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -923,7 +923,7 @@ func TestSysctl(t *testing.T) {
 		Stdout: &stdout,
 		Init:   true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -1058,7 +1058,7 @@ func TestOomScoreAdj(t *testing.T) {
 		Stdout: &stdout,
 		Init:   true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -1164,7 +1164,7 @@ func TestHook(t *testing.T) {
 		Stdout: &stdout,
 		Init:   true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -1276,7 +1276,7 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 		Init:  true,
 	}
 
-	err = container.Run(pconfig)
+	err = container.Run(pconfig, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -1305,7 +1305,7 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 		Stdout: &stdout2,
 	}
 
-	err = container.Run(pconfig2)
+	err = container.Run(pconfig2, libcontainer.CT_ACT_RUN)
 	stdinR2.Close()
 	defer stdinW2.Close()
 	ok(t, err)
@@ -1391,7 +1391,7 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 		Init:  true,
 	}
 
-	err = container.Run(pconfig)
+	err = container.Run(pconfig, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -1426,7 +1426,7 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 	pconfig2.Capabilities.Effective = append(config.Capabilities.Effective, "CAP_SYS_ADMIN")
 	pconfig2.Capabilities.Inheritable = append(config.Capabilities.Inheritable, "CAP_SYS_ADMIN")
 
-	err = container.Run(pconfig2)
+	err = container.Run(pconfig2, libcontainer.CT_ACT_RUN)
 	stdinR2.Close()
 	defer stdinW2.Close()
 	ok(t, err)
@@ -1499,7 +1499,7 @@ func TestInitJoinPID(t *testing.T) {
 		Stdin: stdinR1,
 		Init:  true,
 	}
-	err = container1.Run(init1)
+	err = container1.Run(init1, libcontainer.CT_ACT_RUN)
 	stdinR1.Close()
 	defer stdinW1.Close()
 	ok(t, err)
@@ -1526,7 +1526,7 @@ func TestInitJoinPID(t *testing.T) {
 		Stdin: stdinR2,
 		Init:  true,
 	}
-	err = container2.Run(init2)
+	err = container2.Run(init2, libcontainer.CT_ACT_RUN)
 	stdinR2.Close()
 	defer stdinW2.Close()
 	ok(t, err)
@@ -1556,7 +1556,7 @@ func TestInitJoinPID(t *testing.T) {
 		Env:    standardEnvironment,
 		Stdout: buffers.Stdout,
 	}
-	err = container1.Run(ps)
+	err = container1.Run(ps, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 	waitProcess(ps, t)
 
@@ -1606,7 +1606,7 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 		Stdin: stdinR1,
 		Init:  true,
 	}
-	err = container1.Run(init1)
+	err = container1.Run(init1, libcontainer.CT_ACT_RUN)
 	stdinR1.Close()
 	defer stdinW1.Close()
 	ok(t, err)
@@ -1641,7 +1641,7 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 		Stdin: stdinR2,
 		Init:  true,
 	}
-	err = container2.Run(init2)
+	err = container2.Run(init2, libcontainer.CT_ACT_RUN)
 	stdinR2.Close()
 	defer stdinW2.Close()
 	ok(t, err)
@@ -1703,7 +1703,7 @@ func TestTmpfsCopyUp(t *testing.T) {
 		Stdout: &stdout,
 		Init:   true,
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -40,7 +40,7 @@ func TestExecIn(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -55,7 +55,7 @@ func TestExecIn(t *testing.T) {
 		Stderr: buffers.Stderr,
 	}
 
-	err = container.Run(ps)
+	err = container.Run(ps, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 	waitProcess(ps, t)
 	stdinW.Close()
@@ -111,7 +111,7 @@ func testExecInRlimit(t *testing.T, userns bool) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -130,7 +130,7 @@ func testExecInRlimit(t *testing.T, userns bool) {
 		},
 		Init: true,
 	}
-	err = container.Run(ps)
+	err = container.Run(ps, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 	waitProcess(ps, t)
 
@@ -167,7 +167,7 @@ func TestExecInAdditionalGroups(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -181,7 +181,7 @@ func TestExecInAdditionalGroups(t *testing.T) {
 		Stdout:           &stdout,
 		AdditionalGroups: []string{"plugdev", "audio"},
 	}
-	err = container.Run(&pconfig)
+	err = container.Run(&pconfig, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 
 	// Wait for process
@@ -224,7 +224,7 @@ func TestExecInError(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer func() {
 		stdinW.Close()
@@ -242,7 +242,7 @@ func TestExecInError(t *testing.T) {
 			Env:    standardEnvironment,
 			Stderr: &out,
 		}
-		err = container.Run(unexistent)
+		err = container.Run(unexistent, libcontainer.CT_ACT_RUN)
 		if err == nil {
 			t.Fatal("Should be an error")
 		}
@@ -277,7 +277,7 @@ func TestExecInTTY(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -320,7 +320,7 @@ func TestExecInTTY(t *testing.T) {
 			c: c,
 		}
 	}()
-	err = container.Run(ps)
+	err = container.Run(ps, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 	data := <-dc
 	if data.err != nil {
@@ -374,7 +374,7 @@ func TestExecInEnvironment(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -394,7 +394,7 @@ func TestExecInEnvironment(t *testing.T) {
 		Stderr: buffers.Stderr,
 		Init:   true,
 	}
-	err = container.Run(process2)
+	err = container.Run(process2, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 	waitProcess(process2, t)
 
@@ -440,7 +440,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	if err != nil {
@@ -464,7 +464,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		Stdin:      nil,
 		Stdout:     &stdout,
 	}
-	err = container.Run(inprocess)
+	err = container.Run(inprocess, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +520,7 @@ func TestExecInOomScoreAdj(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -534,7 +534,7 @@ func TestExecInOomScoreAdj(t *testing.T) {
 		Stdout: buffers.Stdout,
 		Stderr: buffers.Stderr,
 	}
-	err = container.Run(ps)
+	err = container.Run(ps, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 	waitProcess(ps, t)
 
@@ -576,7 +576,7 @@ func TestExecInUserns(t *testing.T) {
 		Stdin: stdinR,
 		Init:  true,
 	}
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	stdinR.Close()
 	defer stdinW.Close()
 	ok(t, err)
@@ -596,7 +596,7 @@ func TestExecInUserns(t *testing.T) {
 		Stdout: buffers.Stdout,
 		Stderr: os.Stderr,
 	}
-	err = container.Run(process2)
+	err = container.Run(process2, libcontainer.CT_ACT_RUN)
 	ok(t, err)
 	waitProcess(process2, t)
 	stdinW.Close()

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -51,7 +51,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 		Init:   true,
 	}
 
-	err = container.Run(pwd)
+	err = container.Run(pwd, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 		Init:   true,
 	}
 
-	err = container.Run(dmesg)
+	err = container.Run(dmesg, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 		Init:   true,
 	}
 
-	err = container.Run(dmesg)
+	err = container.Run(dmesg, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -167,7 +167,7 @@ func runContainer(config *configs.Config, console string, args ...string) (buffe
 		Init:   true,
 	}
 
-	err = container.Run(process)
+	err = container.Run(process, libcontainer.CT_ACT_RUN)
 	if err != nil {
 		return buffers, -1, err
 	}

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -231,6 +231,7 @@ type initProcess struct {
 	process         *Process
 	bootstrapData   io.Reader
 	sharePidns      bool
+	IsCreate        bool
 }
 
 func (p *initProcess) pid() int {

--- a/restore.go
+++ b/restore.go
@@ -109,7 +109,7 @@ using the runc checkpoint command.`,
 		if err := setEmptyNsMask(context, options); err != nil {
 			return err
 		}
-		status, err := startContainer(context, spec, CT_ACT_RESTORE, options)
+		status, err := startContainer(context, spec, libcontainer.CT_ACT_RESTORE, options)
 		if err != nil {
 			return err
 		}

--- a/run.go
+++ b/run.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 
+	"github.com/opencontainers/runc/libcontainer"
 	"github.com/urfave/cli"
 )
 
@@ -73,7 +74,7 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 		if err != nil {
 			return err
 		}
-		status, err := startContainer(context, spec, CT_ACT_RUN, nil)
+		status, err := startContainer(context, spec, libcontainer.CT_ACT_RUN, nil)
 		if err == nil {
 			// exit with the container's exit status so any external supervisor is
 			// notified of the exit with the correct exit status.


### PR DESCRIPTION
So far Prestart, Poststart hooks have been called from the context of create, which does not satisfy the runtime spec. That's why the runtime-tools validation tests like `hooks_stdin.t` have failed. Let's move call sites of Prestart, Poststart to correct places.

Unfortunately as for the Poststart hook, in practice it's not possible to tell whether a specific call site is from create context or run context. That's why we needed to allow Create and Run methods to accept another parameter `action` (of type `CtAct`). Doing that, it's possible to set a variable `initProcess.IsCreate` that allows us distinguish Create from Run. That's why the first commit `libcontainer: move CtAct to libcontainer` is needed.

I tested runtime-tools' `validation/hooks_stdin.t` with this PR of runc, and it worked fine. Though if there would be unexpected breakage from changing like this, please let me know.

It depends on a pending PR https://github.com/opencontainers/runc/pull/1741.
See also https://github.com/opencontainers/runc/issues/1710.

/cc @wking @liangchenye