### PR TITLE
tty: close epollConsole on errors

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -97,9 +97,11 @@ func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) error {
 	// set raw mode to stdin and also handle interrupt
 	stdin, err := console.ConsoleFromFile(os.Stdin)
 	if err != nil {
+		epollConsole.Close()
 		return err
 	}
 	if err := stdin.SetRaw(); err != nil {
+		epollConsole.Close()
 		return fmt.Errorf("failed to set the terminal from the stdin: %v", err)
 	}
 	go handleInterrupt(stdin)


### PR DESCRIPTION
make sure epollConsole is closed before returning an error.  It solves
a hang when using these commands with a container that uses a
terminal:

runc run foo &
ssh root@localhost runc exec foo echo hello

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>