### PR TITLE
let runc disable swap in cgroup v2

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -45,10 +45,13 @@ func setMemory(dirPath string, cgroup *configs.Cgroup) error {
 	if err != nil {
 		return err
 	}
-	if val := numToStr(swap); val != "" {
-		if err := fscommon.WriteFile(dirPath, "memory.swap.max", val); err != nil {
-			return err
-		}
+	swapStr := numToStr(swap)
+	if swapStr == "" && swap == 0 && cgroup.Resources.MemorySwap > 0 {
+		// memory and memorySwap set to the same value -- disable swap
+		swapStr = "0"
+	}
+	if err := fscommon.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
+		return err
 	}
 
 	if val := numToStr(cgroup.Resources.Memory); val != "" {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -39,12 +39,12 @@ func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 		properties = append(properties,
 			newProp("MemoryMax", uint64(c.Resources.Memory)))
 	}
-
-	swap, err := cgroups.ConvertMemorySwapToCgroupV2Value(c.Resources.MemorySwap, c.Resources.Memory)
-	if err != nil {
-		return nil, err
-	}
-	if swap > 0 {
+	// swap is set
+	if c.Resources.MemorySwap != 0 {
+		swap, err := cgroups.ConvertMemorySwapToCgroupV2Value(c.Resources.MemorySwap, c.Resources.Memory)
+		if err != nil {
+			return nil, err
+		}
 		properties = append(properties,
 			newProp("MemorySwapMax", uint64(swap)))
 	}

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -639,7 +639,7 @@ func ConvertMemorySwapToCgroupV2Value(memorySwap, memory int64) (int64, error) {
 		return 0, fmt.Errorf("invalid memory value: %d", memory)
 	}
 	if memorySwap < memory {
-		return 0, errors.New("memory+swap limit should be > memory limit")
+		return 0, errors.New("memory+swap limit should be >= memory limit")
 	}
 
 	return memorySwap - memory, nil


### PR DESCRIPTION
fix #2369

I think we should let cgroup fs/systemd driver can use 0 to disable memory swap in cgroup v2.

Signed-off-by: lifubang <lifubang@acmcoder.com>