### PR TITLE
Fix TestGetContainerStateAfterUpdate on cgroup v2

### DIFF
--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type mockCgroupManager struct {
-	pids    []int
-	allPids []int
-	stats   *cgroups.Stats
-	paths   map[string]string
+	pids        []int
+	allPids     []int
+	stats       *cgroups.Stats
+	paths       map[string]string
+	unifiedPath string
 }
 
 type mockIntelRdtManager struct {
@@ -55,7 +56,7 @@ func (m *mockCgroupManager) GetPaths() map[string]string {
 }
 
 func (m *mockCgroupManager) GetUnifiedPath() (string, error) {
-	return "", fmt.Errorf("unimplemented")
+	return m.unifiedPath, nil
 }
 
 func (m *mockCgroupManager) Freeze(state configs.FreezerState) error {


### PR DESCRIPTION
CI was failing on cgroup v2 because `mockCgroupManager.GetUnifiedPath()` was returning an error.

Now the function returns the value of `mockCgroupManager.unifiedPath`, but the value is currently not used in the tests.

Fix #2286
