### PR TITLE
Remove unused consts testScopeWait and testSliceWait

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -65,11 +65,6 @@ var legacySubsystems = subsystemSet{
 	&fs.NameGroup{GroupName: "name=systemd"},
 }
 
-const (
-	testScopeWait = 4
-	testSliceWait = 4
-)
-
 var (
 	connOnce sync.Once
 	connDbus *systemdDbus.Conn


### PR DESCRIPTION
These are unused since commit 518c855833c4 ("Remove libcontainer
detection for systemd features")

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>