### PR TITLE
Simplify cgroup paths handling in v2 via unified v1/v2 API

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -27,27 +27,22 @@ type Manager interface {
 	// Destroys the cgroup set
 	Destroy() error
 
-	// The option func SystemdCgroups() and Cgroupfs() require following attributes:
-	// 	Paths   map[string]string
-	// 	Cgroups *configs.Cgroup
-	// Paths maps cgroup subsystem to path at which it is mounted.
-	// Cgroups specifies specific cgroup settings for the various subsystems
-
-	// Returns cgroup paths to save in a state file and to be able to
-	// restore the object later.
-	GetPaths() map[string]string
-
-	// GetUnifiedPath returns the unified path when running in unified mode.
-	// The value corresponds to the all values of GetPaths() map.
-	//
-	// GetUnifiedPath returns error when running in hybrid mode as well as
-	// in legacy mode.
-	GetUnifiedPath() (string, error)
+	// Path returns a cgroup path to the specified controller/subsystem.
+	// For cgroupv2, the argument is unused and can be empty.
+	Path(string) string
 
 	// Sets the cgroup as configured.
 	Set(container *configs.Config) error
 
-	// Gets the cgroup as configured.
+	// GetPaths returns cgroup path(s) to save in a state file in order to restore later.
+	//
+	// For cgroup v1, a key is cgroup subsystem name, and the value is the path
+	// to the cgroup for this subsystem.
+	//
+	// For cgroup v2 unified hierarchy, a key is "", and the value is the unified path.
+	GetPaths() map[string]string
+
+	// GetCgroups returns the cgroup data as configured.
 	GetCgroups() (*configs.Cgroup, error)
 }
 

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -209,15 +209,10 @@ func (m *manager) Destroy() error {
 	return nil
 }
 
-func (m *manager) GetPaths() map[string]string {
+func (m *manager) Path(subsys string) string {
 	m.mu.Lock()
-	paths := m.paths
-	m.mu.Unlock()
-	return paths
-}
-
-func (m *manager) GetUnifiedPath() (string, error) {
-	return "", errors.New("unified path is only supported when running in unified mode")
+	defer m.mu.Unlock()
+	return m.paths[subsys]
 }
 
 func (m *manager) GetStats() (*cgroups.Stats, error) {
@@ -299,13 +294,11 @@ func (m *manager) Freeze(state configs.FreezerState) error {
 }
 
 func (m *manager) GetPids() ([]int, error) {
-	paths := m.GetPaths()
-	return cgroups.GetPids(paths["devices"])
+	return cgroups.GetPids(m.Path("devices"))
 }
 
 func (m *manager) GetAllPids() ([]int, error) {
-	paths := m.GetPaths()
-	return cgroups.GetAllPids(paths["devices"])
+	return cgroups.GetAllPids(m.Path("devices"))
 }
 
 func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
@@ -409,6 +402,12 @@ func CheckCpushares(path string, c uint64) error {
 	}
 
 	return nil
+}
+
+func (m *manager) GetPaths() map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.paths
 }
 
 func (m *manager) GetCgroups() (*configs.Cgroup, error) {

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -164,22 +164,8 @@ func (m *manager) Destroy() error {
 	return nil
 }
 
-// GetPaths is for compatibility purpose and should be removed in future
-func (m *manager) GetPaths() map[string]string {
-	_ = m.getControllers()
-	paths := map[string]string{
-		// pseudo-controller for compatibility
-		"devices": m.dirPath,
-		"freezer": m.dirPath,
-	}
-	for c := range m.controllers {
-		paths[c] = m.dirPath
-	}
-	return paths
-}
-
-func (m *manager) GetUnifiedPath() (string, error) {
-	return m.dirPath, nil
+func (m *manager) Path(_ string) string {
+	return m.dirPath
 }
 
 func (m *manager) Set(container *configs.Config) error {
@@ -243,6 +229,12 @@ func (m *manager) Set(container *configs.Config) error {
 	}
 	m.config = container.Cgroups
 	return nil
+}
+
+func (m *manager) GetPaths() map[string]string {
+	paths := make(map[string]string, 1)
+	paths[""] = m.dirPath
+	return paths
 }
 
 func (m *manager) GetCgroups() (*configs.Cgroup, error) {

--- a/libcontainer/cgroups/systemd/unsupported.go
+++ b/libcontainer/cgroups/systemd/unsupported.go
@@ -42,8 +42,8 @@ func (m *Manager) GetPaths() map[string]string {
 	return nil
 }
 
-func (m *Manager) GetUnifiedPath() (string, error) {
-	return "", fmt.Errorf("Systemd not supported")
+func (m *Manager) Path(_ string) string {
+	return ""
 }
 
 func (m *Manager) GetStats() (*cgroups.Stats, error) {

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -236,15 +236,10 @@ func (m *legacyManager) Destroy() error {
 	return nil
 }
 
-func (m *legacyManager) GetPaths() map[string]string {
+func (m *legacyManager) Path(subsys string) string {
 	m.mu.Lock()
-	paths := m.paths
-	m.mu.Unlock()
-	return paths
-}
-
-func (m *legacyManager) GetUnifiedPath() (string, error) {
-	return "", errors.New("unified path is only supported when running in unified mode")
+	defer m.mu.Unlock()
+	return m.paths[subsys]
 }
 
 func join(c *configs.Cgroup, subsystem string, pid int) (string, error) {
@@ -434,6 +429,13 @@ func setKernelMemory(c *configs.Cgroup) error {
 	}
 	return fs.EnableKernelMemoryAccounting(path)
 }
+
+func (m *legacyManager) GetPaths() map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.paths
+}
+
 func (m *legacyManager) GetCgroups() (*configs.Cgroup, error) {
 	return m.cgroups, nil
 }

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 type mockCgroupManager struct {
-	pids        []int
-	allPids     []int
-	stats       *cgroups.Stats
-	paths       map[string]string
-	unifiedPath string
+	pids    []int
+	allPids []int
+	stats   *cgroups.Stats
+	paths   map[string]string
 }
 
 type mockIntelRdtManager struct {
@@ -55,8 +54,8 @@ func (m *mockCgroupManager) GetPaths() map[string]string {
 	return m.paths
 }
 
-func (m *mockCgroupManager) GetUnifiedPath() (string, error) {
-	return m.unifiedPath, nil
+func (m *mockCgroupManager) Path(subsys string) string {
+	return m.paths[subsys]
 }
 
 func (m *mockCgroupManager) Freeze(state configs.FreezerState) error {


### PR DESCRIPTION
This unties the Gordian Knot of using GetPaths in cgroupv2 code.

The problem is, the current code uses GetPaths for three kinds of things:

1. Get all the paths to cgroup v1 controllers to save its state (see
   (*linuxContainer).currentState(), (*LinuxFactory).loadState()
   methods).

2. Get all the paths to cgroup v1 controllers to have the setns process
    enter the proper cgroups in `(*setnsProcess).start()`.

3. Get the path to a specific controller (for example,
   `m.GetPaths()["devices"]`).

Now, for cgroup v2 instead of a set of per-controller paths, we have only
one single unified path, and a dedicated function `GetUnifiedPath()` to get it.

This discrepancy between v1 and v2 cgroupManager API leads to the
following problems with the code:

 - multiple if/else code blocks that have to treat v1 and v2 separately;

 - backward-compatible GetPaths() methods in v2 controllers;

 - repeated writing of the PID into the same cgroup for v2;

Overall, it's hard to write the right code with all this, and the code
that is written is kinda hard to follow.

The solution is to slightly change the API to do the 3 things outlined
above in the same manner for v1 and v2:

1. Use `GetPaths()` for state saving and setns process cgroups entering.

2. Introduce and use `Path(subsys string)` to obtain a path to a
   subsystem. For v2, the argument is ignored and the unified path is
   returned.

This commit converts all the controllers to the new API, and modifies
all the users to use it.
