### PR TITLE
Really fix TestGetAdditionalGroups on i686 (Closes: #941)

### DIFF
--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -473,7 +473,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 				return nil, fmt.Errorf("Unable to find group %s", ag)
 			}
 			// Ensure gid is inside gid range.
-			if gid < minId || gid > maxId {
+			if gid < minId || gid >= maxId {
 				return nil, ErrRange
 			}
 			gidMap[gid] = struct{}{}

--- a/libcontainer/user/user_test.go
+++ b/libcontainer/user/user_test.go
@@ -445,7 +445,7 @@ this is just some garbage data
 	if utils.GetIntSize() > 4 {
 		tests = append(tests, foo{
 			// groups with too large id
-			groups:   []string{strconv.Itoa(1 << 31)},
+			groups:   []string{strconv.Itoa(1<<31 - 1)},
 			expected: nil,
 			hasError: true,
 		})


### PR DESCRIPTION
Although #941 has been closed it was never fixed:

~~~~
 src/github.com/opencontainers/runc/libcontainer/user/user_test.go:448:36: constant 2147483648 overflows int
~~~~

https://buildd.debian.org/status/fetch.php?pkg=runc&arch=i386&ver=1.0.0%7Erc5%2Bdfsg1-1&stamp=1529067561&raw=0
