### PR TITLE
nsenter (CVE-2019-5736): remove unneeded parsing

### DIFF
--- a/libcontainer/nsenter/nsenter.go
+++ b/libcontainer/nsenter/nsenter.go
@@ -5,8 +5,8 @@ package nsenter
 /*
 #cgo CFLAGS: -Wall
 extern void nsexec();
-void __attribute__((constructor)) init(void) {
-	nsexec();
+void __attribute__((constructor)) init(int argc, char *argv[]) {
+	nsexec(argv);
 }
 */
 import "C"

--- a/libcontainer/nsenter/nsenter_gccgo.go
+++ b/libcontainer/nsenter/nsenter_gccgo.go
@@ -5,8 +5,8 @@ package nsenter
 /*
 #cgo CFLAGS: -Wall
 extern void nsexec();
-void __attribute__((constructor)) init(void) {
-	nsexec();
+void __attribute__((constructor)) init(int argc, char *argv[]) {
+	nsexec(argv);
 }
 */
 import "C"

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -535,9 +535,9 @@ void join_namespaces(char *nslist)
 }
 
 /* Defined in cloned_binary.c. */
-extern int ensure_cloned_binary(void);
+extern int ensure_cloned_binary(char *argv);
 
-void nsexec(void)
+void nsexec(char *argv[])
 {
 	int pipenum;
 	jmp_buf env;
@@ -557,7 +557,7 @@ void nsexec(void)
 	 * to ensure that containers won't be able to access the host binary
 	 * through /proc/self/exe. See CVE-2019-5736.
 	 */
-	if (ensure_cloned_binary() < 0)
+	if (ensure_cloned_binary(argv) < 0)
 		bail("could not ensure we are a cloned binary");
 
 	/* Parse all of the netlink configuration. */


### PR DESCRIPTION
A __attribute__((constructor)) can get access to argc and argv. With
this there's no need to parse /proc/<pid>/{cmdline,environ}.

Fixes: CVE-2019-5736
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>