### PR TITLE
specconv: fix null spec.Process making runc panic

### DIFF
--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -585,3 +585,16 @@ func TestInitSystemdProps(t *testing.T) {
 		}
 	}
 }
+
+func TestNullProcess(t *testing.T) {
+	spec := Example()
+	spec.Process = nil
+
+	_, err := CreateLibcontainerConfig(&CreateOpts{
+		Spec: spec,
+	})
+
+	if err != nil {
+		t.Errorf("Null process should be forbidden")
+	}
+}


### PR DESCRIPTION
`Process` of `Spec struct` is a pointer:
```go
	Process *Process `json:"process,omitempty"`
```

When calling `CreateLibcontainerConfig()` with  `opts.Spec.Process: nil`, runc will panic.

I added a new test case `TestNullProcess` in `libcontainer/specconv`, it will failed with:
```sh
=== RUN   TestNullProcess
--- FAIL: TestNullProcess (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x540029]

goroutine 20 [running]:
testing.tRunner.func1(0xc42007e9c0)
        /usr/lib/golang/src/testing/testing.go:622 +0x29d
panic(0x57c280, 0x861a20)
        /usr/lib/golang/src/runtime/panic.go:489 +0x2cf
github.com/opencontainers/runc/libcontainer/specconv.CreateLibcontainerConfig(0xc42003af70, 0x3, 0xc42007ad00, 0xc42007c040)
        /home/workspace/src/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go:244 +0x7b9
github.com/opencontainers/runc/libcontainer/specconv.TestNullProcess(0xc42007e9c0)
        /home/workspace/src/github.com/opencontainers/runc/libcontainer/specconv/spec_linux_test.go:456 +0xa8
testing.tRunner(0xc42007e9c0, 0x5b9440)
        /usr/lib/golang/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
        /usr/lib/golang/src/testing/testing.go:697 +0x2ca
FAIL    github.com/opencontainers/runc/libcontainer/specconv    0.009s
```

So I wrote this PR.

Please help to review and share your comments.

Signed-off-by: Jingxiao Lu <lujingxiao@huawei.com>