### PR TITLE
runc exec: don't enable terminal unless -t is set

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -203,6 +203,7 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 	p.Env = append(p.Env, context.StringSlice("env")...)
 
 	// set the tty
+	p.Terminal = false
 	if context.IsSet("tty") {
 		p.Terminal = context.Bool("tty")
 	}

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -68,7 +68,7 @@ function teardown() {
 	testcontainer test_busybox running
 
 	# run the exec
-    runc exec test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
+    runc exec -t test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ /dev/pts/+ ]]
 	[[ ${lines[1]} =~ /dev/pts/+ ]]
@@ -88,7 +88,7 @@ function teardown() {
 	testcontainer test_busybox running
 
 	# run the exec
-    runc exec test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
+    runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ 0 ]]
 	[[ ${lines[1]} =~ 5 ]]
@@ -111,7 +111,7 @@ function teardown() {
 	testcontainer test_busybox running
 
 	# run the exec
-	runc exec test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
+	runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ 1000 ]]
 	[[ ${lines[1]} =~ 5 ]]
@@ -146,7 +146,7 @@ EOF
 	)
 
 	# run the exec
-	runc exec --pid-file pid.txt -d --console-socket $CONSOLE_SOCKET -p <( echo $tty_info_with_consize_size ) test_busybox
+	runc exec -t --pid-file pid.txt -d --console-socket $CONSOLE_SOCKET -p <( echo $tty_info_with_consize_size ) test_busybox
 	[ "$status" -eq 0 ]
 
 	# check the pid was generated
@@ -167,7 +167,7 @@ EOF
 	)
 
 	# run the exec
-	runc exec -p <( echo $tty_info ) test_busybox
+	runc exec -t -p <( echo $tty_info ) test_busybox
 	[ "$status" -eq 0 ]
 
 	# test tty width and height against original process.json


### PR DESCRIPTION
If container's config.json have `"terminal": true` setting in its
"process" section, runc exec assumes that stdin (fd 0) is a terminal
and tries to use it.

This leads to the following error in case stdin is not a terminal:

> ERRO[0000] exec failed: provided file is not a console

So, even if -t/--tty is not set, exec uses stdin as a terminal.
It does not help that urfave/cli v1 parser we use does not allow
to use `-t no` or `-t false`.

Since the settings in config.json is probably for the container run/start,
not for the auxiliary process started inside a container with exec, do
not use a setting from there, only treating stdin as a terminal in case
`-t` is explicitly given.

Fixes https://github.com/opencontainers/runc/issues/1627