### PR TITLE
enable travis for multi-arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,35 @@ matrix:
         - sudo ssh default -t 'cd /vagrant && sudo make localrootlessintegration RUNC_USE_SYSTEMD=yes'
         # same setup but with fs2 driver (rootless) instead of systemd
         - sudo ssh default -t 'cd /vagrant && sudo make localrootlessintegration'
+    - go: 1.13.x
+      name: "test-local-arm64"
+      arch: arm64
+      before_install:
+        - sudo apt-get install -y jq seccomp libseccomp-dev bats
+      script:
+        - make all
+        - sudo PATH="$PATH" make localintegration
+    - go: 1.13.x
+      name: "test-local-ppc64le"
+      arch: ppc64le
+      before_install:
+        - sudo apt-get install -y jq seccomp libseccomp-dev bats
+      script:
+        - make all
+        - sudo PATH="$PATH" make localintegration
+    - go: 1.13.x
+      name: "test-local-s390x"
+      arch: s390x
+      before_install:
+        - sudo apt-get install -y jq seccomp libseccomp-dev bats
+      script:
+        - make all
+        - sudo PATH="$PATH" make localintegration
   allow_failures:
     - go: tip
+    - name: "test-local-arm64"
+    - name: "test-local-ppc64le"
+    - name: "test-local-s390x"
 
 go_import_path: github.com/opencontainers/runc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,30 @@ ARG CRIU_VERSION=v3.14
 FROM golang:${GO_VERSION}-buster
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN dpkg --add-architecture armel \
+# Install cross-compilation dependencies only on x86_64
+RUN [ $(uname -m) = x86_64  ] \
+    && dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \
     && dpkg --add-architecture arm64 \
     && dpkg --add-architecture ppc64el \
+    && dpkg --add-architecture s390x \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential \
         crossbuild-essential-arm64 \
         crossbuild-essential-armel \
         crossbuild-essential-armhf \
         crossbuild-essential-ppc64el \
+        crossbuild-essential-s390x \
+        libseccomp-dev:arm64 \
+        libseccomp-dev:armel \
+        libseccomp-dev:armhf \
+        libseccomp-dev:ppc64el \
+        libseccomp-dev:s390x \
+   || true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
         curl \
         gawk \
         iptables \
@@ -28,10 +41,6 @@ RUN dpkg --add-architecture armel \
         libprotobuf-c-dev \
         libprotobuf-dev \
         libseccomp-dev \
-        libseccomp-dev:arm64 \
-        libseccomp-dev:armel \
-        libseccomp-dev:armhf \
-        libseccomp-dev:ppc64el \
         libseccomp2 \
         pkg-config \
         protobuf-c-compiler \

--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -4,6 +4,12 @@ get_busybox(){
 	arm64)
 		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/glibc/busybox.tar.xz'
 	;;
+	s390x)
+		echo 'https://github.com/docker-library/busybox/raw/dist-s390x/glibc/busybox.tar.xz'
+	;;
+	ppc64le)
+		echo 'https://github.com/docker-library/busybox/raw/dist-ppc64le/glibc/busybox.tar.xz'
+	;;
 	*)
 		echo 'https://github.com/docker-library/busybox/raw/dist-amd64/glibc/busybox.tar.xz'
 	;;
@@ -15,6 +21,12 @@ get_hello(){
         arm64)
                 echo 'hello-world-aarch64.tar'
         ;;
+	s390x)
+		echo 'hello-world-s390x.tar'
+	;;
+	ppc64le)
+		echo 'hello-world-ppc64le.tar'
+	;;
         *)
                 echo 'hello-world.tar'
         ;;


### PR DESCRIPTION
Enable running the tests on arm64, ppc64le and s390x.

Fixes: https://github.com/opencontainers/runc/issues/2383

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>