### PR TITLE
Fix panic with config.json with empty process

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -392,6 +392,9 @@ func (r *runner) checkTerminal(config *specs.Process) error {
 }
 
 func validateProcessSpec(spec *specs.Process) error {
+	if spec == nil {
+		return fmt.Errorf("process property must not be empty")
+	}
 	if spec.Cwd == "" {
 		return fmt.Errorf("Cwd property must not be empty")
 	}


### PR DESCRIPTION
When config.json does not have a "process" section at all, runc paniced
with this error:
> panic: runtime error: invalid memory address or nil pointer dereference

According to the spec, "process" is optional:
https://github.com/opencontainers/runtime-spec/blob/master/config.md#process
> process (object, OPTIONAL) specifies the container process. This property is REQUIRED when start is called.

So the desired behaviour is:
- "runc create": succeed without error
- "runc start": return a proper error without panic

This patch fixes the panic in "runc create". Further work is needed to
allow create but not start.

Signed-off-by: Alban Crequy <alban@kinvolk.io>