### PR TITLE
Add osusergo flag to static build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ contrib/cmd/recvtty/recvtty: $(SOURCES)
 	$(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -tags "$(BUILDTAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
 
 static: $(SOURCES)
-	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo cgo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -o runc .
-	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo cgo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
+	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo cgo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -o runc .
+	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo cgo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
 
 release:
 	script/release.sh -r release/$(VERSION) -v $(VERSION)


### PR DESCRIPTION
This should fix the following (very legitimate) warnings on static build:

> /tmp/go-link-818454663/000019.o: In function `mygetgrouplist':
> /usr/lib/go-1.10/src/os/user/getgrouplist_unix.go:15: warning: Using
> 'getgrouplist' in statically linked applications requires at runtime the
> shared libraries from the glibc version used for linking
>
> /tmp/go-link-818454663/000018.o: In function `mygetgrgid_r':
> /usr/lib/go-1.10/src/os/user/cgo_lookup_unix.go:38: warning: Using
> 'getgrgid_r' in statically linked applications requires at runtime the
> shared libraries from the glibc version used for linking
>
> ...

as well as segfaults in the resulting binary.

For more details, check https://github.com/golang/go/issues/23265