### PR TITLE
checkpoint: don't print error if --pre-dump is set

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -63,12 +63,8 @@ checkpointed.`,
 			fatalf("Container cannot be checkpointed in %s state", status.String())
 		}
 		options := criuOptions(context)
-		if !options.LeaveRunning || !options.PreDump {
-			// destroy prints out an error if we tell CRIU to
-			// leave the container running:
-			// ERRO[0000] container is not destroyed
-			// The message is correct, but we actually do not want
-			// to destroy the container in this case.
+		if !(options.LeaveRunning || options.PreDump) {
+			// destroy container unless we tell CRIU to keep it
 			defer destroy(container)
 		}
 		// these are the mandatory criu options for a container


### PR DESCRIPTION
Obviously, either `--pre-dump` or `--leave-running` implies
that we don't want to remove the container.

Found while working on checkpoint integration tests.

Fixes: 87712d288 (PR #2260) 