### PR TITLE
Make sure signalAllProcesses is invoked in the function of destroy when container shares pid namespace

### DIFF
--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -38,7 +38,8 @@ type containerState interface {
 }
 
 func destroy(c *linuxContainer) error {
-	if !c.config.Namespaces.Contains(configs.NEWPID) {
+	if !c.config.Namespaces.Contains(configs.NEWPID) ||
+		c.config.Namespaces.PathOf(configs.NEWPID) != "" {
 		if err := signalAllProcesses(c.cgroupManager, unix.SIGKILL); err != nil {
 			logrus.Warn(err)
 		}


### PR DESCRIPTION
# issue description
./runc spec
add pid ns config to config.json
```
{
    "type": "pid",
    "path": "/proc/1/ns/pid"
}
```

"./runc run hello" in a console and "./runc exec -t hello ash" in another console, and then exit container.
we will see the following erros,
```
/ # exit
ERRO[0036] Failed to remove paths: map[memory:/sys/fs/cgroup/memory/user.slice/hello blkio:/sys/fs/cgroup/blkio/user.slice/hello hugetlb:/sys/fs/cgroup/hugetlb/hello net_cls:/sys/fs/cgroup/net_cls,net_prio/hello freezer:/sys/fs/cgroup/freezer/hello cpuset:/sys/fs/cgroup/cpuset/hello cpu:/sys/fs/cgroup/cpu,cpuacct/user.slice/hello cpuacct:/sys/fs/cgroup/cpu,cpuacct/user.slice/hello pids:/sys/fs/cgroup/pids/user.slice/hello net_prio:/sys/fs/cgroup/net_cls,net_prio/hello perf_event:/sys/fs/cgroup/perf_event/hello name=systemd:/sys/fs/cgroup/systemd/user.slice/user-0.slice/session-2658.scope/hello devices:/sys/fs/cgroup/devices/user.slice/hello] 
```

# why
It's expect that signalAllProcesses is invoked when container shares pid namespace. share pid ns contains the following conditions:
```
{
    //no specify pid ns
}
{
    "type": "pid",
    "path": "/proc/${num}/ns/pid"
}
```
but the code can't do the second condition. this pr will add the second.





Signed-off-by: Shukui Yang <keloyangsk@gmail.com>