### PR TITLE
cr: get pid from criu notify when restore

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1554,6 +1554,7 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 			if err != nil {
 				return nil
 			}
+			s.Pid = int(notify.GetPid())
 			for i, hook := range c.config.Hooks.Prestart {
 				if err := hook.Run(s); err != nil {
 					return newSystemErrorWithCausef(err, "running prestart hook %d", i)


### PR DESCRIPTION
when restore container from a checkpoint directory, we should get
pid from criu notify, since c.initProcess has not been created.

Signed-off-by: Ace-Tang <aceapril@126.com>

## why I do this

I fail to update runc version in pouch project, https://github.com/alibaba/pouch/pull/2516, I check the restore code, in `criuNotifications` function,  `currentOCIState()` can not get pid since c.initProcess has not been created.
```
    case notify.GetScript() == "setup-namespaces":
        if c.config.Hooks != nil {
            s, err := c.currentOCIState()
            if err != nil {
                return nil
            }
```

I do not figure out how criu notify can get pid, I want invite @avagin and @adrianreber help to check whether the fix in pr is correct.