### PR TITLE
libcontainer: use x/sys/unix instead of the hardcoded value

### DIFF
--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -11,19 +11,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// If arg2 is nonzero, set the "child subreaper" attribute of the
-// calling process; if arg2 is zero, unset the attribute.  When a
-// process is marked as a child subreaper, all of the children
-// that it creates, and their descendants, will be marked as
-// having a subreaper.  In effect, a subreaper fulfills the role
-// of init(1) for its descendant processes.  Upon termination of
-// a process that is orphaned (i.e., its immediate parent has
-// already terminated) and marked as having a subreaper, the
-// nearest still living ancestor subreaper will receive a SIGCHLD
-// signal and be able to wait(2) on the process to discover its
-// termination status.
-const PR_SET_CHILD_SUBREAPER = 36
-
 type ParentDeathSignal int
 
 func (p ParentDeathSignal) Restore() error {
@@ -139,7 +126,7 @@ func GetParentNSeuid() int64 {
 
 // SetSubreaper sets the value i as the subreaper setting for the calling process
 func SetSubreaper(i int) error {
-	return unix.Prctl(PR_SET_CHILD_SUBREAPER, uintptr(i), 0, 0, 0)
+	return unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, uintptr(i), 0, 0, 0)
 }
 
 // GetSubreaper returns the subreaper setting for the calling process


### PR DESCRIPTION
PR_SET_CHILD_SUBREAPER is defined in x/sys/unix.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>