### PR TITLE
Properly remove intermediate directory

### DIFF
--- a/libcontainer/cgroups/systemd/unified_hierarchy.go
+++ b/libcontainer/cgroups/systemd/unified_hierarchy.go
@@ -241,6 +241,7 @@ func createCgroupsv2Path(path string) (Err error) {
 				}
 			} else {
 				// If the directory was created, be sure it is not left around on errors.
+				current := current
 				defer func() {
 					if Err != nil {
 						os.Remove(current)


### PR DESCRIPTION
In createCgroupsv2Path , deferred func removes intermediate directory on error.
However, the path for intermediate directory was global.

This PR properly removes the intermediate directory.