### PR TITLE
Add rootless testpath in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ localintegration: all
 	bats -t tests/integration${TESTPATH}
 
 rootlessintegration: runcimage
-	$(CONTAINER_ENGINE) run ${CONTAINER_ENGINE_RUN_FLAGS} -t --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) make localrootlessintegration
+	$(CONTAINER_ENGINE) run -e ROOTLESS_TESTPATH ${CONTAINER_ENGINE_RUN_FLAGS} -t --privileged --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) make localrootlessintegration
 
 localrootlessintegration: all
 	tests/rootless.sh

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ You can run a specific integration test by setting the `TESTPATH` variable.
 # make test TESTPATH="/checkpoint.bats"
 ```
 
+You can run a specific rootless integration test by setting the `ROOTLESS_TESTPATH` variable.
+
+```bash
+# make test ROOTLESS_TESTPATH="/checkpoint.bats"
+```
+
 You can run a test using your container engine's flags by setting `CONTAINER_ENGINE_BUILD_FLAGS` and `CONTAINER_ENGINE_RUN_FLAGS` variables.
 
 ```bash

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -120,6 +120,6 @@ do
 	set -e
 	echo path: $PATH
 	export ROOTLESS_FEATURES="$enabled_features"
-	sudo -HE -u rootless PATH="$PATH" bats -t "$ROOT/tests/integration$TESTFLAGS"
+	sudo -HE -u rootless PATH="$PATH" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	set +e
 done


### PR DESCRIPTION
I found rootless test could select test path. 
So, this commit modifies Makefile for rootless test to select test path.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>