### PR TITLE
libcontainer: add /proc/loadavg to the white list of bind mount

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -421,6 +421,7 @@ func checkMountDestination(rootfs, dest string) error {
 		"/proc/stat",
 		"/proc/swaps",
 		"/proc/uptime",
+		"/proc/loadavg",
 		"/proc/net/dev",
 	}
 	for _, valid := range validDestinations {


### PR DESCRIPTION
Signed-off-by: JunLi <lijun.git@gmail.com>