### PR TITLE
rootless: make /sys/fs/cgroup/* read-only

### DIFF
--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -19,3 +19,12 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" =~ '/tmp/bind/config.json' ]]
 }
+
+# make sure there is no "df: /foo/bar: No such file or directory" issue in the default configuration
+@test "runc run [df]" {
+	  CONFIG=$(jq '.process.args = ["df"]' config.json)
+	  echo "${CONFIG}" >config.json
+
+	  runc run test_df
+	  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
The default rootless spec bind-mounts /sys with "rbind,ro" (because mounting sysfs
requires netns to be unshared), however, it does not make subfilesystems mounted
under /sys read-only.

So, files under /sys/fs/cgroup were unexpectedly writable when they are chmod/chowned
via privileged helpers such as pam_cgfs.

This patch fixes the issue by mounting /sys/fs/cgroup/* as read-only explicitly.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>