### PR TITLE
travis: run vagrant tests on the host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ matrix:
         - sudo vagrant plugin install vagrant-libvirt
         - sudo vagrant up && sudo mkdir -p /root/.ssh && sudo sh -c "vagrant ssh-config >> /root/.ssh/config"
       script:
-        - sudo ssh default sudo podman build -t test /vagrant
-        # Mounting /lib/modules into the container is necessary as CRIU wants to load (via iptables) additional modules
-        - sudo ssh default sudo podman run --privileged --cgroupns=private -v /lib/modules:/lib/modules:ro test make localunittest
+        - sudo ssh default -t 'cd /vagrant && sudo make localunittest'
         # cgroupv2+systemd: test on vagrant host itself as we need systemd
         - sudo ssh default -t 'cd /vagrant && sudo make localintegration RUNC_USE_SYSTEMD=yes'
         # same setup but with fs2 driver instead of systemd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,14 @@ ts run
 EOF
     dnf clean all
 
+    # Add a user for rootless tests
+    useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
+
+    # Add busybox for libcontainer/integration tests
+    . /vagrant/tests/integration/multi-arch.bash \
+        && mkdir /busybox \
+        && curl -fsSL $(get_busybox) | tar xfJC - /busybox
+
     # TODO: remove this after criu 3.14 is released
     rpm -e --nodeps criu || true
     CRIU_VERSION=v3.13


### PR DESCRIPTION
Since we already have to build everything and run integration tests
on the Vagrant Fedora 31 host (in order to test how runc talks to
systemd), let's do the same for unit tests (otherwise we build
everything twice).