### PR TITLE
vagrant: switch from VirtualBox to KVM + increase HW resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ go:
   - 1.14.x
   - 1.13.x
   - tip
-
+cache:
+  directories:
+  - /home/travis/.vagrant.d/boxes
 matrix:
   include:
     - go: 1.14.x
@@ -21,19 +23,17 @@ matrix:
     - go: 1.13.x
       name: "cgroup-v2"
       env:
-        - VIRTUALBOX_VERSION=6.0
-        - VAGRANT_VERSION=2.2.6
-        - FEDORA_VERSION=31
+        - VAGRANT_VERSION=2.2.7
       before_install:
         - cat /proc/cpuinfo
-        - wget -q https://www.virtualbox.org/download/oracle_vbox_2016.asc -O- | sudo apt-key add - && sudo sh -c "echo deb https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib >> /etc/apt/sources.list" && sudo apt-get update && sudo apt-get install -yq build-essential gcc make linux-headers-$(uname -r) virtualbox-${VIRTUALBOX_VERSION} && sudo usermod -aG vboxusers $(whoami)
-        - wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_$(uname -m).deb && sudo dpkg -i vagrant_${VAGRANT_VERSION}_$(uname -m).deb
-        - vagrant init bento/fedora-${FEDORA_VERSION} && vagrant up && mkdir -p ~/.ssh && vagrant ssh-config >> ~/.ssh/config
-        - ssh default sudo dnf install -y podman
+# https://github.com/alvistack/ansible-role-virtualbox/blob/6887b020b0ca5c59ddb6620d73f053ffb84f4126/.travis.yml#L30
+        - sudo apt-get install -q -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils ruby-dev && wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_$(uname -m).deb && sudo dpkg -i vagrant_${VAGRANT_VERSION}_$(uname -m).deb && rm -f vagrant_${VAGRANT_VERSION}_$(uname -m).deb
+        - sudo vagrant plugin install vagrant-libvirt
+        - sudo vagrant up && sudo mkdir -p /root/.ssh && sudo sh -c "vagrant ssh-config >> /root/.ssh/config"
       script:
-        - ssh default sudo podman build -t test /vagrant
+        - sudo ssh default sudo podman build -t test /vagrant
         # Mounting /lib/modules into the container is necessary as CRIU wants to load (via iptables) additional modules
-        - ssh default sudo podman run --privileged --cgroupns=private -v /lib/modules:/lib/modules:ro test make localunittest
+        - sudo ssh default sudo podman run --privileged --cgroupns=private -v /lib/modules:/lib/modules:ro test make localunittest
   allow_failures:
     - go: tip
     - name: "cgroup-v2"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+# Fedora 31 box is used for testing cgroup v2 support
+  config.vm.box = "fedora/31-cloud-base"
+  config.vm.provider :virtualbox do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+  config.vm.provision "shell", inline: <<-SHELL
+    dnf install -y podman
+  SHELL
+end


### PR DESCRIPTION
* Switch from VirtualBox to KVM because GCE (used in Travis) doesn't officially support VirtualBox:
https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances

* Increase HW resources: 512MB -> 2GB, 1 vCPU -> 2 vCPUs

* Cache `/home/travis/.vagrant.d/boxes`

