### PR TITLE
Add selinux validate in runc exec

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -224,5 +224,5 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 		}
 		p.User.AdditionalGids = append(p.User.AdditionalGids, uint32(gid))
 	}
-	return p, nil
+	return p, validateProcessSpec(p)
 }

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/specconv"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	selinux "github.com/opencontainers/selinux/go-selinux"
 
 	"github.com/coreos/go-systemd/activation"
 	"github.com/pkg/errors"
@@ -386,6 +387,9 @@ func validateProcessSpec(spec *specs.Process) error {
 	}
 	if len(spec.Args) == 0 {
 		return fmt.Errorf("args must not be empty")
+	}
+	if spec.SelinuxLabel != "" && !selinux.GetEnabled() {
+		return fmt.Errorf("selinux label is specified in config, but selinux is disabled or not supported")
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

1. Fix regression introduced by https://github.com/opencontainers/runc/pull/2012/commits/cd96170c10b35a37f90040fe55529185b9a5ec30 , the related commit is in https://github.com/opencontainers/selinux/commit/e5c68ba81868de0c57b61832c2197cb31008a40e#diff-08374585d1f5b66358d612f6292a3fae
There is no `if processLabel == "" {` check now.
Fixed by #2032

2. Fixes #2030 check nil for `selinuxLabel` before we `label.SetKeyLabel`, this is also introduced by https://github.com/opencontainers/runc/pull/2012/commits/cd96170c10b35a37f90040fe55529185b9a5ec30 ;
Because the validate is : https://github.com/opencontainers/runc/blob/84cba4cbc1767353ae9d999c61f62a50c538589f/libcontainer/configs/validate/validator.go#L96-L107
Fixed by #2032

3. Fix if we use `selinuxLabel` in `runc exec`, we should validate selinux again. If the system disable selinux, it will raise error `exec failed: container_linux.go:345: starting container process caused "write /proc/self/attr/keycreate: invalid argument"`. For example:
(1) use '--process-label' in `runc exec`;
(2) use `selinuxLabel` in `process.json` when use `--process` in `runc exec`;
(3) add `selinuxLabel` to config.json in bundle dir after the container started.