### PR TITLE
Fix race checking for process exit and waiting for exec fifo

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -218,12 +218,16 @@ function wait_for_container() {
 	local attempts=$1
 	local delay=$2
 	local cid=$3
+	# optionally wait for a specific status
+	local wait_for_status="${4:-}"
 	local i
 
 	for ((i = 0; i < attempts; i++)); do
 		runc state $cid
 		if [[ "$status" -eq 0 ]]; then
-			return 0
+			if [[ "${output}" == *"${wait_for_status}"* ]]; then
+				return 0
+			fi
 		fi
 		sleep $delay
 	done
@@ -237,12 +241,16 @@ function wait_for_container_inroot() {
 	local attempts=$1
 	local delay=$2
 	local cid=$3
+	# optionally wait for a specific status
+	local wait_for_status="${4:-}"
 	local i
 
 	for ((i = 0; i < attempts; i++)); do
 		ROOT=$4 runc state $cid
 		if [[ "$status" -eq 0 ]]; then
-			return 0
+			if [[ "${output}" == *"${wait_for_status}"* ]]; then
+				return 0
+			fi
 		fi
 		sleep $delay
 	done

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -205,7 +205,7 @@ EOF
 		__runc run test_busybox
 	) &
 
-	wait_for_container 15 1 test_busybox
+	wait_for_container 15 1 test_busybox running
 	testcontainer test_busybox running
 
 	# Kill the container.


### PR DESCRIPTION
Fixes #2183, a race condition in checking for a dead process while waiting for the exec fifo to open:

* Moves the wait for the blocking fifo open (happy path) and the 100ms poll for a missing/zombie process into the same loop
* When the missing/zombie process check fires, does a non-blocking open/read of the fifo to see if the process already completed, and only returns the "container process is already dead" error if that fails.

To test this, I inserted a synthetic 150ms delay in the awaitFifoOpen path after opening the fifo (simulating a slow send on the fifoOpened channel losing the race to the 100ms dead process detection timeout), and the integration suite passed (this PR includes https://github.com/opencontainers/runc/pull/2186 which fixes an existing race condition in one of the integration tests).

```diff
diff --git a/libcontainer/container_linux.go b/libcontainer/container_linux.go
index bec72def..a5a4d1ad 100644
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -301,6 +301,8 @@ func awaitFifoOpen(path string) <-chan openResult {
        fifoOpened := make(chan openResult)
        go func() {
                result := fifoOpen(path, true)
+               // simulate a slow send on fifoOpened, racing with the 100ms dead process detection timeout
+               time.Sleep(150 * time.Millisecond)
                fifoOpened <- result
        }()
        return fifoOpened
```

When I insert the same simulated race in master, 14 integration tests fail with "container is already dead" errors.

Still working out a way to unit/integration test this without modifying non-test code like that.

cc @random-liu 