### PR TITLE
Move systemd.Manager initialization into a function in that module

### DIFF
--- a/libcontainer/cgroups/systemd/apply_nosystemd.go
+++ b/libcontainer/cgroups/systemd/apply_nosystemd.go
@@ -18,6 +18,10 @@ func UseSystemd() bool {
 	return false
 }
 
+func NewSystemdCgroupsManager() (func(config *configs.Cgroup, paths map[string]string) cgroups.Manager, error) {
+	return nil, fmt.Errorf("Systemd not supported")
+}
+
 func (m *Manager) Apply(pid int) error {
 	return fmt.Errorf("Systemd not supported")
 }

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -163,6 +163,18 @@ func UseSystemd() bool {
 	return hasStartTransientUnit
 }
 
+func NewSystemdCgroupsManager() (func(config *configs.Cgroup, paths map[string]string) cgroups.Manager, error) {
+	if !systemdUtil.IsRunningSystemd() {
+		return nil, fmt.Errorf("systemd not running on this host, can't use systemd as a cgroups.Manager")
+	}
+	return func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
+		return &Manager{
+			Cgroups: config,
+			Paths:   paths,
+		}
+	}, nil
+}
+
 func (m *Manager) Apply(pid int) error {
 	var (
 		c          = m.Cgroups

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -51,12 +51,11 @@ func InitArgs(args ...string) func(*LinuxFactory) error {
 // SystemdCgroups is an options func to configure a LinuxFactory to return
 // containers that use systemd to create and manage cgroups.
 func SystemdCgroups(l *LinuxFactory) error {
-	l.NewCgroupsManager = func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
-		return &systemd.Manager{
-			Cgroups: config,
-			Paths:   paths,
-		}
+	systemdCgroupsManager, err := systemd.NewSystemdCgroupsManager()
+	if err != nil {
+		return err
 	}
+	l.NewCgroupsManager = systemdCgroupsManager
 	return nil
 }
 


### PR DESCRIPTION
This will permit us to extend the internals of systemd.Manager to include further information about the system, such as whether cgroupv1, cgroupv2 or both are in effect.

Furthermore, it allows a future refactor of moving more of UseSystemd() code into the factory initialization function.