### PR TITLE
Avoid double close of criuServer

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1488,7 +1488,6 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	criuServer.Close()
 	// cmd.Process will be replaced by a restored init.
 	criuProcess := cmd.Process
 


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

In linuxContainer#criuSwrk, criuServer is potentially closed twice.
See line 1468:
```
	defer criuServer.Close()
```
and the criuServer.Close() call following cmd.Start().

This PR removed the duplicate Close() call.