### PR TITLE
fix build break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get -qq update
   - sudo apt-get install -y libseccomp-dev/trusty-backports
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - go get -u github.com/vbatts/git-validation
   - env | grep TRAVIS_
 


### PR DESCRIPTION
fixes travis ci build break..

"go get -u github.com/golang.org/lint/golint"
fails with 
```expects import "golang.org/x/lint/golint"```

commit switches to use "golang.org/x/lint/golint" as requested at https://github.com/golang/lint 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>