### PR TITLE
Rename Id ID

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -19,7 +19,7 @@ import (
 	"syscall" // only for SysProcAttr and Signal
 	"time"
 
-	"github.com/cyphar/filepath-securejoin"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
@@ -573,7 +573,7 @@ func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 		Cwd:              process.Cwd,
 		Capabilities:     process.Capabilities,
 		PassedFilesCount: len(process.ExtraFiles),
-		ContainerId:      c.ID(),
+		ContainerID:      c.ID(),
 		NoNewPrivileges:  c.config.NoNewPrivileges,
 		RootlessEUID:     c.config.RootlessEUID,
 		RootlessCgroups:  c.config.RootlessCgroups,

--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -30,7 +30,7 @@ const (
 func (c ErrorCode) String() string {
 	switch c {
 	case IDInUse:
-		return "Id already in use"
+		return "ID already in use"
 	case InvalidIdFormat:
 		return "Invalid format"
 	case ContainerPaused:

--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -8,7 +8,7 @@ type ErrorCode int
 // API error codes.
 const (
 	// Factory errors
-	IdInUse ErrorCode = iota
+	IDInUse ErrorCode = iota
 	InvalidIdFormat
 
 	// Container errors
@@ -29,7 +29,7 @@ const (
 
 func (c ErrorCode) String() string {
 	switch c {
-	case IdInUse:
+	case IDInUse:
 		return "Id already in use"
 	case InvalidIdFormat:
 		return "Invalid format"

--- a/libcontainer/error_test.go
+++ b/libcontainer/error_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestErrorCode(t *testing.T) {
 	codes := map[ErrorCode]string{
-		IdInUse:             "Id already in use",
+		IDInUse:             "Id already in use",
 		InvalidIdFormat:     "Invalid format",
 		ContainerPaused:     "Container paused",
 		ConfigInvalid:       "Invalid configuration",

--- a/libcontainer/error_test.go
+++ b/libcontainer/error_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestErrorCode(t *testing.T) {
 	codes := map[ErrorCode]string{
-		IDInUse:             "Id already in use",
+		IDInUse:             "ID already in use",
 		InvalidIdFormat:     "Invalid format",
 		ContainerPaused:     "Container paused",
 		ConfigInvalid:       "Invalid configuration",

--- a/libcontainer/factory.go
+++ b/libcontainer/factory.go
@@ -15,7 +15,7 @@ type Factory interface {
 	// Returns the new container with a running process.
 	//
 	// errors:
-	// IdInUse - id is already in use by a container
+	// IDInUse - id is already in use by a container
 	// InvalidIdFormat - id has incorrect format
 	// ConfigInvalid - config is invalid
 	// Systemerror - System error

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -200,7 +200,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		return nil, err
 	}
 	if _, err := os.Stat(containerRoot); err == nil {
-		return nil, newGenericError(fmt.Errorf("container with id exists: %v", id), IdInUse)
+		return nil, newGenericError(fmt.Errorf("container with id exists: %v", id), IDInUse)
 	} else if !os.IsNotExist(err) {
 		return nil, newGenericError(err, SystemError)
 	}

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -11,7 +11,6 @@ import (
 	"runtime/debug"
 	"strconv"
 
-	"github.com/cyphar/filepath-securejoin"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/cyphar/filepath-securejoin"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
@@ -96,7 +97,7 @@ func IntelRdtFs(l *LinuxFactory) error {
 	l.NewIntelRdtManager = func(config *configs.Config, id string, path string) intelrdt.Manager {
 		return &intelrdt.IntelRdtManager{
 			Config: config,
-			Id:     id,
+			ID:     id,
 			Path:   path,
 		}
 	}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -61,7 +61,7 @@ type initConfig struct {
 	Config           *configs.Config       `json:"config"`
 	Networks         []*network            `json:"network"`
 	PassedFilesCount int                   `json:"passed_files_count"`
-	ContainerId      string                `json:"containerid"`
+	ContainerID      string                `json:"containerid"`
 	Rlimits          []configs.Rlimit      `json:"rlimits"`
 	CreateConsole    bool                  `json:"create_console"`
 	ConsoleWidth     uint16                `json:"console_width"`

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -161,7 +161,7 @@ type Manager interface {
 type IntelRdtManager struct {
 	mu     sync.Mutex
 	Config *configs.Config
-	Id     string
+	ID     string
 	Path   string
 }
 
@@ -534,7 +534,7 @@ func (m *IntelRdtManager) Apply(pid int) (err error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	path, err := d.join(m.Id)
+	path, err := d.join(m.ID)
 	if err != nil {
 		return err
 	}
@@ -558,7 +558,7 @@ func (m *IntelRdtManager) Destroy() error {
 // restore the object later
 func (m *IntelRdtManager) GetPath() string {
 	if m.Path == "" {
-		m.Path, _ = GetIntelRdtPath(m.Id)
+		m.Path, _ = GetIntelRdtPath(m.ID)
 	}
 	return m.Path
 }

--- a/libcontainer/keys/keyctl.go
+++ b/libcontainer/keys/keyctl.go
@@ -15,11 +15,11 @@ import (
 type KeySerial uint32
 
 func JoinSessionKeyring(name string) (KeySerial, error) {
-	sessKeyId, err := unix.KeyctlJoinSessionKeyring(name)
+	sessKeyID, err := unix.KeyctlJoinSessionKeyring(name)
 	if err != nil {
 		return 0, errors.Wrap(err, "create session key")
 	}
-	return KeySerial(sessKeyId), nil
+	return KeySerial(sessKeyID), nil
 }
 
 // ModKeyringPerm modifies permissions on a keyring by reading the current permissions,

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -26,7 +26,7 @@ type linuxSetnsInit struct {
 }
 
 func (l *linuxSetnsInit) getSessionRingName() string {
-	return fmt.Sprintf("_ses.%s", l.config.ContainerId)
+	return fmt.Sprintf("_ses.%s", l.config.ContainerID)
 }
 
 func (l *linuxSetnsInit) Init() error {

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -41,7 +41,7 @@ func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
 
 	// Create a unique per session container name that we can join in setns;
 	// However, other containers can also join it.
-	return fmt.Sprintf("_ses.%s", l.config.ContainerId), 0xffffffff, newperms
+	return fmt.Sprintf("_ses.%s", l.config.ContainerID), 0xffffffff, newperms
 }
 
 func (l *linuxStandardInit) Init() error {

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -55,7 +55,7 @@ func (l *linuxStandardInit) Init() error {
 		ringname, keepperms, newperms := l.getSessionRingParams()
 
 		// Do not inherit the parent's session keyring.
-		if sessKeyId, err := keys.JoinSessionKeyring(ringname); err != nil {
+		if sessKeyID, err := keys.JoinSessionKeyring(ringname); err != nil {
 			// If keyrings aren't supported then it is likely we are on an
 			// older kernel (or inside an LXC container). While we could bail,
 			// the security feature we are using here is best-effort (it only
@@ -71,7 +71,7 @@ func (l *linuxStandardInit) Init() error {
 			// Make session keyring searcheable. If we've gotten this far we
 			// bail on any error -- we don't want to have a keyring with bad
 			// permissions.
-			if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
+			if err := keys.ModKeyringPerm(sessKeyID, keepperms, newperms); err != nil {
 				return errors.Wrap(err, "mod keyring permissions")
 			}
 		}

--- a/update.go
+++ b/update.go
@@ -288,7 +288,7 @@ other options are ignored.
 				config.IntelRdt = &configs.IntelRdt{}
 				intelRdtManager := intelrdt.IntelRdtManager{
 					Config: &config,
-					Id:     container.ID(),
+					ID:     container.ID(),
 					Path:   state.IntelRdtPath,
 				}
 				if err := intelRdtManager.Apply(state.InitProcessPid); err != nil {

--- a/vendor/github.com/vishvananda/netlink/nl/xfrm_state_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/xfrm_state_linux.go
@@ -92,7 +92,7 @@ func (msg *XfrmStats) Serialize() []byte {
 
 type XfrmUsersaInfo struct {
 	Sel          XfrmSelector
-	Id           XfrmId
+	ID           XfrmId
 	Saddr        XfrmAddress
 	Lft          XfrmLifetimeCfg
 	Curlft       XfrmLifetimeCur

--- a/vendor/github.com/vishvananda/netlink/xfrm_state_linux.go
+++ b/vendor/github.com/vishvananda/netlink/xfrm_state_linux.go
@@ -45,11 +45,11 @@ func XfrmStateAdd(state *XfrmState) error {
 
 	msg := &nl.XfrmUsersaInfo{}
 	msg.Family = uint16(nl.GetIPFamily(state.Dst))
-	msg.Id.Daddr.FromIP(state.Dst)
+	msg.ID.Daddr.FromIP(state.Dst)
 	msg.Saddr.FromIP(state.Src)
-	msg.Id.Proto = uint8(state.Proto)
+	msg.ID.Proto = uint8(state.Proto)
 	msg.Mode = uint8(state.Mode)
-	msg.Id.Spi = nl.Swap32(uint32(state.Spi))
+	msg.ID.Spi = nl.Swap32(uint32(state.Spi))
 	msg.Reqid = uint32(state.Reqid)
 	msg.ReplayWindow = uint8(state.ReplayWindow)
 	msg.Lft.SoftByteLimit = nl.XFRM_INF
@@ -128,11 +128,11 @@ func XfrmStateList(family int) ([]XfrmState, error) {
 
 		var state XfrmState
 
-		state.Dst = msg.Id.Daddr.ToIP()
+		state.Dst = msg.ID.Daddr.ToIP()
 		state.Src = msg.Saddr.ToIP()
-		state.Proto = Proto(msg.Id.Proto)
+		state.Proto = Proto(msg.ID.Proto)
 		state.Mode = Mode(msg.Mode)
-		state.Spi = int(nl.Swap32(msg.Id.Spi))
+		state.Spi = int(nl.Swap32(msg.ID.Spi))
 		state.Reqid = int(msg.Reqid)
 		state.ReplayWindow = int(msg.ReplayWindow)
 


### PR DESCRIPTION
Both of Id and ID are used in the source code as the short for "identifier" and ID is preferred in Go(https://github.com/golang/go/wiki/CodeReviewComments#initialisms). Therefore, I have renamed Id ID.