### PR TITLE
runc: not require uid/gid mappings if euid()==0

### DIFF
--- a/libcontainer/configs/validate/rootless.go
+++ b/libcontainer/configs/validate/rootless.go
@@ -43,13 +43,12 @@ func rootlessMappings(config *configs.Config) error {
 		if !config.Namespaces.Contains(configs.NEWUSER) {
 			return fmt.Errorf("rootless containers require user namespaces")
 		}
-	}
-
-	if len(config.UidMappings) == 0 {
-		return fmt.Errorf("rootless containers requires at least one UID mapping")
-	}
-	if len(config.GidMappings) == 0 {
-		return fmt.Errorf("rootless containers requires at least one GID mapping")
+		if len(config.UidMappings) == 0 {
+			return fmt.Errorf("rootless containers requires at least one UID mapping")
+		}
+		if len(config.GidMappings) == 0 {
+			return fmt.Errorf("rootless containers requires at least one GID mapping")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When running in a new unserNS as root, don't require a mapping to be
present in the configuration file.  We are already skipping the test
for a new userns to be present.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>