### PR TITLE
Make public ParseMountinfo

### DIFF
--- a/libcontainer/mount/mount_linux.go
+++ b/libcontainer/mount/mount_linux.go
@@ -37,10 +37,10 @@ func parseMountTable() ([]*Info, error) {
 	}
 	defer f.Close()
 
-	return parseInfoFile(f)
+	return ParseMountinfo(f)
 }
 
-func parseInfoFile(r io.Reader) ([]*Info, error) {
+func ParseMountinfo(r io.Reader) ([]*Info, error) {
 	var (
 		s   = bufio.NewScanner(r)
 		out = []*Info{}


### PR DESCRIPTION
Whilst using libcontainer/mount.GetMounts() I had need of the underlying logic of parsing /proc/self/mountinfo for testing purposes. This PR makes that logic public, allowing for parsing of a Reader whose contents look like /proc/self/mountinfo.