### PR TITLE
fix permission denied

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -127,6 +127,12 @@ func finalizeNamespace(config *initConfig) error {
 		return errors.Wrap(err, "close exec fds")
 	}
 
+	if config.Cwd != "" {
+		if err := unix.Chdir(config.Cwd); err != nil {
+			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
+		}
+	}
+
 	capabilities := &configs.Capabilities{}
 	if config.Capabilities != nil {
 		capabilities = config.Capabilities
@@ -153,11 +159,6 @@ func finalizeNamespace(config *initConfig) error {
 	}
 	if err := w.ApplyCaps(); err != nil {
 		return errors.Wrap(err, "apply caps")
-	}
-	if config.Cwd != "" {
-		if err := unix.Chdir(config.Cwd); err != nil {
-			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
when exec as root and `config.Cwd` is not owned by root, exec will fail
because root doesn't have the caps.

So, Chdir should be done before setting the caps.

to reproduce this error
1. create Dockerfile
```
FROM alpine:latest

RUN mkdir /lala && chown nobody:nobody /lala && chmod 0700 /lala
USER nobody
WORKDIR /lala

ENTRYPOINT ["sh", "-c", "mkfifo lala; cat lala"]
```

2. build and run the container
```
docker build -t asdf .
docker run -it --rm --name hai asdf
```

3. docker exec from another terminal
```
docker exec -it -u 0:0 hai sh
```