### PR TITLE
Use errors.As() and errors.Is() to unwrap errors

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -110,22 +111,18 @@ func isIgnorableError(rootless bool, err error) bool {
 	if !rootless {
 		return false
 	}
+	// TODO: rm errors.Cause once we switch to %w everywhere
+	err = errors.Cause(err)
 	// Is it an ordinary EPERM?
-	if os.IsPermission(errors.Cause(err)) {
+	if errors.Is(err, os.ErrPermission) {
 		return true
 	}
-
-	// Try to handle other errnos.
-	var errno error
-	switch err := errors.Cause(err).(type) {
-	case *os.PathError:
-		errno = err.Err
-	case *os.LinkError:
-		errno = err.Err
-	case *os.SyscallError:
-		errno = err.Err
+	// Handle some specific syscall errors.
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == unix.EROFS || errno == unix.EPERM || errno == unix.EACCES
 	}
-	return errno == unix.EROFS || errno == unix.EPERM || errno == unix.EACCES
+	return false
 }
 
 func (m *Manager) getSubsystems() subsystemSet {

--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -4,7 +4,6 @@ package fs2
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,20 +24,11 @@ func setPids(dirPath string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func isNOTSUP(err error) bool {
-	switch err := err.(type) {
-	case *os.PathError:
-		return err.Err == unix.ENOTSUP
-	default:
-		return false
-	}
-}
-
 func statPidsWithoutController(dirPath string, stats *cgroups.Stats) error {
 	// if the controller is not enabled, let's read PIDS from cgroups.procs
 	// (or threads if cgroup.threads is enabled)
 	contents, err := ioutil.ReadFile(filepath.Join(dirPath, "cgroup.procs"))
-	if err != nil && isNOTSUP(err) {
+	if errors.Is(err, unix.ENOTSUP) {
 		contents, err = ioutil.ReadFile(filepath.Join(dirPath, "cgroup.threads"))
 	}
 	if err != nil {

--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -4,6 +4,7 @@ package fs2
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -24,11 +25,20 @@ func setPids(dirPath string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
+func isNOTSUP(err error) bool {
+	switch err := err.(type) {
+	case *os.PathError:
+		return err.Err == unix.ENOTSUP
+	default:
+		return false
+	}
+}
+
 func statPidsWithoutController(dirPath string, stats *cgroups.Stats) error {
 	// if the controller is not enabled, let's read PIDS from cgroups.procs
 	// (or threads if cgroup.threads is enabled)
 	contents, err := ioutil.ReadFile(filepath.Join(dirPath, "cgroup.procs"))
-	if err != nil && errors.Unwrap(err) == unix.ENOTSUP {
+	if err != nil && isNOTSUP(err) {
 		contents, err = ioutil.ReadFile(filepath.Join(dirPath, "cgroup.threads"))
 	}
 	if err != nil {

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -576,7 +576,7 @@ func WriteCgroupProc(dir string, pid int) error {
 
 		// EINVAL might mean that the task being added to cgroup.procs is in state
 		// TASK_NEW. We should attempt to do so again.
-		if isEINVAL(err) {
+		if errors.Is(err, unix.EINVAL) {
 			time.Sleep(30 * time.Millisecond)
 			continue
 		}
@@ -584,15 +584,6 @@ func WriteCgroupProc(dir string, pid int) error {
 		return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
 	}
 	return err
-}
-
-func isEINVAL(err error) bool {
-	switch err := err.(type) {
-	case *os.PathError:
-		return err.Err == unix.EINVAL
-	default:
-		return false
-	}
 }
 
 // Since the OCI spec is designed for cgroup v1, in some cases

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -576,7 +576,7 @@ func WriteCgroupProc(dir string, pid int) error {
 
 		// EINVAL might mean that the task being added to cgroup.procs is in state
 		// TASK_NEW. We should attempt to do so again.
-		if errors.Unwrap(err) == unix.EINVAL {
+		if isEINVAL(err) {
 			time.Sleep(30 * time.Millisecond)
 			continue
 		}
@@ -584,6 +584,15 @@ func WriteCgroupProc(dir string, pid int) error {
 		return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
 	}
 	return err
+}
+
+func isEINVAL(err error) bool {
+	switch err := err.(type) {
+	case *os.PathError:
+		return err.Err == unix.EINVAL
+	default:
+		return false
+	}
 }
 
 // Since the OCI spec is designed for cgroup v1, in some cases

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1855,10 +1855,7 @@ func (c *linuxContainer) isPaused() (bool, error) {
 	data, err := ioutil.ReadFile(filepath.Join(fcg, filename))
 	if err != nil {
 		// If freezer cgroup is not mounted, the container would just be not paused.
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		if pathError, isPathError := err.(*os.PathError); isPathError && pathError.Err == syscall.ENODEV {
+		if os.IsNotExist(err) || errors.Is(err, syscall.ENODEV) {
 			return false, nil
 		}
 		return false, newSystemErrorWithCause(err, "checking if container is paused")

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1855,7 +1855,10 @@ func (c *linuxContainer) isPaused() (bool, error) {
 	data, err := ioutil.ReadFile(filepath.Join(fcg, filename))
 	if err != nil {
 		// If freezer cgroup is not mounted, the container would just be not paused.
-		if os.IsNotExist(err) || errors.Unwrap(err) == syscall.ENODEV {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		if pathError, isPathError := err.(*os.PathError); isPathError && pathError.Err == syscall.ENODEV {
 			return false, nil
 		}
 		return false, newSystemErrorWithCause(err, "checking if container is paused")


### PR DESCRIPTION
My previous attempt (#2280) was a bit immature (though it worked).

Using errors.Unwrap() is not the best thing to do, since it returns
nil in case of an error which was not wrapped. More to say, 
errors package provides more elegant ways to check for underlying
errors, such as errors.As() and errors.Is().

Revert #2280, and use errors.Is() and errors.As()
    
Make use of errors.Is() and errors.As() where appropriate to check
the underlying error. The biggest motivation is to simplify the code.

The feature requires go 1.13 but since merging #2256 we are already
not supporting go 1.12 (which is an unsupported release anyway).