### PR TITLE
libcontainer: CurrentGroupSubGIDs -> CurrentUserSubGIDs

### DIFF
--- a/libcontainer/user/lookup_unix.go
+++ b/libcontainer/user/lookup_unix.go
@@ -5,6 +5,7 @@ package user
 import (
 	"io"
 	"os"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
@@ -115,22 +116,23 @@ func CurrentGroup() (Group, error) {
 	return LookupGid(unix.Getgid())
 }
 
-func CurrentUserSubUIDs() ([]SubID, error) {
+func currentUserSubIDs(fileName string) ([]SubID, error) {
 	u, err := CurrentUser()
 	if err != nil {
 		return nil, err
 	}
-	return ParseSubIDFileFilter("/etc/subuid",
-		func(entry SubID) bool { return entry.Name == u.Name })
+	filter := func(entry SubID) bool {
+		return entry.Name == u.Name || entry.Name == strconv.Itoa(u.Uid)
+	}
+	return ParseSubIDFileFilter(fileName, filter)
 }
 
-func CurrentGroupSubGIDs() ([]SubID, error) {
-	g, err := CurrentGroup()
-	if err != nil {
-		return nil, err
-	}
-	return ParseSubIDFileFilter("/etc/subgid",
-		func(entry SubID) bool { return entry.Name == g.Name })
+func CurrentUserSubUIDs() ([]SubID, error) {
+	return currentUserSubIDs("/etc/subuid")
+}
+
+func CurrentUserSubGIDs() ([]SubID, error) {
+	return currentUserSubIDs("/etc/subgid")
 }
 
 func CurrentProcessUIDMap() ([]IDMap, error) {


### PR DESCRIPTION
subgid is defined per user, not group (see [`subgid(5)`](http://man7.org/linux/man-pages/man5/subgid.5.html))

This commit also adds support for specifying subuid owner with a numeric UID.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>