### PR TITLE
nsenter: fix leaking unused log fd used for early bootstrap

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -1020,6 +1020,10 @@ void nsexec(void)
 			/* Free netlink data. */
 			nl_free(&config);
 
+			/* Close log pipe. */
+			if (logfd != -1)
+				close(logfd);
+
 			/* Finish executing, let the Go runtime take over. */
 			return;
 		}


### PR DESCRIPTION
Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>