### PR TITLE
show detailed error message when systemd is not available

### DIFF
--- a/libcontainer/cgroups/systemd/apply_nosystemd.go
+++ b/libcontainer/cgroups/systemd/apply_nosystemd.go
@@ -14,8 +14,8 @@ type Manager struct {
 	Paths   map[string]string
 }
 
-func UseSystemd() bool {
-	return false
+func UseSystemd() error {
+	return fmt.Errorf("Systemd not supported")
 }
 
 func NewSystemdCgroupsManager() (func(config *configs.Cgroup, paths map[string]string) cgroups.Manager, error) {

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -97,9 +97,9 @@ func isRunningSystemd() bool {
 	return fi.IsDir()
 }
 
-func UseSystemd() bool {
+func UseSystemd() error {
 	if !isRunningSystemd() {
-		return false
+		return fmt.Errorf("systemd not running on this host, can't use systemd as a cgroups.Manager")
 	}
 
 	connLock.Lock()
@@ -109,10 +109,10 @@ func UseSystemd() bool {
 		var err error
 		theConn, err = systemdDbus.New()
 		if err != nil {
-			return false
+			return err
 		}
 	}
-	return true
+	return nil
 }
 
 func NewSystemdCgroupsManager() (func(config *configs.Cgroup, paths map[string]string) cgroups.Manager, error) {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -506,7 +506,7 @@ func TestFreeze(t *testing.T) {
 }
 
 func TestSystemdFreeze(t *testing.T) {
-	if !systemd.UseSystemd() {
+	if err := systemd.UseSystemd(); err != nil {
 		t.Skip("Systemd is unsupported")
 	}
 	testFreeze(t, true)
@@ -563,7 +563,7 @@ func TestCpuShares(t *testing.T) {
 }
 
 func TestCpuSharesSystemd(t *testing.T) {
-	if !systemd.UseSystemd() {
+	if err := systemd.UseSystemd(); err != nil {
 		t.Skip("Systemd is unsupported")
 	}
 	testCpuShares(t, true)
@@ -598,7 +598,7 @@ func TestPids(t *testing.T) {
 }
 
 func TestPidsSystemd(t *testing.T) {
-	if !systemd.UseSystemd() {
+	if err := systemd.UseSystemd(); err != nil {
 		t.Skip("Systemd is unsupported")
 	}
 	testPids(t, true)
@@ -684,7 +684,7 @@ func TestRunWithKernelMemory(t *testing.T) {
 }
 
 func TestRunWithKernelMemorySystemd(t *testing.T) {
-	if !systemd.UseSystemd() {
+	if err := systemd.UseSystemd(); err != nil {
 		t.Skip("Systemd is unsupported")
 	}
 	testRunWithKernelMemory(t, true)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -47,11 +47,10 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 		cgroupManager = libcontainer.RootlessCgroupfs
 	}
 	if context.GlobalBool("systemd-cgroup") {
-		if systemd.UseSystemd() {
-			cgroupManager = libcontainer.SystemdCgroups
-		} else {
-			return nil, fmt.Errorf("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
+		if err := systemd.UseSystemd(); err != nil {
+			return nil, errors.Wrap(err, "systemd cgroup flag passed, but systemd support for managing cgroups is not available")
 		}
+		cgroupManager = libcontainer.SystemdCgroups
 	}
 
 	intelRdtManager := libcontainer.IntelRdtFs


### PR DESCRIPTION
Changed `func UseSystemd() bool` to `func UseSystemd() error` for propagating detailed error to the CLI (`utils_linux.go`)

