### PR TITLE
Allow to set systemd scope properties via annotations

### DIFF
--- a/docs/systemd-properties.md
+++ b/docs/systemd-properties.md
@@ -1,0 +1,34 @@
+## Changing systemd unit properties
+
+In case runc uses systemd to set cgroup parameters for a container (i.e.
+`--systemd-cgroup` CLI flag is set), systemd creates a scope (a.k.a.
+transient unit) for the container, usually named like `runc-$ID.scope`.
+
+The systemd properties of this unit (shown by `systemctl show runc-$ID.scope`
+after the container is started) can be modified by adding annotations
+to container's runtime spec (`config.json`). For example:
+
+```json
+        "annotations": {
+                "org.systemd.property.TimeoutStopUSec": "uint64 123456789",
+                "org.systemd.property.CollectMode":"'inactive-or-failed'"
+        },
+```
+
+The above will set the following properties:
+
+* `TimeoutStopSec` to 2 minutes and 3 seconds;
+* `CollectMode` to "inactive-or-failed".
+
+The values must be in the gvariant format (for details, see
+[gvariant documentation](https://developer.gnome.org/glib/stable/gvariant-text.html)).
+
+To find out which type systemd expects for a particular parameter, please
+consult systemd sources. In particular, parameters with `USec` suffix are
+in microseconds, and those require an `uint64` typed argument. Since
+gvariant assumes int32 for a numeric values, the explicit type is required.
+
+**Note** that time-typed systemd parameter names must have the `USec`
+suffix, while they are documented with `Sec` suffix.
+For example, the stop timeout used in the example above must be
+set as `TimeoutStopUSec` but is shown and documented as `TimeoutStopSec`.

--- a/docs/systemd-properties.md
+++ b/docs/systemd-properties.md
@@ -24,11 +24,4 @@ The values must be in the gvariant format (for details, see
 [gvariant documentation](https://developer.gnome.org/glib/stable/gvariant-text.html)).
 
 To find out which type systemd expects for a particular parameter, please
-consult systemd sources. In particular, parameters with `USec` suffix are
-in microseconds, and those require an `uint64` typed argument. Since
-gvariant assumes int32 for a numeric values, the explicit type is required.
-
-**Note** that time-typed systemd parameter names must have the `USec`
-suffix, while they are documented with `Sec` suffix.
-For example, the stop timeout used in the example above must be
-set as `TimeoutStopUSec` but is shown and documented as `TimeoutStopSec`.
+consult systemd sources.

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -245,6 +245,8 @@ func (m *LegacyManager) Apply(pid int) error {
 		}
 	}
 
+	properties = append(properties, c.SystemdProps...)
+
 	statusChan := make(chan string, 1)
 	if _, err := theConn.StartTransientUnit(unitName, "replace", properties, statusChan); err == nil {
 		select {

--- a/libcontainer/cgroups/systemd/unified_hierarchy.go
+++ b/libcontainer/cgroups/systemd/unified_hierarchy.go
@@ -128,6 +128,8 @@ func (m *UnifiedManager) Apply(pid int) error {
 			newProp("TasksMax", uint64(c.Resources.PidsLimit)))
 	}
 
+	properties = append(properties, c.SystemdProps...)
+
 	// We have to set kernel memory here, as we can't change it once
 	// processes have been attached to the cgroup.
 	if c.Resources.KernelMemory != 0 {

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -1,5 +1,9 @@
 package configs
 
+import (
+	systemdDbus "github.com/coreos/go-systemd/dbus"
+)
+
 type FreezerState string
 
 const (
@@ -29,6 +33,11 @@ type Cgroup struct {
 
 	// Resources contains various cgroups settings to apply
 	*Resources
+
+	// SystemdProps are any additional properties for systemd,
+	// derived from org.systemd.property.xxx annotations.
+	// Ignored unless systemd is used for managing cgroups.
+	SystemdProps []systemdDbus.Property `json:"-"`
 }
 
 type Resources struct {

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -472,6 +472,61 @@ func TestInitSystemdProps(t *testing.T) {
 			exp: expT{false, "TimeoutStopUSec", uint64(123456789)},
 		},
 		{
+			desc: "convert USec to Sec (default numeric type)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "456"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(456000000)},
+		},
+		{
+			desc: "convert USec to Sec (byte)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "byte 234"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234000000)},
+		},
+		{
+			desc: "convert USec to Sec (int16)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "int16 234"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234000000)},
+		},
+		{
+			desc: "convert USec to Sec (uint16)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "uint16 234"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234000000)},
+		},
+		{
+			desc: "convert USec to Sec (int32)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "int32 234"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234000000)},
+		},
+		{
+			desc: "convert USec to Sec (uint32)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "uint32 234"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234000000)},
+		},
+		{
+			desc: "convert USec to Sec (int64)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "int64 234"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234000000)},
+		},
+		{
+			desc: "convert USec to Sec (uint64)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "uint64 234"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234000000)},
+		},
+		{
+			desc: "convert USec to Sec (float)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "234.789"},
+			exp:  expT{false, "TimeoutStopUSec", uint64(234789000)},
+		},
+		{
+			desc: "convert USec to Sec (bool -- invalid value)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "false"},
+			exp:  expT{true, "", ""},
+		},
+		{
+			desc: "convert USec to Sec (string -- invalid value)",
+			in:   inT{"org.systemd.property.TimeoutStopSec", "'covfefe'"},
+			exp:  expT{true, "", ""},
+		},
+		{
 			in:  inT{"org.systemd.property.CollectMode", "'inactive-or-failed'"},
 			exp: expT{false, "CollectMode", "inactive-or-failed"},
 		},


### PR DESCRIPTION
In case systemd is used as a cgroups driver for container, it creates a scope
(aka transient unit) dedicated to a container (usually named `runc-$ID.scope`). 

This PR adds an ability to set arbitrary properties for the systemd unit via
runtime spec annotations.

### Usage

Add the following to runtime spec (`config.json`):
    
```json
        "annotations": {
                "org.systemd.property.TimeoutStopSec": "300",
                "org.systemd.property.CollectMode":"'inactive-or-failed'"
        },
```

and start the container (e.g. `runc --systemd-cgroup run $ID`).

The above will set the following systemd parameters:
* `TimeoutStopSec` to 2 minutes and 3 seconds;
* `CollectMode` to "inactive-or-failed".
    
The values in spec should be in the gvariant format ([see docs here](https://developer.gnome.org/glib/stable/gvariant-text.html)).

To figure out which type systemd expects for a particular parameter,
please consult systemd sources.

### TODO
- [x] unit tests
- [x] documentation
- [x] allow *Sec parameters, simplify doc

### Notes
- This is needed to fix kubernetes/kubernetes#77873
- This is a carry of #2062, please see the initial discussion in there

### History
* v1: original version from #2062
* v2: use `map[string]interface{}` for `SystemdProperties` as suggesed in https://github.com/opencontainers/runc/pull/2062#discussion_r295835117, generalize cli options parsing
* v3: move `SystemdProperties` into `configs.Cgroup` to simplify code
* v4: cli option removed, setting redone via annotations in a generic fashion
* v5: allow time units with Sec suffix (in addition to USec)