### PR TITLE
cgroupv2: set mem+swap to max if memory is set to max

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -32,13 +32,21 @@ func numToStr(value int64) (ret string) {
 }
 
 func setMemory(dirPath string, cgroup *configs.Cgroup) error {
-	if val := numToStr(cgroup.Resources.MemorySwap); val != "" {
-		if err := fscommon.WriteFile(dirPath, "memory.swap.max", val); err != nil {
+	mem := numToStr(cgroup.Resources.Memory)
+	memSwap := numToStr(cgroup.Resources.MemorySwap)
+	if mem == "max" {
+		// If the memory is set to max, set the mem+swap to max, too
+		memSwap = "max"
+	}
+
+	if memSwap != "" {
+		if err := fscommon.WriteFile(dirPath, "memory.swap.max", memSwap); err != nil {
 			return err
 		}
 	}
-	if val := numToStr(cgroup.Resources.Memory); val != "" {
-		if err := fscommon.WriteFile(dirPath, "memory.max", val); err != nil {
+
+	if mem != "" {
+		if err := fscommon.WriteFile(dirPath, "memory.max", mem); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
In cgroupv1, command `runc update $ID --memory -1` sets both
memory and memory+swap to -1 (aka unlimited). This was introduced
by commit 18ebc51b3cc7 (Reset Swap when memory is set to unlimited,
Oct 19 2016).

This is not the case for cgroupv2. Fix it.

References:
 - https://github.com/opencontainers/runc/pull/1127
 - https://github.com/moby/moby/pull/22578