### PR TITLE
Cpu quota fixes

### DIFF
--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -14,24 +14,29 @@ import (
 )
 
 func isCpuSet(cgroup *configs.Cgroup) bool {
-	return cgroup.Resources.CpuWeight != 0 || cgroup.Resources.CpuMax != ""
+	return cgroup.Resources.CpuWeight != 0 || cgroup.Resources.CpuQuota != 0 || cgroup.Resources.CpuPeriod != 0
 }
 
 func setCpu(dirPath string, cgroup *configs.Cgroup) error {
 	if !isCpuSet(cgroup) {
 		return nil
 	}
+	r := cgroup.Resources
 
 	// NOTE: .CpuShares is not used here. Conversion is the caller's responsibility.
-	if cgroup.Resources.CpuWeight != 0 {
-		if err := fscommon.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(cgroup.Resources.CpuWeight, 10)); err != nil {
+	if r.CpuWeight != 0 {
+		if err := fscommon.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(r.CpuWeight, 10)); err != nil {
 			return err
 		}
 	}
 
-	// NOTE: .CpuQuota and .CpuPeriod are not used here. Conversion is the caller's responsibility.
-	if cgroup.Resources.CpuMax != "" {
-		if err := fscommon.WriteFile(dirPath, "cpu.max", cgroup.Resources.CpuMax); err != nil {
+	if r.CpuQuota != 0 {
+		str := "max"
+		if r.CpuQuota > 0 {
+			str = strconv.FormatInt(r.CpuQuota, 10)
+		}
+		str += " " + strconv.FormatUint(r.CpuPeriod, 10)
+		if err := fscommon.WriteFile(dirPath, "cpu.max", str); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -99,9 +99,6 @@ func genV1ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			if r.CpuQuota == 0 || r.CpuPeriod == 0 {
 				return nil, errors.New("CPU quota and period should both be set")
 			}
-			if r.CpuPeriod < 0 {
-				return nil, fmt.Errorf("Invalid CPU period value: %d", r.CpuPeriod)
-			}
 		}
 		// corresponds to USEC_INFINITY in systemd
 		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -4,9 +4,7 @@ package systemd
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,32 +88,8 @@ func genV1ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("CPUShares", r.CpuShares))
 	}
 
-	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
-	if r.CpuQuota != 0 || r.CpuPeriod != 0 {
-		if r.CpuQuota < -1 {
-			return nil, fmt.Errorf("Invalid CPU quota value: %d", r.CpuQuota)
-		}
-		if r.CpuQuota != -1 {
-			if r.CpuQuota == 0 || r.CpuPeriod == 0 {
-				return nil, errors.New("CPU quota and period should both be set")
-			}
-		}
-		// corresponds to USEC_INFINITY in systemd
-		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
-		// always setting a property value ensures we can apply a quota and remove it later
-		cpuQuotaPerSecUSec := uint64(math.MaxUint64)
-		if r.CpuQuota > 0 {
-			// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
-			// (integer percentage of CPU) internally.  This means that if a fractional percent of
-			// CPU is indicated by r.CpuQuota, we need to round up to the nearest
-			// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
-			cpuQuotaPerSecUSec = uint64(r.CpuQuota*1000000) / r.CpuPeriod
-			if cpuQuotaPerSecUSec%10000 != 0 {
-				cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
-			}
-		}
-		properties = append(properties,
-			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
+	if err := addCpuQuota(&properties, r); err != nil {
+		return nil, err
 	}
 
 	if r.BlkioWeight != 0 {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -3,7 +3,6 @@
 package systemd
 
 import (
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -73,24 +72,8 @@ func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("CPUWeight", r.CpuWeight))
 	}
 
-	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
-	if r.CpuQuota != 0 && r.CpuPeriod != 0 {
-		// corresponds to USEC_INFINITY in systemd
-		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
-		// always setting a property value ensures we can apply a quota and remove it later
-		cpuQuotaPerSecUSec := uint64(math.MaxUint64)
-		if r.CpuQuota > 0 {
-			// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
-			// (integer percentage of CPU) internally.  This means that if a fractional percent of
-			// CPU is indicated by r.CpuQuota, we need to round up to the nearest
-			// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
-			cpuQuotaPerSecUSec = uint64(r.CpuQuota*1000000) / r.CpuPeriod
-			if cpuQuotaPerSecUSec%10000 != 0 {
-				cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
-			}
-		}
-		properties = append(properties,
-			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
+	if err := addCpuQuota(&properties, r); err != nil {
+		return nil, err
 	}
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -37,28 +37,29 @@ func NewUnifiedManager(config *configs.Cgroup, path string, rootless bool) cgrou
 
 func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
+	r := c.Resources
 
 	// NOTE: This is of questionable correctness because we insert our own
 	//       devices eBPF program later. Two programs with identical rules
 	//       aren't the end of the world, but it is a bit concerning. However
 	//       it's unclear if systemd removes all eBPF programs attached when
 	//       doing SetUnitProperties...
-	deviceProperties, err := generateDeviceProperties(c.Resources.Devices)
+	deviceProperties, err := generateDeviceProperties(r.Devices)
 	if err != nil {
 		return nil, err
 	}
 	properties = append(properties, deviceProperties...)
 
-	if c.Resources.Memory != 0 {
+	if r.Memory != 0 {
 		properties = append(properties,
-			newProp("MemoryMax", uint64(c.Resources.Memory)))
+			newProp("MemoryMax", uint64(r.Memory)))
 	}
-	if c.Resources.MemoryReservation != 0 {
+	if r.MemoryReservation != 0 {
 		properties = append(properties,
-			newProp("MemoryLow", uint64(c.Resources.MemoryReservation)))
+			newProp("MemoryLow", uint64(r.MemoryReservation)))
 	}
 
-	swap, err := cgroups.ConvertMemorySwapToCgroupV2Value(c.Resources.MemorySwap, c.Resources.Memory)
+	swap, err := cgroups.ConvertMemorySwapToCgroupV2Value(r.MemorySwap, r.Memory)
 	if err != nil {
 		return nil, err
 	}
@@ -67,23 +68,23 @@ func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("MemorySwapMax", uint64(swap)))
 	}
 
-	if c.Resources.CpuWeight != 0 {
+	if r.CpuWeight != 0 {
 		properties = append(properties,
-			newProp("CPUWeight", c.Resources.CpuWeight))
+			newProp("CPUWeight", r.CpuWeight))
 	}
 
 	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
-	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
+	if r.CpuQuota != 0 && r.CpuPeriod != 0 {
 		// corresponds to USEC_INFINITY in systemd
 		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
 		// always setting a property value ensures we can apply a quota and remove it later
 		cpuQuotaPerSecUSec := uint64(math.MaxUint64)
-		if c.Resources.CpuQuota > 0 {
+		if r.CpuQuota > 0 {
 			// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
 			// (integer percentage of CPU) internally.  This means that if a fractional percent of
-			// CPU is indicated by Resources.CpuQuota, we need to round up to the nearest
+			// CPU is indicated by r.CpuQuota, we need to round up to the nearest
 			// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
-			cpuQuotaPerSecUSec = uint64(c.Resources.CpuQuota*1000000) / c.Resources.CpuPeriod
+			cpuQuotaPerSecUSec = uint64(r.CpuQuota*1000000) / r.CpuPeriod
 			if cpuQuotaPerSecUSec%10000 != 0 {
 				cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
 			}
@@ -92,13 +93,13 @@ func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
 	}
 
-	if c.Resources.PidsLimit > 0 || c.Resources.PidsLimit == -1 {
+	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
 			newProp("TasksAccounting", true),
-			newProp("TasksMax", uint64(c.Resources.PidsLimit)))
+			newProp("TasksMax", uint64(r.PidsLimit)))
 	}
 
-	// ignore c.Resources.KernelMemory
+	// ignore r.KernelMemory
 
 	return properties, nil
 }

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -598,10 +598,6 @@ func ConvertCPUQuotaCPUPeriodToCgroupV2Value(quota int64, period uint64) string 
 	if quota <= 0 && period == 0 {
 		return ""
 	}
-	if period == 0 {
-		// This default value is documented in https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
-		period = 100000
-	}
 	if quota <= 0 {
 		return fmt.Sprintf("max %d", period)
 	}

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -593,17 +593,6 @@ func ConvertCPUSharesToCgroupV2Value(cpuShares uint64) uint64 {
 	return (1 + ((cpuShares-2)*9999)/262142)
 }
 
-// ConvertCPUQuotaCPUPeriodToCgroupV2Value generates cpu.max string.
-func ConvertCPUQuotaCPUPeriodToCgroupV2Value(quota int64, period uint64) string {
-	if quota <= 0 && period == 0 {
-		return ""
-	}
-	if quota <= 0 {
-		return fmt.Sprintf("max %d", period)
-	}
-	return fmt.Sprintf("%d %d", quota, period)
-}
-
 // ConvertMemorySwapToCgroupV2Value converts MemorySwap value from OCI spec
 // for use by cgroup v2 drivers. A conversion is needed since Resources.MemorySwap
 // is defined as memory+swap combined, while in cgroup v2 swap is a separate value.

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -457,46 +457,6 @@ func TestConvertCPUSharesToCgroupV2Value(t *testing.T) {
 	}
 }
 
-func TestConvertCPUQuotaCPUPeriodToCgroupV2Value(t *testing.T) {
-	cases := []struct {
-		quota    int64
-		period   uint64
-		expected string
-	}{
-		{
-			quota:    0,
-			period:   0,
-			expected: "",
-		},
-		{
-			quota:    -1,
-			period:   0,
-			expected: "",
-		},
-		{
-			quota:    1000,
-			period:   5000,
-			expected: "1000 5000",
-		},
-		{
-			quota:    0,
-			period:   5000,
-			expected: "max 5000",
-		},
-		{
-			quota:    -1,
-			period:   5000,
-			expected: "max 5000",
-		},
-	}
-	for _, c := range cases {
-		got := ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.quota, c.period)
-		if got != c.expected {
-			t.Errorf("expected ConvertCPUQuotaCPUPeriodToCgroupV2Value(%d, %d) to be %s, got %s", c.quota, c.period, c.expected, got)
-		}
-	}
-}
-
 func TestConvertMemorySwapToCgroupV2Value(t *testing.T) {
 	cases := []struct {
 		memswap, memory int64

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -488,11 +488,6 @@ func TestConvertCPUQuotaCPUPeriodToCgroupV2Value(t *testing.T) {
 			period:   5000,
 			expected: "max 5000",
 		},
-		{
-			quota:    1000,
-			period:   0,
-			expected: "1000 100000",
-		},
 	}
 	for _, c := range cases {
 		got := ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.quota, c.period)

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -126,7 +126,4 @@ type Resources struct {
 
 	// CpuWeight sets a proportional bandwidth limit.
 	CpuWeight uint64 `json:"cpu_weight"`
-
-	// CpuMax sets she maximum bandwidth limit (format: max period).
-	CpuMax string `json:"cpu_max"`
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -542,6 +542,9 @@ func ConvertResources(r *specs.LinuxResources, c *configs.Resources) error {
 		}
 		if r.CPU.Period != nil {
 			c.CpuPeriod = *r.CPU.Period
+			if r.CPU.Quota == nil {
+				return errors.New("can not set CpuPeriod without setting CpuQuota")
+			}
 		}
 		if r.CPU.Quota != nil {
 			c.CpuQuota = *r.CPU.Quota

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -555,8 +555,6 @@ func ConvertResources(r *specs.LinuxResources, c *configs.Resources) error {
 				c.CpuPeriod = 100000
 			}
 		}
-		//CpuMax is used for cgroupv2 and should be converted
-		c.CpuMax = cgroups.ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.CpuQuota, c.CpuPeriod)
 
 		if r.CPU.RealtimeRuntime != nil {
 			c.CpuRtRuntime = *r.CPU.RealtimeRuntime

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -540,11 +540,17 @@ func ConvertResources(r *specs.LinuxResources, c *configs.Resources) error {
 			//CpuWeight is used for cgroupv2 and should be converted
 			c.CpuWeight = cgroups.ConvertCPUSharesToCgroupV2Value(c.CpuShares)
 		}
-		if r.CPU.Quota != nil {
-			c.CpuQuota = *r.CPU.Quota
-		}
 		if r.CPU.Period != nil {
 			c.CpuPeriod = *r.CPU.Period
+		}
+		if r.CPU.Quota != nil {
+			c.CpuQuota = *r.CPU.Quota
+			if c.CpuPeriod == 0 {
+				// assume the default kernel value of 100000 us (100 ms) as per
+				// https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html and
+				// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
+				c.CpuPeriod = 100000
+			}
 		}
 		//CpuMax is used for cgroupv2 and should be converted
 		c.CpuMax = cgroups.ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.CpuQuota, c.CpuPeriod)

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -269,25 +269,22 @@ EOF
     check_cgroup_value "cpu.shares" 100
     check_systemd_value "CPUShares" 100
 
-    # systemd driver does not allow to update quota and period separately
-    if [ -z "$RUNC_USE_SYSTEMD" ]; then
-        # update cpu period
-        runc update test_update --cpu-period 900000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_period_us" 900000
+    # updating cpu period alone is not allowed
+    runc update test_update --cpu-period 900000
+    [ "$status" -eq 1 ]
 
-        # update cpu quota
-        runc update test_update --cpu-quota 600000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_quota_us" 600000
-    else
-        # update cpu quota and period together
-        runc update test_update --cpu-period 900000 --cpu-quota 600000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_period_us" 900000
-        check_cgroup_value "cpu.cfs_quota_us" 600000
-        check_systemd_value "CPUQuotaPerSecUSec" 670ms
-    fi
+    # update cpu quota
+    runc update test_update --cpu-quota 600000
+    [ "$status" -eq 0 ]
+    check_cgroup_value "cpu.cfs_quota_us" 600000
+    check_systemd_value "CPUQuotaPerSecUSec" 600ms
+
+    # update cpu quota and period together
+    runc update test_update --cpu-period 900000 --cpu-quota 600000
+    [ "$status" -eq 0 ]
+    check_cgroup_value "cpu.cfs_period_us" 900000
+    check_cgroup_value "cpu.cfs_quota_us" 600000
+    check_systemd_value "CPUQuotaPerSecUSec" 670ms
 
     # update cpu-shares
     runc update test_update --cpu-share 200

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -281,13 +281,6 @@ EOF
         [ "$status" -eq 0 ]
         check_cgroup_value "cpu.cfs_quota_us" 600000
     else
-        # update cpu quota
-        runc update test_update --cpu-quota 600000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_quota_us" 600000
-        # this is currently broken
-        #check_systemd_value "CPUQuotaPerSecUSec" 600ms
-
         # update cpu quota and period together
         runc update test_update --cpu-period 900000 --cpu-quota 600000
         [ "$status" -eq 0 ]

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -253,47 +253,66 @@ EOF
     check_systemd_value "TasksMax" 20
 }
 
-@test "update cgroup v1 cpu limits" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    requires cgroups_v1
+function check_cpu_quota() {
+	local quota=$1
+	local period=$2
+	local sd_quota=$3
 
-    # run a few busyboxes detached
-    runc run -d --console-socket $CONSOLE_SOCKET test_update
-    [ "$status" -eq 0 ]
+	if [ "$CGROUP_UNIFIED" = "yes" ]; then
+		check_cgroup_value "cpu.max" "$quota $period"
+		check_systemd_value "CPUQuotaPerSecUSec" $sd_quota
+	else
+		check_cgroup_value "cpu.cfs_quota_us" $quota
+		check_cgroup_value "cpu.cfs_period_us" $period
+		# no systemd support in v1
+	fi
+}
 
-    # check that initial values were properly set
-    check_cgroup_value "cpu.cfs_period_us" 1000000
-    check_cgroup_value "cpu.cfs_quota_us" 500000
-    check_systemd_value "CPUQuotaPerSecUSec" 500ms
+function check_cpu_shares() {
+	local shares=$1
 
-    check_cgroup_value "cpu.shares" 100
-    check_systemd_value "CPUShares" 100
+	if [ "$CGROUP_UNIFIED" = "yes" ]; then
+		local weight=$((1 + ((shares - 2) * 9999) / 262142))
+		check_cgroup_value "cpu.weight" $weight
+		check_systemd_value "CPUWeight" $weight
+	else
+		check_cgroup_value "cpu.shares" $shares
+		check_systemd_value "CPUShares" $shares
+	fi
+}
 
-    # updating cpu period alone is not allowed
-    runc update test_update --cpu-period 900000
-    [ "$status" -eq 1 ]
+@test "update cgroup cpu limits" {
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    # update cpu quota
-    runc update test_update --cpu-quota 600000
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_quota_us" 600000
-    check_systemd_value "CPUQuotaPerSecUSec" 600ms
+	# run a few busyboxes detached
+	runc run -d --console-socket $CONSOLE_SOCKET test_update
+	[ "$status" -eq 0 ]
 
-    # update cpu quota and period together
-    runc update test_update --cpu-period 900000 --cpu-quota 600000
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_period_us" 900000
-    check_cgroup_value "cpu.cfs_quota_us" 600000
-    check_systemd_value "CPUQuotaPerSecUSec" 670ms
+	# check that initial values were properly set
+	check_cpu_quota 500000 1000000 "500ms"
+	check_cpu_shares 100
 
-    # update cpu-shares
-    runc update test_update --cpu-share 200
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.shares" 200
-    check_systemd_value "CPUShares" 200
+	# updating cpu period alone is not allowed
+	runc update test_update --cpu-period 900000
+	[ "$status" -eq 1 ]
 
-    # Revert to the test initial value via json on stding
-    runc update  -r - test_update <<EOF
+	# update cpu quota
+	runc update test_update --cpu-quota 600000
+	[ "$status" -eq 0 ]
+	check_cpu_quota 600000 1000000 "600ms"
+
+	# update cpu quota and period together
+	runc update test_update --cpu-period 900000 --cpu-quota 600000
+	[ "$status" -eq 0 ]
+	check_cpu_quota 600000 900000 "670ms"
+
+	# update cpu-shares
+	runc update test_update --cpu-share 200
+	[ "$status" -eq 0 ]
+	check_cpu_shares 200
+
+	# Revert to the test initial value via json on stding
+	runc update -r - test_update <<EOF
 {
   "cpu": {
     "shares": 100,
@@ -302,27 +321,19 @@ EOF
   }
 }
 EOF
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_period_us" 1000000
-    check_cgroup_value "cpu.cfs_quota_us" 500000
-    check_systemd_value "CPUQuotaPerSecUSec" 500ms
+	[ "$status" -eq 0 ]
+	check_cpu_quota 500000 1000000 "500ms"
+	check_cpu_shares 100
 
-    check_cgroup_value "cpu.shares" 100
-    check_systemd_value "CPUShares" 100
+	# redo all the changes at once
+	runc update test_update \
+		--cpu-period 900000 --cpu-quota 600000 --cpu-share 200
+	[ "$status" -eq 0 ]
+	check_cpu_quota 600000 900000 "670ms"
+	check_cpu_shares 200
 
-    # redo all the changes at once
-    runc update test_update \
-        --cpu-period 900000 --cpu-quota 600000 --cpu-share 200
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_period_us" 900000
-    check_cgroup_value "cpu.cfs_quota_us" 600000
-    check_systemd_value "CPUQuotaPerSecUSec" 670ms
-
-    check_cgroup_value "cpu.shares" 200
-    check_systemd_value "CPUShares" 200
-
-    # reset to initial test value via json file
-    cat << EOF > $BATS_TMPDIR/runc-cgroups-integration-test.json
+	# reset to initial test value via json file
+	cat << EOF > $BATS_TMPDIR/runc-cgroups-integration-test.json
 {
   "cpu": {
     "shares": 100,
@@ -332,14 +343,10 @@ EOF
 }
 EOF
 
-    runc update  -r $BATS_TMPDIR/runc-cgroups-integration-test.json test_update
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_period_us" 1000000
-    check_cgroup_value "cpu.cfs_quota_us" 500000
-    check_systemd_value "CPUQuotaPerSecUSec" 500ms
-
-    check_cgroup_value "cpu.shares" 100
-    check_systemd_value "CPUShares" 100
+	runc update -r $BATS_TMPDIR/runc-cgroups-integration-test.json test_update
+	[ "$status" -eq 0 ]
+	check_cpu_quota 500000 1000000 "500ms"
+	check_cpu_shares 100
 }
 
 @test "update rt period and runtime" {


### PR DESCRIPTION
This fixes a few bugs wrt setting cpu quota, including a recent regression, adds more tests for cpu quota, and (hopefully) simplifies the code handling all this.

The bugs being fixed are:

1. The regression introduced by commit 06d7c1d2616052974e (PR #2423), which made
   it impossible to only set CpuQuota (without the CpuPeriod). Reported by @haircommander
    
2. ~~The discrepancy in how various cgroup drivers interpret the case of
       missing CpuPeriod. Before this, the fs2 driver assumed the default,
       while the fs driver assumed the previously set value. Now the
       behavior is the same.~~ I was wrong, all drivers assume previously set value.

3. An invalid configuration (CpuPeriod set without CpuQuota) was not rejected
  by some drivers.

4. The fs2 driver ignored `--cpu-quota=-1` when CpuPeriod was not set.

The test cases added are

1. CPU quota/period/weight/shares tests **for cgroup v2** :tada:

2. Unlimited CPU quota test. 