### PR TITLE
user: Always return supplementary groups

### DIFF
--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -417,8 +417,8 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 
 				// Okay, so it's numeric. We can just roll with this.
 			}
-		} else if len(groups) > 0 {
-			// Supplementary group ids only make sense if in the implicit form.
+		}
+		if len(groups) > 0 {
 			user.Sgids = make([]int, len(groups))
 			for i, group := range groups {
 				user.Sgids[i] = group.Gid


### PR DESCRIPTION
The caller can ignore it if they don't care about using them.

cc: @cyphar @runcom 

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>