### PR TITLE
Add minimal cgroup2 checkpoint/restore support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ matrix:
         - ssh default sudo dnf install -y podman
       script:
         - ssh default sudo podman build -t test /vagrant
-        - ssh default sudo podman run --privileged --cgroupns=private test make localunittest
+        # Mounting /lib/modules into the container is necessary as CRIU wants to load (via iptables) additional modules
+        - ssh default sudo podman run --privileged --cgroupns=private -v /lib/modules:/lib/modules:ro test make localunittest
   allow_failures:
     - go: tip
     - name: "cgroup-v2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.13
 ARG BATS_VERSION=03608115df2071fff4eaaff1605768c275e5f81f
-ARG CRIU_VERSION=v3.12
+ARG CRIU_VERSION=v3.13
 
 FROM golang:${GO_VERSION}-buster
 ARG DEBIAN_FRONTEND=noninteractive
@@ -62,7 +62,13 @@ ARG CRIU_VERSION
 RUN mkdir -p /usr/src/criu \
     && curl -fsSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \
+    && echo 1 > .gitid \
+    && curl -sSL https://github.com/checkpoint-restore/criu/commit/4c27b3db4f4325a311d8bfa9a50ea3efb4d6e377.patch | patch -p1 \
+    && curl -sSL https://github.com/checkpoint-restore/criu/commit/aac41164b2cd7f0d2047f207b32844524682e43f.patch | patch -p1 \
+    && curl -sSL https://github.com/checkpoint-restore/criu/commit/6f19249b2565f3f7c0a1f8f65b4ae180e8f7f34b.patch | patch -p1 \
+    && curl -sSL https://github.com/checkpoint-restore/criu/commit/378337a496ca759848180bc5411e4446298c5e4e.patch | patch -p1 \
     && make install-criu \
+    && cd - \
     && rm -rf /usr/src/criu
 
 COPY script/tmpmount /

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1015,9 +1015,14 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 		}
 	}
 
-	fcg := c.cgroupManager.GetPaths()["freezer"]
-	if fcg != "" {
-		rpcOpts.FreezeCgroup = proto.String(fcg)
+	if !cgroups.IsCgroup2UnifiedMode() && c.checkCriuVersion(31400) == nil {
+		// CRIU currently cannot handle the v2 freezer correctly
+		// before release 3.14. For older releases we are telling
+		// CRIU to not use the cgroup v2 freezer. CRIU will pause
+		// each process manually using ptrace().
+		if fcg := c.cgroupManager.GetPaths()["freezer"]; fcg != "" {
+			rpcOpts.FreezeCgroup = proto.String(fcg)
+		}
 	}
 
 	// append optional criu opts, e.g., page-server and port


### PR DESCRIPTION
The newest CRIU version supports freezer v2 and this tells runc to use it if new enough or fall back to non-freezer based process freezing on cgroup v2 system.

The Travis tests running on Fedora 31 with cgroup2 on Vagrant had the CRIU parts disabled because of a couple of problems.

One problem was a bug in runc and CRIU handling that Andrei fixed in #2226 

In addition four patches from the upcoming  CRIU 3.14 are needed for minimal cgroup2 support (freezer and mounting of cgroup2). With Andrei's fix and the CRIU cgroup2 support and the runc CRIU cgroup2 integration it is now possible to run the checkpoint integration tests again on the FedoraVagrant cgroup2 based integration test.

This also updates the Dockerfile to use buster instead of stretch for the container (needed for the container to load the modules of the host) as well as updating from Go 1.12 to 1.13.

To run CRIU based tests the modules of Fedora 31 (the test host system) are mounted inside of the container used to test runc in the buster based container with -v /lib/modules:/lib/modules.
