### PR TITLE
libcontainer: fix InitArgs options func to set factory.InitPath

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -452,8 +452,7 @@ func (c *linuxContainer) newParentProcess(p *Process) (parentProcess, error) {
 }
 
 func (c *linuxContainer) commandTemplate(p *Process, childPipe *os.File) (*exec.Cmd, error) {
-	cmd := exec.Command(c.initPath, c.initArgs[1:]...)
-	cmd.Args[0] = c.initArgs[0]
+	cmd := exec.Command(c.initPath, c.initArgs...)
 	cmd.Stdin = p.Stdin
 	cmd.Stdout = p.Stdout
 	cmd.Stderr = p.Stderr

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -43,7 +43,10 @@ func InitArgs(args ...string) func(*LinuxFactory) error {
 			}
 		}
 
-		l.InitArgs = args
+		l.InitPath = args[0]
+		if len(args) > 1 {
+			l.InitArgs = args[1:]
+		}
 		return nil
 	}
 }

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -141,7 +141,7 @@ func New(root string, options ...func(*LinuxFactory) error) (Factory, error) {
 	l := &LinuxFactory{
 		Root:      root,
 		InitPath:  "/proc/self/exe",
-		InitArgs:  []string{os.Args[0], "init"},
+		InitArgs:  []string{"init"},
 		Validator: validate.New(),
 		CriuPath:  "criu",
 	}

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -50,6 +50,41 @@ func TestFactoryNew(t *testing.T) {
 	}
 }
 
+func TestFactoryNewInitArgs(t *testing.T) {
+	root, rerr := newTestRoot()
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	defer os.RemoveAll(root)
+
+	path := "/bin/sleep"
+	args := []string{"100"}
+	combined := append([]string{path}, args...)
+
+	factory, err := New(root, InitArgs(combined...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if factory == nil {
+		t.Fatal("factory should not be nil")
+	}
+	lfactory, ok := factory.(*LinuxFactory)
+	if !ok {
+		t.Fatal("expected linux factory returned on linux based systems")
+	}
+	if lfactory.InitPath != path {
+		t.Fatalf("expected factory init path: '%s' but recieved: '%s'", path, lfactory.InitPath)
+	}
+	if len(lfactory.InitArgs) != len(args) {
+		t.Fatalf("expected factory args length: '%d' but recieved: '%d'", len(args), len(lfactory.InitArgs))
+	}
+	for i, arg := range args {
+		if lfactory.InitArgs[i] != arg {
+			t.Fatalf("expected factory args[%d]: '%s' but recieved: '%s'", i, arg, lfactory.InitArgs[i])
+		}
+	}
+}
+
 func TestFactoryNewIntelRdt(t *testing.T) {
 	root, rerr := newTestRoot()
 	if rerr != nil {


### PR DESCRIPTION
Greetings!

From the godocs it looks like `InitArgs` should be setting the full path and args for the init process:
>InitArgs returns an options func to configure a LinuxFactory with the provided init binary **path and arguments.**

This isn't the case so here is a PR to fix that + a unit test.

Thanks!
-Nick