### PR TITLE
cgroup2: do not parse /proc/cgroups

### DIFF
--- a/libcontainer/cgroups/fs/io_v2.go
+++ b/libcontainer/cgroups/fs/io_v2.go
@@ -17,12 +17,11 @@ type IOGroupV2 struct {
 }
 
 func (s *IOGroupV2) Name() string {
-	// for compatibility with v1 blkio controller
-	return "blkio"
+	return "io"
 }
 
 func (s *IOGroupV2) Apply(d *cgroupData) error {
-	_, err := d.join("blkio")
+	_, err := d.join("io")
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err
 	}
@@ -62,7 +61,7 @@ func (s *IOGroupV2) Set(path string, cgroup *configs.Cgroup) error {
 }
 
 func (s *IOGroupV2) Remove(d *cgroupData) error {
-	return removePath(d.path("blkio"))
+	return removePath(d.path("io"))
 }
 
 func readCgroup2MapFile(path string, name string) (map[string][]string, error) {


### PR DESCRIPTION
`/proc/cgroups` is meaningless for v2 and should be ignored.

https://github.com/torvalds/linux/blob/v5.3/Documentation/admin-guide/cgroup-v2.rst#deprecated-v1-core-features

* Now `GetAllSubsystems()` parses `/sys/fs/cgroup/cgroup.controller`, not `/proc/cgroups`.
  The function result also contains "pseudo" controllers: `{"devices", "freezer"}`.
  As it is hard to detect availability of pseudo controllers, pseudo controllers are always assumed to be available.

* Now `IOGroupV2.Name()` returns `"io"`, not `"blkio"`.

Fix #2155 #2156

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>