### PR TITLE
main: not reopen /dev/stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "log",
-			Value: "/dev/stderr",
+			Value: "",
 			Usage: "set the log file path where internal debug information is written",
 		},
 		cli.StringFlag{
@@ -157,9 +157,15 @@ func (f *FatalWriter) Write(p []byte) (n int, err error) {
 }
 
 func createLogConfig(context *cli.Context) logs.Config {
+	logFilePath := context.GlobalString("log")
+	logPipeFd := ""
+	if logFilePath == "" {
+		logPipeFd = "2"
+	}
 	config := logs.Config{
+		LogPipeFd:   logPipeFd,
 		LogLevel:    logrus.InfoLevel,
-		LogFilePath: context.GlobalString("log"),
+		LogFilePath: logFilePath,
 		LogFormat:   context.GlobalString("log-format"),
 	}
 	if context.GlobalBool("debug") {


### PR DESCRIPTION
commit a1460818288b8addfe9b70c8931da83864251f7a introduced a change to
write to /dev/stderr by default.  Do not reopen the file in this case,
but use directly the fd 2.

Closes: https://github.com/opencontainers/runc/issues/2056
Closes: https://github.com/kubernetes/kubernetes/issues/77615
Closes: https://github.com/cri-o/cri-o/issues/2368

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>