### PR TITLE
cr: don't restore net namespace by default

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -109,6 +109,9 @@ using the runc checkpoint command.`,
 			return err
 		}
 		options := criuOptions(context)
+		if err := setEmptyNsMask(context, options); err != nil {
+			return err
+		}
 		status, err := startContainer(context, spec, CT_ACT_RESTORE, options)
 		if err != nil {
 			return err


### PR DESCRIPTION
since runc don't manage net device and their configuration, checkpoint
also don't dump net namespace by default, so set 'nsmask = unix.CLONE_NEWNET'
by default in restore. Or if user do not pass 'empty-ns network', criu will
cost extra time in restore.

Signed-off-by: Ace-Tang <aceapril@126.com>
