### PR TITLE
specconv: always set "type: bind" in case of MS_BIND

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -277,9 +277,10 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	source := m.Source
 	device := m.Type
 	if flags&unix.MS_BIND != 0 {
-		if device == "" {
-			device = "bind"
-		}
+		// Any "type" the user specified is meaningless (and ignored) for
+		// bind-mounts -- so we set it to "bind" because rootfs_linux.go
+		// (incorrectly) relies on this for some checks.
+		device = "bind"
 		if !filepath.IsAbs(source) {
 			source = filepath.Join(cwd, m.Source)
 		}


### PR DESCRIPTION
We discovered in umoci that setting a dummy type of "none" would result
in file-based bind-mounts no longer working properly, which is caused by
a restriction for when specconv will change the device type to "bind" to
work around rootfs_linux.go's ... issues.

However, bind-mounts don't have a type (and Linux will ignore any type
specifier you give it) because the type is copied from the source of the
bind-mount. So we should always overwrite it to avoid user confusion.

Ref: opencontainers/runc#1753
Ref: openSUSE/umoci#294
Signed-off-by: Aleksa Sarai <asarai@suse.de>