### PR TITLE
libcontainer: workaround for empty key label bug in RHEL7

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -35,7 +35,10 @@ func (l *linuxSetnsInit) Init() error {
 
 	if !l.config.Config.NoNewKeyring {
 		if err := label.SetKeyLabel(l.config.ProcessLabel); err != nil {
-			return err
+			// workaround for RHEL7 kernel which may return EACCES for an empty label
+			if !(l.config.ProcessLabel == "" && os.IsPermission(err)) {
+				return err
+			}
 		}
 		defer label.SetKeyLabel("")
 		// Do not inherit the parent's session keyring.

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -49,7 +49,10 @@ func (l *linuxStandardInit) Init() error {
 	defer runtime.UnlockOSThread()
 	if !l.config.Config.NoNewKeyring {
 		if err := label.SetKeyLabel(l.config.ProcessLabel); err != nil {
-			return err
+			// workaround for RHEL7 kernel which may return EACCES for an empty label
+			if !(l.config.ProcessLabel == "" && os.IsPermission(err)) {
+				return err
+			}
 		}
 		defer label.SetKeyLabel("")
 		ringname, keepperms, newperms := l.getSessionRingParams()


### PR DESCRIPTION
On a freshly installed CentOS 7 system (kernel 3.10.0-957.12.2.el7.x86_64)
with SELinux enabled, the kernel does not allow to write an empty label
to the keycreate file. Here's an strace except from containerd:

> 20396 openat(AT_FDCWD, "/proc/self/attr/keycreate", O_WRONLY|O_CLOEXEC) = 7
> ...
> 20396 write(7, "", 0)                   = -1 EACCES (Permission denied)

NOTE: upgrading or downgrading container-selinux makes this to go
away, so in order to reproduce you need a freshly booted system.

Here is a reproducer in C:

```
[root@kir-ce7-selinux-01 ~]# cat a.c
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>

int main(void) {
    int fd, r;

    fd = open("/proc/self/attr/keycreate", O_WRONLY);
    if (fd < 0) {
	    perror("open");
    }

    r = write(fd, "", 0);
    if (r < 0) {
	    perror("write");
    }

    return 0;
}

[root@kir-ce7-selinux-01 ~]# uname -a
Linux kir-ce7-selinux-01 3.10.0-957.12.2.el7.x86_64 #1 SMP Tue May 14 21:24:32 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

[root@kir-ce7-selinux-01 ~]# gcc -Wall -O2 -o a a.c

[root@kir-ce7-selinux-01 ~]# ./a
write: Permission denied
[root@kir-ce7-selinux-01 ~]# strace ./a
...
open("/proc/self/attr/keycreate", O_WRONLY) = 3
write(3, "", 0)                         = -1 EACCES (Permission denied)
...
```

So, this is presumably a kernel bug, but since there is no update
available for this kernel, we have to have this workaround here.

This fixes non-working docker/containerd/runc on CentOS 7 (and,
presumably, RHEL 7, too).

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>