### PR TITLE
Partially revert "CreateCgroupPath: only enable needed controllers"

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -110,6 +110,17 @@ EOF
 
     runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_permissions
     [ "$status" -eq 0 ]
+    if [ "$CGROUP_UNIFIED" != "no" ]; then
+        if [ -n "${RUNC_USE_SYSTEMD}" ] ; then
+            if [ $(id -u) = "0" ]; then
+                check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
+            else
+                check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/user.slice/user-$(id -u).slice/cgroup.controllers)"
+            fi
+        else
+            check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"
+        fi
+    fi
 }
 
 @test "runc exec (limits + cgrouppath + permission on the cgroup dir) succeeds" {


### PR DESCRIPTION
fix #2394 

1. Partially revert "CreateCgroupPath: only enable needed controllers"
Because if we update a resource which did not limited in the beginning, it will
have no effective.
2. Returns err if we use an non enabled controller, or else the user may feel success, but actually
there are no effective.

For #2367 , I think we don't need fully revert https://github.com/opencontainers/runc/commit/4b4bc995ad4ee4679ffbe38f1672be01c24256fc , because rootless need some part in it to check errors.

Signed-off-by: lifubang <lifubang@acmcoder.com>