### PR TITLE
cgroupv2: default join cgroup namespace in runc example

### DIFF
--- a/libcontainer/specconv/example.go
+++ b/libcontainer/specconv/example.go
@@ -4,13 +4,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Example returns an example spec file, with many options set so a user can
 // see what a standard spec file looks like.
 func Example() *specs.Spec {
-	return &specs.Spec{
+	spec := &specs.Spec{
 		Version: specs.Version,
 		Root: &specs.Root{
 			Path:     "rootfs",
@@ -155,6 +156,12 @@ func Example() *specs.Spec {
 			},
 		},
 	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		spec.Linux.Namespaces = append(spec.Linux.Namespaces, specs.LinuxNamespace{
+			Type: "cgroup",
+		})
+	}
+	return spec
 }
 
 // ToRootless converts the given spec file into one that should work with


### PR DESCRIPTION
I think the runc example should join cgroup namespace by default if we use cgroup v2.

Signed-off-by: lifubang <lifubang@acmcoder.com>