### PR TITLE
Fix regression with mounts with non-absolute source path

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -270,7 +270,7 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	flags, pgflags, data, ext := parseMountOptions(m.Options)
 	source := m.Source
 	device := m.Type
-	if flags|unix.MS_BIND != 0 {
+	if flags&unix.MS_BIND != 0 {
 		if device == "" {
 			device = "bind"
 		}


### PR DESCRIPTION
PR #1753 introduced a test on the mount flags but the binary operator was wrong, see https://github.com/opencontainers/runc/pull/1753#discussion_r203445652

This was noticed when investigating https://github.com/opencontainers/runtime-tools/issues/651

Symptoms: in the container, /proc/self/mountinfo displays some mounts as follow:
```
296 279 0:67 / /tmp rw,nosuid - tmpfs /home/dpark/go/src/github.com/opencontainers/runc/tmpfs rw,size=65536k,mode=755
```
Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

/cc @wking 