### PR TITLE
cgroupv2: never write empty string to memory.swap.max

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -50,8 +50,11 @@ func setMemory(dirPath string, cgroup *configs.Cgroup) error {
 		// memory and memorySwap set to the same value -- disable swap
 		swapStr = "0"
 	}
-	if err := fscommon.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
-		return err
+	// never write empty string to `memory.swap.max`, it means set to 0.
+	if swapStr != "" {
+		if err := fscommon.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
+			return err
+		}
 	}
 
 	if val := numToStr(cgroup.Resources.Memory); val != "" {


### PR DESCRIPTION
Never write empty string to memory.swap.max
Because the empty string means set swap to 0.

For example:
with memory limit:
```
"memory": {
        "limit": 33554432,
        "swap": 33558528
 }
```
The value of `memory.swap.max` is 4096.
After we run `runc update --memory 33554432 test`, the value of `memory.swap.max` becomes 0.
This is a regression introduced by #2370 . I'm so sorry.

Signed-off-by: lifubang <lifubang@acmcoder.com>