### PR TITLE
cgroup2: exec: join the cgroup of the init process on EBUSY

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -566,6 +566,7 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, messageSockP
 		config:          c.newInitConfig(p),
 		process:         p,
 		bootstrapData:   data,
+		initProcessPid:  state.InitProcessPid,
 	}, nil
 }
 

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -55,12 +55,7 @@ function teardown() {
 @test "runc delete --force in cgroupv2 with subcgroups" {
   requires cgroups_v2 root
   set_cgroups_path "$BUSYBOX_BUNDLE"
-
-  # grant `rw` priviledge to `/sys/fs/cgroup`
-  cat "${BUSYBOX_BUNDLE}/config.json"\
-   | jq '.mounts |= map((select(.type=="cgroup") | .options -= ["ro"]) // .)'\
-   > "${BUSYBOX_BUNDLE}/config.json.tmp"
-  mv "${BUSYBOX_BUNDLE}/config.json"{.tmp,}
+  set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
 
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -197,6 +197,15 @@ function set_resources_limit() {
   sed -i 's/\("linux": {\)/\1\n   "resources": { "pids": { "limit": 100 } },/'  "$bundle/config.json"
 }
 
+# Helper function to make /sys/fs/cgroup writable
+function set_cgroup_mount_writable() {
+	bundle="${1:-.}"
+	cat "$bundle/config.json" \
+        |  jq '.mounts |= map((select(.type == "cgroup") | .options -= ["ro"]) // .)' \
+		>"$bundle/config.json.tmp"
+	mv "$bundle/config.json"{.tmp,}
+}
+
 # Fails the current test, providing the error given.
 function fail() {
 	echo "$@" >&2


### PR DESCRIPTION
Fix #2356.

~~Contains https://github.com/opencontainers/runc/pull/2418~~

- - -

Note: this behavior is different from crun v0.13.
crun joins "crun-exec` group rather than the init group: https://github.com/containers/crun/commit/af1080b175cac63fe1c42397bfe3cca982a93896
The next version of crun will switch to the init cgroup: https://github.com/containers/crun/pull/365