### PR TITLE
libcontainer: fix a bug when setting shared rootfs propagation mode

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -157,6 +157,15 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds mountFds) (
 		return fmt.Errorf("error jailing process inside rootfs: %w", err)
 	}
 
+	// mount with MS_SHARED flag does not work well with pivotRoot, because
+	// of the checks in the Linux kernel. So we need to first pivotRoot with
+	// a private rootfs, and after that make it shared.
+	if config.RootPropagation&unix.MS_SHARED != 0 {
+		if err := rootfsParentMountShared(config.Rootfs); err != nil {
+			return err
+		}
+	}
+
 	if setupDev {
 		if err := reOpenDevNull(); err != nil {
 			return fmt.Errorf("error reopening /dev/null inside container: %w", err)
@@ -829,6 +838,31 @@ func rootfsParentMountPrivate(rootfs string) error {
 	// parent namespace and we don't want that to happen.
 	if sharedMount {
 		return mount("", parentMount, "", unix.MS_PRIVATE, "")
+	}
+
+	return nil
+}
+
+// Make parent mount shared if it was not shared.
+func rootfsParentMountShared(rootfs string) error {
+	sharedMount := false
+
+	parentMount, optionalOpts, err := getParentMount(rootfs)
+	if err != nil {
+		return err
+	}
+
+	optsSplit := strings.Split(optionalOpts, " ")
+	for _, opt := range optsSplit {
+		if strings.HasPrefix(opt, "shared:") {
+			sharedMount = true
+			break
+		}
+	}
+
+	// Make parent mount SHARED if it was not shared.
+	if !sharedMount {
+		return mount("", parentMount, "", uintptr(unix.MS_SHARED), "")
 	}
 
 	return nil

--- a/tests/integration/mounts_propagation.bats
+++ b/tests/integration/mounts_propagation.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	requires root
+
+	setup_debian
+
+	mkdir -p rootfs/{proc,sys,tmp}
+	mkdir -p rootfs/tmp/mount1
+
+	update_config ' .mounts += [
+					{
+						"source": "tmpfs",
+						"destination": "/tmp/mount1",
+						"type": "tmpfs"
+					}
+				] '
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+# https://github.com/opencontainers/runc/issues/1755
+@test "runc run [tmpfs mount propagation]" {
+	update_config ' .process.args = ["sh", "-c", "findmnt --noheadings -o PROPAGATION /tmp/mount1"]'
+	# Add the shared option to the mount
+	update_config ' .mounts |= map((select(.destination == "/tmp/mount1") | .options += ["shared"]) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"shared"* ]]
+}


### PR DESCRIPTION
So far when the input mount flags contain `MS_SHARED`, the flag has not been applied to the container rootfs. That's because we call `rootfsParentMountPrivate()` after applying the original mount flags. Though we actually need to mount the container rootfs with `MS_PRIVATE`, to avoid failure from `pivot_root()` in the Linux kernel.

Thus if the mount flags contain `MS_SHARED`, we need a special case handling. First do `pivotRoot()` (or `msMoveRoot`, `chroot`) with the rootfs with a mount flag `MS_PRIVATE`. Then after `pivotRoot()`, again mount the rootfs with `MS_SHARED`.

With this fix, `validation/linux_rootfs_propagation.t` of runtime-tools works well with the shared mode finally.

Fixes https://github.com/opencontainers/runc/issues/1755

/cc @alban 

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>