### PR TITLE
libcontainer: update masked paths of /proc

### DIFF
--- a/libcontainer/specconv/example.go
+++ b/libcontainer/specconv/example.go
@@ -110,7 +110,10 @@ func Example() *specs.Spec {
 		},
 		Linux: &specs.Linux{
 			MaskedPaths: []string{
+				"/proc/acpi",
+				"/proc/asound",
 				"/proc/kcore",
+				"/proc/keys",
 				"/proc/latency_stats",
 				"/proc/timer_list",
 				"/proc/timer_stats",
@@ -119,7 +122,6 @@ func Example() *specs.Spec {
 				"/proc/scsi",
 			},
 			ReadonlyPaths: []string{
-				"/proc/asound",
 				"/proc/bus",
 				"/proc/fs",
 				"/proc/irq",


### PR DESCRIPTION
This commit updates the masked paths of /proc.

Related issues:
* https://github.com/moby/moby/pull/37404
* https://github.com/moby/moby/pull/38299
* https://github.com/moby/moby/pull/36368

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>