### PR TITLE
mountinfo: parse empty strings in source

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -94,7 +94,7 @@ func FindCgroupMountpointDir() (string, error) {
 		fields := strings.Split(text, " ")
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
 		index := strings.Index(text, " - ")
-		postSeparatorFields := strings.Fields(text[index+3:])
+		postSeparatorFields := strings.Split(text[index+3:], " ")
 		numPostFields := len(postSeparatorFields)
 
 		// This is an error as we can't detect if the mount is for "cgroup"
@@ -103,10 +103,7 @@ func FindCgroupMountpointDir() (string, error) {
 		}
 
 		if postSeparatorFields[0] == "cgroup" {
-			// Check that the mount is properly formated.
-			if numPostFields < 3 {
-				return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
-			}
+			// No need to parse the rest of the postSeparatorFields
 
 			return filepath.Dir(fields[4]), nil
 		}

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -168,7 +168,7 @@ func findIntelRdtMountpointDir() (string, error) {
 		fields := strings.Split(text, " ")
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
 		index := strings.Index(text, " - ")
-		postSeparatorFields := strings.Fields(text[index+3:])
+		postSeparatorFields := strings.Split(text[index+3:], " ")
 		numPostFields := len(postSeparatorFields)
 
 		// This is an error as we can't detect if the mount is for "Intel RDT"
@@ -177,10 +177,7 @@ func findIntelRdtMountpointDir() (string, error) {
 		}
 
 		if postSeparatorFields[0] == "resctrl" {
-			// Check that the mount is properly formated.
-			if numPostFields < 3 {
-				return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
-			}
+			// No need to parse the rest of the postSeparatorFields
 
 			return fields[4], nil
 		}

--- a/libcontainer/mount/mount_linux.go
+++ b/libcontainer/mount/mount_linux.go
@@ -64,7 +64,10 @@ func parseInfoFile(r io.Reader) ([]*Info, error) {
 		}
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
 		index := strings.Index(text, " - ")
-		postSeparatorFields := strings.Fields(text[index+3:])
+		// Source can be an empty string ("") so strings.Fields() won't work here.
+		// Test with:
+		//     $ sudo mount -t tmpfs "" /tmp/bb
+		postSeparatorFields := strings.Split(text[index+3:], " ")
 		if len(postSeparatorFields) < 3 {
 			return nil, fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
 		}


### PR DESCRIPTION
The source of a mount in /proc/self/mountinfo can unfortunately be an
empty string. Before this patch, 'mount' and 'mountpoint' fail as
following:

```
$ sudo mount -t tmpfs "" /tmp/bb
$ mount
mount: /proc/self/mountinfo: parse error at line 64 -- ignored
$ mountpoint /tmp/bb
/tmp/bb is not a mountpoint
```

And docker fails with the following:
```
$ sudo docker run -ti --rm busybox
/usr/bin/docker-current: Error response from daemon: devmapper: Error mounting
'/dev/mapper/docker-253:1-5778711-4a86058b044487d3ee73dbc1349f1f9a4b4f78c9b026494f8d3e75a37ee6fcb6-init'
on '/var/lib/docker/devicemapper/mnt/4a86058b044487d3ee73dbc1349f1f9a4b4f78c9b026494f8d3e75a37ee6fcb6-init'.
fstype=xfs options=nouuid: Error found less than 3 fields post '-' in
"242 45 0:66 / /tmp/bb rw,relatime shared:212 - tmpfs  rw,seclabel"
```
This patch fixes the parsing.

Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

Similar patch in util-linux: https://www.spinics.net/lists/linux-fsdevel/msg128896.html
Similar PR in runtime-tools: https://github.com/opencontainers/runtime-tools/pull/652
Related patch that would fix this kernel-side: https://patchwork.kernel.org/patch/10349095/
