### PR TITLE
keyring: handle ENOSYS with keyctl(KEYCTL_JOIN_SESSION_KEYRING)

### DIFF
--- a/libcontainer/keys/keyctl.go
+++ b/libcontainer/keys/keyctl.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -15,7 +17,7 @@ type KeySerial uint32
 func JoinSessionKeyring(name string) (KeySerial, error) {
 	sessKeyId, err := unix.KeyctlJoinSessionKeyring(name)
 	if err != nil {
-		return 0, fmt.Errorf("could not create session key: %v", err)
+		return 0, errors.Wrap(err, "create session key")
 	}
 	return KeySerial(sessKeyId), nil
 }

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -48,13 +48,25 @@ func (l *linuxStandardInit) Init() error {
 		ringname, keepperms, newperms := l.getSessionRingParams()
 
 		// Do not inherit the parent's session keyring.
-		sessKeyId, err := keys.JoinSessionKeyring(ringname)
-		if err != nil {
-			return errors.Wrap(err, "join session keyring")
-		}
-		// Make session keyring searcheable.
-		if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
-			return errors.Wrap(err, "mod keyring permissions")
+		if sessKeyId, err := keys.JoinSessionKeyring(ringname); err != nil {
+			// If keyrings aren't supported then it is likely we are on an
+			// older kernel (or inside an LXC container). While we could bail,
+			// the security feature we are using here is best-effort (it only
+			// really provides marignal protection since VFS credentials are
+			// the only significant protection of keyrings).
+			//
+			// TODO(cyphar): Log this so people know what's going on, once we
+			//               have proper logging in 'runc init'.
+			if errors.Cause(err) != unix.ENOSYS {
+				return errors.Wrap(err, "join session keyring")
+			}
+		} else {
+			// Make session keyring searcheable. If we've gotten this far we
+			// bail on any error -- we don't want to have a keyring with bad
+			// permissions.
+			if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
+				return errors.Wrap(err, "mod keyring permissions")
+			}
 		}
 	}
 


### PR DESCRIPTION
While all modern kernels (and I do mean _all_ of them -- this syscall
was added in 2.6.10 before git had begun development!) have support for
this syscall, LXC has a default seccomp profile that returns ENOSYS for
this syscall. For most syscalls this would be a deal-breaker, and our
use of session keyrings is security-based there are a few mitigating
factors that make this change not-completely-insane:

  * We already have a flag that disables the use of session keyrings
    (for older kernels that had system-wide keyring limits and so
    on). So disabling it is not a new idea.

  * While the primary justification of using session keys *is*
    security-based, it's more of a security-by-obscurity protection.
    The main defense keyrings have is VFS credentials -- which is
    something that users already have better security tools for
    (setuid(2) and user namespaces).

  * Given the security justification you might argue that we
    shouldn't silently ignore this. However, the only way for the
    kernel to return -ENOSYS is either being ridiculously old (at
    which point we wouldn't work anyway) or that there is a seccomp
    profile in place blocking it.

    Given that the seccomp profile (if malicious) could very easily
    just return 0 or a silly return code (or something even more
    clever with seccomp-bpf) and trick us without this patch, there
    isn't much of a significant change in how much seccomp can trick
    us with or without this patch.

Given all of that over-analysis, I'm pretty convinced there isn't a
security problem in this very specific case and it will help out the
ChromeOS folks by allowing Docker to run inside their LXC container
setup. I'd be happy to be proven wrong.

Fixes #1889
Ref: https://bugs.chromium.org/p/chromium/issues/detail?id=860565
Signed-off-by: Aleksa Sarai <asarai@suse.de>