### PR TITLE
temporarily disable CRIU tests

### DIFF
--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -205,5 +205,10 @@ func (m *manager) Set(container *configs.Config) error {
 	if len(errs) > 0 && !m.rootless {
 		return errors.Errorf("error while setting cgroup v2: %+v", errs)
 	}
+	m.config = container.Cgroups
 	return nil
+}
+
+func (m *manager) GetCgroups() (*configs.Cgroup, error) {
+	return m.config, nil
 }

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -42,6 +42,7 @@ func showFile(t *testing.T, fname string) error {
 }
 
 func TestUsernsCheckpoint(t *testing.T) {
+	t.Skip("Ubuntu kernel is broken to run criu (#2196, #2198)")
 	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
 		t.Skip("userns is unsupported")
 	}
@@ -53,6 +54,7 @@ func TestUsernsCheckpoint(t *testing.T) {
 }
 
 func TestCheckpoint(t *testing.T) {
+	t.Skip("Ubuntu kernel is broken to run criu (#2196, #2198)")
 	testCheckpoint(t, false)
 }
 


### PR DESCRIPTION
~~update criu to the latest revision on criu-dev branch (v3.13 is not enough to fix the issue)~~

~~Fix #2196~~

**EDIT:** Changed PR to skip the tests until Ubuntu kernel gets fixed (https://github.com/opencontainers/runc/pull/2198#issuecomment-571124087)


contains https://github.com/opencontainers/runc/pull/2206