### PR TITLE
fix data inconsistent when runc update in systemd driven cgroup

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -163,6 +163,17 @@ function check_cgroup_value() {
 	[ "$current" = "$expected" ]
 }
 
+# Helper to check a value in systemd.
+function check_systemd_value() {
+	unitname=$1
+	source=$2
+	expected=$3
+	
+	current=$(systemctl show $unitname | grep $source)
+	echo "current" $current "!?" "$expected"
+	[ "$current" = "$expected" ]
+}
+
 # Helper function to set a resources limit
 function set_resources_limit() {
   bundle="${1:-.}"

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -84,10 +84,24 @@ EOF
     runc update test_update --memory 67108864
     [ "$status" -eq 0 ]
     check_cgroup_value $MEM_LIMIT 67108864
+    if [[ -n "${RUNC_USE_SYSTEMD}" ]] ; then
+        if [ "$CGROUP_UNIFIED" != "yes" ]; then
+            check_systemd_value "runc-cgroups-integration-test.scope" "MemoryLimit=" "MemoryLimit=67108864"
+        else
+            check_systemd_value "runc-cgroups-integration-test.scope" "MemoryMax=" "MemoryMax=67108864"
+        fi
+    fi
 
     runc update test_update --memory 50M
     [ "$status" -eq 0 ]
     check_cgroup_value $MEM_LIMIT 52428800
+    if [[ -n "${RUNC_USE_SYSTEMD}" ]] ; then
+        if [ "$CGROUP_UNIFIED" != "yes" ]; then
+            check_systemd_value "runc-cgroups-integration-test.scope" "MemoryLimit=" "MemoryLimit=52428800"
+        else
+            check_systemd_value "runc-cgroups-integration-test.scope" "MemoryMax=" "MemoryMax=52428800"
+        fi
+    fi
 
     # update memory soft limit
     runc update test_update --memory-reservation 33554432
@@ -123,6 +137,9 @@ EOF
     runc update test_update --pids-limit 10
     [ "$status" -eq 0 ]
     check_cgroup_value "pids.max" 10
+    if [[ -n "${RUNC_USE_SYSTEMD}" ]] ; then
+        check_systemd_value "runc-cgroups-integration-test.scope" "TasksMax=" "TasksMax=10"
+    fi
 
     # Revert to the test initial value via json on stdin
     runc update  -r - test_update <<EOF


### PR DESCRIPTION
fix #2287 
`runc --systemd-cgroup update does not update systemd scope`

As pointed out by @kolyshkin `The cause of this is Set() method of systemd.UnifiedManager, which only uses fsManager to set the updated values.`
So when we use systemd driven cgroup v2, we should use `SetUnitProperties` method to update container resource constraints.

Signed-off-by: lifubang <lifubang@acmcoder.com>