### PR TITLE
libcontainer: fix the way to get network stats

### DIFF
--- a/events.go
+++ b/events.go
@@ -32,6 +32,7 @@ type stats struct {
 	Blkio    blkio              `json:"blkio"`
 	Hugetlb  map[string]hugetlb `json:"hugetlb"`
 	IntelRdt intelRdt           `json:"intel_rdt"`
+	Network  []*libcontainer.NetworkInterface `json:"network"`
 }
 
 type hugetlb struct {
@@ -275,6 +276,8 @@ func convertLibcontainerStats(ls *libcontainer.Stats) *stats {
 			s.IntelRdt.MemBwSchema = is.MemBwSchema
 		}
 	}
+
+	s.Network = append(s.Network, ls.Interfaces...)
 
 	return &s
 }

--- a/libcontainer/stats.go
+++ b/libcontainer/stats.go
@@ -2,14 +2,14 @@ package libcontainer
 
 type NetworkInterface struct {
 	// Name is the name of the network interface.
-	Name string
+	Name string `json:"name,omitempty"`
 
-	RxBytes   uint64
-	RxPackets uint64
-	RxErrors  uint64
-	RxDropped uint64
-	TxBytes   uint64
-	TxPackets uint64
-	TxErrors  uint64
-	TxDropped uint64
+	RxBytes   uint64 `json:"rx_bytes,omitempty"`
+	RxPackets uint64 `json:"rx_packets,omitempty"`
+	RxErrors  uint64 `json:"rx_errors,omitempty"`
+	RxDropped uint64 `json:"rx_dropped,omitempty"`
+	TxBytes   uint64 `json:"tx_bytes,omitempty"`
+	TxPackets uint64 `json:"tx_packets,omitempty"`
+	TxErrors  uint64 `json:"tx_errors,omitempty"`
+	TxDropped uint64 `json:"tx_dropped,omitempty"`
 }


### PR DESCRIPTION
Although `getNetworkInterfaceStats(interfaceName string)` was implemented in runc,  containerd does not transfer the interface name to runc. So we still can’t get the network stats from libcontainer’s Stats().

Because in a runc container, we can get network stats by `cat /proc/<init pid>/root/sys/class/net/<EthInterface>/statistics/rx_bytes`. So I leverage this point. 

With this PR, `runc events --stats <containerd-id>` can return network stats.