### PR TITLE
Remove "-buildmode=pie" from platforms that don't support it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,12 @@ VERSION := $(shell cat ./VERSION)
 ifneq ($(GO111MODULE),off)
 	MOD_VENDOR := "-mod=vendor"
 endif
-GO_BUILD := $(GO) build $(MOD_VENDOR) -buildmode=pie $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
+ifeq ($(shell $(GO) env GOOS),linux)
+	ifeq (,$(filter $(shell $(GO) env GOARCH),mips mipsle mips64 mips64le ppc64))
+		GO_BUILDMODE := "-buildmode=pie"
+	endif
+endif
+GO_BUILD := $(GO) build $(MOD_VENDOR) $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
 	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build $(MOD_VENDOR) $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
 	-ldflags "-w -extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"


### PR DESCRIPTION
This sequence (and syntax) is taken directly from containerd's Makefile:
https://github.com/containerd/containerd/blob/4e08c2de67ec514b5602eea47804d41dfeabdc72/Makefile.linux#L21-L26