### PR TITLE
Use "command -v" shell builtin instead of "which"

### DIFF
--- a/man/md2man-all.sh
+++ b/man/md2man-all.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 	pwd
 }
 
-if ! ( which go-md2man &>/dev/null ); then
+if ! type go-md2man; then
 	echo "To install man pages, please install 'go-md2man'."
 	exit 0
 fi


### PR DESCRIPTION
Took me awhile to figure out why it wasn't finding my go-md2man... centos image doesn't have `which` in it.
So this is just a little more convenient and one less required build dep.