### PR TITLE
systemd cgroup driver: Split support for unified cgroup2 hierarchy into its own Manager

### DIFF
--- a/libcontainer/cgroups/systemd/unified_hierarchy.go
+++ b/libcontainer/cgroups/systemd/unified_hierarchy.go
@@ -1,0 +1,62 @@
+// +build linux,!static_build
+
+package systemd
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
+)
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
+func IsCgroup2UnifiedMode() (bool, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
+		return false, fmt.Errorf("cannot statfs cgroup root: %v", err)
+	}
+	return st.Type == unix.CGROUP2_SUPER_MAGIC, nil
+}
+
+type UnifiedManager struct {
+	Cgroups *configs.Cgroup
+	Paths   map[string]string
+}
+
+func NewUnifiedSystemdCgroupsManager() (func(config *configs.Cgroup, paths map[string]string) cgroups.Manager, error) {
+	return nil, fmt.Errorf("unified hierarchy not supported")
+}
+
+func (m *UnifiedManager) Apply(pid int) error {
+	return fmt.Errorf("unified hierarchy not supported")
+}
+
+func (m *UnifiedManager) GetPids() ([]int, error) {
+	return nil, fmt.Errorf("unified hierarchy not supported")
+}
+
+func (m *UnifiedManager) GetAllPids() ([]int, error) {
+	return nil, fmt.Errorf("unified hierarchy not supported")
+}
+
+func (m *UnifiedManager) Destroy() error {
+	return fmt.Errorf("unified hierarchy not supported")
+}
+
+func (m *UnifiedManager) GetPaths() map[string]string {
+	return nil
+}
+
+func (m *UnifiedManager) GetStats() (*cgroups.Stats, error) {
+	return nil, fmt.Errorf("unified hierarchy not supported")
+}
+
+func (m *UnifiedManager) Set(container *configs.Config) error {
+	return fmt.Errorf("unified hierarchy not supported")
+}
+
+func (m *UnifiedManager) Freeze(state configs.FreezerState) error {
+	return fmt.Errorf("unified hierarchy not supported")
+}


### PR DESCRIPTION
Split support for unified cgroup2 hierarchy into its own Manager in the systemd cgroup driver

Detection is done only once, as the manager is instantiated, and then the two implementations are for the most part separate.

This will allow us to iterate on the unified cgroup2 implementation without worrying about compatibility with the legacy implementation.

For now, the unified cgroup2 implementation consists of stubs that need to be filled up with actual implementation.

/cc @giuseppe @rhatdan 

I think I'd prefer if we started from a split like this, then added the bits needed for cgroup2 support. What do you think?
