### PR TITLE
checkpoint: remove error message with --leave-running

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -62,8 +62,15 @@ checkpointed.`,
 		if status == libcontainer.Created || status == libcontainer.Stopped {
 			fatalf("Container cannot be checkpointed in %s state", status.String())
 		}
-		defer destroy(container)
 		options := criuOptions(context)
+		if !options.LeaveRunning || !options.PreDump {
+			// destroy prints out an error if we tell CRIU to
+			// leave the container running:
+			// ERRO[0000] container is not destroyed
+			// The message is correct, but we actually do not want
+			// to destroy the container in this case.
+			defer destroy(container)
+		}
 		// these are the mandatory criu options for a container
 		setPageServer(context, options)
 		setManageCgroupsMode(context, options)


### PR DESCRIPTION
If checkpointing a container with '--leave-running' runc started to print the following message:

 `ERRO[0000] container is not destroyed`

The message is correct, because CRIU did not terminate the process, but as that was requested by the user the message is wrong.

So now the container is only destroyed if the user did not specify '--leave-running'.

Fixes: #2253