### PR TITLE
checkpoint: Set descriptors.json file mode to 0600

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1111,7 +1111,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 			return err
 		}
 
-		err = ioutil.WriteFile(filepath.Join(criuOpts.ImagesDirectory, descriptorsFilename), fdsJSON, 0655)
+		err = ioutil.WriteFile(filepath.Join(criuOpts.ImagesDirectory, descriptorsFilename), fdsJSON, 0600)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Prevent unprivileged users from being able to read `descriptors.json`

cc: @avagin @adrianreber 