### PR TITLE
Set default CRIU WorkDirectory = ImagesDirectory

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -901,7 +901,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 	}
 
 	if criuOpts.WorkDirectory == "" {
-		criuOpts.WorkDirectory = filepath.Join(c.root, "criu.work")
+		criuOpts.WorkDirectory = criuOpts.ImagesDirectory
 	}
 
 	if err := os.Mkdir(criuOpts.WorkDirectory, 0755); err != nil && !os.IsExist(err) {
@@ -1127,7 +1127,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 		return err
 	}
 	if criuOpts.WorkDirectory == "" {
-		criuOpts.WorkDirectory = filepath.Join(c.root, "criu.work")
+		criuOpts.WorkDirectory = criuOpts.ImagesDirectory
 	}
 	// Since a container can be C/R'ed multiple times,
 	// the work directory may already exist.


### PR DESCRIPTION
CRIU is using both images and work directory to store files during
checkpoint and restore. The work directory contains files such as logs
and irmap cache.

Currently runc sets the default value of the work directory to
`filepath.Join(c.root, "criu.work")`, and in case of failure outputs
the following message:

    # runc restore --image-path /tmp/test/ mycontainer
    criu failed: type NOTIFY errno 0
    log file: /run/runc/mycontainer/criu.work/restore.log

However, this is not very useful because the directory
`/run/runc/mycontainer/criu.work` is removed in case of failure, and
therefore the `restore.log` file does not exist.

This patch changes runc to follow the default behaviour of CRIU by
setting the working directory to be the same as the images directory,
and therefore preserve the log file in case of failure.

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>