### PR TITLE
libcontainer: cgroup namespaces enabled utility function

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -22,6 +22,19 @@ const (
 	CgroupProcesses  = "cgroup.procs"
 )
 
+// http://man7.org/linux/man-pages/man7/cgroup_namespaces.7.html
+func CgroupNamespacesEnabled() (bool, error) {
+	if _, err := os.Stat("/proc/self/ns/cgroup"); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
 func FindCgroupMountpoint(cgroupPath, subsystem string) (string, error) {
 	mnt, _, err := FindCgroupMountpointAndRoot(cgroupPath, subsystem)

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -5,6 +5,7 @@ package cgroups
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -419,5 +420,21 @@ func TestFindCgroupMountpointAndRoot(t *testing.T) {
 		if mountpoint != c.output {
 			t.Errorf("expected %s, got %s", c.output, mountpoint)
 		}
+	}
+}
+
+func TestCgroupNamespacesEnabled(t *testing.T) {
+	expectedEnabled := true
+	if _, err := os.Stat("/proc/self/ns/cgroup"); err != nil && os.IsNotExist(err) {
+		expectedEnabled = false
+	}
+
+	enabled, err := CgroupNamespacesEnabled()
+	if err != nil {
+		t.Errorf("unexpected namespace error returned: %s", err)
+	}
+
+	if enabled != expectedEnabled {
+		t.Errorf("expected namespace enabled value of %t but got %t", expectedEnabled, enabled)
 	}
 }

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	selinux "github.com/opencontainers/selinux/go-selinux"
@@ -121,7 +122,7 @@ func (v *ConfigValidator) usernamespace(config *configs.Config) error {
 
 func (v *ConfigValidator) cgroupnamespace(config *configs.Config) error {
 	if config.Namespaces.Contains(configs.NEWCGROUP) {
-		if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
+		if enabled, _ := cgroups.CgroupNamespacesEnabled(); !enabled {
 			return fmt.Errorf("cgroup namespaces aren't enabled in the kernel")
 		}
 	}

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -1718,7 +1719,7 @@ func TestTmpfsCopyUp(t *testing.T) {
 }
 
 func TestCGROUPPrivate(t *testing.T) {
-	if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
+	if supported, _ := cgroups.CgroupNamespacesEnabled(); !supported {
 		t.Skip("cgroupns is unsupported")
 	}
 	if testing.Short() {
@@ -1747,7 +1748,7 @@ func TestCGROUPPrivate(t *testing.T) {
 }
 
 func TestCGROUPHost(t *testing.T) {
-	if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
+	if supported, _ := cgroups.CgroupNamespacesEnabled(); !supported {
 		t.Skip("cgroupns is unsupported")
 	}
 	if testing.Short() {


### PR DESCRIPTION
Move code for checking if cgroup namespaces are enabled into a utility function that can be used in other projects.

Fixes #1975.