### PR TITLE
use lazy-pages ready notification for criu >= 3.15

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1575,23 +1575,24 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 	if notify == nil {
 		return fmt.Errorf("invalid response: %s", resp.String())
 	}
-	logrus.Debugf("notify: %s\n", notify.GetScript())
-	switch {
-	case notify.GetScript() == "post-dump":
+	script := notify.GetScript()
+	logrus.Debugf("notify: %s\n", script)
+	switch script {
+	case "post-dump":
 		f, err := os.Create(filepath.Join(c.root, "checkpoint"))
 		if err != nil {
 			return err
 		}
 		f.Close()
-	case notify.GetScript() == "network-unlock":
+	case "network-unlock":
 		if err := unlockNetwork(c.config); err != nil {
 			return err
 		}
-	case notify.GetScript() == "network-lock":
+	case "network-lock":
 		if err := lockNetwork(c.config); err != nil {
 			return err
 		}
-	case notify.GetScript() == "setup-namespaces":
+	case "setup-namespaces":
 		if c.config.Hooks != nil {
 			s, err := c.currentOCIState()
 			if err != nil {
@@ -1604,7 +1605,7 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 				}
 			}
 		}
-	case notify.GetScript() == "post-restore":
+	case "post-restore":
 		pid := notify.GetPid()
 
 		p, err := os.FindProcess(int(pid))
@@ -1634,7 +1635,7 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 				logrus.Error(err)
 			}
 		}
-	case notify.GetScript() == "orphan-pts-master":
+	case "orphan-pts-master":
 		scm, err := unix.ParseSocketControlMessage(oob)
 		if err != nil {
 			return err


### PR DESCRIPTION
_~~NOTE: this builds on top of and currently includes #2341. Will rebase once that one is merged. The commit to review is the last one.~~ Rebased_
  
This relies on https://github.com/checkpoint-restore/criu/pull/1069 (which ~~is not merged yet!~~ was recently merged)
and emulates the previous behavior by writing `\0` and closing status
fd (as it was done by criu).
