### PR TITLE
Use criu 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.13
 ARG BATS_VERSION=v1.1.0
-ARG CRIU_VERSION=v3.13
+ARG CRIU_VERSION=v3.14
 
 FROM golang:${GO_VERSION}-buster
 ARG DEBIAN_FRONTEND=noninteractive
@@ -63,10 +63,6 @@ RUN mkdir -p /usr/src/criu \
     && curl -fsSL https://github.com/checkpoint-restore/criu/archive/${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \
     && echo 1 > .gitid \
-    && curl -sSL https://github.com/checkpoint-restore/criu/commit/4c27b3db4f4325a311d8bfa9a50ea3efb4d6e377.patch | patch -p1 \
-    && curl -sSL https://github.com/checkpoint-restore/criu/commit/aac41164b2cd7f0d2047f207b32844524682e43f.patch | patch -p1 \
-    && curl -sSL https://github.com/checkpoint-restore/criu/commit/6f19249b2565f3f7c0a1f8f65b4ae180e8f7f34b.patch | patch -p1 \
-    && curl -sSL https://github.com/checkpoint-restore/criu/commit/378337a496ca759848180bc5411e4446298c5e4e.patch | patch -p1 \
     && make install-criu \
     && cd - \
     && rm -rf /usr/src/criu

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,15 +13,15 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
   end
   config.vm.provision "shell", inline: <<-SHELL
+    curl -OSs https://kojipkgs.fedoraproject.org/packages/criu/3.14/1.fc32/x86_64/criu-3.14-1.fc32.x86_64.rpm
     cat << EOF | dnf -y shell
+localinstall criu-3.14-1.fc32.x86_64.rpm
 update
-install iptables gcc make golang-go libseccomp-devel bats jq \
- patch protobuf protobuf-c protobuf-c-compiler protobuf-c-devel protobuf-compiler \
- protobuf-devel libnl3-devel libcap-devel libnet-devel \
- nftables-devel libbsd-devel gnutls-devel
+install iptables gcc make golang-go libseccomp-devel bats jq
 ts run
 EOF
     dnf clean all
+    rm -f criu-3.14-1.fc32.x86_64.rpm
 
     # Add a user for rootless tests
     useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
@@ -30,12 +30,5 @@ EOF
     . /vagrant/tests/integration/multi-arch.bash \
         && mkdir /busybox \
         && curl -fsSL $(get_busybox) | tar xfJC - /busybox
-
-    # Apr 25, 2020 (master)
-    ( git clone https://github.com/checkpoint-restore/criu.git /usr/src/criu \
-     && cd /usr/src/criu \
-     && git checkout 5c5e7695a51318b17e3d982df8231ac83971641c  \
-     && make install-criu )
-    rm -rf /usr/src/criu
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,9 +15,11 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     curl -OSs https://kojipkgs.fedoraproject.org/packages/criu/3.14/1.fc32/x86_64/criu-3.14-1.fc32.x86_64.rpm
     cat << EOF | dnf -y shell
+config exclude kernel,kernel-core
+config install_weak_deps false
 localinstall criu-3.14-1.fc32.x86_64.rpm
 update
-install iptables gcc make golang-go libseccomp-devel bats jq
+install iptables gcc make golang-go libseccomp-devel bats jq git-core
 ts run
 EOF
     dnf clean all


### PR DESCRIPTION
* Dockerfile: bump criu to version π (3.14)
* Vagrantfile: use criu 3.14 from testing
*  Vagrantfile: install less packages