### PR TITLE
libcontainer: improve "kernel.{domainname,hostname}" sysctl handling

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -151,6 +151,16 @@ func (v *ConfigValidator) sysctl(config *configs.Config) error {
 				return fmt.Errorf("sysctl %q is not allowed in the hosts network namespace", s)
 			}
 		}
+		if config.Namespaces.Contains(configs.NEWUTS) {
+			switch s {
+			case "kernel.domainname":
+				// This is namespaced and there's no explicit OCI field for it.
+				continue
+			case "kernel.hostname":
+				// This is namespaced but there's a conflicting (dedicated) OCI field for it.
+				return fmt.Errorf("sysctl %q is not allowed as it conflicts with the OCI %q field", s, "hostname")
+			}
+		}
 		return fmt.Errorf("sysctl %q is not in a separate kernel namespace", s)
 	}
 


### PR DESCRIPTION
These sysctls are namespaced by CLONE_NEWUTS, and we need to use
"kernel.domainname" if we want users to be able to set an NIS domainname
on Linux. However we disallow "kernel.hostname" because it would
conflict with the "hostname" field and cause confusion (but we include a
helpful message to make it clearer to the user).

Signed-off-by: Aleksa Sarai <asarai@suse.de>