### PR TITLE
[RFC] Implement systemd-specific per-cgroup support (+ proof-of-concept "devices" and "memory")

### DIFF
--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -3,9 +3,14 @@
 package fs
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"
+
+	systemdDbus "github.com/coreos/go-systemd/dbus"
+	"github.com/godbus/dbus"
 )
 
 type DevicesGroup struct {
@@ -68,7 +73,74 @@ func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
 		}
 	}
 
+	return s.SetCgroupv1(path, cgroup)
+}
+
+func (s *DevicesGroup) SetCgroupv1(path string, cgroup *configs.Cgroup) error {
 	return nil
+}
+
+type deviceAllow struct {
+	Path        string
+	Permissions string
+}
+
+func (s *DevicesGroup) ToSystemdProperties(cgroup *configs.Cgroup) ([]systemdDbus.Property, error) {
+	var devAllows []deviceAllow
+	devPolicy := "strict"
+
+	devices := cgroup.Resources.Devices
+	if len(devices) > 0 {
+		blockedAll := false
+		for _, dev := range devices {
+			if !blockedAll {
+				// Expect the first rule to block all, in which
+				// case we can translate this cgroup config to
+				// something systemd will understand.
+				if dev.Type == 'a' && !dev.Allow {
+					blockedAll = true
+				} else {
+					return []systemdDbus.Property{}, fmt.Errorf("systemd only supports a whitelist on device cgroup, please use AllowedDevices instead.")
+				}
+				continue
+			}
+			// Ok, now we're handling the second+ device rules to
+			// whitelist the items that matter to us.
+			if !dev.Allow {
+				// We already blocked all, so continue...
+				continue
+			}
+			if devPath := dev.SystemdCgroupPath(); devPath != "" {
+				devAllows = append(devAllows, deviceAllow{
+					Path:        devPath,
+					Permissions: dev.Permissions,
+				})
+			}
+		}
+	} else if cgroup.Resources.AllowAllDevices != nil {
+		if *cgroup.Resources.AllowAllDevices {
+			devPolicy = "auto"
+		} else {
+			for _, dev := range cgroup.Resources.AllowedDevices {
+				if devPath := dev.SystemdCgroupPath(); devPath != "" {
+					devAllows = append(devAllows, deviceAllow{
+						Path:        devPath,
+						Permissions: dev.Permissions,
+					})
+				}
+			}
+		}
+	}
+	return []systemdDbus.Property{
+		{
+			Name:  "DevicePolicy",
+			Value: dbus.MakeVariant(devPolicy),
+		},
+		{
+			Name:  "DeviceAllow",
+			Value: dbus.MakeVariant(devAllows),
+		},
+	}, nil
 }
 
 func (s *DevicesGroup) Remove(d *cgroupData) error {


### PR DESCRIPTION
This PR is trying to accomplish two things:

1. Define a new interface that will allow subsystems/controllers to
   implement systemd-based configuration, by using systemd directives
   rather than writing directly to the cgroup subtree.

2. Add a systemd-based implementation to the "devices" subsystem, to
   illustrate how it is meant to be used.

The initial point I'd like to make here is towards discussing (1) as an idea and whether the Go abstractions/interfaces are appropriate here or whether we should move things around.

Consider part (2) to be really a draft and not really finished (even though it actually works to a large extent, the D-Bus messages are correct and that has been tested to do what's expected.)

I tested this with Podman using:

```
$ podman --runtime ~/go/src/github.com/opencontainers/runc/runc run -t fedora:29 echo hello
```

And also bringing up a container and checking the contents of "device.list" in the cgroup subtree:

```
$ podman --runtime ~/go/src/github.com/opencontainers/runc/runc run -t fedora:29 sleep 1h
$ cat /sys/fs/cgroup/devices/machine.slice/libpod-12fc7bd62fd6*/devices.list
c 10:200 rwm
c 5:2 rwm
c 136:* rwm
c 5:1 rwm
c 1:9 rwm
c 1:5 rwm
c 5:0 rwm
c 1:7 rwm
c 1:8 rwm
c 1:3 rwm
b *:* m
c *:* m
```

This matches the output of devices.list when using the official "runc" binary, only difference being the lines are inverted in order (again, we can fix that on a second step.)

Querying systemd for this unit also works as expected:

```
$ systemctl show libpod-12fc7bd62fd66ff62fa1b045c2d717c7b2076c072c20de14f5c1ad86b78865eb.scope -p DevicePolicy -p DeviceAllow
DevicePolicy=strict
DeviceAllow=/dev/net/tun rwm
DeviceAllow=/dev/ptmx rwm
DeviceAllow=char-136 rwm
DeviceAllow=/dev/console rwm
DeviceAllow=/dev/urandom rwm
DeviceAllow=/dev/zero rwm
DeviceAllow=/dev/tty rwm
DeviceAllow=/dev/full rwm
DeviceAllow=/dev/random rwm
DeviceAllow=/dev/null rwm
DeviceAllow=block-* m
DeviceAllow=char-* m
```

/cc @cyphar @crosbymichael @mrunalp 

Also @rhatdan 

Maybe @sargun might be interested, since he was working on #1708 and this here is a step towards supporting cgroupv2 in unified hierarchy in runc/libcontainer.

Also @AkihiroSuda who has been working on rootless/usernetes and has been asking about this.

Cheers!
Filipe
