### PR TITLE
Logging nits

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -60,7 +60,7 @@ checkpointed.`,
 			return err
 		}
 		if status == libcontainer.Created || status == libcontainer.Stopped {
-			fatalf("Container cannot be checkpointed in %s state", status.String())
+			fatal(fmt.Errorf("Container cannot be checkpointed in %s state", status.String()))
 		}
 		options := criuOptions(context)
 		if !(options.LeaveRunning || options.PreDump) {

--- a/main.go
+++ b/main.go
@@ -159,7 +159,10 @@ type FatalWriter struct {
 
 func (f *FatalWriter) Write(p []byte) (n int, err error) {
 	logrus.Error(string(p))
-	return f.cliErrWriter.Write(p)
+	if !logrusToStderr() {
+		return f.cliErrWriter.Write(p)
+	}
+	return len(p), nil
 }
 
 func createLogConfig(context *cli.Context) logs.Config {

--- a/utils.go
+++ b/utils.go
@@ -45,12 +45,20 @@ func checkArgs(context *cli.Context, expected, checkType int) error {
 	return nil
 }
 
+func logrusToStderr() bool {
+	l, ok := logrus.StandardLogger().Out.(*os.File)
+	return ok && l.Fd() == os.Stderr.Fd()
+}
+
 // fatal prints the error's details if it is a libcontainer specific error type
 // then exits the program with an exit status of 1.
 func fatal(err error) {
 	// make sure the error is written to the logger
 	logrus.Error(err)
-	fmt.Fprintln(os.Stderr, err)
+	if !logrusToStderr() {
+		fmt.Fprintln(os.Stderr, err)
+	}
+
 	os.Exit(1)
 }
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -91,10 +91,6 @@ func getContainer(context *cli.Context) (libcontainer.Container, error) {
 	return factory.Load(id)
 }
 
-func fatalf(t string, v ...interface{}) {
-	fatal(fmt.Errorf(t, v...))
-}
-
 func getDefaultImagePath(context *cli.Context) string {
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
1. Remove a function `fatalf()` which were only used once.

2. Fix error "stuttering" (printing the error twice).