### PR TITLE
travis: move `cgroup-v2` out of `allow_failures`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
         - sudo ssh default sudo podman run --privileged --cgroupns=private -v /lib/modules:/lib/modules:ro test make localunittest
   allow_failures:
     - go: tip
-    - name: "cgroup-v2"
 
 go_import_path: github.com/opencontainers/runc
 


### PR DESCRIPTION
`cgroup-v2` was marked `allow_failures` because of the flakiness of VirtualBox VM: dc7d0bf

The flakiness seems to have gone away since we switched from VirtualBox to QEMU/KVM and increased HW resources: b8eed86

Close #2301
