### PR TITLE
Add integration tests for Oci hooks: CreateRuntime, CreateContainer and StartContainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,24 @@ RUN mkdir -p /usr/src/criu \
     && cd - \
     && rm -rf /usr/src/criu
 
+# install skopeo
+RUN echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_Unstable/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list \
+    && wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_Unstable/Release.key -O- | sudo apt-key add - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends skopeo \
+    && rm -rf /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list \
+    && apt-get clean \
+    && rm -rf /var/cache/apt /var/lib/apt/lists/*;
+
+# install umoci
+RUN go get -d github.com/openSUSE/umoci \
+    && go get -u github.com/cpuguy83/go-md2man \
+    && go get -u golang.org/x/lint/golint \
+    && go get -u github.com/securego/gosec/cmd/gosec \
+    && cd $GOPATH/src/github.com/openSUSE/umoci \
+    && make umoci \
+    && mv umoci /usr/local/bin
+
 COPY script/tmpmount /
 WORKDIR /go/src/github.com/opencontainers/runc
 ENTRYPOINT ["/tmpmount"]
@@ -81,5 +99,10 @@ ENV ROOTFS /busybox
 RUN mkdir -p "${ROOTFS}"
 RUN . tests/integration/multi-arch.bash \
     && curl -fsSL `get_busybox` | tar xfJC - "${ROOTFS}"
+
+ENV DEBIAN_ROOTFS /debian
+RUN mkdir -p "${DEBIAN_ROOTFS}"
+RUN . tests/integration/multi-arch.bash \
+    && get_and_extract_debian "$DEBIAN_ROOTFS"
 
 COPY . .

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -220,6 +220,11 @@ type Hooks struct {
 	// CreateContainer commands are called in the Container namespace.
 	CreateContainer []Hook
 
+	// StartContainer commands MUST be called as part of the start operation and before
+	// the container process is started.
+	// StartContainer commands are called in the Container namespace.
+	StartContainer []Hook
+
 	// Poststart commands are executed after the container init process starts.
 	// Poststart commands are called in the Runtime Namespace.
 	Poststart []Hook
@@ -235,6 +240,7 @@ const (
 	Prestart HookName = iota
 	CreateRuntime
 	CreateContainer
+	StartContainer
 	Poststart
 	Poststop
 )
@@ -243,6 +249,7 @@ var HookToName = map[HookName]string{
 	Prestart:        "Prestart",
 	CreateRuntime:   "CreateRuntime",
 	CreateContainer: "CreateContainer",
+	StartContainer:  "StartContainer",
 	Poststart:       "Poststart",
 	Poststop:        "Poststop",
 }
@@ -265,6 +272,7 @@ func (hooks *Hooks) RunHooks(name HookName, spec *specs.State) error {
 		Prestart:        hooks.Prestart,
 		CreateRuntime:   hooks.CreateRuntime,
 		CreateContainer: hooks.CreateContainer,
+		StartContainer:  hooks.StartContainer,
 		Poststart:       hooks.Poststart,
 		Poststop:        hooks.Poststop,
 	}
@@ -282,6 +290,7 @@ func (hooks *Hooks) UnmarshalJSON(b []byte) error {
 		Prestart        []CommandHook
 		CreateRuntime   []CommandHook
 		CreateContainer []CommandHook
+		StartContainer  []CommandHook
 		Poststart       []CommandHook
 		Poststop        []CommandHook
 	}
@@ -301,6 +310,7 @@ func (hooks *Hooks) UnmarshalJSON(b []byte) error {
 	hooks.Prestart = deserialize(state.Prestart)
 	hooks.CreateRuntime = deserialize(state.CreateRuntime)
 	hooks.CreateContainer = deserialize(state.CreateContainer)
+	hooks.StartContainer = deserialize(state.StartContainer)
 	hooks.Poststart = deserialize(state.Poststart)
 	hooks.Poststop = deserialize(state.Poststop)
 	return nil
@@ -324,6 +334,7 @@ func (hooks Hooks) MarshalJSON() ([]byte, error) {
 		"prestart":        serialize(hooks.Prestart),
 		"createRuntime":   serialize(hooks.CreateRuntime),
 		"createContainer": serialize(hooks.CreateContainer),
+		"startContainer":  serialize(hooks.StartContainer),
 		"poststart":       serialize(hooks.Poststart),
 		"poststop":        serialize(hooks.Poststop),
 	})

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -246,12 +246,12 @@ const (
 )
 
 var HookToName = map[HookName]string{
-	Prestart:        "Prestart",
-	CreateRuntime:   "CreateRuntime",
-	CreateContainer: "CreateContainer",
-	StartContainer:  "StartContainer",
-	Poststart:       "Poststart",
-	Poststop:        "Poststop",
+	Prestart:        "prestart",
+	CreateRuntime:   "createRuntime",
+	CreateContainer: "createContainer",
+	StartContainer:  "startContainer",
+	Poststart:       "poststart",
+	Poststop:        "poststop",
 }
 
 type Capabilities struct {

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -36,10 +36,11 @@ func TestUnmarshalHooks(t *testing.T) {
 		}
 
 		hooksMap := map[configs.HookName][]configs.Hook{
-			configs.Prestart:      hook.Prestart,
-			configs.CreateRuntime: hook.CreateRuntime,
-			configs.Poststart:     hook.Poststart,
-			configs.Poststop:      hook.Poststop,
+			configs.Prestart:        hook.Prestart,
+			configs.CreateRuntime:   hook.CreateRuntime,
+			configs.CreateContainer: hook.CreateContainer,
+			configs.Poststart:       hook.Poststart,
+			configs.Poststop:        hook.Poststop,
 		}
 
 		if !reflect.DeepEqual(hooksMap[hookName][0], hookCmd) {
@@ -81,7 +82,7 @@ func TestMarshalHooks(t *testing.T) {
 
 	// Note Marshal seems to output fields in alphabetical order
 	hookCmdJson := `[{"path":"/var/vcap/hooks/hook","args":["--pid=123"],"env":["FOO=BAR"],"dir":"/var/vcap","timeout":1000000000}]`
-	h := fmt.Sprintf(`{"createRuntime":%[1]s,"poststart":%[1]s,"poststop":%[1]s,"prestart":%[1]s}`, hookCmdJson)
+	h := fmt.Sprintf(`{"createContainer":null,"createRuntime":%[1]s,"poststart":%[1]s,"poststop":%[1]s,"prestart":%[1]s}`, hookCmdJson)
 	if string(hooks) != h {
 		t.Errorf("Expected hooks %s to equal %s", string(hooks), h)
 	}
@@ -131,7 +132,7 @@ func TestMarshalHooksWithUnexpectedType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := `{"createRuntime":null,"poststart":null,"poststop":null,"prestart":null}`
+	h := `{"createContainer":null,"createRuntime":null,"poststart":null,"poststop":null,"prestart":null}`
 	if string(hooks) != h {
 		t.Errorf("Expected hooks %s to equal %s", string(hooks), h)
 	}

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -39,6 +39,7 @@ func TestUnmarshalHooks(t *testing.T) {
 			configs.Prestart:        hook.Prestart,
 			configs.CreateRuntime:   hook.CreateRuntime,
 			configs.CreateContainer: hook.CreateContainer,
+			configs.StartContainer:  hook.StartContainer,
 			configs.Poststart:       hook.Poststart,
 			configs.Poststop:        hook.Poststop,
 		}
@@ -82,7 +83,7 @@ func TestMarshalHooks(t *testing.T) {
 
 	// Note Marshal seems to output fields in alphabetical order
 	hookCmdJson := `[{"path":"/var/vcap/hooks/hook","args":["--pid=123"],"env":["FOO=BAR"],"dir":"/var/vcap","timeout":1000000000}]`
-	h := fmt.Sprintf(`{"createContainer":null,"createRuntime":%[1]s,"poststart":%[1]s,"poststop":%[1]s,"prestart":%[1]s}`, hookCmdJson)
+	h := fmt.Sprintf(`{"createContainer":null,"createRuntime":%[1]s,"poststart":%[1]s,"poststop":%[1]s,"prestart":%[1]s,"startContainer":null}`, hookCmdJson)
 	if string(hooks) != h {
 		t.Errorf("Expected hooks %s to equal %s", string(hooks), h)
 	}
@@ -132,7 +133,7 @@ func TestMarshalHooksWithUnexpectedType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := `{"createContainer":null,"createRuntime":null,"poststart":null,"poststop":null,"prestart":null}`
+	h := `{"createContainer":null,"createRuntime":null,"poststart":null,"poststop":null,"prestart":null,"startContainer":null}`
 	if string(hooks) != h {
 		t.Errorf("Expected hooks %s to equal %s", string(hooks), h)
 	}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -67,6 +68,7 @@ type initConfig struct {
 	ConsoleHeight    uint16                `json:"console_height"`
 	RootlessEUID     bool                  `json:"rootless_euid,omitempty"`
 	RootlessCgroups  bool                  `json:"rootless_cgroups,omitempty"`
+	SpecState        *specs.State          `json:"spec_state,omitempty"`
 }
 
 type initer interface {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1132,9 +1132,10 @@ func TestHook(t *testing.T) {
 	}
 
 	hookFiles := map[configs.HookName]string{
-		configs.Prestart:      "prestart",
-		configs.CreateRuntime: "createRuntime",
-		configs.Poststart:     "poststart",
+		configs.Prestart:        "prestart",
+		configs.CreateRuntime:   "createRuntime",
+		configs.CreateContainer: "createContainer",
+		configs.Poststart:       "poststart",
 	}
 
 	config.Hooks = &configs.Hooks{
@@ -1152,6 +1153,12 @@ func TestHook(t *testing.T) {
 					t.Fatalf("Expected createRuntime hook bundlePath '%s'; got '%s'", expectedBundle, s.Bundle)
 				}
 				return createFileFromBundle(hookFiles[configs.CreateRuntime], s.Bundle)
+			}),
+		},
+		CreateContainer: []configs.Hook{
+			configs.NewCommandHook(configs.Command{
+				Path: "/bin/bash",
+				Args: []string{"/bin/bash", "-c", fmt.Sprintf("touch ./%s", hookFiles[configs.CreateContainer])},
 			}),
 		},
 		Poststart: []configs.Hook{

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1131,10 +1131,13 @@ func TestHook(t *testing.T) {
 		return f.Close()
 	}
 
+	// Note FunctionHooks can't be serialized to json this means they won't be passed down to the container
+	// For CreateContainer and StartContainer which run in the container namespace, this means we need to pass Command Hooks.
 	hookFiles := map[configs.HookName]string{
 		configs.Prestart:        "prestart",
 		configs.CreateRuntime:   "createRuntime",
 		configs.CreateContainer: "createContainer",
+		configs.StartContainer:  "startContainer",
 		configs.Poststart:       "poststart",
 	}
 
@@ -1159,6 +1162,12 @@ func TestHook(t *testing.T) {
 			configs.NewCommandHook(configs.Command{
 				Path: "/bin/bash",
 				Args: []string{"/bin/bash", "-c", fmt.Sprintf("touch ./%s", hookFiles[configs.CreateContainer])},
+			}),
+		},
+		StartContainer: []configs.Hook{
+			configs.NewCommandHook(configs.Command{
+				Path: "/bin/sh",
+				Args: []string{"/bin/sh", "-c", fmt.Sprintf("touch /%s", hookFiles[configs.StartContainer])},
 			}),
 		},
 		Poststart: []configs.Hook{

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -487,6 +487,15 @@ func (p *initProcess) startTime() (uint64, error) {
 }
 
 func (p *initProcess) sendConfig() error {
+	if p.config.Config.Hooks != nil {
+		s, err := p.container.currentOCIState()
+		if err != nil {
+			return err
+		}
+
+		p.config.SpecState = s
+	}
+
 	// send the config to the container's init process, we don't use JSON Encode
 	// here because there might be a problem in JSON decoder in some cases, see:
 	// https://github.com/docker/docker/issues/14203#issuecomment-174177790

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -98,6 +98,15 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 		return newSystemErrorWithCausef(err, "changing dir to %q", config.Rootfs)
 	}
 
+	s := iConfig.SpecState
+	if s != nil {
+		s.Pid = unix.Getpid()
+		s.Status = "creating"
+		if err := iConfig.Config.Hooks.RunHooks(configs.CreateContainer, s); err != nil {
+			return err
+		}
+	}
+
 	if config.NoPivotRoot {
 		err = msMoveRoot(config.Rootfs)
 	} else if config.Namespaces.Contains(configs.NEWNS) {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -896,6 +896,10 @@ func createHooks(rspec *specs.Spec, config *configs.Config) {
 			cmd := createCommandHook(h)
 			config.Hooks.Prestart = append(config.Hooks.Prestart, configs.NewCommandHook(cmd))
 		}
+		for _, h := range rspec.Hooks.CreateRuntime {
+			cmd := createCommandHook(h)
+			config.Hooks.CreateRuntime = append(config.Hooks.CreateRuntime, configs.NewCommandHook(cmd))
+		}
 		for _, h := range rspec.Hooks.Poststart {
 			cmd := createCommandHook(h)
 			config.Hooks.Poststart = append(config.Hooks.Poststart, configs.NewCommandHook(cmd))

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -900,6 +900,10 @@ func createHooks(rspec *specs.Spec, config *configs.Config) {
 			cmd := createCommandHook(h)
 			config.Hooks.CreateRuntime = append(config.Hooks.CreateRuntime, configs.NewCommandHook(cmd))
 		}
+		for _, h := range rspec.Hooks.CreateContainer {
+			cmd := createCommandHook(h)
+			config.Hooks.CreateContainer = append(config.Hooks.CreateContainer, configs.NewCommandHook(cmd))
+		}
 		for _, h := range rspec.Hooks.Poststart {
 			cmd := createCommandHook(h)
 			config.Hooks.Poststart = append(config.Hooks.Poststart, configs.NewCommandHook(cmd))

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -904,6 +904,10 @@ func createHooks(rspec *specs.Spec, config *configs.Config) {
 			cmd := createCommandHook(h)
 			config.Hooks.CreateContainer = append(config.Hooks.CreateContainer, configs.NewCommandHook(cmd))
 		}
+		for _, h := range rspec.Hooks.StartContainer {
+			cmd := createCommandHook(h)
+			config.Hooks.StartContainer = append(config.Hooks.StartContainer, configs.NewCommandHook(cmd))
+		}
 		for _, h := range rspec.Hooks.Poststart {
 			cmd := createCommandHook(h)
 			config.Hooks.Poststart = append(config.Hooks.Poststart, configs.NewCommandHook(cmd))

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -51,6 +51,15 @@ func TestCreateHooks(t *testing.T) {
 					Args: []string{"--some", "thing"},
 				},
 			},
+			CreateContainer: []specs.Hook{
+				{
+					Path: "/some/hook/path",
+				},
+				{
+					Path: "/some/hook2/path",
+					Args: []string{"--some", "thing"},
+				},
+			},
 			Poststart: []specs.Hook{
 				{
 					Path: "/some/hook/path",
@@ -96,6 +105,12 @@ func TestCreateHooks(t *testing.T) {
 
 	if len(createRuntime) != 2 {
 		t.Error("Expected 2 createRuntime hooks")
+	}
+
+	createContainer := conf.Hooks.CreateContainer
+
+	if len(createContainer) != 2 {
+		t.Error("Expected 2 createContainer hooks")
 	}
 
 	poststart := conf.Hooks.Poststart

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -60,6 +60,15 @@ func TestCreateHooks(t *testing.T) {
 					Args: []string{"--some", "thing"},
 				},
 			},
+			StartContainer: []specs.Hook{
+				{
+					Path: "/some/hook/path",
+				},
+				{
+					Path: "/some/hook2/path",
+					Args: []string{"--some", "thing"},
+				},
+			},
 			Poststart: []specs.Hook{
 				{
 					Path: "/some/hook/path",
@@ -111,6 +120,12 @@ func TestCreateHooks(t *testing.T) {
 
 	if len(createContainer) != 2 {
 		t.Error("Expected 2 createContainer hooks")
+	}
+
+	startContainer := conf.Hooks.StartContainer
+
+	if len(startContainer) != 2 {
+		t.Error("Expected 2 startContainer hooks")
 	}
 
 	poststart := conf.Hooks.Poststart

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -42,6 +42,15 @@ func TestCreateHooks(t *testing.T) {
 					Args: []string{"--some", "thing"},
 				},
 			},
+			CreateRuntime: []specs.Hook{
+				{
+					Path: "/some/hook/path",
+				},
+				{
+					Path: "/some/hook2/path",
+					Args: []string{"--some", "thing"},
+				},
+			},
 			Poststart: []specs.Hook{
 				{
 					Path: "/some/hook/path",
@@ -81,6 +90,12 @@ func TestCreateHooks(t *testing.T) {
 
 	if len(prestart) != 2 {
 		t.Error("Expected 2 Prestart hooks")
+	}
+
+	createRuntime := conf.Hooks.CreateRuntime
+
+	if len(createRuntime) != 2 {
+		t.Error("Expected 2 createRuntime hooks")
 	}
 
 	poststart := conf.Hooks.Poststart

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -206,6 +206,16 @@ func (l *linuxStandardInit) Init() error {
 			return newSystemErrorWithCause(err, "init seccomp")
 		}
 	}
+
+	s := l.config.SpecState
+	if s != nil {
+		s.Pid = unix.Getpid()
+		s.Status = "starting"
+		if err := l.config.Config.Hooks.RunHooks(configs.StartContainer, s); err != nil {
+			return err
+		}
+	}
+
 	if err := unix.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
 		return newSystemErrorWithCause(err, "exec user process")
 	}

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -61,17 +61,20 @@ func destroy(c *linuxContainer) error {
 }
 
 func runPoststopHooks(c *linuxContainer) error {
-	if c.config.Hooks != nil {
-		s, err := c.currentOCIState()
-		if err != nil {
-			return err
-		}
-		for _, hook := range c.config.Hooks.Poststop {
-			if err := hook.Run(s); err != nil {
-				return err
-			}
-		}
+	hooks := c.config.Hooks
+	if hooks == nil {
+		return nil
 	}
+
+	s, err := c.currentOCIState()
+	if err != nil {
+		return err
+	}
+
+	if err := hooks.RunHooks(configs.Poststop, s); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# CR = CreateRuntime
+# CC = CreataContainer
+HOOKLIBCR=librunc-hooks-create-runtime.so
+HOOKLIBCC=librunc-hooks-create-container.so
+LIBPATH="$DEBIAN_BUNDLE/rootfs/lib/"
+
+function setup() {
+	umount "$DEBIAN_BUNDLE/dev/runc-dev" &> /dev/null || true
+	umount $LIBPATH/$HOOKLIBCR.1.0.0 &> /dev/null || true
+	umount $LIBPATH/$HOOKLIBCC.1.0.0 &> /dev/null || true
+
+	teardown_debian
+	setup_debian
+}
+
+function teardown() {
+	umount "$DEBIAN_BUNDLE/dev/runc-dev" &> /dev/null || true
+	umount $LIBPATH/$HOOKLIBCR.1.0.0 &> /dev/null || true
+	umount $LIBPATH/$HOOKLIBCC.1.0.0 &> /dev/null || true
+
+	rm -f $HOOKLIBCR.1.0.0 $HOOKLIBCC.1.0.0
+	teardown_debian
+}
+
+@test "runc run (hooks library tests)" {
+	requires root
+
+	# setup some dummy libs
+	gcc -shared -Wl,-soname,librunc-hooks-create-runtime.so.1 -o "$HOOKLIBCR.1.0.0"
+	gcc -shared -Wl,-soname,librunc-hooks-create-container.so.1 -o "$HOOKLIBCC.1.0.0"
+
+	current_pwd="$(pwd)"
+
+	# To mount $HOOKLIBCR we need to do that in the container namespace
+	create_runtime_hook=$(cat <<-EOF
+		pid=\$(cat - | jq -r '.pid')
+		touch "$LIBPATH/$HOOKLIBCR.1.0.0"
+		nsenter -m \$ns -t \$pid mount --bind "$current_pwd/$HOOKLIBCR.1.0.0" "$LIBPATH/$HOOKLIBCR.1.0.0"
+	EOF)
+
+	create_container_hook="touch ./lib/$HOOKLIBCC.1.0.0 && mount --bind $current_pwd/$HOOKLIBCC.1.0.0 ./lib/$HOOKLIBCC.1.0.0"
+
+	CONFIG=$(jq --arg create_runtime_hook "$create_runtime_hook" --arg create_container_hook "$create_container_hook" '
+		.hooks |= . + {"createRuntime": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_runtime_hook]}]} |
+		.hooks |= . + {"createContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_container_hook]}]} |
+		.hooks |= . + {"startContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", "ldconfig"]}]} |
+		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' $DEBIAN_BUNDLE/config.json)
+	echo "${CONFIG}" > config.json
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+
+	echo "Checking create-runtime library"
+	echo $output | grep $HOOKLIBCR
+	[ "$?" -eq 0 ]
+
+	echo "Checking create-container library"
+	echo $output | grep $HOOKLIBCC
+	[ "$?" -eq 0 ]
+}
+
+@test "runc run (hooks device tests)" {
+	requires cgroups_devices
+	requires root
+
+	# setup dummy device
+	mknod "./runc-dev" c 99 99
+	current_pwd="$(pwd)"
+
+	set_cgroups_path "$DEBIAN_BUNDLE"
+
+	create_container_hook=$(cat <<-EOF
+		pid=\$(cat - | jq -r '.pid')
+		touch "./dev/runc-dev"
+		mount --bind "$current_pwd/runc-dev" "./dev/runc-dev"
+		echo "c 99:99 rwm" > "${CGROUP_DEVICES_BASE_PATH}/${OCI_CGROUPS_PATH}/devices.allow"
+	EOF)
+
+	# We expect cat /dev/runc-dev to show the error 'No such device or address' rather than 'Operation not permitted'
+	CONFIG=$(jq --arg create_container_hook "$create_container_hook" '
+		.hooks |= . + {"createContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_container_hook]}]} |
+		.process.args = ["/bin/sh", "-c", "cat /dev/runc-dev"]' $DEBIAN_BUNDLE/config.json)
+	echo "${CONFIG}" > config.json
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+
+	echo $output | grep "No such device or address"
+	[ "$?" -eq 0 ]
+}

--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-get_busybox(){
+get_busybox() {
 	case $(go env GOARCH) in
 	arm64)
 		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/glibc/busybox.tar.xz'
@@ -10,13 +10,35 @@ get_busybox(){
 	esac
 }
 
-get_hello(){
+get_hello() {
 	case $(go env GOARCH) in
-        arm64)
-                echo 'hello-world-aarch64.tar'
-        ;;
-        *)
-                echo 'hello-world.tar'
-        ;;
-        esac
+	arm64)
+		echo 'hello-world-aarch64.tar'
+	;;
+	*)
+		echo 'hello-world.tar'
+	;;
+	esac
+}
+
+get_and_extract_debian() {
+	tmp=$(mktemp -d)
+	cd "$tmp"
+
+	debian="debian:3.11.6"
+
+	case $(go env GOARCH) in
+	arm64)
+		skopeo copy docker://arm64v8/debian:buster "oci:$debian"
+	;;
+	*)
+		skopeo copy docker://amd64/debian:buster "oci:$debian"
+	;;
+	esac
+
+	args="$([ -z "${ROOTLESS_TESTPATH+x}" ] && echo "--rootless")"
+	umoci unpack $args --image "$debian" "$1"
+
+	cd -
+	rm -rf "$tmp"
 }


### PR DESCRIPTION
Hello!

This PR is a followup of https://github.com/opencontainers/runc/pull/2229
It is best reviewed by looking at the following single commit: https://github.com/opencontainers/runc/pull/2402/commits/4ec35109a304df3c197a2816ec00f03e8a756fa8
All other commits are based of the above mentioned PR.

With these integration test, I wanted to check real world scenarios, that we depend on in libnvidia-container, the two that I had in mind were the following:
1) mount a library, run ldconfig and check that it picked up these library
2) mount a device, update the cgroups and check that the container has access to that device

Unfortunately the first use case requires a more complete container than busybox, which doesn't have ldconfig, or the hello container. I ended up installing skopeo and umoci for that.

Note that at first I wanted to use alpine to keep the image small, but alpine has it's own implementation of ldconfig (10 line shell script) which doesn't support printing the libraries it has in its cache.

Let me know if you think there is an easier path than adding a new image :)!
With this last PR (and the previous merged), I think we should have unblocked runc 1.0.0!

/assign @cyphar @AkihiroSuda @mikebrow 
/cc @mrunalp @h-vetinari
