### PR TITLE
linux: drop check for /proc as invalid dest

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -413,7 +413,7 @@ func checkMountDestination(rootfs, dest string) error {
 		if err != nil {
 			return err
 		}
-		if path == "." || !strings.HasPrefix(path, "..") {
+		if path != "." && !strings.HasPrefix(path, "..") {
 			return fmt.Errorf("%q cannot be mounted because it is located inside %q", dest, invalid)
 		}
 	}

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -9,10 +9,18 @@ import (
 )
 
 func TestCheckMountDestOnProc(t *testing.T) {
-	dest := "/rootfs/proc/"
+	dest := "/rootfs/proc/sys"
 	err := checkMountDestination("/rootfs", dest)
 	if err == nil {
 		t.Fatal("destination inside proc should return an error")
+	}
+}
+
+func TestCheckMountDestOnProcChroot(t *testing.T) {
+	dest := "/rootfs/proc/"
+	err := checkMountDestination("/rootfs", dest)
+	if err != nil {
+		t.Fatal("destination inside proc when using chroot should not return an error")
 	}
 }
 


### PR DESCRIPTION
it is now allowed to bind mount /proc when the PID namespace is shared
with the host.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>