### PR TITLE
cannot exec in a created state

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -115,6 +115,9 @@ func execProcess(context *cli.Context) (int, error) {
 	if err != nil {
 		return -1, err
 	}
+	if status == libcontainer.Created {
+		return -1, fmt.Errorf("cannot exec a container which is in a created state")
+	}
 	if status == libcontainer.Stopped {
 		return -1, fmt.Errorf("cannot exec a container that has stopped")
 	}

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -31,7 +31,7 @@ function teardown() {
   testcontainer test_busybox created
 
   runc exec test_busybox true
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 1 ]
 
   testcontainer test_busybox created
 
@@ -40,6 +40,9 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox running
+
+  runc exec test_busybox true
+  [ "$status" -eq 0 ]
 }
 
 @test "runc create --pid-file" {


### PR DESCRIPTION
I don't know why we can exec a command when a container is in a created state. If it is useful, please close this PR.
**for example**
```
root@iZ2ze1o61blvco5p5ducnnZ:/opt/busybox# runc create test
root@iZ2ze1o61blvco5p5ducnnZ:/opt/busybox# runc list
ID          PID         STATUS      BUNDLE                                            CREATED                          OWNER
test        3351        created     /opt/busybox   2019-02-24T06:04:41.965845861Z   root
root@iZ2ze1o61blvco5p5ducnnZ:/opt/busybox# runc exec test ls /proc/1/fd -lh
total 0      
lrwx------    1 root     root          64 Feb 24 06:04 0 -> /dev/pts/2
lrwx------    1 root     root          64 Feb 24 06:04 1 -> /dev/pts/2
lrwx------    1 root     root          64 Feb 24 06:04 2 -> /dev/pts/2
l---------    1 root     root          64 Feb 24 06:04 4 -> /run/runc/test/exec.fifo
l-wx------    1 root     root          64 Feb 24 06:04 5 -> /null
lrwx------    1 root     root          64 Feb 24 06:04 6 -> anon_inode:[eventpoll]
root@iZ2ze1o61blvco5p5ducnnZ:/opt/busybox# runc exec test ls /proc/1/exe -lh
lrwxrwxrwx    1 root     root           0 Feb 24 06:05 /proc/1/exe -> /usr/bin/runc
```

Signed-off-by: Lifubang <lifubang@acmcoder.com>