### PR TITLE
.travis.yml: add Fedora 31 vagrant box (for cgroup2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: go
 go:
   - 1.11.x
@@ -13,6 +13,20 @@ matrix:
       script:
         - make BUILDTAGS="${BUILDTAGS}" all
         - sudo PATH="$PATH" make localintegration RUNC_USE_SYSTEMD=1
+    - go: 1.12.x
+      env:
+        - VIRTUALBOX_VERSION=6.0
+        - VAGRANT_VERSION=2.2.6
+        - FEDORA_VERSION=31
+      before_install:
+        - cat /proc/cpuinfo
+        - wget -q https://www.virtualbox.org/download/oracle_vbox_2016.asc -O- | sudo apt-key add - && sudo sh -c "echo deb https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib >> /etc/apt/sources.list" && sudo apt-get update && sudo apt-get install -yq build-essential gcc make linux-headers-$(uname -r) virtualbox-${VIRTUALBOX_VERSION} && sudo usermod -aG vboxusers $(whoami)
+        - wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_$(uname -m).deb && sudo dpkg -i vagrant_${VAGRANT_VERSION}_$(uname -m).deb
+        - vagrant init bento/fedora-${FEDORA_VERSION} && vagrant up && mkdir -p ~/.ssh && vagrant ssh-config >> ~/.ssh/config
+        - ssh default sudo dnf install -y podman
+      script:
+        - ssh default sudo podman build -t test /vagrant
+        - ssh default sudo podman run --privileged --cgroupns=private test make localunittest
   allow_failures:
     - go: tip
 

--- a/libcontainer/cgroups/cgroups_test.go
+++ b/libcontainer/cgroups/cgroups_test.go
@@ -11,7 +11,9 @@ func TestParseCgroups(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	if IsCgroup2UnifiedMode() {
+		return
+	}
 	if _, ok := cgroups["cpu"]; !ok {
 		t.Fail()
 	}

--- a/libcontainer/cgroups/fs/apply_raw_test.go
+++ b/libcontainer/cgroups/fs/apply_raw_test.go
@@ -7,10 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func TestInvalidCgroupPath(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)
@@ -42,6 +46,9 @@ func TestInvalidCgroupPath(t *testing.T) {
 }
 
 func TestInvalidAbsoluteCgroupPath(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)
@@ -74,6 +81,9 @@ func TestInvalidAbsoluteCgroupPath(t *testing.T) {
 
 // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
 func TestInvalidCgroupParent(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)
@@ -107,6 +117,9 @@ func TestInvalidCgroupParent(t *testing.T) {
 
 // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
 func TestInvalidAbsoluteCgroupParent(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)
@@ -140,6 +153,9 @@ func TestInvalidAbsoluteCgroupParent(t *testing.T) {
 
 // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
 func TestInvalidCgroupName(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)
@@ -174,6 +190,9 @@ func TestInvalidCgroupName(t *testing.T) {
 
 // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
 func TestInvalidAbsoluteCgroupName(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)
@@ -207,6 +226,9 @@ func TestInvalidAbsoluteCgroupName(t *testing.T) {
 
 // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
 func TestInvalidCgroupNameAndParent(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)
@@ -240,6 +262,9 @@ func TestInvalidCgroupNameAndParent(t *testing.T) {
 
 // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
 func TestInvalidAbsoluteCgroupNameAndParent(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 	root, err := getCgroupRoot()
 	if err != nil {
 		t.Errorf("couldn't get cgroup root: %v", err)

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 
 	"golang.org/x/sys/unix"
@@ -59,6 +60,10 @@ func testCheckpoint(t *testing.T, userns bool) {
 	if testing.Short() {
 		return
 	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
+
 	root, err := newTestRoot()
 	if err != nil {
 		t.Fatal(err)

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -205,6 +206,9 @@ func testRlimit(t *testing.T, userns bool) {
 func TestEnter(t *testing.T) {
 	if testing.Short() {
 		return
+	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
 	}
 
 	rootfs, err := newRootfs()
@@ -512,6 +516,9 @@ func testFreeze(t *testing.T, systemd bool) {
 	if testing.Short() {
 		return
 	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
 
 	rootfs, err := newRootfs()
 	ok(t, err)
@@ -566,6 +573,10 @@ func testCpuShares(t *testing.T, systemd bool) {
 	if testing.Short() {
 		return
 	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
+
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
@@ -596,6 +607,9 @@ func TestPidsSystemd(t *testing.T) {
 func testPids(t *testing.T, systemd bool) {
 	if testing.Short() {
 		return
+	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
 	}
 
 	rootfs, err := newRootfs()
@@ -680,6 +694,10 @@ func testRunWithKernelMemory(t *testing.T, systemd bool) {
 	if testing.Short() {
 		return
 	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v1 is not supported")
+	}
+
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)


### PR DESCRIPTION
As the baby step, only unit tests are executed.

Failing tests are currently skipped and will be fixed in follow-up PRs.

Fix #2124

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>