### PR TITLE
Pass runc env to criu

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1343,6 +1343,7 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 	if extraFiles != nil {
 		cmd.ExtraFiles = append(cmd.ExtraFiles, extraFiles...)
 	}
+	cmd.Env = append(cmd.Env, os.Environ()...)
 
 	if err := cmd.Start(); err != nil {
 		return err


### PR DESCRIPTION
This is so criu is exec'd with the same env and any modifications to
PATH or libs.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>