### PR TITLE
fix cloned_binary fallback corner case

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -483,6 +483,7 @@ func (c *linuxContainer) commandTemplate(p *Process, childPipe *os.File) (*exec.
 	cmd.Env = append(cmd.Env,
 		fmt.Sprintf("_LIBCONTAINER_INITPIPE=%d", stdioFdCount+len(cmd.ExtraFiles)-1),
 		fmt.Sprintf("_LIBCONTAINER_STATEDIR=%s", c.root),
+		fmt.Sprintf("_LIBCONTAINER_USERHOME=%s", os.Getenv("HOME")),
 	)
 	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
 	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason


### PR DESCRIPTION
Because the `/run` folder in all my linux cloud server have `noexec` mount flag. So if cloned_binary fallback to temp file copy, there will be `nsenter: could not ensure we are a cloned binary: Permission denied` error.

I think we can check `noexec` mount flag first before we clone binary.

I think this is a corner case, so it is not important. It may just only effect kernel < 3.17 .

Signed-off-by: Lifubang <lifubang@acmcoder.com>