### PR TITLE
libcontainer: change seccomp test for clone syscall

### DIFF
--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/configs/validate"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -104,7 +106,7 @@ func TestSetupSeccomp(t *testing.T) {
 				Args: []specs.LinuxSeccompArg{
 					{
 						Index:    0,
-						Value:    2080505856,
+						Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
 						ValueTwo: 0,
 						Op:       "SCMP_CMP_MASKED_EQ",
 					},
@@ -154,7 +156,7 @@ func TestSetupSeccomp(t *testing.T) {
 			expectedCloneSyscallArgs := configs.Arg{
 				Index:    0,
 				Op:       7, // SCMP_CMP_MASKED_EQ
-				Value:    2080505856,
+				Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
 				ValueTwo: 0,
 			}
 			if expectedCloneSyscallArgs != *call.Args[0] {


### PR DESCRIPTION
This commit changes the value of seccomp test for clone syscall.
Also hardcoded values should be changed because it is unclear to
understand what flags are tested.

Related issues:

* https://github.com/containerd/containerd/pull/3314
* https://github.com/moby/moby/pull/39308
* https://github.com/opencontainers/runtime-tools/pull/694

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>