### PR TITLE
Stop using unix.SIGUNUSED which has been removed from golang.org/x/sys

### DIFF
--- a/signalmap.go
+++ b/signalmap.go
@@ -37,7 +37,6 @@ var signalMap = map[string]syscall.Signal{
 	"TSTP":   unix.SIGTSTP,
 	"TTIN":   unix.SIGTTIN,
 	"TTOU":   unix.SIGTTOU,
-	"UNUSED": unix.SIGUNUSED,
 	"URG":    unix.SIGURG,
 	"USR1":   unix.SIGUSR1,
 	"USR2":   unix.SIGUSR2,


### PR DESCRIPTION
Bug-Debian: https://bugs.debian.org/889704

Fixes FTBFS `undefined: unix.SIGUNUSED`.