### PR TITLE
cgroups/fs2: don't always parse /proc/self/cgroup

### DIFF
--- a/libcontainer/cgroups/fs2/defaultpath.go
+++ b/libcontainer/cgroups/fs2/defaultpath.go
@@ -44,19 +44,10 @@ func defaultDirPath(c *configs.Cgroup) (string, error) {
 	cgParent := libcontainerUtils.CleanPath(c.Parent)
 	cgName := libcontainerUtils.CleanPath(c.Name)
 
-	ownCgroup, err := parseCgroupFile("/proc/self/cgroup")
-	if err != nil {
-		return "", err
-	}
-	// The current user scope most probably has tasks in it already,
-	// making it impossible to enable controllers for its sub-cgroup.
-	// A parent cgroup (with no tasks in it) is what we need.
-	ownCgroup = filepath.Dir(ownCgroup)
-
-	return _defaultDirPath(UnifiedMountpoint, cgPath, cgParent, cgName, ownCgroup)
+	return _defaultDirPath(UnifiedMountpoint, cgPath, cgParent, cgName)
 }
 
-func _defaultDirPath(root, cgPath, cgParent, cgName, ownCgroup string) (string, error) {
+func _defaultDirPath(root, cgPath, cgParent, cgName string) (string, error) {
 	if (cgName != "" || cgParent != "") && cgPath != "" {
 		return "", errors.New("cgroup: either Path or Name and Parent should be used")
 	}
@@ -67,6 +58,16 @@ func _defaultDirPath(root, cgPath, cgParent, cgName, ownCgroup string) (string, 
 	if filepath.IsAbs(innerPath) {
 		return filepath.Join(root, innerPath), nil
 	}
+
+	ownCgroup, err := parseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+	// The current user scope most probably has tasks in it already,
+	// making it impossible to enable controllers for its sub-cgroup.
+	// A parent cgroup (with no tasks in it) is what we need.
+	ownCgroup = filepath.Dir(ownCgroup)
+
 	return filepath.Join(root, ownCgroup, innerPath), nil
 }
 


### PR DESCRIPTION
Function `defaultPath` always parses `/proc/self/cgroup`, but
the resulting value is not always used.

Avoid unnecessary reading/parsing by moving the code
to just before its use.

Modify the test case accordingly.