### PR TITLE
Nits

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/opencontainers/runc/libcontainer"
@@ -19,7 +18,7 @@ func killContainer(container libcontainer.Container) error {
 	_ = container.Signal(unix.SIGKILL, false)
 	for i := 0; i < 100; i++ {
 		time.Sleep(100 * time.Millisecond)
-		if err := container.Signal(syscall.Signal(0), false); err != nil {
+		if err := container.Signal(unix.Signal(0), false); err != nil {
 			destroy(container)
 			return nil
 		}

--- a/kill.go
+++ b/kill.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/urfave/cli"
 	"golang.org/x/sys/unix"
@@ -23,7 +22,7 @@ Where "<container-id>" is the name for the instance of the container and
 EXAMPLE:
 For example, if the container id is "ubuntu01" the following will send a "KILL"
 signal to the init process of the "ubuntu01" container:
-	 
+
        # runc kill ubuntu01 KILL`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
@@ -56,10 +55,10 @@ signal to the init process of the "ubuntu01" container:
 	},
 }
 
-func parseSignal(rawSignal string) (syscall.Signal, error) {
+func parseSignal(rawSignal string) (unix.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
-		return syscall.Signal(s), nil
+		return unix.Signal(s), nil
 	}
 	sig := strings.ToUpper(rawSignal)
 	if !strings.HasPrefix(sig, "SIG") {

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -118,7 +117,7 @@ func isIgnorableError(rootless bool, err error) bool {
 		return true
 	}
 	// Handle some specific syscall errors.
-	var errno syscall.Errno
+	var errno unix.Errno
 	if errors.As(err, &errno) {
 		return errno == unix.EROFS || errno == unix.EPERM || errno == unix.EACCES
 	}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"strings"
-	"syscall" // only for Errno
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -455,7 +454,7 @@ func isWaitable(pid int) (bool, error) {
 // isNoChildren returns true if err represents a unix.ECHILD (formerly syscall.ECHILD) false otherwise
 func isNoChildren(err error) bool {
 	switch err := err.(type) {
-	case syscall.Errno:
+	case unix.Errno:
 		if err == unix.ECHILD {
 			return true
 		}

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"syscall" // only for Signal
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -76,7 +75,7 @@ func (p *setnsProcess) startTime() (uint64, error) {
 }
 
 func (p *setnsProcess) signal(sig os.Signal) error {
-	s, ok := sig.(syscall.Signal)
+	s, ok := sig.(unix.Signal)
 	if !ok {
 		return errors.New("os: unsupported signal type")
 	}
@@ -506,7 +505,7 @@ func (p *initProcess) createNetworkInterfaces() error {
 }
 
 func (p *initProcess) signal(sig os.Signal) error {
-	s, ok := sig.(syscall.Signal)
+	s, ok := sig.(unix.Signal)
 	if !ok {
 		return errors.New("os: unsupported signal type")
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"syscall" //only for Exec
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -207,7 +206,7 @@ func (l *linuxStandardInit) Init() error {
 			return newSystemErrorWithCause(err, "init seccomp")
 		}
 	}
-	if err := syscall.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
+	if err := unix.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
 		return newSystemErrorWithCause(err, "exec user process")
 	}
 	return nil

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -5,7 +5,6 @@ package system
 import (
 	"os"
 	"os/exec"
-	"syscall" // only for exec
 	"unsafe"
 
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -51,7 +50,7 @@ func Execv(cmd string, args []string, env []string) error {
 		return err
 	}
 
-	return syscall.Exec(name, args, env)
+	return unix.Exec(name, args, env)
 }
 
 func Prlimit(pid, resource int, limit unix.Rlimit) error {

--- a/signals.go
+++ b/signals.go
@@ -5,7 +5,6 @@ package main
 import (
 	"os"
 	"os/signal"
-	"syscall" // only for Signal
 
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/system"
@@ -103,7 +102,7 @@ func (h *signalHandler) forward(process *libcontainer.Process, tty *tty, detach 
 			}
 		default:
 			logrus.Debugf("sending signal to process %s", s)
-			if err := unix.Kill(pid1, s.(syscall.Signal)); err != nil {
+			if err := unix.Kill(pid1, s.(unix.Signal)); err != nil {
 				logrus.Error(err)
 			}
 		}


### PR DESCRIPTION
A few nitpicks to simplify the code.

### 1. Do not use `syscall` package where `unix` can be used.

In many places (not all of them though) we can use `unix.`
instead of `syscall.` as these are indentical.

In particular, x/sys/unix defines:

```go
type Signal = syscall.Signal
type Errno = syscall.Errno
type SysProcAttr = syscall.SysProcAttr

const ENODEV      = syscall.Errno(0x13)
```

and unix.Exec() calls syscall.Exec().

### 2. Use `errors.Is()` to check for EINTR.

This is a forgotten hunk from PR #2291.
