### PR TITLE
libcontainer/utils: fix compilation on Darwin

### DIFF
--- a/libcontainer/utils/cmsg.go
+++ b/libcontainer/utils/cmsg.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build !windows
 
 package utils
 

--- a/libcontainer/utils/utils_linux.go
+++ b/libcontainer/utils/utils_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package utils
 
 import (


### PR DESCRIPTION
NewSockPair() only works on Linux due to the presence of the
SOCK_CLOEXEC constant, which is only present for Linux machines.

Fixes #2048.