### PR TITLE
Respect container's cgroup path

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -311,7 +311,7 @@ func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
 }
 
 func (raw *cgroupData) path(subsystem string) (string, error) {
-	mnt, err := cgroups.FindCgroupMountpoint(subsystem)
+	mnt, err := cgroups.FindCgroupMountpoint(raw.root, subsystem)
 	// If we didn't mount the subsystem, there is no point we make the path.
 	if err != nil {
 		return "", err

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -464,7 +464,7 @@ func ExpandSlice(slice string) (string, error) {
 }
 
 func getSubsystemPath(c *configs.Cgroup, subsystem string) (string, error) {
-	mountpoint, err := cgroups.FindCgroupMountpoint(subsystem)
+	mountpoint, err := cgroups.FindCgroupMountpoint(c.Path, subsystem)
 	if err != nil {
 		return "", err
 	}

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -22,31 +22,41 @@ const (
 )
 
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
-func FindCgroupMountpoint(subsystem string) (string, error) {
-	mnt, _, err := FindCgroupMountpointAndRoot(subsystem)
+func FindCgroupMountpoint(cgroupPath, subsystem string) (string, error) {
+	mnt, _, err := FindCgroupMountpointAndRoot(cgroupPath, subsystem)
 	return mnt, err
 }
 
-func FindCgroupMountpointAndRoot(subsystem string) (string, string, error) {
+func FindCgroupMountpointAndRoot(cgroupPath, subsystem string) (string, string, error) {
 	// We are not using mount.GetMounts() because it's super-inefficient,
 	// parsing it directly sped up x10 times because of not using Sscanf.
 	// It was one of two major performance drawbacks in container start.
 	if !isSubsystemAvailable(subsystem) {
 		return "", "", NewNotFoundError(subsystem)
 	}
+
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return "", "", err
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
+	return findCgroupMountpointAndRootFromReader(f, cgroupPath, subsystem)
+}
+
+func findCgroupMountpointAndRootFromReader(reader io.Reader, cgroupPath, subsystem string) (string, string, error) {
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		txt := scanner.Text()
-		fields := strings.Split(txt, " ")
-		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
-			if opt == subsystem {
-				return fields[4], fields[3], nil
+		fields := strings.Fields(txt)
+		if len(fields) < 5 {
+			continue
+		}
+		if strings.HasPrefix(fields[4], cgroupPath) {
+			for _, opt := range strings.Split(fields[len(fields)-1], ",") {
+				if opt == subsystem {
+					return fields[4], fields[3], nil
+				}
 			}
 		}
 	}
@@ -256,7 +266,7 @@ func GetInitCgroupPath(subsystem string) (string, error) {
 }
 
 func getCgroupPathHelper(subsystem, cgroup string) (string, error) {
-	mnt, root, err := FindCgroupMountpointAndRoot(subsystem)
+	mnt, root, err := FindCgroupMountpointAndRoot("", subsystem)
 	if err != nil {
 		return "", err
 	}

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -301,7 +301,8 @@ func TestIgnoreCgroup2Mount(t *testing.T) {
 	}
 }
 
-const fakeMountInfo = ` 18 24 0:17 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw
+func TestGetClosestMountpointAncestor(t *testing.T) {
+	fakeMountInfo := ` 18 24 0:17 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw
 100 99 1:31 / /foo/bar rw,relatime - fake fake rw,fake
 100 99 1:31 / /foo/bar/baz2 rw,relatime - fake fake rw,fake
 100 99 1:31 / /foo/bar/baz rw,relatime - fake fake rw,fake
@@ -311,21 +312,39 @@ const fakeMountInfo = ` 18 24 0:17 / /sys rw,nosuid,nodev,noexec,relatime - sysf
 100 99 1:31 / /unrelated rw,relatime - fake fake rw,fake
 100 99 1:31 / / rw,relatime - fake fake rw,fake
 `
-
-func TestGetClosestMountpointAncestor(t *testing.T) {
 	testCases := []struct {
-		input      string
-		mountinfos string
-		output     string
+		input  string
+		output string
 	}{
-		{input: "/foo/bar/baz/a/b/c", mountinfos: fakeMountInfo, output: "/foo/bar/baz"},
-		{input: "/foo/bar/baz", mountinfos: fakeMountInfo, output: "/foo/bar/baz"},
-		{input: "/foo/bar/bazza", mountinfos: fakeMountInfo, output: "/foo/bar/bazza"},
-		{input: "/a/b/c/d", mountinfos: fakeMountInfo, output: "/"},
+		{input: "/foo/bar/baz/a/b/c", output: "/foo/bar/baz"},
+		{input: "/foo/bar/baz", output: "/foo/bar/baz"},
+		{input: "/foo/bar/bazza", output: "/foo/bar/bazza"},
+		{input: "/a/b/c/d", output: "/"},
 	}
 
 	for _, c := range testCases {
-		mountpoint := GetClosestMountpointAncestor(c.input, c.mountinfos)
+		mountpoint := GetClosestMountpointAncestor(c.input, fakeMountInfo)
+		if mountpoint != c.output {
+			t.Errorf("expected %s, got %s", c.output, mountpoint)
+		}
+	}
+}
+
+func TestFindCgroupMountpointAndRoot(t *testing.T) {
+	fakeMountInfo := `
+35 27 0:29 / /foo rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,devices
+35 27 0:29 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,devices
+`
+	testCases := []struct {
+		cgroupPath string
+		output     string
+	}{
+		{cgroupPath: "/sys/fs", output: "/sys/fs/cgroup/devices"},
+		{cgroupPath: "", output: "/foo"},
+	}
+
+	for _, c := range testCases {
+		mountpoint, _, _ := findCgroupMountpointAndRootFromReader(strings.NewReader(fakeMountInfo), c.cgroupPath, "devices")
 		if mountpoint != c.output {
 			t.Errorf("expected %s, got %s", c.output, mountpoint)
 		}


### PR DESCRIPTION
Hi there!

We have a testing environment where we have multiple instances of garden/runc running, where each instance creates and destroys containers for its tests. Each of these testing nodes are run in isolation on the same host, so each have their own cgroup directories to minimise interference.

We have noticed that occasionally, when runc is trying to write properties to a cgroup, it chooses a neighbours cgroup by accident.

We think this is to do with the implementation of [`FindCgroupMountpointAndRoot`](https://github.com/opencontainers/runc/blob/20aff4f0488c6d4b8df4d85b4f63f1f704c11abd/libcontainer/cgroups/utils.go#L30), which finds the *first* occurrence of a subsystem in the mount table. When we run multiple instances in parallel, this is not always the right one.

We'd like to improve this function to respect the containers cgroup path, which we can find from the containers spec.

Looking forward to your feedback,

Cheers, the garden team.


Signed-off-by: Danail Branekov <danailster@gmail.com>
Signed-off-by: Oliver Stenbom <ostenbom@pivotal.io>