### PR TITLE
WIP - Support for logging from children processes

### DIFF
--- a/libcontainer/logs.go
+++ b/libcontainer/logs.go
@@ -1,0 +1,70 @@
+package libcontainer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+func forwardLogs(p *os.File) {
+	defer p.Close()
+
+	type jsonLog struct {
+		Level string `json:"level"`
+		Msg   string `json:"msg"`
+	}
+
+	dec := json.NewDecoder(p)
+	for {
+		var jl jsonLog
+
+		type logFuncTable map[logrus.Level]func(args ...interface{})
+		logMapping := logFuncTable{
+			logrus.PanicLevel: logrus.Panic,
+			logrus.FatalLevel: logrus.Fatal,
+			logrus.ErrorLevel: logrus.Error,
+			logrus.WarnLevel:  logrus.Warn,
+			logrus.InfoLevel:  logrus.Info,
+			logrus.DebugLevel: logrus.Debug,
+		}
+
+		err := dec.Decode(&jl)
+		if err != nil {
+			if err == io.EOF {
+				logrus.Debug("child pipe closed")
+				return
+			}
+			logrus.Errorf("json logs decoding error: %+v", err)
+			return
+		}
+
+		lvl, err := logrus.ParseLevel(jl.Level)
+		if err != nil {
+			fmt.Printf("parsing error\n")
+		}
+		if logMapping[lvl] != nil {
+			logMapping[lvl](jl.Msg)
+		}
+	}
+}
+
+func rawLogs(p *os.File) {
+	defer p.Close()
+
+	data := make([]byte, 128)
+	for {
+		_, err := p.Read(data)
+
+		if err != nil {
+			if err == io.EOF {
+				logrus.Debug("child pipe closed")
+				return
+			}
+			return
+		}
+		fmt.Printf("Read data: %s\n", string(data))
+	}
+}

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -21,6 +21,11 @@ type pid struct {
 	Pid int `json:"Pid"`
 }
 
+type logentry struct {
+	Msg   string
+	Level string
+}
+
 func TestNsenterValidPaths(t *testing.T) {
 	args := []string{"nsenter-exec"}
 	parent, child, err := newPipe()
@@ -156,6 +161,60 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 
 	if err := cmd.Wait(); err == nil {
 		t.Fatalf("nsenter exits with a zero exit status")
+	}
+}
+
+func TestNsenterChildLogging(t *testing.T) {
+	args := []string{"nsenter-exec"}
+	parent, child, err := newPipe()
+	logread, logwrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe %v", err)
+	}
+
+	namespaces := []string{
+		// join pid ns of the current process
+		fmt.Sprintf("pid:/proc/%d/ns/pid", os.Getpid()),
+	}
+	cmd := &exec.Cmd{
+		Path:       os.Args[0],
+		Args:       args,
+		ExtraFiles: []*os.File{child, logwrite},
+		Env:        []string{"_LIBCONTAINER_INITPIPE=3", "_LIBCONTAINER_LOGPIPE=4"},
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("nsenter failed to start %v", err)
+	}
+	// write cloneFlags
+	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
+	r.AddData(&libcontainer.Int32msg{
+		Type:  libcontainer.CloneFlagsAttr,
+		Value: uint32(unix.CLONE_NEWNET),
+	})
+	r.AddData(&libcontainer.Bytemsg{
+		Type:  libcontainer.NsPathsAttr,
+		Value: []byte(strings.Join(namespaces, ",")),
+	})
+	if _, err := io.Copy(parent, bytes.NewReader(r.Serialize())); err != nil {
+		t.Fatal(err)
+	}
+
+	logsDecoder := json.NewDecoder(logread)
+	var logentry *logentry
+
+	err = logsDecoder.Decode(&logentry)
+	if err != nil {
+		t.Fatalf("child log: %v", err)
+	}
+	if logentry.Level == "" || logentry.Msg == "" {
+		t.Fatalf("child log: empty log fileds: level=\"%s\" msg=\"%s\"", logentry.Level, logentry.Msg)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("nsenter exits with a non-zero exit status")
 	}
 }
 

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -89,6 +89,17 @@ struct nlconfig_t {
 	size_t gidmappath_len;
 };
 
+typedef enum {
+	PANIC = 0,
+	FATAL,
+	ERROR,
+	WARNING,
+	INFO,
+	DEBUG,
+} loglevel_t;
+
+int logfd;
+
 /*
  * List of netlink message types sent to us as part of bootstrapping the init.
  * These constants are defined in libcontainer/message_linux.go.
@@ -346,6 +357,22 @@ static int initpipe(void)
 	return pipenum;
 }
 
+static int logpipe(void)
+{
+	int pipenum;
+	char *logpipe, *endptr;
+
+	logpipe = getenv("_LIBCONTAINER_LOGPIPE");
+	if (logpipe == NULL || *logpipe == '\0')
+		return -1;
+
+	pipenum = strtol(logpipe, &endptr, 10);
+	if (*endptr != '\0')
+		bail("unable to parse _LIBCONTAINER_LOGPIPE");
+
+	return pipenum;
+}
+
 /* Returns the clone(2) flag for a namespace, given the name of a namespace. */
 static int nsflag(char *name)
 {
@@ -528,6 +555,27 @@ void join_namespaces(char *nslist)
 	free(namespaces);
 }
 
+void write_log(loglevel_t level, const char *format, ...)
+{
+	static const char *strlevel[] = {"panic", "fatal", "error", "warning", "info", "debug"};
+	static char jsonbuffer[1024];
+	int len;
+	va_list args;
+	if (logfd < 0 || level >= sizeof(strlevel) / sizeof(strlevel[0])) {
+		return;
+	}
+
+	len = snprintf(jsonbuffer, sizeof(jsonbuffer),
+				   "{\"level\":\"%s\", \"msg\": \"", strlevel[level]);
+
+	va_start(args, format);
+	len += vsnprintf(&jsonbuffer[len], sizeof(jsonbuffer) - len, format, args);
+	va_end(args);
+
+	len += snprintf(&jsonbuffer[len], sizeof(jsonbuffer) - len, "\"}");
+	write(logfd, jsonbuffer, len);
+}
+
 void nsexec(void)
 {
 	int pipenum;
@@ -542,6 +590,11 @@ void nsexec(void)
 	pipenum = initpipe();
 	if (pipenum == -1)
 		return;
+
+	/* Get the log pipe */
+	logfd = logpipe();
+
+	write_log(DEBUG, "%s started", __FUNCTION__);
 
 	/* Parse all of the netlink configuration. */
 	nl_parse(pipenum, &config);

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -43,12 +43,20 @@ type parentProcess interface {
 	externalDescriptors() []string
 
 	setExternalDescriptors(fds []string)
+
+	getChildLogs()
+}
+
+type pipePair struct {
+	r *os.File
+	w *os.File
 }
 
 type setnsProcess struct {
 	cmd           *exec.Cmd
 	parentPipe    *os.File
 	childPipe     *os.File
+	logPipe       pipePair
 	cgroupPaths   map[string]string
 	intelRdtPath  string
 	config        *initConfig
@@ -73,7 +81,9 @@ func (p *setnsProcess) signal(sig os.Signal) error {
 func (p *setnsProcess) start() (err error) {
 	defer p.parentPipe.Close()
 	err = p.cmd.Start()
+	// close the write-side of the pipes (controlled by child)
 	p.childPipe.Close()
+	p.logPipe.w.Close()
 	if err != nil {
 		return newSystemErrorWithCause(err, "starting setns process")
 	}
@@ -202,10 +212,15 @@ func (p *setnsProcess) setExternalDescriptors(newFds []string) {
 	p.fds = newFds
 }
 
+func (p *setnsProcess) getChildLogs() {
+	go forwardLogs(p.logPipe.r)
+}
+
 type initProcess struct {
 	cmd             *exec.Cmd
 	parentPipe      *os.File
 	childPipe       *os.File
+	logPipe         pipePair
 	config          *initConfig
 	manager         cgroups.Manager
 	intelRdtManager intelrdt.Manager
@@ -267,7 +282,9 @@ func (p *initProcess) start() error {
 	defer p.parentPipe.Close()
 	err := p.cmd.Start()
 	p.process.ops = p
+	// close the write-side of the pipes (controlled by child)
 	p.childPipe.Close()
+	p.logPipe.w.Close()
 	if err != nil {
 		p.process.ops = nil
 		return newSystemErrorWithCause(err, "starting init process command")
@@ -478,6 +495,10 @@ func (p *initProcess) signal(sig os.Signal) error {
 
 func (p *initProcess) setExternalDescriptors(newFds []string) {
 	p.fds = newFds
+}
+
+func (p *initProcess) getChildLogs() {
+	go forwardLogs(p.logPipe.r)
 }
 
 func getPipeFds(pid int) ([]string, error) {

--- a/libcontainer/restored_process.go
+++ b/libcontainer/restored_process.go
@@ -76,6 +76,9 @@ func (p *restoredProcess) setExternalDescriptors(newFds []string) {
 	p.fds = newFds
 }
 
+func (p *restoredProcess) getChildLogs() {
+}
+
 // nonChildProcess represents a process where the calling process is not
 // the parent process.  This process is created when a factory loads a container from
 // a persisted state.
@@ -119,4 +122,7 @@ func (p *nonChildProcess) externalDescriptors() []string {
 
 func (p *nonChildProcess) setExternalDescriptors(newFds []string) {
 	p.fds = newFds
+}
+
+func (p *nonChildProcess) getChildLogs() {
 }

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"golang.org/x/sys/unix"
 )
@@ -187,6 +188,10 @@ func (l *linuxStandardInit) Init() error {
 			return newSystemErrorWithCause(err, "init seccomp")
 		}
 	}
+
+	logPipe, _ := (logrus.StandardLogger().Out).(*(os.File))
+	logPipe.Close()
+
 	if err := syscall.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
 		return newSystemErrorWithCause(err, "exec user process")
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -15,7 +15,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	"golang.org/x/sys/unix"
 )
@@ -188,10 +187,6 @@ func (l *linuxStandardInit) Init() error {
 			return newSystemErrorWithCause(err, "init seccomp")
 		}
 	}
-
-	logPipe, _ := (logrus.StandardLogger().Out).(*(os.File))
-	logPipe.Close()
-
 	if err := syscall.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
 		return newSystemErrorWithCause(err, "exec user process")
 	}

--- a/main.go
+++ b/main.go
@@ -138,6 +138,12 @@ func main() {
 		updateCommand,
 	}
 	app.Before = func(context *cli.Context) error {
+
+		// do nothing if logrus was already initialized in init.go
+		if logrus.StandardLogger().Out != logrus.New().Out {
+			return nil
+		}
+
 		if context.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)
 		}


### PR DESCRIPTION
Add support for children processes logging (including nsexec).
A pipe is used to send logs from children to parent in JSON.
The JSON format used is the same used by logrus JSON formatted,
i.e. children process can use standard logrus APIs.

This improves debugging and can also be used to report warning messages from the children.
