### PR TITLE
Bump CRIU to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,14 +45,10 @@ RUN cd /tmp \
     && rm -rf /tmp/bats
 
 # install criu
-# For criu v3.10, a patch is needed for `@test "checkpoint --lazy-pages and restore"`.
-# Starting with v3.11, the patch will no longer be needed.
-# See https://github.com/opencontainers/runc/issues/1863#issuecomment-412074413
-ENV CRIU_VERSION v3.10
+ENV CRIU_VERSION v3.11
 RUN mkdir -p /usr/src/criu \
     && curl -sSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \
-    && curl https://github.com/checkpoint-restore/criu/commit/27034e7c64b00a1f2467afb5ebb1d5b9b1a06ce1.patch | patch -p1 \
     && make install-criu \
     && rm -rf /usr/src/criu
 


### PR DESCRIPTION
Upgrade CRIU to 3.11 in the Dockerfile as it includes the patch which
was manually added to fix an error with read-only root containers.

Now that the patch is part of the CRIU 3.11 release this simplifies the
Dockerfile (minimal).

Signed-off-by: Adrian Reber <areber@redhat.com>