### PR TITLE
libcontainer: intelrdt: add missing destroy handler in defer func

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -337,6 +337,9 @@ func (p *initProcess) start() error {
 		if err != nil {
 			// TODO: should not be the responsibility to call here
 			p.manager.Destroy()
+			if p.intelRdtManager != nil {
+				p.intelRdtManager.Destroy()
+			}
 		}
 	}()
 	if err := p.createNetworkInterfaces(); err != nil {


### PR DESCRIPTION
In the exception handling of initProcess.start(), we need to add the
missing IntelRdtManager.Destroy() handler in defer func.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>