### PR TITLE
libcontainer/stacktrace: fix inline func name

### DIFF
--- a/libcontainer/stacktrace/capture_test.go
+++ b/libcontainer/stacktrace/capture_test.go
@@ -21,8 +21,8 @@ func TestCaptureTestFunc(t *testing.T) {
 	if expected := "captureFunc"; frame.Function != expected {
 		t.Fatalf("expected function %q but received %q", expected, frame.Function)
 	}
-	expected := "/runc/libcontainer/stacktrace"
-	if !strings.HasSuffix(frame.Package, expected) {
+	// captureFunc is inlined in gccgo, so don't expect the full package path
+	if expected := "stacktrace"; !strings.HasSuffix(frame.Package, expected) {
 		t.Fatalf("expected package %q but received %q", expected, frame.Package)
 	}
 	if expected := "capture_test.go"; frame.File != expected {

--- a/libcontainer/stacktrace/frame.go
+++ b/libcontainer/stacktrace/frame.go
@@ -6,18 +6,13 @@ import (
 	"strings"
 )
 
-// NewFrame returns a new stack frame for the provided information
-func NewFrame(pc uintptr, file string, line int) Frame {
-	fn := runtime.FuncForPC(pc)
-	if fn == nil {
-		return Frame{}
-	}
-	pack, name := parseFunctionName(fn.Name())
+func newFrame(frame runtime.Frame) Frame {
+	pack, name := parseFunctionName(frame.Function)
 	return Frame{
-		Line:     line,
-		File:     filepath.Base(file),
-		Package:  pack,
+		File:     filepath.Base(frame.File),
 		Function: name,
+		Package:  pack,
+		Line:     frame.Line,
 	}
 }
 


### PR DESCRIPTION
The TestCaptureTestFunc fails on gccgo, because captureFunc is inlined
there. Instead of using FuncForPC directly, using CallersFrames from
runtime package, which is available since go1.7

This commit has an API break for the stacktrace package, which removes
NewFrame func. But I think it's safe as the stacktrace is somehow an
internal package of libcontainer.

Signed-off-by: Shengjing Zhu <zhsj@debian.org>