### PR TITLE
cgroupv2: only treat -1 as "max"

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -17,15 +17,16 @@ import (
 
 // numToStr converts an int64 value to a string for writing to a
 // cgroupv2 files with .min, .max, .low, or .high suffix.
-// Negative values are converted to "max" for cgroupv1 compatibility
+// The value of -1 is converted to "max" for cgroupv1 compatibility
 // (which used to write -1 to remove the limit).
 func numToStr(value int64) (ret string) {
-	if value > 0 {
-		ret = strconv.FormatInt(value, 10)
-	} else if value < 0 {
-		ret = "max"
-	} else {
+	switch {
+	case value == 0:
 		ret = ""
+	case value == -1:
+		ret = "max"
+	default:
+		ret = strconv.FormatInt(value, 10)
 	}
 
 	return ret


### PR DESCRIPTION
Commit 6905b72154642 (PR #2272) treats all negative values as "max",
citing cgroup v1 compatibility as a reason. In fact, in
cgroup v1 only -1 is treated as "unlimited", and other
negative values usually calse an error.

Treat -1 as "max", pass other negative values as is
(the error will be returned from the kernel).

Fixes: 6905b72154642 (PR #2272)