### PR TITLE
Avoid duplicate calls to runner#destroy

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -349,7 +349,9 @@ func (r *runner) run(config *specs.Process) (int, error) {
 	if detach {
 		return 0, nil
 	}
-	r.destroy()
+	if err == nil {
+		r.destroy()
+	}
 	return status, err
 }
 


### PR DESCRIPTION
From runner#run:
```
	status, err := handler.forward(process, tty, detach)
	if err != nil {
		r.terminate(process)
	}
	if detach {
		return 0, nil
	}
	r.destroy()
	return status, err
```

If forward() returns non-nil error, destroy() would be called twice: once on line 352 and once in the deferred func.

This PR avoids the duplicate call to destroy().