### PR TITLE
Dockerfile: update criu to v3.10 + checkpoint-restore/criu@27034e7c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,14 @@ RUN cd /tmp \
     && rm -rf /tmp/bats
 
 # install criu
-ENV CRIU_VERSION v3.7
+# For criu v3.10, a patch is needed for `@test "checkpoint --lazy-pages and restore"`.
+# Starting with v3.11, the patch will no longer be needed.
+# See https://github.com/opencontainers/runc/issues/1863#issuecomment-412074413
+ENV CRIU_VERSION v3.10
 RUN mkdir -p /usr/src/criu \
     && curl -sSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \
+    && curl https://github.com/checkpoint-restore/criu/commit/27034e7c64b00a1f2467afb5ebb1d5b9b1a06ce1.patch | patch -p1 \
     && make install-criu \
     && rm -rf /usr/src/criu
 


### PR DESCRIPTION
For criu v3.10, a patch is needed for `@test "checkpoint --lazy-pages and restore"`.
Starting with v3.11, the patch will no longer be needed.

See https://github.com/opencontainers/runc/issues/1863#issuecomment-412074413

The issue had not been caught in Travis because the kernel is too old and the test
had not been executed in Travis.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>