### PR TITLE
libcontainer: fix potential panic if spec.Process is nil

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -251,19 +251,19 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 			}
 		}
 	}
-	if spec.Process.SelinuxLabel != "" {
-		config.ProcessLabel = spec.Process.SelinuxLabel
-	}
 	if spec.Process != nil {
 		config.OomScoreAdj = spec.Process.OOMScoreAdj
-	}
-	if spec.Process.Capabilities != nil {
-		config.Capabilities = &configs.Capabilities{
-			Bounding:    spec.Process.Capabilities.Bounding,
-			Effective:   spec.Process.Capabilities.Effective,
-			Permitted:   spec.Process.Capabilities.Permitted,
-			Inheritable: spec.Process.Capabilities.Inheritable,
-			Ambient:     spec.Process.Capabilities.Ambient,
+		if spec.Process.SelinuxLabel != "" {
+			config.ProcessLabel = spec.Process.SelinuxLabel
+		}
+		if spec.Process.Capabilities != nil {
+			config.Capabilities = &configs.Capabilities{
+				Bounding:    spec.Process.Capabilities.Bounding,
+				Effective:   spec.Process.Capabilities.Effective,
+				Permitted:   spec.Process.Capabilities.Permitted,
+				Inheritable: spec.Process.Capabilities.Inheritable,
+				Ambient:     spec.Process.Capabilities.Ambient,
+			}
 		}
 	}
 	createHooks(spec, config)


### PR DESCRIPTION
for the code logic, pointer 'spec.Process' should be judge first
to avoid panic.

Signed-off-by: Ace-Tang <aceapril@126.com>