### PR TITLE
Add public API interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,19 +29,23 @@ SHELL := $(shell command -v bash 2>/dev/null)
 
 .DEFAULT: runc
 
+LDFLAGS := -X $(PROJECT)/api.gitCommit=${COMMIT} \
+	-X $(PROJECT)/api.version=${VERSION} \
+	$(EXTRA_LDFLAGS)
+
 runc: $(SOURCES)
-	$(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -tags "$(BUILDTAGS)" -o runc .
+	$(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "$(LDFLAGS)" -tags "$(BUILDTAGS)" -o runc .
 
 all: runc recvtty
 
 recvtty: contrib/cmd/recvtty/recvtty
 
 contrib/cmd/recvtty/recvtty: $(SOURCES)
-	$(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -tags "$(BUILDTAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
+	$(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "$(LDFLAGS)" -tags "$(BUILDTAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
 
 static: $(SOURCES)
-	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -o runc .
-	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
+	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo static_build" -installsuffix netgo -ldflags "-w -extldflags -static $(LDFLAGS)" -o runc .
+	CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo static_build" -installsuffix netgo -ldflags "-w -extldflags -static $(LDFLAGS)" -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
 
 release:
 	script/release.sh -r release/$(VERSION) -v $(VERSION)
@@ -122,10 +126,10 @@ cross: runcimage
 	docker run ${DOCKER_RUN_PROXY} -e BUILDTAGS="$(BUILDTAGS)" --rm -v $(CURDIR):/go/src/$(PROJECT) $(RUNC_IMAGE) make localcross
 
 localcross:
-	CGO_ENABLED=1 GOARCH=arm GOARM=6 CC=arm-linux-gnueabi-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-armel .
-	CGO_ENABLED=1 GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-armhf .
-	CGO_ENABLED=1 GOARCH=arm64 CC=aarch64-linux-gnu-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-arm64 .
-	CGO_ENABLED=1 GOARCH=ppc64le CC=powerpc64le-linux-gnu-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION} $(EXTRA_LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-ppc64le .
+	CGO_ENABLED=1 GOARCH=arm GOARM=6 CC=arm-linux-gnueabi-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "$(LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-armel .
+	CGO_ENABLED=1 GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "$(LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-armhf .
+	CGO_ENABLED=1 GOARCH=arm64 CC=aarch64-linux-gnu-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "$(LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-arm64 .
+	CGO_ENABLED=1 GOARCH=ppc64le CC=powerpc64le-linux-gnu-gcc $(GO) build -buildmode=pie $(EXTRA_FLAGS) -ldflags "$(LDFLAGS)" -tags "$(BUILDTAGS)" -o runc-ppc64le .
 
 # memoize allpackages, so that it's executed only once and only if used
 _allpackages = $(shell $(GO) list ./... | grep -v vendor)

--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,46 @@
+// Package api provides a general purpose API which matches the main command
+// line interface
+package api
+
+// Runc specifies the public interface of the public API
+type Runc interface {
+	// Version returns the Runc Version instance
+	Version() *Version
+
+	// WithDebug configures Runc to enable or disable debug output
+	WithDebug(bool) Runc
+
+	// WithRoot configures Runc to set the runtime root directory
+	WithRoot(string) Runc
+
+	// instance returns the internally used private runc type
+	instance() *runc
+}
+
+// runc is the internal state type
+type runc struct {
+	root  string
+	debug bool
+}
+
+// NewRunc creats a new instance of the Runc interface
+func New() Runc {
+	return &runc{
+		root:  "/run/runc",
+		debug: false,
+	}
+}
+
+func (r *runc) instance() *runc {
+	return r
+}
+
+func (r *runc) WithRoot(root string) Runc {
+	r.instance().root = root
+	return r
+}
+
+func (r *runc) WithDebug(debug bool) Runc {
+	r.instance().debug = debug
+	return r
+}

--- a/api/version.go
+++ b/api/version.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+var (
+	// version will be populated by the Makefile, read from VERSION file of the
+	// source code.
+	version = ""
+
+	// gitCommit will be the hash that the binary was built from and will be
+	// populated by the Makefile
+	gitCommit = ""
+)
+
+// Version specifies all available version strings
+type Version struct {
+	Runc      string
+	Spec      string
+	GitCommit string
+}
+
+// Version returns the Runc Version instance
+func (r *runc) Version() *Version {
+	return &Version{
+		Runc:      version,
+		Spec:      specs.Version,
+		GitCommit: gitCommit,
+	}
+}
+
+// Strings returns a string representation of the Version
+func (v *Version) String() string {
+	strs := []string{}
+	if v.Runc != "" {
+		strs = append(strs, v.Runc)
+	}
+	if v.GitCommit != "" {
+		strs = append(strs, fmt.Sprintf("commit: %s", v.GitCommit))
+	}
+	strs = append(strs, fmt.Sprintf("spec: %s", specs.Version))
+	return strings.Join(strs, "\n")
+}


### PR DESCRIPTION
Main motivation of this commit is that dependent projects do not have to
shell out for using runc. This provides better performance and a general
type-safety.

This commit adds a public API to runc, which currently implements the
basic Version() API for demonstration purposes. A public interface
provides the possibility to mock the results by the consumer of the API.
The configuration of the API will be done via a modified builder
pattern, which is directly part of the public interface.

Later on, the all CLI commands within the `main` package should utilize
the configured API instance from the context to retrieve its results.