### PR TITLE
fix path error in systemd when stopped

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -47,6 +47,9 @@ type Manager interface {
 
 	// GetFreezerState retrieves the current FreezerState of the cgroup.
 	GetFreezerState() (configs.FreezerState, error)
+
+	// Whether the cgroup path exists or not
+	Exists() bool
 }
 
 type NotFoundError struct {

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -392,3 +392,7 @@ func (m *manager) GetFreezerState() (configs.FreezerState, error) {
 	}
 	return freezer.(*FreezerGroup).GetState(dir)
 }
+
+func (m *manager) Exists() bool {
+	return cgroups.PathExists(m.paths["devices"])
+}

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -262,3 +262,7 @@ func (m *manager) GetCgroups() (*configs.Cgroup, error) {
 func (m *manager) GetFreezerState() (configs.FreezerState, error) {
 	return getFreezer(m.dirPath)
 }
+
+func (m *manager) Exists() bool {
+	return cgroups.PathExists(m.dirPath)
+}

--- a/libcontainer/cgroups/systemd/unsupported.go
+++ b/libcontainer/cgroups/systemd/unsupported.go
@@ -65,3 +65,7 @@ func Freeze(c *configs.Cgroup, state configs.FreezerState) error {
 func (m *Manager) GetCgroups() (*configs.Cgroup, error) {
 	return nil, errors.New("Systemd not supported")
 }
+
+func (m *Manager) Exists() bool {
+	return false
+}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -481,3 +481,7 @@ func (m *legacyManager) GetFreezerState() (configs.FreezerState, error) {
 	}
 	return freezer.(*fs.FreezerGroup).GetState(path)
 }
+
+func (m *legacyManager) Exists() bool {
+	return cgroups.PathExists(m.paths["devices"])
+}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -370,3 +370,7 @@ func (m *unifiedManager) GetFreezerState() (configs.FreezerState, error) {
 	}
 	return fsMgr.GetFreezerState()
 }
+
+func (m *unifiedManager) Exists() bool {
+	return cgroups.PathExists(m.path)
+}

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -25,6 +25,10 @@ function teardown() {
 
   retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
 
+  # we should ensure kill work after the container stopped
+  runc kill -a test_busybox 0
+  [ "$status" -eq 0 ]
+
   runc delete test_busybox
   [ "$status" -eq 0 ]
 }

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -60,3 +60,27 @@ function teardown() {
   [[ ${lines[0]} =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
   [[ "${lines[1]}" =~ [0-9]+ ]]
 }
+
+@test "ps after the container stopped" {
+  # ps requires cgroups
+  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+  set_cgroups_path "$BUSYBOX_BUNDLE"
+
+  # start busybox detached
+  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  [ "$status" -eq 0 ]
+
+  # check state
+  testcontainer test_busybox running
+
+  runc ps test_busybox
+  [ "$status" -eq 0 ]
+
+  runc kill test_busybox KILL
+  [ "$status" -eq 0 ]
+
+  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+
+  runc ps test_busybox
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
fix #2337 

Because when the container is in stopped state, the cgroup path has been deleted by systemd driver.

Signed-off-by: lifubang <lifubang@acmcoder.com>