### PR TITLE
doc: First process in container needs `Init: true`

### DIFF
--- a/libcontainer/README.md
+++ b/libcontainer/README.md
@@ -261,6 +261,7 @@ process := &libcontainer.Process{
 	Stdin:  os.Stdin,
 	Stdout: os.Stdout,
 	Stderr: os.Stderr,
+	Init:   true,
 }
 
 err := container.Run(process)


### PR DESCRIPTION
`Init` on the `Process` struct specifies whether the process is the first process in the container. This needs to be set to `true` when running the container.