### PR TITLE
Honor spec.Process.NoNewPrivileges in specconv.CreateLibcontainerConfig

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -260,6 +260,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	}
 	if spec.Process != nil {
 		config.OomScoreAdj = spec.Process.OOMScoreAdj
+		config.NoNewPrivileges = spec.Process.NoNewPrivileges
 		if spec.Process.SelinuxLabel != "" {
 			config.ProcessLabel = spec.Process.SelinuxLabel
 		}

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -391,6 +391,11 @@ func TestSpecconvExampleValidate(t *testing.T) {
 		t.Errorf("Couldn't create libcontainer config: %v", err)
 	}
 
+	if config.NoNewPrivileges != spec.Process.NoNewPrivileges {
+		t.Errorf("specconv NoNewPrivileges mismatch. Expected %v got %v",
+			spec.Process.NoNewPrivileges, config.NoNewPrivileges)
+	}
+
 	validator := validate.New()
 	if err := validator.Validate(config); err != nil {
 		t.Errorf("Expected specconv to produce valid container config: %v", err)


### PR DESCRIPTION
The change ensures that the passed in value of NoNewPrivileges under spec.Process
is reflected in the container config generated by specconv.CreateLibcontainerConfig

Closes #2397

Signed-off-by: Pradyumna Agrawal <pradyumnaa@vmware.com>