### PR TITLE
integration: remove blkio.weight (unavailable in kernel 5.0)

### DIFF
--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -29,9 +29,6 @@ function setup() {
         "period": 1000000,
         "cpus": "0"
     },
-    "blockio": {
-        "weight": 1000
-    },
     "pids": {
         "limit": 20
     },
@@ -70,7 +67,6 @@ function check_cgroup_value() {
     CGROUP_SYSTEM_MEMORY=$(grep "cgroup"  /proc/self/mountinfo | gawk 'toupper($NF) ~ /\<'MEMORY'\>/ { print $5; exit }')
 
     # check that initial values were properly set
-    check_cgroup_value $CGROUP_BLKIO "blkio.weight" 1000
     check_cgroup_value $CGROUP_CPU "cpu.cfs_period_us" 1000000
     check_cgroup_value $CGROUP_CPU "cpu.cfs_quota_us" 500000
     check_cgroup_value $CGROUP_CPU "cpu.shares" 100
@@ -80,11 +76,6 @@ function check_cgroup_value() {
     check_cgroup_value $CGROUP_MEMORY "memory.limit_in_bytes" 33554432
     check_cgroup_value $CGROUP_MEMORY "memory.soft_limit_in_bytes" 25165824
     check_cgroup_value $CGROUP_PIDS "pids.max" 20
-
-    # update blkio-weight
-    runc update test_update --blkio-weight 500
-    [ "$status" -eq 0 ]
-    check_cgroup_value $CGROUP_BLKIO "blkio.weight" 500
 
     # update cpu-period
     runc update test_update --cpu-period 900000
@@ -182,16 +173,12 @@ function check_cgroup_value() {
     "period": 1000000,
     "cpus": "0"
   },
-  "blockIO": {
-    "weight": 1000
-  },
   "pids": {
     "limit": 20
   }
 }
 EOF
     [ "$status" -eq 0 ]
-    check_cgroup_value $CGROUP_BLKIO "blkio.weight" 1000
     check_cgroup_value $CGROUP_CPU "cpu.cfs_period_us" 1000000
     check_cgroup_value $CGROUP_CPU "cpu.cfs_quota_us" 500000
     check_cgroup_value $CGROUP_CPU "cpu.shares" 100
@@ -203,12 +190,11 @@ EOF
     check_cgroup_value $CGROUP_PIDS "pids.max" 20
 
     # redo all the changes at once
-    runc update test_update --blkio-weight 500 \
+    runc update test_update \
         --cpu-period 900000 --cpu-quota 600000 --cpu-share 200 --memory 67108864 \
         --memory-reservation 33554432 --kernel-memory 50331648 --kernel-memory-tcp 41943040 \
         --pids-limit 10
     [ "$status" -eq 0 ]
-    check_cgroup_value $CGROUP_BLKIO "blkio.weight" 500
     check_cgroup_value $CGROUP_CPU "cpu.cfs_period_us" 900000
     check_cgroup_value $CGROUP_CPU "cpu.cfs_quota_us" 600000
     check_cgroup_value $CGROUP_CPU "cpu.shares" 200
@@ -233,9 +219,6 @@ EOF
     "period": 1000000,
     "cpus": "0"
   },
-  "blockIO": {
-    "weight": 1000
-  },
   "pids": {
     "limit": 20
   }
@@ -246,7 +229,6 @@ EOF
 
     runc update  -r $BATS_TMPDIR/runc-cgroups-integration-test.json test_update
     [ "$status" -eq 0 ]
-    check_cgroup_value $CGROUP_BLKIO "blkio.weight" 1000
     check_cgroup_value $CGROUP_CPU "cpu.cfs_period_us" 1000000
     check_cgroup_value $CGROUP_CPU "cpu.cfs_quota_us" 500000
     check_cgroup_value $CGROUP_CPU "cpu.shares" 100


### PR DESCRIPTION
weight, leafWeight, and weightDevice are removed in kernel 5.0

https://github.com/torvalds/linux/commit/f382fb0bcef4c37dc049e9f6963e3baf204d815c
https://github.com/opencontainers/runtime-spec/issues/1015

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>