### PR TITLE
fix rootless container: unrelated error with root flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,19 +64,12 @@ func main() {
 	v = append(v, fmt.Sprintf("spec: %s", specs.Version))
 	app.Version = strings.Join(v, "\n")
 
+	xdgRuntimeDir := ""
 	root := "/run/runc"
 	if shouldHonorXDGRuntimeDir() {
 		if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
 			root = runtimeDir + "/runc"
-			// According to the XDG specification, we need to set anything in
-			// XDG_RUNTIME_DIR to have a sticky bit if we don't want it to get
-			// auto-pruned.
-			if err := os.MkdirAll(root, 0700); err != nil {
-				fatal(err)
-			}
-			if err := os.Chmod(root, 0700|os.ModeSticky); err != nil {
-				fatal(err)
-			}
+			xdgRuntimeDir = root
 		}
 	}
 
@@ -135,6 +128,19 @@ func main() {
 		updateCommand,
 	}
 	app.Before = func(context *cli.Context) error {
+		if !context.IsSet("root") && xdgRuntimeDir != "" {
+			// According to the XDG specification, we need to set anything in
+			// XDG_RUNTIME_DIR to have a sticky bit if we don't want it to get
+			// auto-pruned.
+			if err := os.MkdirAll(root, 0700); err != nil {
+				fmt.Fprintln(os.Stderr, "the path in $XDG_RUNTIME_DIR must be writable by the user")
+				fatal(err)
+			}
+			if err := os.Chmod(root, 0700|os.ModeSticky); err != nil {
+				fmt.Fprintln(os.Stderr, "you should check permission of the path in $XDG_RUNTIME_DIR")
+				fatal(err)
+			}
+		}
 		return logs.ConfigureLogging(createLogConfig(context))
 	}
 


### PR DESCRIPTION
If we provide `--root`, we shold not check the XDG_RUNTIME_DIR env value.
For example:
```
test@test:~/busybox$ runc --root ./runc list
ERRO[0000] mkdir /run/user/0/runc: permission denied    
mkdir /run/user/0/runc: permission denied
```
This error is unrelated, because we use ./runc as root dir.

Actually, at that time, we use `--root` first.
But we check the value of XDG_RUNTIME_DIR and create related folder too early.

By the way, if we don't provide `--root`, we should provide the information of `XDG_RUNTIME_DIR env` when there is an permission error.

Signed-off-by: lifubang <lifubang@acmcoder.com>