### PR TITLE
cgroupv1: minimal fix for cpu quota regression

### DIFF
--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -4,7 +4,6 @@ package systemd
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"math"
 	"os"
@@ -90,18 +89,7 @@ func genV1ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 	}
 
 	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
-	if c.Resources.CpuQuota != 0 || c.Resources.CpuPeriod != 0 {
-		if c.Resources.CpuQuota < -1 {
-			return nil, fmt.Errorf("Invalid CPU quota value: %d", c.Resources.CpuQuota)
-		}
-		if c.Resources.CpuQuota != -1 {
-			if c.Resources.CpuQuota == 0 || c.Resources.CpuPeriod == 0 {
-				return nil, errors.New("CPU quota and period should both be set")
-			}
-			if c.Resources.CpuPeriod < 0 {
-				return nil, fmt.Errorf("Invalid CPU period value: %d", c.Resources.CpuPeriod)
-			}
-		}
+	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
 		// corresponds to USEC_INFINITY in systemd
 		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
 		// always setting a property value ensures we can apply a quota and remove it later

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -281,6 +281,13 @@ EOF
         [ "$status" -eq 0 ]
         check_cgroup_value "cpu.cfs_quota_us" 600000
     else
+        # update cpu quota
+        runc update test_update --cpu-quota 600000
+        [ "$status" -eq 0 ]
+        check_cgroup_value "cpu.cfs_quota_us" 600000
+        # this is currently broken
+        #check_systemd_value "CPUQuotaPerSecUSec" 600ms
+
         # update cpu quota and period together
         runc update test_update --cpu-period 900000 --cpu-quota 600000
         [ "$status" -eq 0 ]


### PR DESCRIPTION
This is a quick-n-dirty fix the regression introduced by commit
06d7c1d (in PR #2423), which made it impossible to only set CpuQuota
(without the CpuPeriod). It partially reverts the above commit,
and adds a test case.

The proper fix is in #2428.