### PR TITLE
fix: may kill other process when container has been stopped

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -374,10 +374,18 @@ func (c *linuxContainer) Signal(s os.Signal, all bool) error {
 	if all {
 		return signalAllProcesses(c.cgroupManager, s)
 	}
-	if err := c.initProcess.signal(s); err != nil {
-		return newSystemErrorWithCause(err, "signaling init process")
+	status, err := c.currentStatus()
+	if err != nil {
+		return err
 	}
-	return nil
+	// to avoid a PID reuse attack
+	if status == Running || status == Created {
+		if err := c.initProcess.signal(s); err != nil {
+			return newSystemErrorWithCause(err, "signaling init process")
+		}
+		return nil
+	}
+	return newGenericError(fmt.Errorf("container not running"), ContainerNotRunning)
 }
 
 func (c *linuxContainer) createExecFifo() error {


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

If a container A has been stopped, and after a long time, the host start a new process B whose process id is just equal to container A's process id.
When `runc kill A 9` again, process B will be killed.
So, we need to check container's status when we want to kill it.