### PR TITLE
cgroups: nokmem: error out on explicitly-set kmemcg limits

### DIFF
--- a/libcontainer/cgroups/fs/kmem_disabled.go
+++ b/libcontainer/cgroups/fs/kmem_disabled.go
@@ -2,10 +2,14 @@
 
 package fs
 
+import (
+	"errors"
+)
+
 func EnableKernelMemoryAccounting(path string) error {
 	return nil
 }
 
 func setKernelMemory(path string, kernelMemoryLimit int64) error {
-	return nil
+	return errors.New("kernel memory accounting disabled in this runc build")
 }


### PR DESCRIPTION
When built with nokmem we explicitly are disabling support for kmemcg,
but it is a strict specification requirement that if we cannot fulfil an
aspect of the container configuration that we error out.

Completely ignoring explicitly-requested kmemcg limits with nokmem would
undoubtably lead to problems.

Fixes #1938
Fixes: 6a2c15596845 ("libcontainer: ability to compile without kmem")
Signed-off-by: Aleksa Sarai <asarai@suse.de>