### PR TITLE
Add $RUNC_USE_SYSTEMD to run tests using systemd cgroup driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ go:
   - tip
 
 matrix:
+  include:
+    - go: 1.11.x
+      env:
+        - RUNC_USE_SYSTEMD=1
+      script:
+        - make BUILDTAGS="${BUILDTAGS}" all
+        - sudo PATH="$PATH" make localintegration RUNC_USE_SYSTEMD=1
   allow_failures:
     - go: tip
 

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -325,7 +325,7 @@ func createCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
 			// for e.g. "system.slice:docker:1234"
 			parts := strings.Split(myCgroupPath, ":")
 			if len(parts) != 3 {
-				return nil, fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups")
+				return nil, fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups, got %q instead", myCgroupPath)
 			}
 			c.Parent = parts[0]
 			c.ScopePrefix = parts[1]

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -3,6 +3,10 @@
 load helpers
 
 function setup() {
+  if [[ -n "${RUNC_USE_SYSTEMD}" ]] ; then
+    skip "CRIU test suite is skipped on systemd cgroup driver for now."
+  fi
+
   teardown_busybox
   setup_busybox
 }

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -133,7 +133,7 @@ function teardown() {
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox
   [ "$status" -eq 0 ]
 
-  run bash -c "cat hello > preserve-fds.test; exec 3<preserve-fds.test; $RUNC --log /proc/self/fd/2 --root $ROOT exec --preserve-fds=1 test_busybox cat /proc/self/fd/3"
+  run bash -c "cat hello > preserve-fds.test; exec 3<preserve-fds.test; $RUNC ${RUNC_USE_SYSTEMD:+--systemd-cgroup} --log /proc/self/fd/2 --root $ROOT exec --preserve-fds=1 test_busybox cat /proc/self/fd/3"
   [ "$status" -eq 0 ]
 
   [[ "${output}" == *"hello"* ]]

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -39,7 +39,11 @@ CONSOLE_SOCKET="$BATS_TMPDIR/console.sock"
 # Cgroup paths
 CGROUP_MEMORY_BASE_PATH=$(grep "cgroup" /proc/self/mountinfo | gawk 'toupper($NF) ~ /\<MEMORY\>/ { print $5; exit }')
 CGROUP_CPU_BASE_PATH=$(grep "cgroup" /proc/self/mountinfo | gawk 'toupper($NF) ~ /\<CPU\>/ { print $5; exit }')
-CGROUPS_PATH="/runc-cgroups-integration-test/test-cgroup"
+if [[ -n "${RUNC_USE_SYSTEMD}" ]] ; then
+	CGROUPS_PATH="/machine.slice/runc-cgroups-integration-test.scope"
+else
+	CGROUPS_PATH="/runc-cgroups-integration-test/test-cgroup"
+fi
 CGROUP_MEMORY="${CGROUP_MEMORY_BASE_PATH}${CGROUPS_PATH}"
 
 # CONFIG_MEMCG_KMEM support
@@ -118,7 +122,11 @@ function runc_rootless_cgroup() {
 # Helper function to set cgroupsPath to the value of $CGROUPS_PATH
 function set_cgroups_path() {
   bundle="${1:-.}"
-  sed -i 's/\("linux": {\)/\1\n    "cgroupsPath": "\/runc-cgroups-integration-test\/test-cgroup",/' "$bundle/config.json"
+  cgroups_path="/runc-cgroups-integration-test/test-cgroup"
+  if [[ -n "${RUNC_USE_SYSTEMD}" ]] ; then
+    cgroups_path="machine.slice:runc-cgroups:integration-test"
+  fi
+  sed -i 's#\("linux": {\)#\1\n    "cgroupsPath": "'"${cgroups_path}"'",#' "$bundle/config.json"
 }
 
 # Helper function to set a resources limit

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -61,7 +61,7 @@ function runc() {
 
 # Raw wrapper for runc.
 function __runc() {
-	"$RUNC" --log /proc/self/fd/2 --root "$ROOT" "$@"
+	"$RUNC" ${RUNC_USE_SYSTEMD+--systemd-cgroup} --log /proc/self/fd/2 --root "$ROOT" "$@"
 }
 
 # Wrapper for runc spec, which takes only one argument (the bundle path).


### PR DESCRIPTION
This allows us to test runc using libcontainer's systemd driver, by passing a `RUNC_USE_SYSTEMD=1` argument to localintegration tests.

Tested:
```
$ sudo make localintegration RUNC_USE_SYSTEMD=1
```

All tests passed to me (with exception of one writing to `blkio.weight` which for some reason is missing on my Linux kernel 5.0, will look into that...)

And confirmed that systemd was in use by looking at creation and removal of <code>libcontainer_<em>&lt;pid&gt;</em>_systemd_test_default.slice</code> test slices. Also introduced a breakage in systemd cgroup driver and confirmed that the tests failed as expected.
