### PR TITLE
Fix travis Go: tip

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1197,7 +1197,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 			netns, err := os.Open(nsPath)
 			defer netns.Close()
 			if err != nil {
-				logrus.Error("If a specific network namespace is defined it must exist: %s", err)
+				logrus.Errorf("If a specific network namespace is defined it must exist: %s", err)
 				return fmt.Errorf("Requested network namespace %v does not exist", nsPath)
 			}
 			inheritFd := new(criurpc.InheritFd)


### PR DESCRIPTION
This fixes

 libcontainer/container_linux.go:1200: Error call has possible formatting directive %s

Signed-off-by: Adrian Reber <areber@redhat.com>