### PR TITLE
MAINTAINERS: remove @rjnagal and @vmarmol

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,4 @@
 Michael Crosby <michael@docker.com> (@crosbymichael)
-Rohit Jnagal <jnagal@google.com> (@rjnagal)
 Victor Marmol <vmarmol@google.com> (@vmarmol)
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
 Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,4 @@
 Michael Crosby <michael@docker.com> (@crosbymichael)
-Victor Marmol <vmarmol@google.com> (@vmarmol)
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
 Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)
 Qiang Huang <h.huangqiang@huawei.com> (@hqhq)


### PR DESCRIPTION
After talking to Rohit, he mentioned that he wasn't aware he was still a
maintainer (and that his maintainership was grandfathered from his
Docker maintainership). He's moved on to other projects now, and thus
said he would happily step down as maintainer. (Since he's stepping down
voluntarily, this doesn't require a mailing-list vote.)

After discussion with Victor, he mentioned that he wanted to rescind
his maintainership a few years ago (due to a change in priorities and
what he's been working on) but wasn't sure what the right process is.

Thanks for all of your hard work, Rohit and Victor!

/cc @rjnagal  @vmarmol 
Signed-off-by: Aleksa Sarai <asarai@suse.de>