### PR TITLE
cgroup2: implement `runc ps`

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -37,6 +37,13 @@ type Manager interface {
 	// restore the object later.
 	GetPaths() map[string]string
 
+	// GetUnifiedPath returns the unified path when running in unified mode.
+	// The value corresponds to the all values of GetPaths() map.
+	//
+	// GetUnifiedPath returns error when running in hybrid mode as well as
+	// in legacy mode.
+	GetUnifiedPath() (string, error)
+
 	// Sets the cgroup as configured.
 	Set(container *configs.Config) error
 }

--- a/libcontainer/cgroups/systemd/apply_nosystemd.go
+++ b/libcontainer/cgroups/systemd/apply_nosystemd.go
@@ -42,6 +42,10 @@ func (m *Manager) GetPaths() map[string]string {
 	return nil
 }
 
+func (m *Manager) GetUnifiedPath() (string, error) {
+	return "", fmt.Errorf("Systemd not supported")
+}
+
 func (m *Manager) GetStats() (*cgroups.Stats, error) {
 	return nil, fmt.Errorf("Systemd not supported")
 }

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -297,6 +297,10 @@ func (m *LegacyManager) GetPaths() map[string]string {
 	return paths
 }
 
+func (m *LegacyManager) GetUnifiedPath() (string, error) {
+	return "", errors.New("unified path is only supported when running in unified mode")
+}
+
 func join(c *configs.Cgroup, subsystem string, pid int) (string, error) {
 	path, err := getSubsystemPath(c, subsystem)
 	if err != nil {

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -54,6 +54,10 @@ func (m *mockCgroupManager) GetPaths() map[string]string {
 	return m.paths
 }
 
+func (m *mockCgroupManager) GetUnifiedPath() (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
+
 func (m *mockCgroupManager) Freeze(state configs.FreezerState) error {
 	return nil
 }


### PR DESCRIPTION
Implemented `runc ps` for cgroup v2 , using a newly added method `m.GetUnifiedPath()`.
Unlike the v1  implementation that checks `m.GetPaths()["devices"]`, the v2 implementation does not require the device controller to be available.