### PR TITLE
clean mountpoint path

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -280,8 +280,8 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	}
 	return &configs.Mount{
 		Device:           device,
-		Source:           source,
-		Destination:      m.Destination,
+		Source:           libcontainerUtils.CleanPath(source),
+		Destination:      libcontainerUtils.CleanPath(m.Destination),
 		Data:             data,
 		Flags:            flags,
 		PropagationFlags: pgflags,


### PR DESCRIPTION
clean mountpoint source and destination path in 'createLibcontainerMount'.

Signed-off-by: Ace-Tang <aceapril@126.com>

### why I do this

1. clean path seems reasonable in linux, produce a canonicalized pathname. (I remove the absolute word, it was add by mistake, I do not want to resolve path to absolute path, but only do clean)

2. actually, I failed to restore a checkpointed container caused I passed a pathname like '/foo/bar/' in -v,  note I am not using docker(docker will do the path clean in the high level). 
https://github.com/checkpoint-restore/criu/issues/547


Please check if the modification make sense !