### PR TITLE
Modify empty value handling of global options --log

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,6 +142,14 @@ func main() {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 		if path := context.GlobalString("log"); path != "" {
+			for _, flags := range app.Flags {
+				for _, flag := range strings.Split(flags.GetName(), ",") {
+					flagtrim := strings.TrimSpace(flag)
+					if (len(flagtrim) == 1 && (path == "-" + flagtrim)) || (len(flagtrim) > 1 && (path == "--" + flagtrim)) {
+						path = "/dev/null"
+					}
+				}
+			}
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)
 			if err != nil {
 				return err


### PR DESCRIPTION
runc cannot handle empty arguments of global option "--log" correctly. For example, "runc --log --debug run con1" will create the log file named "--debug" and I think it should not be assumed.
So, this commit modifies empty arguments handling for global option "--log"  to use "/dev/null" as runc help specified.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>