### PR TITLE
fix merging #2177 and #2169

### DIFF
--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -205,5 +205,10 @@ func (m *manager) Set(container *configs.Config) error {
 	if len(errs) > 0 && !m.rootless {
 		return errors.Errorf("error while setting cgroup v2: %+v", errs)
 	}
+	m.config = container.Cgroups
 	return nil
+}
+
+func (m *manager) GetCgroups() (*configs.Cgroup, error) {
+	return m.config, nil
 }


### PR DESCRIPTION
A new method was added to the cgroup interface when #2177 was merged.

After #2177 got merged, #2169 was merged without rebase (sorry!) and compilation was failing:

  libcontainer/cgroups/fs2/fs2.go:208:22: container.Cgroup undefined (type *configs.Config has no field or method Cgroup)
