### PR TITLE
cleanupTmp doesn't need to return error

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -167,9 +167,9 @@ func prepareTmp(topTmpDir string) (string, error) {
 	return tmpdir, nil
 }
 
-func cleanupTmp(tmpdir string) error {
+func cleanupTmp(tmpdir string) {
 	unix.Unmount(tmpdir, 0)
-	return os.RemoveAll(tmpdir)
+	os.RemoveAll(tmpdir)
 }
 
 func mountCmd(cmd configs.Command) error {


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

Since the return value from cleanupTmp is not checked, this PR drops the error return.
