### PR TITLE
Chroot rootfs path usage fix

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -867,10 +867,7 @@ func msMoveRoot(rootfs string) error {
 }
 
 func chroot(rootfs string) error {
-	if rootfs == "" {
-		rootfs = "."
-	}
-	if err := unix.Chroot(rootfs); err != nil {
+	if err := unix.Chroot(filepath.Clean(rootfs)); err != nil {
 		return err
 	}
 	return unix.Chdir("/")

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -867,6 +867,9 @@ func msMoveRoot(rootfs string) error {
 }
 
 func chroot(rootfs string) error {
+	if rootfs == "" {
+		rootfs = "."
+	}
 	if err := unix.Chroot(rootfs); err != nil {
 		return err
 	}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -867,7 +867,7 @@ func msMoveRoot(rootfs string) error {
 }
 
 func chroot(rootfs string) error {
-	if err := unix.Chroot("."); err != nil {
+	if err := unix.Chroot(rootfs); err != nil {
 		return err
 	}
 	return unix.Chdir("/")


### PR DESCRIPTION
Fixes: #2214 

In order to avoid misunderstanding, it's better to use path parameter in chroot() func.

Signed-off-by: Boris Popovschi <zyqsempai@mail.ru>