### PR TITLE
bifio.Scan.Err usage nits

### DIFF
--- a/libcontainer/cgroups/fs2/defaultpath.go
+++ b/libcontainer/cgroups/fs2/defaultpath.go
@@ -80,9 +80,6 @@ func parseCgroupFromReader(r io.Reader) (string, error) {
 		s = bufio.NewScanner(r)
 	)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return "", err
-		}
 		var (
 			text  = s.Text()
 			parts = strings.SplitN(text, ":", 3)
@@ -94,6 +91,9 @@ func parseCgroupFromReader(r io.Reader) (string, error) {
 		if parts[0] == "0" && parts[1] == "" {
 			return parts[2], nil
 		}
+	}
+	if err := s.Err(); err != nil {
+		return "", err
 	}
 	return "", errors.New("cgroup path not found")
 }

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -313,7 +313,7 @@ func parseCpuInfoFile(path string) (bool, bool, error) {
 		line := s.Text()
 
 		// Search "cat_l3" and "mba" flags in first "flags" line
-		if strings.Contains(line, "flags") {
+		if strings.HasPrefix(line, "flags") {
 			flags := strings.Split(line, " ")
 			// "cat_l3" flag for CAT and "mba" flag for MBA
 			for _, flag := range flags {

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -310,10 +310,6 @@ func parseCpuInfoFile(path string) (bool, bool, error) {
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return false, false, err
-		}
-
 		line := s.Text()
 
 		// Search "cat_l3" and "mba" flags in first "flags" line
@@ -331,6 +327,10 @@ func parseCpuInfoFile(path string) (bool, bool, error) {
 			return isCatFlagSet, isMbaFlagSet, nil
 		}
 	}
+	if err := s.Err(); err != nil {
+		return false, false, err
+	}
+
 	return isCatFlagSet, isMbaFlagSet, nil
 }
 

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -162,10 +162,6 @@ func ParsePasswdFilter(r io.Reader, filter func(User) bool) ([]User, error) {
 	)
 
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
-
 		line := strings.TrimSpace(s.Text())
 		if line == "" {
 			continue
@@ -182,6 +178,9 @@ func ParsePasswdFilter(r io.Reader, filter func(User) bool) ([]User, error) {
 		if filter == nil || filter(p) {
 			out = append(out, p)
 		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
 	}
 
 	return out, nil
@@ -221,10 +220,6 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 	)
 
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
-
 		text := s.Text()
 		if text == "" {
 			continue
@@ -241,6 +236,9 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 		if filter == nil || filter(p) {
 			out = append(out, p)
 		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
 	}
 
 	return out, nil
@@ -532,10 +530,6 @@ func ParseSubIDFilter(r io.Reader, filter func(SubID) bool) ([]SubID, error) {
 	)
 
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
-
 		line := strings.TrimSpace(s.Text())
 		if line == "" {
 			continue
@@ -548,6 +542,9 @@ func ParseSubIDFilter(r io.Reader, filter func(SubID) bool) ([]SubID, error) {
 		if filter == nil || filter(p) {
 			out = append(out, p)
 		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
 	}
 
 	return out, nil
@@ -586,10 +583,6 @@ func ParseIDMapFilter(r io.Reader, filter func(IDMap) bool) ([]IDMap, error) {
 	)
 
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
-
 		line := strings.TrimSpace(s.Text())
 		if line == "" {
 			continue
@@ -602,6 +595,9 @@ func ParseIDMapFilter(r io.Reader, filter func(IDMap) bool) ([]IDMap, error) {
 		if filter == nil || filter(p) {
 			out = append(out, p)
 		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
 	}
 
 	return out, nil


### PR DESCRIPTION
## Nit: fix use of bufio.Scanner.Err
    
The Err() method should be called after the Scan() loop, not inside it.
    
Found by
    
     git grep -A3 -F '.Scan()' | grep Err

## libcontainer/intelrdt: optimize parseCpuInfoFile
    
The line we are parsing looks like this
    
> flags         : fpu vme de pse <...>
    
so look for "flags" as a prefix, not substring.
