### PR TITLE
criu image path permission error when checkpoint rootless container

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -122,7 +122,7 @@ using the runc checkpoint command.`,
 
 func criuOptions(context *cli.Context) *libcontainer.CriuOpts {
 	imagePath := getCheckpointImagePath(context)
-	if err := os.MkdirAll(imagePath, 0655); err != nil {
+	if err := os.MkdirAll(imagePath, 0755); err != nil {
 		fatal(err)
 	}
 	return &libcontainer.CriuOpts{


### PR DESCRIPTION
```
test@ubuntu:~/busybox$ runc --root ./runc checkpoint test
open /home/test/busybox/checkpoint/descriptors.json: permission denied
```
Because we need 0755, not 0655 permission, please see:
https://github.com/opencontainers/runc/blob/472fe623a76a039c438429345c0ccf71dc7722e8/libcontainer/container_linux.go#L927 

Signed-off-by: Lifubang <lifubang@acmcoder.com>