### PR TITLE
Close fd in case fd.Write() returns error

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -886,10 +886,10 @@ func waitForCriuLazyServer(r *os.File, status string) error {
 		return err
 	}
 	_, err = fd.Write(data)
+	fd.Close()
 	if err != nil {
 		return err
 	}
-	fd.Close()
 
 	return nil
 }


### PR DESCRIPTION
In waitForCriuLazyServer(), if fd.Write() returns error, current code would return without closing fd.

This PR closes the fd in above case to avoid leak.