### PR TITLE
Check the error return from startTime()

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1890,7 +1890,10 @@ func (c *linuxContainer) currentState() (*State, error) {
 	)
 	if c.initProcess != nil {
 		pid = c.initProcess.pid()
-		startTime, _ = c.initProcess.startTime()
+		var err error
+		if startTime, err = c.initProcess.startTime(); err != nil {
+			return nil, err
+		}
 		externalDescriptors = c.initProcess.externalDescriptors()
 	}
 	intelRdtPath, err := intelrdt.GetIntelRdtPath(c.ID())


### PR DESCRIPTION
In linuxContainer#currentState(), the error return from initProcess.startTime() is ignored.

Looking at various Process implementations, not every implementation returns nil error. e.g. setnsProcess#startTime() may return non-nil error.

This PR adds error check for the return value.