### PR TITLE
Update busybox source and fix runc exec bug

### DIFF
--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -122,10 +122,10 @@ function teardown() {
 
   wait_for_container 15 1 test_busybox
 
-  runc exec --user 1000:1000 --additional-gids 100 --additional-gids 99 test_busybox id 
+  runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id
   [ "$status" -eq 0 ]
 
-  [[ ${output} == "uid=1000 gid=1000 groups=99(nogroup),100(users)" ]]
+  [[ ${output} == "uid=1000 gid=1000 groups=100(users),65534(nogroup)" ]]
 }
 
 @test "runc exec --preserve-fds" {

--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -2,10 +2,10 @@
 get_busybox(){
 	case $(go env GOARCH) in
 	arm64)
-		echo 'https://github.com/docker-library/busybox/raw/23fbd9c43e0f4bec7605091bfba23db278c367ac/glibc/busybox.tar.xz'
+		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/glibc/busybox.tar.xz'
 	;;
 	*)
-		echo 'https://github.com/docker-library/busybox/raw/a0558a9006ce0dd6f6ec5d56cfd3f32ebeeb815f/glibc/busybox.tar.xz'
+		echo 'https://github.com/docker-library/busybox/raw/dist-amd64/glibc/busybox.tar.xz'
 	;;
 	esac
 }


### PR DESCRIPTION
Currently, the id verification in integration test failed on arm
platform due to the inconsistent /etc/group in the busybox images
for arm and x86. To be specific, the nogroup id in x86 is 99 while
that in arm is 65534.

99 is old id for nogroup, and no longer be used in recent system,
so sync the busybox image for arm and x86 to the image in busybox
github. Also change the id verification rule in integration test.

Signed-off-by: Howard Zhang <howard.zhang@arm.com>