### PR TITLE
Resilience in adding of exec tasks to cgroups

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	units "github.com/docker/go-units"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -463,11 +464,40 @@ func WriteCgroupProc(dir string, pid int) error {
 		return fmt.Errorf("no such directory for %s", CgroupProcesses)
 	}
 
-	// Don't attach any pid to the cgroup if -1 is specified as a pid
-	if pid != -1 {
-		if err := ioutil.WriteFile(filepath.Join(dir, CgroupProcesses), []byte(strconv.Itoa(pid)), 0700); err != nil {
-			return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
-		}
+	// Dont attach any pid to the cgroup if -1 is specified as a pid
+	if pid == -1 {
+		return nil
 	}
-	return nil
+
+	cgroupProcessesFile, err := os.OpenFile(filepath.Join(dir, CgroupProcesses), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
+	}
+	defer cgroupProcessesFile.Close()
+
+	for i := 0; i < 5; i++ {
+		_, err = cgroupProcessesFile.WriteString(strconv.Itoa(pid))
+		if err == nil {
+			return nil
+		}
+
+		// EINVAL might mean that the task being added to cgroup.procs is in state
+		// TASK_NEW. We should attempt to do so again.
+		if isEINVAL(err) {
+			time.Sleep(30 * time.Millisecond)
+			continue
+		}
+
+		return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
+	}
+	return err
+}
+
+func isEINVAL(err error) bool {
+	switch err := err.(type) {
+	case *os.PathError:
+		return err.Err == unix.EINVAL
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
This is related to https://github.com/opencontainers/runc/issues/1884

This fix allows more leniency for setting up cgroups on exec when cgroup namespaces are not used.

The issue linked above was partly resolved by https://github.com/opencontainers/runc/pull/1916 - we can avoid the issue entirely by using cgroup namespaces. Cloud Foundry's use of runc does not yet use cgroup namespaces and we encounter the issue above frequently.

We believe that since not using cgroup namespaces is a valid configuration of a config.json, runc should be more resilient when we choose not to. This PR will attempt to write to cgroup.procs a few times when execing, only retrying on seeing EINVAL (which, unless you're using realtime processes, means the task's state in the kernel is still TASK_NEW: https://elixir.bootlin.com/linux/v4.8/source/kernel/sched/core.c#L8286)

We replaced the ioutil.WriteFile with a Open/Write dance because we don't want to open the file each time we attempt to write to cgroup.procs, and we reduce the surface for error types changing underneath us within golang.
