### PR TITLE
fix delete other file bug when container id is ..

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -359,23 +359,7 @@ func (l *LinuxFactory) loadState(root, id string) (*State, error) {
 }
 
 func (l *LinuxFactory) validateID(id string) error {
-	if !idRegex.MatchString(id) || id == ".." || id == "." {
-		return newGenericError(fmt.Errorf("invalid id format: %v", id), InvalidIdFormat)
-	}
-
-	//For unforeseen invalid id situations, can checked by is SubDir?
-	rootPath, err := filepath.Abs(l.Root)
-	if err != nil {
-		return err
-	}
-
-	containerRoot := filepath.Join(l.Root, id)
-	rootCheckPath, err := filepath.Abs(filepath.Join(containerRoot, ".."))
-	if err != nil {
-		return err
-	}
-
-	if rootPath != rootCheckPath {
+	if id == "." || !idRegex.MatchString(id) || utils.CleanPath(id) != id {
 		return newGenericError(fmt.Errorf("invalid id format: %v", id), InvalidIdFormat)
 	}
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"strconv"
 
+	"github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
@@ -195,7 +196,10 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	if err := l.Validator.Validate(config); err != nil {
 		return nil, newGenericError(err, ConfigInvalid)
 	}
-	containerRoot := filepath.Join(l.Root, id)
+	containerRoot, err := securejoin.SecureJoin(l.Root, id)
+	if err != nil {
+		return nil, err
+	}
 	if _, err := os.Stat(containerRoot); err == nil {
 		return nil, newGenericError(fmt.Errorf("container with id exists: %v", id), IdInUse)
 	} else if !os.IsNotExist(err) {
@@ -233,7 +237,10 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	if err := l.validateID(id); err != nil {
 		return nil, err
 	}
-	containerRoot := filepath.Join(l.Root, id)
+	containerRoot, err := securejoin.SecureJoin(l.Root, id)
+	if err != nil {
+		return nil, err
+	}
 	state, err := l.loadState(containerRoot, id)
 	if err != nil {
 		return nil, err
@@ -343,7 +350,11 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 }
 
 func (l *LinuxFactory) loadState(root, id string) (*State, error) {
-	f, err := os.Open(filepath.Join(root, stateFilename))
+	stateFilePath, err := securejoin.SecureJoin(root, stateFilename)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(stateFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, newGenericError(fmt.Errorf("container %q does not exist", id), ContainerNotExists)
@@ -359,7 +370,7 @@ func (l *LinuxFactory) loadState(root, id string) (*State, error) {
 }
 
 func (l *LinuxFactory) validateID(id string) error {
-	if id == "." || !idRegex.MatchString(id) || utils.CleanPath(id) != id {
+	if !idRegex.MatchString(id) || string(os.PathSeparator)+id != utils.CleanPath(string(os.PathSeparator)+id) {
 		return newGenericError(fmt.Errorf("invalid id format: %v", id), InvalidIdFormat)
 	}
 


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

There is a big bug which can delete files not belonging to the container when use runc delete --force.
Command history is:

/opt/runc/runcroot is ruc's root dir.
```
root@dockerdemo:/opt/runc# ls -lh
total 16K
drwxr-xr-x 2 root root 4.0K Aug 31 11:19 dbback
drwx------ 2 root root 4.0K Aug 31 10:49 runcroot
-rw-r--r-- 1 root root    5 Aug 31 11:19 test
-rw-r--r-- 1 root root    6 Aug 31 11:19 test1
```
While **dbback dir** have very important db backup files.

run two container:
```
root@dockerdemo:/opt/runctest/redis# runc --root /opt/runc/runcroot run -d redis
root@dockerdemo:/opt/runctest/redis# 6:C 31 Aug 03:24:24.741 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo

root@dockerdemo:/opt/runctest/redis# runc --root /opt/runc/runcroot run -d ..0
root@dockerdemo:/opt/runctest/redis# 6:C 31 Aug 03:24:33.669 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo

root@dockerdemo:/opt/runctest/redis# runc --root /opt/runc/runcroot list
ID          PID         STATUS      BUNDLE                CREATED                          OWNER
..0         4170        running     /opt/runctest/redis   2018-08-31T03:24:33.664173003Z   root
redis       4121        running     /opt/runctest/redis   2018-08-31T03:24:24.73616634Z    root
root@dockerdemo:/opt/runctest/redis#
```

backup a state.json to /opt/runc
```
root@dockerdemo:/opt/runctest/redis# runc --root /opt/runc/runcroot list
ID          PID         STATUS      BUNDLE                CREATED                          OWNER
..0         4170        running     /opt/runctest/redis   2018-08-31T03:24:33.664173003Z   root
redis       4121        running     /opt/runctest/redis   2018-08-31T03:24:24.73616634Z    root
root@dockerdemo:/opt/runctest/redis# cp /opt/runc/runcroot/redis/state.json /opt/runc/
root@dockerdemo:/opt/runctest/redis# ls /opt/runc
dbback  runcroot  state.json  test  test1
root@dockerdemo:/opt/runctest/redis#
```

When I want to delete ..0, but I typed a wrong word: ..0 -> .. lost a 0
```
root@dockerdemo:/opt/runctest/redis# runc --root /opt/runc/runcroot delete --force ..
root@dockerdemo:/opt/runctest/redis# runc --root /opt/runc/runcroot list
ID          PID         STATUS      BUNDLE      CREATED     OWNER
root@dockerdemo:/opt/runctest/redis# ls /opt/runc
runcroot
root@dockerdemo:/opt/runctest/redis# ls /opt/runc/runcroot/
root@dockerdemo:/opt/runctest/redis#
```
**Everything is deleted, include my dbback dir.**

This is because there is no strict id validate method in Container Load function in "libcontainer/factory_linux.go", especially when delete.

Please check it, thanks.