### PR TITLE
Overlayfs can be fooled to copyup on append in readonly mode.

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -653,7 +653,7 @@ func prepareRoot(config *configs.Config) error {
 }
 
 func setReadonly() error {
-	return unix.Mount("/", "/", "bind", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_REC, "")
+	return unix.Mount("/", "/", "bind", unix.MS_REMOUNT|unix.MS_RDONLY, "")
 }
 
 func setupPtmx(config *configs.Config) error {


### PR DESCRIPTION
This change converts all mount points.

all mount points (host, container or any other namespace) will be converted to ro

Currently with an overlayfs back end if I do

podman run --name test fedora bash -c "echo hello >> /bin/sh"
5f393f523c1fb97d47ac6dfd1304e18a5c73a0893b28c09d1e2fb31e39570b94
bash: /bin/sh: Read-only file system
C /run
A /run/.containerenv
A /run/secrets
C /usr
C /usr/bin
C /usr/bin/bash

After this fix we see.

bc609feec03cdd544bf8fd2e1935687d5b95d9445fe6a0c57a295ee17e9c841e
bash: /bin/sh: Read-only file system
C /run
A /run/.containerenv
A /run/secrets

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>