### PR TITLE
Add CreateRuntime, CreateContainer and StartContainer Hooks

### DIFF
--- a/Vagrantfile.centos7
+++ b/Vagrantfile.centos7
@@ -18,11 +18,15 @@ Vagrant.configure("2") do |config|
 
     # install yum packages
     yum install -y -q epel-release
-    yum install -y -q gcc git iptables jq libseccomp-devel make
+    yum install -y -q gcc git iptables jq libseccomp-devel make skopeo
     yum clean all
 
     # install Go
     curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar Cxz /usr/local
+
+    # Install umoci
+    curl -o /usr/local/bin/umoci -fsSL https://github.com/opencontainers/umoci/releases/download/v0.4.5/umoci.amd64
+    chmod +x /usr/local/bin/umoci
 
     # install bats
     git clone https://github.com/bats-core/bats-core

--- a/Vagrantfile.fedora32
+++ b/Vagrantfile.fedora32
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
 config exclude kernel,kernel-core
 config install_weak_deps false
 update
-install iptables gcc make golang-go libseccomp-devel bats jq git-core criu
+install iptables gcc make golang-go libseccomp-devel bats jq git-core criu skopeo
 ts run
 EOF
     dnf clean all
@@ -31,10 +31,15 @@ EOF
     cat /root/rootless.key.pub >> /home/rootless/.ssh/authorized_keys
     chown -R rootless.rootless /home/rootless
 
+    # Install umoci
+    curl -o /usr/local/bin/umoci -fsSL https://github.com/opencontainers/umoci/releases/download/v0.4.5/umoci.amd64
+    chmod +x /usr/local/bin/umoci
+
     # Add busybox for libcontainer/integration tests
     . /vagrant/tests/integration/multi-arch.bash \
-        && mkdir /busybox \
-        && curl -fsSL $(get_busybox) | tar xfJC - /busybox
+        && mkdir /busybox /debian \
+        && curl -fsSL $(get_busybox) | tar xfJC - /busybox \
+        && get_and_extract_debian /debian
 
     # Delegate cgroup v2 controllers to rootless user via --systemd-cgroup
     mkdir -p /etc/systemd/system/user@.service.d

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -239,10 +239,6 @@ const (
 	Poststop = "poststop"
 )
 
-var (
-	HookNameList = []HookName{Prestart, CreateRuntime, CreateContainer, StartContainer, Poststart, Poststop}
-)
-
 // TODO move this to runtime-spec
 // See: https://github.com/opencontainers/runtime-spec/pull/1046
 const (

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
-
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -176,7 +176,7 @@ type Config struct {
 
 	// Hooks are a collection of actions to perform at various container lifecycle events.
 	// CommandHooks are serialized to JSON, but other hooks are not.
-	Hooks *Hooks
+	Hooks Hooks
 
 	// Version is the version of opencontainer specification that is supported.
 	Version string `json:"version"`
@@ -203,17 +203,54 @@ type Config struct {
 	RootlessCgroups bool `json:"rootless_cgroups,omitempty"`
 }
 
-type Hooks struct {
+type HookName string
+type HookList []Hook
+type Hooks map[HookName]HookList
+
+const (
 	// Prestart commands are executed after the container namespaces are created,
 	// but before the user supplied command is executed from init.
-	Prestart []Hook
+	// Note: This hook is now deprecated
+	// Prestart commands are called in the Runtime namespace.
+	Prestart HookName = "prestart"
+
+	// CreateRuntime commands MUST be called as part of the create operation after
+	// the runtime environment has been created but before the pivot_root has been executed.
+	// CreateRuntime is called immediately after the deprecated Prestart hook.
+	// CreateRuntime commands are called in the Runtime Namespace.
+	CreateRuntime = "createRuntime"
+
+	// CreateContainer commands MUST be called as part of the create operation after
+	// the runtime environment has been created but before the pivot_root has been executed.
+	// CreateContainer commands are called in the Container namespace.
+	CreateContainer = "createContainer"
+
+	// StartContainer commands MUST be called as part of the start operation and before
+	// the container process is started.
+	// StartContainer commands are called in the Container namespace.
+	StartContainer = "startContainer"
 
 	// Poststart commands are executed after the container init process starts.
-	Poststart []Hook
+	// Poststart commands are called in the Runtime Namespace.
+	Poststart = "poststart"
 
 	// Poststop commands are executed after the container init process exits.
-	Poststop []Hook
-}
+	// Poststop commands are called in the Runtime Namespace.
+	Poststop = "poststop"
+)
+
+var (
+	HookNameList = []HookName{Prestart, CreateRuntime, CreateContainer, StartContainer, Poststart, Poststop}
+)
+
+// TODO move this to runtime-spec
+// See: https://github.com/opencontainers/runtime-spec/pull/1046
+const (
+	Creating = "creating"
+	Created  = "created"
+	Running  = "running"
+	Stopped  = "stopped"
+)
 
 type Capabilities struct {
 	// Bounding is the set of capabilities checked by the kernel.
@@ -228,32 +265,39 @@ type Capabilities struct {
 	Ambient []string
 }
 
-func (hooks *Hooks) UnmarshalJSON(b []byte) error {
-	var state struct {
-		Prestart  []CommandHook
-		Poststart []CommandHook
-		Poststop  []CommandHook
+func (hooks HookList) RunHooks(state *specs.State) error {
+	for i, h := range hooks {
+		if err := h.Run(state); err != nil {
+			return errors.Wrapf(err, "Running hook #%d:", i)
+		}
 	}
+
+	return nil
+}
+
+func (hooks *Hooks) UnmarshalJSON(b []byte) error {
+	var state map[HookName][]CommandHook
 
 	if err := json.Unmarshal(b, &state); err != nil {
 		return err
 	}
 
-	deserialize := func(shooks []CommandHook) (hooks []Hook) {
-		for _, shook := range shooks {
-			hooks = append(hooks, shook)
+	*hooks = Hooks{}
+	for n, commandHooks := range state {
+		if len(commandHooks) == 0 {
+			continue
 		}
 
-		return hooks
+		(*hooks)[n] = HookList{}
+		for _, h := range commandHooks {
+			(*hooks)[n] = append((*hooks)[n], h)
+		}
 	}
 
-	hooks.Prestart = deserialize(state.Prestart)
-	hooks.Poststart = deserialize(state.Poststart)
-	hooks.Poststop = deserialize(state.Poststop)
 	return nil
 }
 
-func (hooks Hooks) MarshalJSON() ([]byte, error) {
+func (hooks *Hooks) MarshalJSON() ([]byte, error) {
 	serialize := func(hooks []Hook) (serializableHooks []CommandHook) {
 		for _, hook := range hooks {
 			switch chook := hook.(type) {
@@ -268,9 +312,12 @@ func (hooks Hooks) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(map[string]interface{}{
-		"prestart":  serialize(hooks.Prestart),
-		"poststart": serialize(hooks.Poststart),
-		"poststop":  serialize(hooks.Poststop),
+		"prestart":        serialize((*hooks)[Prestart]),
+		"createRuntime":   serialize((*hooks)[CreateRuntime]),
+		"createContainer": serialize((*hooks)[CreateContainer]),
+		"startContainer":  serialize((*hooks)[StartContainer]),
+		"poststart":       serialize((*hooks)[Poststart]),
+		"poststop":        serialize((*hooks)[Poststop]),
 	})
 }
 

--- a/libcontainer/configs/config_linux_test.go
+++ b/libcontainer/configs/config_linux_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+var (
+	HookNameList = []HookName{Prestart, CreateRuntime, CreateContainer, StartContainer, Poststart, Poststop}
+)
+
 func loadConfig(name string) (*Config, error) {
 	f, err := os.Open(filepath.Join("../sample_configs", name))
 	if err != nil {

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -35,7 +35,7 @@ func TestUnmarshalHooks(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !reflect.DeepEqual(hooks[hookName], hookCmd) {
+		if !reflect.DeepEqual(hooks[hookName], configs.HookList{hookCmd}) {
 			t.Errorf("Expected %s to equal %+v but it was %+v", hookName, hookCmd, hooks[hookName])
 		}
 	}

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -157,14 +157,14 @@ func TestFactoryLoadContainer(t *testing.T) {
 	// setup default container config and state for mocking
 	var (
 		id            = "1"
-		expectedHooks = &configs.Hooks{
-			Prestart: []configs.Hook{
+		expectedHooks = configs.Hooks{
+			configs.Prestart: configs.HookList{
 				configs.CommandHook{Command: configs.Command{Path: "prestart-hook"}},
 			},
-			Poststart: []configs.Hook{
+			configs.Poststart: configs.HookList{
 				configs.CommandHook{Command: configs.Command{Path: "poststart-hook"}},
 			},
-			Poststop: []configs.Hook{
+			configs.Poststop: configs.HookList{
 				unserializableHook{},
 				configs.CommandHook{Command: configs.Command{Path: "poststop-hook"}},
 			},
@@ -201,7 +201,7 @@ func TestFactoryLoadContainer(t *testing.T) {
 	if config.Rootfs != expectedConfig.Rootfs {
 		t.Fatalf("expected rootfs %q but received %q", expectedConfig.Rootfs, config.Rootfs)
 	}
-	expectedHooks.Poststop = expectedHooks.Poststop[1:] // expect unserializable hook to be skipped
+	expectedHooks[configs.Poststop] = expectedHooks[configs.Poststop][1:] // expect unserializable hook to be skipped
 	if !reflect.DeepEqual(config.Hooks, expectedHooks) {
 		t.Fatalf("expects hooks %q but received %q", expectedHooks, config.Hooks)
 	}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -67,6 +68,7 @@ type initConfig struct {
 	ConsoleHeight    uint16                `json:"console_height"`
 	RootlessEUID     bool                  `json:"rootless_euid,omitempty"`
 	RootlessCgroups  bool                  `json:"rootless_cgroups,omitempty"`
+	SpecState        *specs.State          `json:"spec_state,omitempty"`
 }
 
 type initer interface {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -98,6 +98,13 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 		return newSystemErrorWithCausef(err, "changing dir to %q", config.Rootfs)
 	}
 
+	s := iConfig.SpecState
+	s.Pid = unix.Getpid()
+	s.Status = configs.Creating
+	if err := iConfig.Config.Hooks[configs.CreateContainer].RunHooks(s); err != nil {
+		return err
+	}
+
 	if config.NoPivotRoot {
 		err = msMoveRoot(config.Rootfs)
 	} else if config.Namespaces.Contains(configs.NEWNS) {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -881,20 +881,31 @@ func SetupSeccomp(config *specs.LinuxSeccomp) (*configs.Seccomp, error) {
 }
 
 func createHooks(rspec *specs.Spec, config *configs.Config) {
-	config.Hooks = &configs.Hooks{}
+	config.Hooks = configs.Hooks{}
 	if rspec.Hooks != nil {
-
 		for _, h := range rspec.Hooks.Prestart {
 			cmd := createCommandHook(h)
-			config.Hooks.Prestart = append(config.Hooks.Prestart, configs.NewCommandHook(cmd))
+			config.Hooks[configs.Prestart] = append(config.Hooks[configs.Prestart], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.CreateRuntime {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.CreateRuntime] = append(config.Hooks[configs.CreateRuntime], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.CreateContainer {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.CreateContainer] = append(config.Hooks[configs.CreateContainer], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.StartContainer {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.StartContainer] = append(config.Hooks[configs.StartContainer], configs.NewCommandHook(cmd))
 		}
 		for _, h := range rspec.Hooks.Poststart {
 			cmd := createCommandHook(h)
-			config.Hooks.Poststart = append(config.Hooks.Poststart, configs.NewCommandHook(cmd))
+			config.Hooks[configs.Poststart] = append(config.Hooks[configs.Poststart], configs.NewCommandHook(cmd))
 		}
 		for _, h := range rspec.Hooks.Poststop {
 			cmd := createCommandHook(h)
-			config.Hooks.Poststop = append(config.Hooks.Poststop, configs.NewCommandHook(cmd))
+			config.Hooks[configs.Poststop] = append(config.Hooks[configs.Poststop], configs.NewCommandHook(cmd))
 		}
 	}
 }

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -42,6 +42,33 @@ func TestCreateHooks(t *testing.T) {
 					Args: []string{"--some", "thing"},
 				},
 			},
+			CreateRuntime: []specs.Hook{
+				{
+					Path: "/some/hook/path",
+				},
+				{
+					Path: "/some/hook2/path",
+					Args: []string{"--some", "thing"},
+				},
+			},
+			CreateContainer: []specs.Hook{
+				{
+					Path: "/some/hook/path",
+				},
+				{
+					Path: "/some/hook2/path",
+					Args: []string{"--some", "thing"},
+				},
+			},
+			StartContainer: []specs.Hook{
+				{
+					Path: "/some/hook/path",
+				},
+				{
+					Path: "/some/hook2/path",
+					Args: []string{"--some", "thing"},
+				},
+			},
 			Poststart: []specs.Hook{
 				{
 					Path: "/some/hook/path",
@@ -77,19 +104,37 @@ func TestCreateHooks(t *testing.T) {
 	conf := &configs.Config{}
 	createHooks(rspec, conf)
 
-	prestart := conf.Hooks.Prestart
+	prestart := conf.Hooks[configs.Prestart]
 
 	if len(prestart) != 2 {
 		t.Error("Expected 2 Prestart hooks")
 	}
 
-	poststart := conf.Hooks.Poststart
+	createRuntime := conf.Hooks[configs.CreateRuntime]
+
+	if len(createRuntime) != 2 {
+		t.Error("Expected 2 createRuntime hooks")
+	}
+
+	createContainer := conf.Hooks[configs.CreateContainer]
+
+	if len(createContainer) != 2 {
+		t.Error("Expected 2 createContainer hooks")
+	}
+
+	startContainer := conf.Hooks[configs.StartContainer]
+
+	if len(startContainer) != 2 {
+		t.Error("Expected 2 startContainer hooks")
+	}
+
+	poststart := conf.Hooks[configs.Poststart]
 
 	if len(poststart) != 3 {
 		t.Error("Expected 3 Poststart hooks")
 	}
 
-	poststop := conf.Hooks.Poststop
+	poststop := conf.Hooks[configs.Poststop]
 
 	if len(poststop) != 4 {
 		t.Error("Expected 4 Poststop hooks")

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -207,6 +207,14 @@ func (l *linuxStandardInit) Init() error {
 			return newSystemErrorWithCause(err, "init seccomp")
 		}
 	}
+
+	s := l.config.SpecState
+	s.Pid = unix.Getpid()
+	s.Status = configs.Created
+	if err := l.config.Config.Hooks[configs.StartContainer].RunHooks(s); err != nil {
+		return err
+	}
+
 	if err := unix.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
 		return newSystemErrorWithCause(err, "exec user process")
 	}

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -61,17 +61,21 @@ func destroy(c *linuxContainer) error {
 }
 
 func runPoststopHooks(c *linuxContainer) error {
-	if c.config.Hooks != nil {
-		s, err := c.currentOCIState()
-		if err != nil {
-			return err
-		}
-		for _, hook := range c.config.Hooks.Poststop {
-			if err := hook.Run(s); err != nil {
-				return err
-			}
-		}
+	hooks := c.config.Hooks
+	if hooks == nil {
+		return nil
 	}
+
+	s, err := c.currentOCIState()
+	if err != nil {
+		return err
+	}
+	s.Status = configs.Stopped
+
+	if err := hooks[configs.Poststop].RunHooks(s); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# CR = CreateRuntime
+# CC = CreataContainer
+HOOKLIBCR=librunc-hooks-create-runtime.so
+HOOKLIBCC=librunc-hooks-create-container.so
+LIBPATH="$DEBIAN_BUNDLE/rootfs/lib/"
+
+function setup() {
+	umount $LIBPATH/$HOOKLIBCR.1.0.0 &> /dev/null || true
+	umount $LIBPATH/$HOOKLIBCC.1.0.0 &> /dev/null || true
+
+	teardown_debian
+	setup_debian
+}
+
+function teardown() {
+	umount $LIBPATH/$HOOKLIBCR.1.0.0 &> /dev/null || true
+	umount $LIBPATH/$HOOKLIBCC.1.0.0 &> /dev/null || true
+
+	rm -f $HOOKLIBCR.1.0.0 $HOOKLIBCC.1.0.0
+	teardown_debian
+}
+
+@test "runc run (hooks library tests)" {
+	requires root
+	requires no_systemd
+
+	# setup some dummy libs
+	gcc -shared -Wl,-soname,librunc-hooks-create-runtime.so.1 -o "$HOOKLIBCR.1.0.0"
+	gcc -shared -Wl,-soname,librunc-hooks-create-container.so.1 -o "$HOOKLIBCC.1.0.0"
+
+	current_pwd="$(pwd)"
+
+	# To mount $HOOKLIBCR we need to do that in the container namespace
+	create_runtime_hook=$(cat <<-EOF
+		pid=\$(cat - | jq -r '.pid')
+		touch "$LIBPATH/$HOOKLIBCR.1.0.0"
+		nsenter -m \$ns -t \$pid mount --bind "$current_pwd/$HOOKLIBCR.1.0.0" "$LIBPATH/$HOOKLIBCR.1.0.0"
+	EOF)
+
+	create_container_hook="touch ./lib/$HOOKLIBCC.1.0.0 && mount --bind $current_pwd/$HOOKLIBCC.1.0.0 ./lib/$HOOKLIBCC.1.0.0"
+
+	CONFIG=$(jq --arg create_runtime_hook "$create_runtime_hook" --arg create_container_hook "$create_container_hook" '
+		.hooks |= . + {"createRuntime": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_runtime_hook]}]} |
+		.hooks |= . + {"createContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_container_hook]}]} |
+		.hooks |= . + {"startContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", "ldconfig"]}]} |
+		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' $DEBIAN_BUNDLE/config.json)
+	echo "${CONFIG}" > config.json
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+
+	echo "Checking create-runtime library"
+	echo $output | grep $HOOKLIBCR
+	[ "$?" -eq 0 ]
+
+	echo "Checking create-container library"
+	echo $output | grep $HOOKLIBCC
+	[ "$?" -eq 0 ]
+}

--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-get_busybox(){
+get_busybox() {
 	case $(go env GOARCH) in
 	arm64)
 		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/glibc/busybox.tar.xz'
@@ -10,13 +10,35 @@ get_busybox(){
 	esac
 }
 
-get_hello(){
+get_hello() {
 	case $(go env GOARCH) in
-        arm64)
-                echo 'hello-world-aarch64.tar'
-        ;;
-        *)
-                echo 'hello-world.tar'
-        ;;
-        esac
+	arm64)
+		echo 'hello-world-aarch64.tar'
+	;;
+	*)
+		echo 'hello-world.tar'
+	;;
+	esac
+}
+
+get_and_extract_debian() {
+	tmp=$(mktemp -d)
+	cd "$tmp"
+
+	debian="debian:3.11.6"
+
+	case $(go env GOARCH) in
+	arm64)
+		skopeo copy docker://arm64v8/debian:buster "oci:$debian"
+	;;
+	*)
+		skopeo copy docker://amd64/debian:buster "oci:$debian"
+	;;
+	esac
+
+	args="$([ -z "${ROOTLESS_TESTPATH+x}" ] && echo "--rootless")"
+	umoci unpack $args --image "$debian" "$1"
+
+	cd -
+	rm -rf "$tmp"
 }


### PR DESCRIPTION
Hello!

This PR implements the new `CreateRuntime` hook as defined in https://github.com/opencontainers/runtime-spec/blob/master/config.md#posix-platform-hooks

This is a fairly simple change, `CreateRuntime` are basically `prestart` hooks with the requirement of being called after the now deprecated `prestart` hooks.

I've done of refactoring to not have too much duplication of code by adding a function: `(*Hooks) RunHooks(name HookName, spec *specs.State) error`.
This allows us to have a nicer statement in the code:
```golang
if err := c.config.Hooks.RunHooks(configs.Prestart, s); err != nil {
    return err
}

// Rather than
for i, hook := range c.config.Hooks.Prestart {
    if err := hook.Run(s); err != nil {
        return newSystemErrorWithCausef(err, "running prestart hook %d", i)
    }
}
```

I'm looking into how to implement the `createContainer` and `startContainer` changes but am not super familiar with the code base and would happily take pointers.

fixes #1710
cc @cyphar @mrunalp @vbatts 