### PR TITLE
nsenter: cloned_binary: do not clone exe if on readonly rootfs

### DIFF
--- a/libcontainer/nsenter/cloned_binary.c
+++ b/libcontainer/nsenter/cloned_binary.c
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/statvfs.h>
 #include <sys/vfs.h>
 #include <sys/mman.h>
 #include <sys/mount.h>
@@ -86,15 +87,34 @@ static void *must_realloc(void *ptr, size_t size)
 /*
  * Verify whether we are currently in a self-cloned program (namely, is
  * /proc/self/exe a memfd). F_GET_SEALS will only succeed for memfds (or rather
- * for shmem files), and we want to be sure it's actually sealed.
+ * for shmem files), and we want to be sure it's actually sealed. In case the
+ * the program is on a read-only rootfs, do not clone.
  */
 static int is_self_cloned(void)
 {
 	int fd, ret, is_cloned = 0;
 	struct stat statbuf = {};
 	struct statfs fsbuf = {};
+	struct statvfs stat;
+	char abs_path[1024];
 
-	fd = open("/proc/self/exe", O_RDONLY|O_CLOEXEC);
+	memset(&stat, 0, sizeof(struct statvfs));
+	const char *path = "/proc/self/exe";
+
+	ssize_t len = readlink(path, abs_path, sizeof(abs_path)-1);
+	if (len != -1) {
+		/* readlink does not provide the path with null terminated character. */
+		abs_path[len] = '\0';
+
+		if (statvfs(abs_path, &stat) == 0) {
+			/* Checks whether a program is on a read-only rootfs. */
+			if (stat.f_flag & ST_RDONLY) {
+				return true;
+			}
+		}
+	}
+
+	fd = open(path, O_RDONLY|O_CLOEXEC);
 	if (fd < 0)
 		return -ENOTRECOVERABLE;
 


### PR DESCRIPTION
Fix for CVE-2019-5736 introduces a logic to clone the /proc/self/exe
so that no malicious container can modify the host binary. Due to this
bind mount was done in try_bindfd() which introduces three libmount
events. In systemd <= 232, for every libmount event, iteration over
all mounts present in /proc/self/mountinfo is done to check which
mount got changed. In case of large number of mounts already present,
systemd will require high cpu utilization for iteration over all the
mounts. In case of a read-only rootfs, cloning of /proc/self/exe is
not required and therefore, generation of libmount events can be
avoided.

This patch adds a check to see whether /proc/self/exe is on a
read-only rootfs or not. In case, it is present on a read-only
rootfs, cloning is not required.

Signed-off-by: Vaibhav Rustagi <vaibhavrustagi@google.com>