### PR TITLE
cgroupv2: don't enable threaded mode by default

### DIFF
--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -99,13 +99,6 @@ function enable_cgroup() {
 		chown root:rootless "$CGROUP_MOUNT/$CGROUP_PATH" "$CGROUP_MOUNT/$CGROUP_PATH/cgroup.subtree_control" "$CGROUP_MOUNT/$CGROUP_PATH/cgroup.procs" "$CGROUP_MOUNT/cgroup.procs"
 		chmod g+rwx "$CGROUP_MOUNT/$CGROUP_PATH"
 		chmod g+rw "$CGROUP_MOUNT/$CGROUP_PATH/cgroup.subtree_control" "$CGROUP_MOUNT/$CGROUP_PATH/cgroup.procs" "$CGROUP_MOUNT/cgroup.procs"
-		# Fix up cgroup.type.
-		echo threaded > "$CGROUP_MOUNT/$CGROUP_PATH/cgroup.type"
-		# Make sure cgroup.type doesn't contain "invalid". Otherwise write ops will fail with ENOTSUP.
-		# See http://man7.org/linux/man-pages/man7/cgroups.7.html
-		if grep -qw invalid "$CGROUP_MOUNT/$CGROUP_PATH/cgroup.type"; then
-			exit 1
-		fi
 	fi
 }
 


### PR DESCRIPTION
After this commit: https://github.com/opencontainers/runc/commit/60c647e3b8e0d04cc8fe85b957ba2addfcc4fc4f 
Runc enable `threaded` mode in cgroup v2 by default.
If the cgroupPath is set to a absolute path like `/docker/********`, the memory subsystem can't be used by this mode.
So, I think we should use `domain` mode by default.

Signed-off-by: lifubang <lifubang@acmcoder.com>