### PR TITLE
Avoid repeated os.SetEnv calls in container init.

### DIFF
--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -110,3 +110,15 @@ func Annotations(labels []string) (bundle string, userAnnotations map[string]str
 func GetIntSize() int {
 	return int(unsafe.Sizeof(1))
 }
+
+// StringMapToSlice takes a string map, and converts its values into
+// a slice with an undefined ordering.
+func StringMapToSlice(m map[string]string) []string {
+	slice := make([]string, len(m))
+	i := 0
+	for _, value := range m {
+		slice[i] = value
+		i++
+	}
+	return slice
+}

--- a/libcontainer/utils/utils_test.go
+++ b/libcontainer/utils/utils_test.go
@@ -140,3 +140,36 @@ func TestCleanPath(t *testing.T) {
 		t.Errorf("expected to receive '/foo' and received %s", path)
 	}
 }
+
+func contains(slice []string, item string) bool {
+	for _, v := range slice {
+		if v == item {
+			return true
+		}
+	}
+	return false
+}
+
+func TestStringMapToSlice(t *testing.T) {
+	slice := StringMapToSlice(nil)
+	if len(slice) != 0 || slice == nil {
+		t.Errorf("expected 0 length slice, instead got %+v", slice)
+	}
+
+	m := make(map[string]string)
+	slice = StringMapToSlice(m)
+	if len(slice) != 0 || slice == nil {
+		t.Errorf("expected 0 length slice, instead got %+v", slice)
+	}
+
+	m = make(map[string]string)
+	m["key1"] = "value1"
+	m["key2"] = "value2"
+	slice = StringMapToSlice(m)
+	if len(slice) != 2 {
+		t.Errorf("expected slice of length 2, instead got slice of length %d", len(slice))
+	}
+	if !contains(slice, "value1") || !contains(slice, "value2") {
+		t.Errorf("expected slice to contain both value1 and value2, instead got %+v", slice)
+	}
+}


### PR DESCRIPTION
In a Kubernetes cluster with a large number of services (>5000, causing a large amount of environment variables for the container) with guaranteed pods, the `runc init` process can take a long time to run. This is caused by two issues:

1. `runc init` calls `os.SetEnv` for every environment variable in the bundle, which can be expensive due to the underlying mutex locking and syscall logic. 
2. The cgroup is limited before the `runc init` process runs. This is outside the perview of runc I believe.

This PR targets the former by removing the `os.SetEnv` calls, which causes the `runc init` process to run much faster in cases where there are a large number of configured environment variables in the bundle.