### PR TITLE
test: fix TestDupNamespaces fail to test dup-ns error

### DIFF
--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -4,6 +4,7 @@ package specconv
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -395,6 +396,9 @@ func TestSpecconvExampleValidate(t *testing.T) {
 
 func TestDupNamespaces(t *testing.T) {
 	spec := &specs.Spec{
+		Root: &specs.Root{
+			Path: "rootfs",
+		},
 		Linux: &specs.Linux{
 			Namespaces: []specs.LinuxNamespace{
 				{
@@ -412,7 +416,7 @@ func TestDupNamespaces(t *testing.T) {
 		Spec: spec,
 	})
 
-	if err == nil {
+	if !strings.Contains(err.Error(), "malformed spec file: duplicated ns") {
 		t.Errorf("Duplicated namespaces should be forbidden")
 	}
 }


### PR DESCRIPTION
add Root in created spec, or `TestDupNamespaces` is not test dup-namespace ,but test `lack of Root`,  error message is 'Root must be specified'

Signed-off-by: Ace-Tang <aceapril@126.com>

if not add Root field, test will fail at 
```
if spec.Root == nil {
        return nil, fmt.Errorf("Root must be specified")
    }
```