### PR TITLE
libcontainer: export and add new methods to allow cgroups manipulation

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -46,6 +46,9 @@ type Manager interface {
 
 	// Sets the cgroup as configured.
 	Set(container *configs.Config) error
+
+	// Gets the cgroup as configured.
+	GetCgroups() (*configs.Cgroup, error)
 }
 
 type NotFoundError struct {

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -467,3 +467,7 @@ func CheckCpushares(path string, c uint64) error {
 
 	return nil
 }
+
+func (m *Manager) GetCgroups() (*configs.Cgroup, error) {
+	return m.Cgroups, nil
+}

--- a/libcontainer/cgroups/systemd/apply_nosystemd.go
+++ b/libcontainer/cgroups/systemd/apply_nosystemd.go
@@ -61,3 +61,7 @@ func (m *Manager) Freeze(state configs.FreezerState) error {
 func Freeze(c *configs.Cgroup, state configs.FreezerState) error {
 	return fmt.Errorf("Systemd not supported")
 }
+
+func (m *Manager) GetCgroups() (*configs.Cgroup, error) {
+	return nil, fmt.Errorf("Systemd not supported")
+}

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -528,3 +528,7 @@ func isUnitExists(err error) bool {
 	}
 	return false
 }
+
+func (m *LegacyManager) GetCgroups() (*configs.Cgroup, error) {
+	return m.Cgroups, nil
+}

--- a/libcontainer/cgroups/systemd/unified_hierarchy.go
+++ b/libcontainer/cgroups/systemd/unified_hierarchy.go
@@ -346,3 +346,7 @@ func (m *UnifiedManager) Set(container *configs.Config) error {
 	}
 	return nil
 }
+
+func (m *UnifiedManager) GetCgroups() (*configs.Cgroup, error) {
+	return m.Cgroups, nil
+}

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -61,6 +61,9 @@ func (m *mockCgroupManager) GetUnifiedPath() (string, error) {
 func (m *mockCgroupManager) Freeze(state configs.FreezerState) error {
 	return nil
 }
+func (m *mockCgroupManager) GetCgroups() (*configs.Cgroup, error) {
+	return nil, nil
+}
 
 func (m *mockIntelRdtManager) Apply(pid int) error {
 	return nil
@@ -80,6 +83,10 @@ func (m *mockIntelRdtManager) GetPath() string {
 
 func (m *mockIntelRdtManager) Set(container *configs.Config) error {
 	return nil
+}
+
+func (m *mockIntelRdtManager) GetCgroups() (*configs.Cgroup, error) {
+	return nil, nil
 }
 
 type mockProcess struct {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -196,7 +196,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	if err := createDevices(spec, config); err != nil {
 		return nil, err
 	}
-	c, err := createCgroupConfig(opts)
+	c, err := CreateCgroupConfig(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	}
 }
 
-func createCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
+func CreateCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
 	var (
 		myCgroupPath string
 

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -213,7 +213,7 @@ func TestLinuxCgroupWithMemoryResource(t *testing.T) {
 		Spec:             spec,
 	}
 
-	cgroup, err := createCgroupConfig(opts)
+	cgroup, err := CreateCgroupConfig(opts)
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestLinuxCgroupSystemd(t *testing.T) {
 		Spec:             spec,
 	}
 
-	cgroup, err := createCgroupConfig(opts)
+	cgroup, err := CreateCgroupConfig(opts)
 
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
@@ -293,7 +293,7 @@ func TestLinuxCgroupSystemdWithEmptyPath(t *testing.T) {
 		Spec:             spec,
 	}
 
-	cgroup, err := createCgroupConfig(opts)
+	cgroup, err := CreateCgroupConfig(opts)
 
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
@@ -328,7 +328,7 @@ func TestLinuxCgroupSystemdWithInvalidPath(t *testing.T) {
 		Spec:             spec,
 	}
 
-	_, err := createCgroupConfig(opts)
+	_, err := CreateCgroupConfig(opts)
 	if err == nil {
 		t.Error("Expected to produce an error if not using the correct format for cgroup paths belonging to systemd")
 	}
@@ -347,7 +347,7 @@ func TestLinuxCgroupsPathSpecified(t *testing.T) {
 		Spec:             spec,
 	}
 
-	cgroup, err := createCgroupConfig(opts)
+	cgroup, err := CreateCgroupConfig(opts)
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestLinuxCgroupsPathNotSpecified(t *testing.T) {
 		Spec:             spec,
 	}
 
-	cgroup, err := createCgroupConfig(opts)
+	cgroup, err := CreateCgroupConfig(opts)
 	if err != nil {
 		t.Errorf("Couldn't create Cgroup config: %v", err)
 	}


### PR DESCRIPTION
libcontainer: export createCgroupConfig

A `config.Cgroups` object is required to manipulate cgroups v1 and v2 using
libcontainer.
Export `createCgroupConfig` to allow API users to create `config.Cgroups`
objects using directly libcontainer API.

libcontainer: add method to get cgroup config from cgroup Manager

`configs.Cgroup` contains the configuration used to create cgroups. This
configuration must be saved to disk, since it's required to restore the
cgroup manager that was used to create the cgroups.
Add method to get cgroup configuration from cgroup Manager to allow API users
save it to disk and restore a cgroup manager later.

fixes #2176

