### PR TITLE
CI cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       env:
         - RUNC_USE_SYSTEMD=1
       script:
-        - make BUILDTAGS="${BUILDTAGS}" all
+        - make all
         - sudo PATH="$PATH" make localintegration RUNC_USE_SYSTEMD=1
     - go: 1.13.x
       name: "cgroup-v2"
@@ -46,10 +46,6 @@ sudo: required
 services:
   - docker
 
-env:
-  global:
-    - BUILDTAGS="seccomp apparmor selinux"
-
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libseccomp-dev
@@ -59,5 +55,5 @@ before_install:
 
 script:
   - git-validation -run DCO,short-subject -v
-  - make BUILDTAGS="${BUILDTAGS}"
-  - make BUILDTAGS="${BUILDTAGS}" clean ci cross
+  - make
+  - make clean ci cross

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,6 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provision "shell", inline: <<-SHELL
     cat << EOF | dnf -y shell
-config install_weak_deps: False
 update
 install podman make golang-go libseccomp-devel bats jq
 ts run


### PR DESCRIPTION
### 1. rm disablng weak deps in Vagrantfile
  
1. it was not working previously because of a typo
    
2. when a typo is removed, important packages such
       as container-selinux are not updated, so let's
       just remove this flag to avoid confusion.

Fixes: 84583eb1a4a5a53 (#2295)

### 2. rm BUILDTAGS from travis.yml

It is not needed since commit 89c108b.