### PR TITLE
cr: don't dump network devices and their configuration

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -125,7 +125,8 @@ var namespaceMapping = map[specs.LinuxNamespaceType]int{
 }
 
 func setEmptyNsMask(context *cli.Context, options *libcontainer.CriuOpts) error {
-	var nsmask int
+	/* Runc doesn't manage network devices and their configuration */
+	nsmask := unix.CLONE_NEWNET
 
 	for _, ns := range context.StringSlice("empty-ns") {
 		f, exists := namespaceMapping[specs.LinuxNamespaceType(ns)]


### PR DESCRIPTION
RunC doesn't manage network devices and their configurations,
so it is impossible to describe external dependencies to restore them
back.

This means that all users have to set --empty-ns network, so let's do
this by default.

Signed-off-by: Andrei Vagin <avagin@openvz.org>