### PR TITLE
Vagrantfile: use Fedora 32 (and remove unused Podman)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-# Fedora 31 box is used for testing cgroup v2 support
-  config.vm.box = "fedora/31-cloud-base"
+# Fedora box is used for testing cgroup v2 support
+  config.vm.box = "fedora/32-cloud-base"
   config.vm.provider :virtualbox do |v|
     v.memory = 2048
     v.cpus = 2
@@ -15,9 +15,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     cat << EOF | dnf -y shell
 update
-install podman make golang-go libseccomp-devel bats jq \
- patch protobuf protobuf-c protobuf-c-devel protobuf-compiler \
- protobuf-devel protobuf-python libnl3-devel libcap-devel libnet-devel \
+install iptables gcc make golang-go libseccomp-devel bats jq \
+ patch protobuf protobuf-c protobuf-c-compiler protobuf-c-devel protobuf-compiler \
+ protobuf-devel libnl3-devel libcap-devel libnet-devel \
  nftables-devel libbsd-devel gnutls-devel
 ts run
 EOF
@@ -31,19 +31,11 @@ EOF
         && mkdir /busybox \
         && curl -fsSL $(get_busybox) | tar xfJC - /busybox
 
-    # TODO: remove this after criu 3.14 is released
-    rpm -e --nodeps criu || true
-    CRIU_VERSION=v3.13
-    mkdir -p /usr/src/criu \
-        && curl -fsSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
-        && cd /usr/src/criu \
-        && echo 1 > .gitid \
-        && curl -sSL https://github.com/checkpoint-restore/criu/commit/4c27b3db4f4325a311d8bfa9a50ea3efb4d6e377.patch | patch -p1 \
-        && curl -sSL https://github.com/checkpoint-restore/criu/commit/aac41164b2cd7f0d2047f207b32844524682e43f.patch | patch -p1 \
-        && curl -sSL https://github.com/checkpoint-restore/criu/commit/6f19249b2565f3f7c0a1f8f65b4ae180e8f7f34b.patch | patch -p1 \
-        && curl -sSL https://github.com/checkpoint-restore/criu/commit/378337a496ca759848180bc5411e4446298c5e4e.patch | patch -p1 \
-        && make install-criu \
-        && cd - \
-        && rm -rf /usr/src/criu
+    # Apr 25, 2020 (master)
+    ( git clone https://github.com/checkpoint-restore/criu.git /usr/src/criu \
+     && cd /usr/src/criu \
+     && git checkout 5c5e7695a51318b17e3d982df8231ac83971641c  \
+     && make install-criu )
+    rm -rf /usr/src/criu
   SHELL
 end


### PR DESCRIPTION
Fedora 32 comes with systemd 245, which supports delegation of cpuset controller to unprivileged users (ref: #2281)