### PR TITLE
libcontainer: fix TestGetContainerState to check configs.NEWCGROUP

### DIFF
--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -200,6 +200,7 @@ func TestGetContainerState(t *testing.T) {
 				{Type: configs.NEWUTS},
 				// emulate host for IPC
 				//{Type: configs.NEWIPC},
+				{Type: configs.NEWCGROUP},
 			},
 		},
 		initProcess: &mockProcess{
@@ -278,6 +279,8 @@ func TestGetContainerState(t *testing.T) {
 				file = "user"
 			case configs.NEWUTS:
 				file = "uts"
+			case configs.NEWCGROUP:
+				file = "cgroup"
 			}
 			expected := fmt.Sprintf("/proc/%d/ns/%s", pid, file)
 			if expected != path {


### PR DESCRIPTION
This test needs to handle the case of configs.NEWCGROUP
as Namespace's type.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>