### PR TITLE
Dockerfile: add -f to curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cd /tmp \
 # install criu
 ENV CRIU_VERSION v3.12
 RUN mkdir -p /usr/src/criu \
-    && curl -sSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
+    && curl -fsSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \
     && make install-criu \
     && rm -rf /usr/src/criu
@@ -63,4 +63,4 @@ ENTRYPOINT ["/tmpmount"]
 ADD . /go/src/github.com/opencontainers/runc
 
 RUN . tests/integration/multi-arch.bash \
-    && curl -o- -sSL `get_busybox` | tar xfJC - ${ROOTFS}
+    && curl -fsSL `get_busybox` | tar xfJC - ${ROOTFS}


### PR DESCRIPTION
When github is giving HTTP 404 (or other error), it still sends some
document (to be viewed in a browser), but we have tar on the other end
of the pipe, so the end result is like this:

> Step 13/13 : RUN . tests/integration/multi-arch.bash     && curl -o- -sSL `get_busybox` | tar xfJC - ${ROOTFS}
> 4872 ---> Running in ad84646a69f3
> 4873xz: (stdin): File format not recognized
> 4874tar: Child returned status 1
> 4875tar: Error is not recoverable: exiting now
> 4876The command '/bin/sh -c . tests/integration/multi-arch.bash     && curl -o- -sSL `get_busybox` | tar xfJC - ${ROOTFS}' returned a non-zero code: 2

Add -f switch to curl, so it will display an HTTP error and exit:

> curl: (22) The requested URL returned error: 404 Not Found
> xz: (stdin): File format not recognized
> tar: Child returned status 1
> tar: Error is not recoverable: exiting now

While at it, also
 * remove -v from criu untar (too much output)
 * remove -o - from curl (it does the same by default)

@thaJeztah PTAL