### PR TITLE
libcontainer: devices: fix mips builds

### DIFF
--- a/libcontainer/devices/devices.go
+++ b/libcontainer/devices/devices.go
@@ -30,8 +30,9 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 	}
 
 	var (
-		devNumber = stat.Rdev
+		devNumber = uint64(stat.Rdev)
 		major     = unix.Major(devNumber)
+		minor     = unix.Minor(devNumber)
 	)
 	if major == 0 {
 		return nil, ErrNotADevice
@@ -51,7 +52,7 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 		Type:        devType,
 		Path:        path,
 		Major:       int64(major),
-		Minor:       int64(unix.Minor(devNumber)),
+		Minor:       int64(minor),
 		Permissions: permissions,
 		FileMode:    os.FileMode(mode),
 		Uid:         stat.Uid,


### PR DESCRIPTION
It turns out that MIPS uses uint32 in the device number returned by
stat(2), so explicitly wrap everything to make the compiler happy. I
really wish that Go had C-like numeric type promotion.

Fixes #1823
Signed-off-by: Aleksa Sarai <asarai@suse.de>