### PR TITLE
Synchronize the call to linuxContainer.Signal()

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -379,6 +379,8 @@ func (c *linuxContainer) start(process *Process) error {
 }
 
 func (c *linuxContainer) Signal(s os.Signal, all bool) error {
+	c.m.Lock()
+	defer c.m.Unlock()
 	if all {
 		return signalAllProcesses(c.cgroupManager, s)
 	}


### PR DESCRIPTION
linuxContainer.Signal() can race with another call to say Destroy()
which clears the container's initProcess. This can cause a nil pointer
dereference in Signal().

This patch will synchronize Signal() and Destroy() by grabbing the
container's mutex as part of the Signal() call.

Closes #2251

Signed-off-by: Pradyumna Agrawal <pradyumnaa@vmware.com>