### PR TITLE
Vagrantfile: use criu from stable repo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,17 +13,14 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
   end
   config.vm.provision "shell", inline: <<-SHELL
-    curl -OSs https://kojipkgs.fedoraproject.org/packages/criu/3.14/1.fc32/x86_64/criu-3.14-1.fc32.x86_64.rpm
     cat << EOF | dnf -y shell
 config exclude kernel,kernel-core
 config install_weak_deps false
-localinstall criu-3.14-1.fc32.x86_64.rpm
 update
-install iptables gcc make golang-go libseccomp-devel bats jq git-core
+install iptables gcc make golang-go libseccomp-devel bats jq git-core criu
 ts run
 EOF
     dnf clean all
-    rm -f criu-3.14-1.fc32.x86_64.rpm
 
     # Add a user for rootless tests
     useradd -u2000 -m -d/home/rootless -s/bin/bash rootless


### PR DESCRIPTION
CRIU 3.14 has made its way to the F32 stable repo, let's use it.
