### PR TITLE
switched travis to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 go:
   - 1.9.x
@@ -21,9 +22,8 @@ env:
     - BUILDTAGS="seccomp apparmor selinux ambient"
 
 before_install:
-  - echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get -qq update
-  - sudo apt-get install -y libseccomp-dev/trusty-backports
+  - sudo apt-get install -y libseccomp-dev
   - go get -u golang.org/x/lint/golint
   - go get -u github.com/vbatts/git-validation
   - env | grep TRAVIS_


### PR DESCRIPTION
The CRIU test for lazy migration was always skipped in Travis because
the kernel was too old. This switches Travis testing to dist: xenial
which provides a newer kernel which enables CRIU lazy migration testing.

Not sure if this is something runc cannot or does not want to do (yet).

Tests are all successful, so switching to a newer distribution in Travis seems doable.