### PR TITLE
[WIP] cgroupv2: fix systemd driver not putting pid into cgroup

### DIFF
--- a/libcontainer/cgroups/systemd/unified_hierarchy.go
+++ b/libcontainer/cgroups/systemd/unified_hierarchy.go
@@ -151,6 +151,9 @@ func (m *UnifiedManager) Apply(pid int) error {
 	if err := createCgroupsv2Path(path); err != nil {
 		return err
 	}
+	if err := cgroups.WriteCgroupProc(path, pid); err != nil {
+		return err
+	}
 	m.Paths = map[string]string{
 		"pids":    path,
 		"memory":  path,


### PR DESCRIPTION
Apparently, the driver never cared to add pid to the cgroup.

Fixes: #2310