### PR TITLE
fix failure when selinux enabled in old kernel

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -34,10 +34,12 @@ func (l *linuxSetnsInit) Init() error {
 	defer runtime.UnlockOSThread()
 
 	if !l.config.Config.NoNewKeyring {
-		if err := label.SetKeyLabel(l.config.ProcessLabel); err != nil {
-			return err
+		if l.config.ProcessLabel != "" {
+			if err := label.SetKeyLabel(l.config.ProcessLabel); err != nil {
+				return err
+			}
+			defer label.SetKeyLabel("")
 		}
-		defer label.SetKeyLabel("")
 		// Do not inherit the parent's session keyring.
 		if _, err := keys.JoinSessionKeyring(l.getSessionRingName()); err != nil {
 			// Same justification as in standart_init_linux.go as to why we
@@ -62,10 +64,12 @@ func (l *linuxSetnsInit) Init() error {
 			return err
 		}
 	}
-	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
-		return err
+	if l.config.ProcessLabel != "" {
+		if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
+			return err
+		}
+		defer label.SetProcessLabel("")
 	}
-	defer label.SetProcessLabel("")
 	// Without NoNewPrivileges seccomp is a privileged operation, so we need to
 	// do this before dropping capabilities; otherwise do it as late as possible
 	// just before execve so as few syscalls take place after it as possible.

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -48,10 +48,12 @@ func (l *linuxStandardInit) Init() error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	if !l.config.Config.NoNewKeyring {
-		if err := label.SetKeyLabel(l.config.ProcessLabel); err != nil {
-			return err
+		if l.config.ProcessLabel != "" {
+			if err := label.SetKeyLabel(l.config.ProcessLabel); err != nil {
+				return err
+			}
+			defer label.SetKeyLabel("")
 		}
-		defer label.SetKeyLabel("")
 		ringname, keepperms, newperms := l.getSessionRingParams()
 
 		// Do not inherit the parent's session keyring.
@@ -146,10 +148,12 @@ func (l *linuxStandardInit) Init() error {
 	if err := syncParentReady(l.pipe); err != nil {
 		return errors.Wrap(err, "sync ready")
 	}
-	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
-		return errors.Wrap(err, "set process label")
+	if l.config.ProcessLabel != "" {
+		if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
+			return errors.Wrap(err, "set process label")
+		}
+		defer label.SetProcessLabel("")
 	}
-	defer label.SetProcessLabel("")
 	// Without NoNewPrivileges seccomp is a privileged operation, so we need to
 	// do this before dropping capabilities; otherwise do it as late as possible
 	// just before execve so as few syscalls take place after it as possible.


### PR DESCRIPTION
Signed-off-by: lifubang <lifubang@acmcoder.com>

I think #2032 fixed the problem on disabled SELinux Machines.
But on enabled SELinux Machines with some old kernels, it still be fail when `selinuxLabel` is empty.

So, I think we should add `selinuxLabel` check in runc, it will be more safe to run.

And I will send a PR to selinux project soon.