### PR TITLE
Add dlogf facility for nsexec logging

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -93,6 +93,10 @@ following will output a list of processes running in the container:
 			Name:  "preserve-fds",
 			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
 		},
+		cli.StringFlag{
+			Name:  "exec-log",
+			Usage: "exec log file",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, minArgs); err != nil {
@@ -143,6 +147,7 @@ func execProcess(context *cli.Context) (int, error) {
 		consoleSocket:   context.String("console-socket"),
 		detach:          detach,
 		pidFile:         context.String("pid-file"),
+		execLog:         context.String("exec-log"),
 		action:          CT_ACT_RUN,
 		init:            false,
 		preserveFDs:     context.Int("preserve-fds"),

--- a/run.go
+++ b/run.go
@@ -61,6 +61,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "preserve-fds",
 			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
 		},
+		cli.StringFlag{
+			Name:  "exec-log",
+			Usage: "exec log file",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {


### PR DESCRIPTION
Whilst trying to debug a hang in runc exec, we (Garden, Cloud Foundry) were struggling to find useful information to help us with discovering where a hang was occuring.

We noticed that nsexec does not log or have the ability to log any details about what's going on. We propose adding a `dlogf` (like the printf family of functions) that will log to some fd defined as an ENV by libcontainer, and can be specified as a command line parameter to the runc binary.

We're probably going to patch this into our runc build script (at least temporarily whilst we figure out our hang), but thought this feature might be useful more generally. We deliberately haven't added any use of the `dlogf` function except an example to show its use as what we want to log is open for discussion and if you're into this idea then we'd love input on what should be logged.

(Our original issue that we're trying to debug is documented here: https://github.com/cloudfoundry/garden-runc-release/issues/121)