### PR TITLE
Update to Go 1.12 and drop obsolete versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 dist: xenial
 language: go
 go:
-  - 1.9.x
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 
 matrix:
   include:
-    - go: 1.11.x
+    - go: 1.12.x
       env:
         - RUNC_USE_SYSTEMD=1
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch
+FROM golang:1.12-stretch
 
 RUN dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \


### PR DESCRIPTION
I noticed there's still a mention of Go 1.6 in the README;

https://github.com/opencontainers/runc/blob/master/README.md#building

> It must be built with Go version 1.6 or higher in order for some features to function properly.

Not sure if we want to keep that mention, or if it's a bit redundant now that Go versions older than 1.6 reached EOL