### PR TITLE
criu tests: rename criu feature check

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -128,7 +128,7 @@ function teardown() {
   requires criu root
 
   # check if lazy-pages is supported
-  run ${CRIU} check --feature lazy_pages
+  run ${CRIU} check --feature uffd-noncoop
   if [ "$status" -eq 1 ]; then
     # this criu does not support lazy migration; skip the test
     skip "this criu does not support lazy migration"


### PR DESCRIPTION
Upstream renamed the feature check for lazy migration support from
'lazy_pages' to 'uffd'. The lazy migration test case was therefore
not running at all. This enables the lazy migration test case in runc
again.

The test will, however, not run in travis as the kernel is too old.
But it works again locally.

Signed-off-by: Adrian Reber <areber@redhat.com>