### PR TITLE
fix two swap limit regressions in cgroup v2

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -50,8 +50,11 @@ func setMemory(dirPath string, cgroup *configs.Cgroup) error {
 		// memory and memorySwap set to the same value -- disable swap
 		swapStr = "0"
 	}
-	if err := fscommon.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
-		return err
+	// never write empty string to `memory.swap.max`, it means set to 0.
+	if swapStr != "" {
+		if err := fscommon.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
+			return err
+		}
 	}
 
 	if val := numToStr(cgroup.Resources.Memory); val != "" {

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -627,12 +627,17 @@ func ConvertCPUQuotaCPUPeriodToCgroupV2Value(quota int64, period uint64) string 
 // for use by cgroup v2 drivers. A conversion is needed since Resources.MemorySwap
 // is defined as memory+swap combined, while in cgroup v2 swap is a separate value.
 func ConvertMemorySwapToCgroupV2Value(memorySwap, memory int64) (int64, error) {
+	// If the memory update is set to -1 we should also
+	// set swap to -1, it means unlimited memory.
+	if memory == -1 {
+		return -1, nil
+	}
 	if memorySwap == -1 || memorySwap == 0 {
 		// -1 is "max", 0 is "unset", so treat as is
 		return memorySwap, nil
 	}
 	// sanity checks
-	if memory == 0 || memory == -1 {
+	if memory == 0 {
 		return 0, errors.New("unable to set swap limit without memory limit")
 	}
 	if memory < 0 {

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -588,9 +588,9 @@ func TestConvertMemorySwapToCgroupV2Value(t *testing.T) {
 			expErr:  true,
 		},
 		{
-			memswap: 300,
-			memory:  -1,
-			expErr:  true,
+			memswap:  300,
+			memory:   -1,
+			expected: -1,
 		},
 	}
 

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -75,7 +75,7 @@ EOF
         SYSTEM_MEM="max"
         SYSTEM_MEM_SWAP="max"
         # checking swap is currently disabled for v2
-        #CGROUP_MEMORY=$CGROUP_PATH
+        CGROUP_MEMORY=$CGROUP_PATH
         ;;
     esac
 
@@ -133,9 +133,22 @@ EOF
         check_cgroup_value "$MEM_SWAP" $SYSTEM_MEM_SWAP
 
         # update memory swap
-        runc update test_update --memory-swap 96468992
+        runc update test_update --memory 50M --memory-swap 96468992
         [ "$status" -eq 0 ]
-        check_cgroup_value "$MEM_SWAP" 96468992
+        if [ "$CGROUP_UNIFIED" != "yes" ]; then
+            check_cgroup_value "$MEM_SWAP" 96468992
+        else
+            check_cgroup_value "$MEM_SWAP" 44040192
+        fi
+        
+        # check we don't set swap to 0
+        runc update test_update --memory 50M
+        [ "$status" -eq 0 ]
+        if [ "$CGROUP_UNIFIED" != "yes" ]; then
+            check_cgroup_value "$MEM_SWAP" 96468992
+        else
+            check_cgroup_value "$MEM_SWAP" 44040192
+        fi
     fi
 
     # try to remove memory limit


### PR DESCRIPTION
(1) never write empty string to memory.swap.max
Because the empty string means set swap to 0.

fixed by #2410 

For example:
with memory limit:
```
"memory": {
        "limit": 33554432,
        "swap": 33558528
 }
```
The value of `memory.swap.max` is 4096.
After we run `runc update --memory 33554432 test`, the value of `memory.swap.max` becomes 0.

(2) If the memory update is set to -1 we should also set swap to -1, it means unlimited memory.

Signed-off-by: lifubang <lifubang@acmcoder.com>