### PR TITLE
Remove unused veth setup code

### DIFF
--- a/libcontainer/network_linux.go
+++ b/libcontainer/network_linux.go
@@ -5,18 +5,15 @@ package libcontainer
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/vishvananda/netlink"
 )
 
 var strategies = map[string]networkStrategy{
-	"veth":     &veth{},
 	"loopback": &loopback{},
 }
 
@@ -101,159 +98,5 @@ func (l *loopback) attach(n *configs.Network) (err error) {
 }
 
 func (l *loopback) detach(n *configs.Network) (err error) {
-	return nil
-}
-
-// veth is a network strategy that uses a bridge and creates
-// a veth pair, one that is attached to the bridge on the host and the other
-// is placed inside the container's namespace
-type veth struct {
-}
-
-func (v *veth) detach(n *configs.Network) (err error) {
-	return netlink.LinkSetMaster(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: n.HostInterfaceName}}, nil)
-}
-
-// attach a container network interface to an external network
-func (v *veth) attach(n *configs.Network) (err error) {
-	brl, err := netlink.LinkByName(n.Bridge)
-	if err != nil {
-		return err
-	}
-	br, ok := brl.(*netlink.Bridge)
-	if !ok {
-		return fmt.Errorf("Wrong device type %T", brl)
-	}
-	host, err := netlink.LinkByName(n.HostInterfaceName)
-	if err != nil {
-		return err
-	}
-
-	if err := netlink.LinkSetMaster(host, br); err != nil {
-		return err
-	}
-	if err := netlink.LinkSetMTU(host, n.Mtu); err != nil {
-		return err
-	}
-	if n.HairpinMode {
-		if err := netlink.LinkSetHairpin(host, true); err != nil {
-			return err
-		}
-	}
-	if err := netlink.LinkSetUp(host); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (v *veth) create(n *network, nspid int) (err error) {
-	tmpName, err := v.generateTempPeerName()
-	if err != nil {
-		return err
-	}
-	n.TempVethPeerName = tmpName
-	if n.Bridge == "" {
-		return fmt.Errorf("bridge is not specified")
-	}
-	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:   n.HostInterfaceName,
-			TxQLen: n.TxQueueLen,
-		},
-		PeerName: n.TempVethPeerName,
-	}
-	if err := netlink.LinkAdd(veth); err != nil {
-		return err
-	}
-	defer func() {
-		if err != nil {
-			netlink.LinkDel(veth)
-		}
-	}()
-	if err := v.attach(&n.Network); err != nil {
-		return err
-	}
-	child, err := netlink.LinkByName(n.TempVethPeerName)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetNsPid(child, nspid)
-}
-
-func (v *veth) generateTempPeerName() (string, error) {
-	return utils.GenerateRandomName("veth", 7)
-}
-
-func (v *veth) initialize(config *network) error {
-	peer := config.TempVethPeerName
-	if peer == "" {
-		return fmt.Errorf("peer is not specified")
-	}
-	child, err := netlink.LinkByName(peer)
-	if err != nil {
-		return err
-	}
-	if err := netlink.LinkSetDown(child); err != nil {
-		return err
-	}
-	if err := netlink.LinkSetName(child, config.Name); err != nil {
-		return err
-	}
-	// get the interface again after we changed the name as the index also changes.
-	if child, err = netlink.LinkByName(config.Name); err != nil {
-		return err
-	}
-	if config.MacAddress != "" {
-		mac, err := net.ParseMAC(config.MacAddress)
-		if err != nil {
-			return err
-		}
-		if err := netlink.LinkSetHardwareAddr(child, mac); err != nil {
-			return err
-		}
-	}
-	ip, err := netlink.ParseAddr(config.Address)
-	if err != nil {
-		return err
-	}
-	if err := netlink.AddrAdd(child, ip); err != nil {
-		return err
-	}
-	if config.IPv6Address != "" {
-		ip6, err := netlink.ParseAddr(config.IPv6Address)
-		if err != nil {
-			return err
-		}
-		if err := netlink.AddrAdd(child, ip6); err != nil {
-			return err
-		}
-	}
-	if err := netlink.LinkSetMTU(child, config.Mtu); err != nil {
-		return err
-	}
-	if err := netlink.LinkSetUp(child); err != nil {
-		return err
-	}
-	if config.Gateway != "" {
-		gw := net.ParseIP(config.Gateway)
-		if err := netlink.RouteAdd(&netlink.Route{
-			Scope:     netlink.SCOPE_UNIVERSE,
-			LinkIndex: child.Attrs().Index,
-			Gw:        gw,
-		}); err != nil {
-			return err
-		}
-	}
-	if config.IPv6Gateway != "" {
-		gw := net.ParseIP(config.IPv6Gateway)
-		if err := netlink.RouteAdd(&netlink.Route{
-			Scope:     netlink.SCOPE_UNIVERSE,
-			LinkIndex: child.Attrs().Index,
-			Gw:        gw,
-		}); err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"io"
 	"os"
@@ -16,19 +14,6 @@ import (
 const (
 	exitSignalOffset = 128
 )
-
-// GenerateRandomName returns a new name joined with a prefix.  This size
-// specified is used to truncate the randomly generated value
-func GenerateRandomName(prefix string, size int) (string, error) {
-	id := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, id); err != nil {
-		return "", err
-	}
-	if size > 64 {
-		size = 64
-	}
-	return prefix + hex.EncodeToString(id)[:size], nil
-}
 
 // ResolveRootfs ensures that the current working directory is
 // not a symlink and returns the absolute path to the rootfs

--- a/libcontainer/utils/utils_test.go
+++ b/libcontainer/utils/utils_test.go
@@ -10,28 +10,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestGenerateName(t *testing.T) {
-	name, err := GenerateRandomName("veth", 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := 5 + len("veth")
-	if len(name) != expected {
-		t.Fatalf("expected name to be %d chars but received %d", expected, len(name))
-	}
-
-	name, err = GenerateRandomName("veth", 65)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected = 64 + len("veth")
-	if len(name) != expected {
-		t.Fatalf("expected name to be %d chars but received %d", expected, len(name))
-	}
-}
-
 var labelTest = []struct {
 	labels        []string
 	query         string


### PR DESCRIPTION
Networking is setup by plugins for users of runc so it makes sense
to get rid of the veth strategy.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>