### PR TITLE
Dockerfile: use bats-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_VERSION=1.13
-ARG BATS_VERSION=03608115df2071fff4eaaff1605768c275e5f81f
+ARG BATS_VERSION=v1.1.0
 ARG CRIU_VERSION=v3.13
 
 FROM golang:${GO_VERSION}-buster
@@ -51,11 +51,11 @@ RUN useradd -u1000 -m -d/home/rootless -s/bin/bash rootless
 # install bats
 ARG BATS_VERSION
 RUN cd /tmp \
-    && git clone https://github.com/sstephenson/bats.git \
-    && cd bats \
+    && git clone https://github.com/bats-core/bats-core.git \
+    && cd bats-core \
     && git reset --hard "${BATS_VERSION}" \
     && ./install.sh /usr/local \
-    && rm -rf /tmp/bats
+    && rm -rf /tmp/bats-core
 
 # install criu
 ARG CRIU_VERSION


### PR DESCRIPTION
_this is a replacement for #2307, see some initial discussion in there_

The bats testing framework we use for integration test is not maintained
since 2015 and was superceded by bats-core [1]. More to say, we were
using an unreleased version and relying on some features of it
(unfortunately I don't remember now what are those features exactly).

As Debian still packages very old version of bats from the old repo,
so let's Use recent bats-core from the new, supposedly better maintained,
github repo.

[1] https://github.com/sstephenson/bats/pull/269