### PR TITLE
libcontainer/cgroups: optimize Get*Cgroup for v2

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -307,6 +307,10 @@ func GetAllSubsystems() ([]string, error) {
 
 // GetOwnCgroup returns the relative path to the cgroup docker is running in.
 func GetOwnCgroup(subsystem string) (string, error) {
+	if IsCgroup2UnifiedMode() {
+		return "/", nil
+	}
+
 	cgroups, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		return "", err
@@ -325,6 +329,10 @@ func GetOwnCgroupPath(subsystem string) (string, error) {
 }
 
 func GetInitCgroup(subsystem string) (string, error) {
+	if IsCgroup2UnifiedMode() {
+		return "/", nil
+	}
+
 	cgroups, err := ParseCgroupFile("/proc/1/cgroup")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Functions `GetOwnCgroup` and `GetInitCgroup` do this:

1. call `ParseCgroupFile()` to read and parse `/proc/*/cgroup` file
2. call `getControllerPath()`

In the case of cgroup2 unified hierarchy, the results from `ParseCgroupFile`
are not used by `getControllerPath`, so we can avoid the parsing
altogether.