### PR TITLE
Change the permissions of the notify listener socket to rwx for everyone

### DIFF
--- a/notify_socket.go
+++ b/notify_socket.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -57,6 +58,12 @@ func (s *notifySocket) setupSocket() error {
 
 	socket, err := net.ListenUnixgram("unixgram", &addr)
 	if err != nil {
+		return err
+	}
+
+	err = os.Chmod(s.socketPath, 0777)
+	if err != nil {
+		socket.Close()
 		return err
 	}
 


### PR DESCRIPTION
When runc is started as a `Type=notify` systemd service, runc opens up its own listening socket inside the container to act as a proxy between the container and systemd for passing notify messages.

The domain socket that runc creates is only writeable by the user running runc however, so if the container has a different UID/GID then nothing inside the container will be able to write to the socket.

The fix is to change the permissions of the notify listener socket to 0777.

Signed-off-by: Joe Burianek <joe.burianek@pantheon.io>