### PR TITLE
Makefile: set selinux and apparmor build tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ services:
 
 env:
   global:
-    - BUILDTAGS="seccomp apparmor selinux ambient"
+    - BUILDTAGS="seccomp apparmor selinux"
 
 before_install:
   - sudo apt-get -qq update

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
-BUILDTAGS ?= seccomp
+BUILDTAGS ?= seccomp selinux apparmor
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ make BUILDTAGS='seccomp apparmor'
 | seccomp   | Syscall filtering                  | libseccomp  |
 | selinux   | selinux process and mount labeling | <none>      |
 | apparmor  | apparmor profile support           | <none>      |
-| ambient   | ambient capability support         | kernel 4.3  |
 | nokmem    | disable kernel memory account      | <none>      |
 
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ It must be built with Go version 1.6 or higher in order for some features to fun
 In order to enable seccomp support you will need to install `libseccomp` on your platform.
 > e.g. `libseccomp-devel` for CentOS, or `libseccomp-dev` for Ubuntu
 
-Otherwise, if you do not want to build `runc` with seccomp support you can add `BUILDTAGS=""` when running make.
-
 ```bash
 # create a 'github.com/opencontainers' in your GOPATH/src
 cd github.com/opencontainers
@@ -60,19 +58,22 @@ sudo make install
 
 #### Build Tags
 
-`runc` supports optional build tags for compiling support of various features.
-To add build tags to the make option the `BUILDTAGS` variable must be set.
+`runc` supports optional build tags for compiling support of various features,
+with some of them enabled by default (see `BUILDTAGS` in top-level `Makefile`).
+
+To change build tags from the default, set the `BUILDTAGS` variable for make,
+e.g.
 
 ```bash
 make BUILDTAGS='seccomp apparmor'
 ```
 
-| Build Tag | Feature                            | Dependency  |
-|-----------|------------------------------------|-------------|
-| seccomp   | Syscall filtering                  | libseccomp  |
-| selinux   | selinux process and mount labeling | <none>      |
-| apparmor  | apparmor profile support           | <none>      |
-| nokmem    | disable kernel memory account      | <none>      |
+| Build Tag | Feature                            | Enabled by default | Dependency |
+|-----------|------------------------------------|--------------------|------------|
+| seccomp   | Syscall filtering                  | yes                | libseccomp |
+| selinux   | selinux process and mount labeling | yes                | <none>     |
+| apparmor  | apparmor profile support           | yes                | <none>     |
+| nokmem    | disable kernel memory accounting   | no                 | <none>     |
 
 
 ### Running the test suite


### PR DESCRIPTION
Both selinux and apparmor subsystem can detect whether it is enabled,
and act accordingly. Compiling it in by default should help avoid
some frustration cased by missing build tags.
    
This should not change anything in case BUILDTAGS is already set.
    
README.md is amended to clarify what BUILDTAGS are enabled by
default.
