### PR TITLE
Dockerfile: some refactoring, and switch to "buster" variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,31 +9,38 @@ RUN dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \
     && dpkg --add-architecture arm64 \
     && dpkg --add-architecture ppc64el \
-    && apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    sudo \
-    gawk \
-    iptables \
-    jq \
-    pkg-config \
-    libaio-dev \
-    libcap-dev \
-    libprotobuf-dev \
-    libprotobuf-c0-dev \
-    libnl-3-dev \
-    libnet-dev \
-    libseccomp2 \
-    libseccomp-dev \
-    protobuf-c-compiler \
-    protobuf-compiler \
-    python-minimal \
-    uidmap \
-    kmod \
-    crossbuild-essential-armel crossbuild-essential-armhf crossbuild-essential-arm64 crossbuild-essential-ppc64el \
-    libseccomp-dev:armel libseccomp-dev:armhf libseccomp-dev:arm64 libseccomp-dev:ppc64el \
-    --no-install-recommends \
-    && apt-get clean
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        crossbuild-essential-arm64 \
+        crossbuild-essential-armel \
+        crossbuild-essential-armhf \
+        crossbuild-essential-ppc64el \
+        curl \
+        gawk \
+        iptables \
+        jq \
+        kmod \
+        libaio-dev \
+        libcap-dev \
+        libnet-dev \
+        libnl-3-dev \
+        libprotobuf-c0-dev \
+        libprotobuf-dev \
+        libseccomp-dev \
+        libseccomp-dev:arm64 \
+        libseccomp-dev:armel \
+        libseccomp-dev:armhf \
+        libseccomp-dev:ppc64el \
+        libseccomp2 \
+        pkg-config \
+        protobuf-c-compiler \
+        protobuf-compiler \
+        python-minimal \
+        sudo \
+        uidmap \
+    && apt-get clean \
+    && rm -rf /var/cache/apt /var/lib/apt/lists/*;
 
 # Add a dummy user for the rootless integration tests. While runC does
 # not require an entry in /etc/passwd to operate, one of the tests uses

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG BATS_VERSION=03608115df2071fff4eaaff1605768c275e5f81f
 ARG CRIU_VERSION=v3.12
 
 FROM golang:${GO_VERSION}-stretch
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GO_VERSION=1.13
 ARG BATS_VERSION=03608115df2071fff4eaaff1605768c275e5f81f
 ARG CRIU_VERSION=v3.12
 
-FROM golang:${GO_VERSION}-stretch
+FROM golang:${GO_VERSION}-buster
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN dpkg --add-architecture armel \
@@ -25,7 +25,7 @@ RUN dpkg --add-architecture armel \
         libcap-dev \
         libnet-dev \
         libnl-3-dev \
-        libprotobuf-c0-dev \
+        libprotobuf-c-dev \
         libprotobuf-dev \
         libseccomp-dev \
         libseccomp-dev:arm64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.13-stretch
+ARG GO_VERSION=1.13
+ARG BATS_VERSION=03608115df2071fff4eaaff1605768c275e5f81f
+ARG CRIU_VERSION=v3.12
+
+FROM golang:${GO_VERSION}-stretch
 
 RUN dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \
@@ -37,15 +41,16 @@ RUN dpkg --add-architecture armel \
 RUN useradd -u1000 -m -d/home/rootless -s/bin/bash rootless
 
 # install bats
+ARG BATS_VERSION
 RUN cd /tmp \
     && git clone https://github.com/sstephenson/bats.git \
     && cd bats \
-    && git reset --hard 03608115df2071fff4eaaff1605768c275e5f81f \
+    && git reset --hard "${BATS_VERSION}" \
     && ./install.sh /usr/local \
     && rm -rf /tmp/bats
 
 # install criu
-ENV CRIU_VERSION v3.12
+ARG CRIU_VERSION
 RUN mkdir -p /usr/src/criu \
     && curl -fsSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,15 +65,15 @@ RUN mkdir -p /usr/src/criu \
     && make install-criu \
     && rm -rf /usr/src/criu
 
-# setup a playground for us to spawn containers in
-ENV ROOTFS /busybox
-RUN mkdir -p ${ROOTFS}
-
 COPY script/tmpmount /
 WORKDIR /go/src/github.com/opencontainers/runc
 ENTRYPOINT ["/tmpmount"]
 
-ADD . /go/src/github.com/opencontainers/runc
-
+# setup a playground for us to spawn containers in
+COPY tests/integration/multi-arch.bash tests/integration/
+ENV ROOTFS /busybox
+RUN mkdir -p "${ROOTFS}"
 RUN . tests/integration/multi-arch.bash \
-    && curl -fsSL `get_busybox` | tar xfJC - ${ROOTFS}
+    && curl -fsSL `get_busybox` | tar xfJC - "${ROOTFS}"
+
+COPY . .


### PR DESCRIPTION
Debian buster is the current stable, so might be good to switch to that version; also did some refactoring of the dockerfile (see individual commits for details).

I'll open a follow-up PR to update to go 1.13, but thought to first make the switch to "buster" to keep changes smaller.