### PR TITLE
Use errors.Unwrap() where possible

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -110,21 +110,13 @@ func isIgnorableError(rootless bool, err error) bool {
 	if !rootless {
 		return false
 	}
+	err = errors.Cause(err)
 	// Is it an ordinary EPERM?
-	if os.IsPermission(errors.Cause(err)) {
+	if os.IsPermission(err) {
 		return true
 	}
-
-	// Try to handle other errnos.
-	var errno error
-	switch err := errors.Cause(err).(type) {
-	case *os.PathError:
-		errno = err.Err
-	case *os.LinkError:
-		errno = err.Err
-	case *os.SyscallError:
-		errno = err.Err
-	}
+	// Handle some specific syscall errors.
+	errno := errors.Unwrap(err)
 	return errno == unix.EROFS || errno == unix.EPERM || errno == unix.EACCES
 }
 

--- a/libcontainer/cgroups/fs/kmem.go
+++ b/libcontainer/cgroups/fs/kmem.go
@@ -6,10 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
-	"syscall" // for Errno type only
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"golang.org/x/sys/unix"
@@ -49,12 +47,8 @@ func setKernelMemory(path string, kernelMemoryLimit int64) error {
 		// The EBUSY signal is returned on attempts to write to the
 		// memory.kmem.limit_in_bytes file if the cgroup has children or
 		// once tasks have been attached to the cgroup
-		if pathErr, ok := err.(*os.PathError); ok {
-			if errNo, ok := pathErr.Err.(syscall.Errno); ok {
-				if errNo == unix.EBUSY {
-					return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
-				}
-			}
+		if errors.Unwrap(err) == unix.EBUSY {
+			return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
 		}
 		return fmt.Errorf("failed to write %v to %v: %v", kernelMemoryLimit, cgroupKernelMemoryLimit, err)
 	}

--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -4,7 +4,6 @@ package fs2
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,20 +24,11 @@ func setPids(dirPath string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func isNOTSUP(err error) bool {
-	switch err := err.(type) {
-	case *os.PathError:
-		return err.Err == unix.ENOTSUP
-	default:
-		return false
-	}
-}
-
 func statPidsWithoutController(dirPath string, stats *cgroups.Stats) error {
 	// if the controller is not enabled, let's read PIDS from cgroups.procs
 	// (or threads if cgroup.threads is enabled)
 	contents, err := ioutil.ReadFile(filepath.Join(dirPath, "cgroup.procs"))
-	if err != nil && isNOTSUP(err) {
+	if err != nil && errors.Unwrap(err) == unix.ENOTSUP {
 		contents, err = ioutil.ReadFile(filepath.Join(dirPath, "cgroup.threads"))
 	}
 	if err != nil {

--- a/libcontainer/cgroups/fscommon/fscommon.go
+++ b/libcontainer/cgroups/fscommon/fscommon.go
@@ -41,20 +41,10 @@ func ReadFile(dir, file string) (string, error) {
 func retryingWriteFile(filename string, data []byte, perm os.FileMode) error {
 	for {
 		err := ioutil.WriteFile(filename, data, perm)
-		if isInterruptedWriteFile(err) {
+		if errors.Unwrap(err) == syscall.EINTR {
 			logrus.Infof("interrupted while writing %s to %s", string(data), filename)
 			continue
 		}
 		return err
 	}
-}
-
-func isInterruptedWriteFile(err error) bool {
-	if patherr, ok := err.(*os.PathError); ok {
-		errno, ok2 := patherr.Err.(syscall.Errno)
-		if ok2 && errno == syscall.EINTR {
-			return true
-		}
-	}
-	return false
 }

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -576,7 +576,7 @@ func WriteCgroupProc(dir string, pid int) error {
 
 		// EINVAL might mean that the task being added to cgroup.procs is in state
 		// TASK_NEW. We should attempt to do so again.
-		if isEINVAL(err) {
+		if errors.Unwrap(err) == unix.EINVAL {
 			time.Sleep(30 * time.Millisecond)
 			continue
 		}
@@ -584,15 +584,6 @@ func WriteCgroupProc(dir string, pid int) error {
 		return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
 	}
 	return err
-}
-
-func isEINVAL(err error) bool {
-	switch err := err.(type) {
-	case *os.PathError:
-		return err.Err == unix.EINVAL
-	default:
-		return false
-	}
 }
 
 // Since the OCI spec is designed for cgroup v1, in some cases

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1837,10 +1837,7 @@ func (c *linuxContainer) isPaused() (bool, error) {
 	data, err := ioutil.ReadFile(filepath.Join(fcg, filename))
 	if err != nil {
 		// If freezer cgroup is not mounted, the container would just be not paused.
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		if pathError, isPathError := err.(*os.PathError); isPathError && pathError.Err == syscall.ENODEV {
+		if os.IsNotExist(err) || errors.Unwrap(err) == syscall.ENODEV {
 			return false, nil
 		}
 		return false, newSystemErrorWithCause(err, "checking if container is paused")


### PR DESCRIPTION
This set makes use of errors.Unwrap() where possible to get to an underlying error. The biggest motivation is to simplify the code.

The feature requires go 1.13 but since merging https://github.com/opencontainers/runc/pull/2256 we are already not supporting go 1.12 (which is an unsupported release anyway).