### PR TITLE
cgroupv2: don't use GetCgroupMounts for criu c/r

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1093,6 +1093,11 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 			case "bind":
 				c.addCriuDumpMount(req, m)
 			case "cgroup":
+				if cgroups.IsCgroup2UnifiedMode() {
+					c.addCriuDumpMount(req, m)
+					continue
+				}
+				// cgroup v1
 				binds, err := getCgroupMounts(m)
 				if err != nil {
 					return err
@@ -1357,6 +1362,11 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 		case "bind":
 			c.addCriuRestoreMount(req, m)
 		case "cgroup":
+			if cgroups.IsCgroup2UnifiedMode() {
+				c.addCriuRestoreMount(req, m)
+				continue
+			}
+			// cgroup v1
 			binds, err := getCgroupMounts(m)
 			if err != nil {
 				return err


### PR DESCRIPTION
When performing checkpoint or restore of cgroupv2 unified hierarchy,
there is no need to call getCgroupMounts() / cgroups.GetCgroupMounts()
as there's only a single mount in there.

This eliminates the last internal (i.e. runc) use of
`cgroups.GetCgroupMounts()` for v2 unified case. Unfortunately, there
are external ones (e.g. moby/moby) so we can't yet let it
return an error.

@adrianreber PTAL