### PR TITLE
get rid of cgroupPaths for v2 case

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -40,9 +40,9 @@ type Manager interface {
 	// GetUnifiedPath returns the unified path when running in unified mode.
 	// The value corresponds to the all values of GetPaths() map.
 	//
-	// GetUnifiedPath returns error when running in hybrid mode as well as
+	// GetUnifiedPath panics when running in hybrid mode as well as
 	// in legacy mode.
-	GetUnifiedPath() (string, error)
+	GetUnifiedPath() string
 
 	// Sets the cgroup as configured.
 	Set(container *configs.Config) error

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -208,8 +208,8 @@ func (m *Manager) GetPaths() map[string]string {
 	return paths
 }
 
-func (m *Manager) GetUnifiedPath() (string, error) {
-	return "", errors.New("unified path is only supported when running in unified mode")
+func (m *Manager) GetUnifiedPath() string {
+	panic("GetUnifiedPath is only supported when running in unified mode")
 }
 
 func (m *Manager) GetStats() (*cgroups.Stats, error) {

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -178,8 +178,8 @@ func (m *manager) GetPaths() map[string]string {
 	return paths
 }
 
-func (m *manager) GetUnifiedPath() (string, error) {
-	return m.dirPath, nil
+func (m *manager) GetUnifiedPath() string {
+	return m.dirPath
 }
 
 func (m *manager) Set(container *configs.Config) error {

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -164,18 +164,8 @@ func (m *manager) Destroy() error {
 	return nil
 }
 
-// GetPaths is for compatibility purpose and should be removed in future
 func (m *manager) GetPaths() map[string]string {
-	_ = m.getControllers()
-	paths := map[string]string{
-		// pseudo-controller for compatibility
-		"devices": m.dirPath,
-		"freezer": m.dirPath,
-	}
-	for c := range m.controllers {
-		paths[c] = m.dirPath
-	}
-	return paths
+	panic("GetPaths can only be used for cgroupv1")
 }
 
 func (m *manager) GetUnifiedPath() string {

--- a/libcontainer/cgroups/systemd/unsupported.go
+++ b/libcontainer/cgroups/systemd/unsupported.go
@@ -42,8 +42,8 @@ func (m *Manager) GetPaths() map[string]string {
 	return nil
 }
 
-func (m *Manager) GetUnifiedPath() (string, error) {
-	return "", fmt.Errorf("Systemd not supported")
+func (m *Manager) GetUnifiedPath() string {
+	return ""
 }
 
 func (m *Manager) GetStats() (*cgroups.Stats, error) {

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -228,8 +228,8 @@ func (m *LegacyManager) GetPaths() map[string]string {
 	return paths
 }
 
-func (m *LegacyManager) GetUnifiedPath() (string, error) {
-	return "", errors.New("unified path is only supported when running in unified mode")
+func (m *LegacyManager) GetUnifiedPath() string {
+	panic("GetUnifiedPath is only supported when running in unified mode")
 }
 
 func join(c *configs.Cgroup, subsystem string, pid int) (string, error) {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -174,19 +174,9 @@ func (m *unifiedManager) Destroy() error {
 	return nil
 }
 
-// this method is for v1 backward compatibility and will be removed
+// must not be called for this controller
 func (m *unifiedManager) GetPaths() map[string]string {
-	_ = m.initPath()
-	paths := map[string]string{
-		"pids":    m.path,
-		"memory":  m.path,
-		"io":      m.path,
-		"cpu":     m.path,
-		"devices": m.path,
-		"cpuset":  m.path,
-		"freezer": m.path,
-	}
-	return paths
+	panic("GetPaths can only be used for cgroupv1")
 }
 
 func (m *unifiedManager) GetUnifiedPath() string {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -551,9 +551,18 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, messageSockP
 	if err != nil {
 		return nil, err
 	}
+	var paths map[string]string
+	if cgroups.IsCgroup2UnifiedMode() {
+		// there's only one path to enter, add it to the map
+		paths = make(map[string]string, 1)
+		paths[""] = c.cgroupManager.GetUnifiedPath()
+	} else {
+		paths = c.cgroupManager.GetPaths()
+	}
+
 	return &setnsProcess{
 		cmd:             cmd,
-		cgroupPaths:     c.cgroupManager.GetPaths(),
+		cgroupPaths:     paths,
 		rootlessCgroups: c.config.RootlessCgroups,
 		intelRdtPath:    state.IntelRdtPath,
 		messageSockPair: messageSockPair,

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1023,11 +1023,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 	case true:
 		// cgroup v2 freezer is only supported since CRIU release 3.14
 		if c.checkCriuVersion(31400) == nil {
-			fcg, err = c.cgroupManager.GetUnifiedPath()
-			if err != nil {
-				// should not happen
-				return err
-			}
+			fcg = c.cgroupManager.GetUnifiedPath()
 		}
 	}
 	if fcg != "" {
@@ -1861,12 +1857,7 @@ func (c *linuxContainer) isPaused() (bool, error) {
 		filename = "freezer.state"
 		pausedState = "FROZEN"
 	} else {
-		var err error
-		fcg, err = c.cgroupManager.GetUnifiedPath()
-		if err != nil {
-			// should not happen
-			return false, err
-		}
+		fcg = c.cgroupManager.GetUnifiedPath()
 		filename = "cgroup.freeze"
 		pausedState = "1"
 	}

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -55,8 +55,8 @@ func (m *mockCgroupManager) GetPaths() map[string]string {
 	return m.paths
 }
 
-func (m *mockCgroupManager) GetUnifiedPath() (string, error) {
-	return m.unifiedPath, nil
+func (m *mockCgroupManager) GetUnifiedPath() string {
+	return m.unifiedPath
 }
 
 func (m *mockCgroupManager) Freeze(state configs.FreezerState) error {


### PR DESCRIPTION
This patchset fixes the remaining users of GetPaths() in v2 mode, and makes it panic for v2 controllers.

Similarly, make `GetUnifiedPath()` panic for v1 controllers since it must not be used in this case.