### PR TITLE
Dockerfile: use bats-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG GO_VERSION=1.13
-ARG BATS_VERSION=03608115df2071fff4eaaff1605768c275e5f81f
 ARG CRIU_VERSION=v3.13
 
 FROM golang:${GO_VERSION}-buster
@@ -33,6 +32,7 @@ RUN dpkg --add-architecture armel \
         libseccomp-dev:armhf \
         libseccomp-dev:ppc64el \
         libseccomp2 \
+        npm \
         pkg-config \
         protobuf-c-compiler \
         protobuf-compiler \
@@ -49,13 +49,7 @@ RUN dpkg --add-architecture armel \
 RUN useradd -u1000 -m -d/home/rootless -s/bin/bash rootless
 
 # install bats
-ARG BATS_VERSION
-RUN cd /tmp \
-    && git clone https://github.com/sstephenson/bats.git \
-    && cd bats \
-    && git reset --hard "${BATS_VERSION}" \
-    && ./install.sh /usr/local \
-    && rm -rf /tmp/bats
+RUN npm install -g bats
 
 # install criu
 ARG CRIU_VERSION


### PR DESCRIPTION
The bats testing framework we use for integration test is not maintained
since 2015 and was superceded by bats-core [1]. Also, we are using an
unreleased version (and as far as I remember depend on its functionality,
although I don't remember what is it exactly).

Unfortunately, Debian still packages very old version of bats from the old repo.

Use recent bats-core as installed by npm, as recommended in [3].

[1] https://github.com/sstephenson/bats/pull/269
[3] https://github.com/bats-core/bats-core/wiki/Install-Bats-Using-a-Package

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>