### PR TITLE
Handle ENODEV when accessing the freezer.state file

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1824,7 +1824,7 @@ func (c *linuxContainer) isPaused() (bool, error) {
 	data, err := ioutil.ReadFile(filepath.Join(fcg, filename))
 	if err != nil {
 		// If freezer cgroup is not mounted, the container would just be not paused.
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) || err == syscall.ENODEV {
 			return false, nil
 		}
 		return false, newSystemErrorWithCause(err, "checking if container is paused")


### PR DESCRIPTION
...when checking if a container is paused

We saw the following failure multiple times when trying to destroy a container: 
```
container_linux.go:1807: checking if container is paused caused \"read /tmp/cgroups-2/freezer/7b63e111-f0cc-4ce2-67fb-bcded8f7fb63/garden-3/134bbc40-0713-4456-6960-3ca2586b4e03/freezer.state: no such device\"
```

We asynchronously delete two containers that share the same freezer cgroup and PID namespace and something like this is happening:
1. We start destroying both the containers in the same time
1. Since the process of one of them is PID 1 in the PID namespace, killing `container-1` also kills the processes of `container-2`. That results in no processes in the freezer cgroup so the deletion of `container-1` starts destroying it. 
1. In the meantime, the deletion of `container-2` reaches the point where it checks if the container is paused by looking at the freezer.state file. Sometimes the file is still there, but the cgroup is dead (it does not have the `CSS_ONLINE` flag) because it is currently being deleted by the deletion of `container-1` which results in ENODEV. 

Signed-off-by: Julia Nedialkova <julianedialkova@hotmail.com>