### PR TITLE
libcontainer: intelrdt: fix null intelrdt path issue in Destroy()

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -547,7 +547,7 @@ func (m *IntelRdtManager) Apply(pid int) (err error) {
 func (m *IntelRdtManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if err := os.RemoveAll(m.Path); err != nil {
+	if err := os.RemoveAll(m.GetPath()); err != nil {
 		return err
 	}
 	m.Path = ""


### PR DESCRIPTION
This patch fixes a corner case when destroy a container:

If we start a container without 'intelRdt' config set, and then we run
“runc update --l3-cache-schema/--mem-bw-schema” to add 'intelRdt' config
implicitly.

Now if we enter "exit" from the container inside, we will pass through
linuxContainer.Destroy() -> state.destroy() -> intelRdtManager.Destroy().
But in IntelRdtManager.Destroy(), IntelRdtManager.Path is still null
string, it hasn’t been initialized yet. As a result, the created rdt
group directory during "runc update" will not be removed as expected.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>