### PR TITLE
[DO NOT MERGE] cgroup v1: optimize code to avoid parsing mountinfo if possible

### DIFF
--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -74,10 +74,6 @@ func (s *BlkioGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *BlkioGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("blkio"))
-}
-
 /*
 examples:
 

--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -22,12 +22,8 @@ func (s *BlkioGroup) Name() string {
 	return "blkio"
 }
 
-func (s *BlkioGroup) Apply(d *cgroupData) error {
-	_, err := d.join("blkio")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+func (s *BlkioGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *BlkioGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -21,17 +21,7 @@ func (s *CpuGroup) Name() string {
 	return "cpu"
 }
 
-func (s *CpuGroup) Apply(d *cgroupData) error {
-	// We always want to join the cpu group, to allow fair cpu scheduling
-	// on a container basis
-	path, err := d.path("cpu")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return s.ApplyDir(path, d.config, d.pid)
-}
-
-func (s *CpuGroup) ApplyDir(path string, cgroup *configs.Cgroup, pid int) error {
+func (s *CpuGroup) Apply(path string, d *cgroupData) error {
 	// This might happen if we have no cpu cgroup mounted.
 	// Just do nothing and don't fail.
 	if path == "" {
@@ -43,12 +33,12 @@ func (s *CpuGroup) ApplyDir(path string, cgroup *configs.Cgroup, pid int) error 
 	// We should set the real-Time group scheduling settings before moving
 	// in the process because if the process is already in SCHED_RR mode
 	// and no RT bandwidth is set, adding it will fail.
-	if err := s.SetRtSched(path, cgroup); err != nil {
+	if err := s.SetRtSched(path, d.config); err != nil {
 		return err
 	}
-	// because we are not using d.join we need to place the pid into the procs file
-	// unlike the other subsystems
-	return cgroups.WriteCgroupProc(path, pid)
+	// Since we are not using join(), we need to place the pid
+	// into the procs file unlike other subsystems.
+	return cgroups.WriteCgroupProc(path, d.pid)
 }
 
 func (s *CpuGroup) SetRtSched(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -96,10 +96,6 @@ func (s *CpuGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return s.SetRtSched(path, cgroup)
 }
 
-func (s *CpuGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("cpu"))
-}
-
 func (s *CpuGroup) GetStats(path string, stats *cgroups.Stats) error {
 	f, err := os.Open(filepath.Join(path, "cpu.stat"))
 	if err != nil {

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -182,7 +182,9 @@ func TestCpuSetRtSchedAtApply(t *testing.T) {
 	helper.CgroupData.config.Resources.CpuRtRuntime = rtRuntimeAfter
 	helper.CgroupData.config.Resources.CpuRtPeriod = rtPeriodAfter
 	cpu := &CpuGroup{}
-	if err := cpu.ApplyDir(helper.CgroupPath, helper.CgroupData.config, 1234); err != nil {
+
+	helper.CgroupData.pid = 1234
+	if err := cpu.Apply(helper.CgroupPath, helper.CgroupData); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -53,10 +53,6 @@ func (s *CpuacctGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *CpuacctGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("cpuacct"))
-}
-
 func (s *CpuacctGroup) GetStats(path string, stats *cgroups.Stats) error {
 	userModeUsage, kernelModeUsage, err := getCpuUsageBreakdown(path)
 	if err != nil {

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -40,13 +40,8 @@ func (s *CpuacctGroup) Name() string {
 	return "cpuacct"
 }
 
-func (s *CpuacctGroup) Apply(d *cgroupData) error {
-	// we just want to join this group even though we don't set anything
-	if _, err := d.join("cpuacct"); err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-
-	return nil
+func (s *CpuacctGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *CpuacctGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -45,10 +45,6 @@ func (s *CpusetGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *CpusetGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("cpuset"))
-}
-
 func (s *CpusetGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -23,12 +23,8 @@ func (s *CpusetGroup) Name() string {
 	return "cpuset"
 }
 
-func (s *CpusetGroup) Apply(d *cgroupData) error {
-	dir, err := d.path("cpuset")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return s.ApplyDir(dir, d.config, d.pid)
+func (s *CpusetGroup) Apply(path string, d *cgroupData) error {
+	return s.ApplyDir(path, d.config, d.pid)
 }
 
 func (s *CpusetGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -103,10 +103,6 @@ func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *DevicesGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("devices"))
-}
-
 func (s *DevicesGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -22,14 +22,13 @@ func (s *DevicesGroup) Name() string {
 	return "devices"
 }
 
-func (s *DevicesGroup) Apply(d *cgroupData) error {
-	_, err := d.join("devices")
-	if err != nil {
-		// We will return error even it's `not found` error, devices
-		// cgroup is hard requirement for container's security.
-		return err
+func (s *DevicesGroup) Apply(path string, d *cgroupData) error {
+	if path == "" {
+		// Return error here, since devices cgroup
+		// is a hard requirement for container's security.
+		return errSubsystemDoesNotExist
 	}
-	return nil
+	return join(path, d.pid)
 }
 
 func loadEmulator(path string) (*devices.Emulator, error) {

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -61,10 +61,6 @@ func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *FreezerGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("freezer"))
-}
-
 func (s *FreezerGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -22,12 +22,8 @@ func (s *FreezerGroup) Name() string {
 	return "freezer"
 }
 
-func (s *FreezerGroup) Apply(d *cgroupData) error {
-	_, err := d.join("freezer")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+func (s *FreezerGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *FreezerGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -305,10 +305,7 @@ func (m *manager) Freeze(state configs.FreezerState) (Err error) {
 		}
 	}()
 
-	freezer, err := subsystems.Get("freezer")
-	if err != nil {
-		return err
-	}
+	freezer := &FreezerGroup{}
 	if err := freezer.Set(path, m.cgroups); err != nil {
 		return err
 	}
@@ -407,13 +404,12 @@ func (m *manager) GetCgroups() (*configs.Cgroup, error) {
 
 func (m *manager) GetFreezerState() (configs.FreezerState, error) {
 	dir := m.Path("freezer")
-	freezer, err := subsystems.Get("freezer")
-
 	// If the container doesn't have the freezer cgroup, say it's undefined.
-	if err != nil || dir == "" {
+	if dir == "" {
 		return configs.Undefined, nil
 	}
-	return freezer.(*FreezerGroup).GetState(dir)
+	freezer := &FreezerGroup{}
+	return freezer.GetState(dir)
 }
 
 func (m *manager) Exists() bool {

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -291,7 +291,7 @@ func (m *manager) Set(container *configs.Config) error {
 
 // Freeze toggles the container's freezer cgroup depending on the state
 // provided
-func (m *manager) Freeze(state configs.FreezerState) (Err error) {
+func (m *manager) Freeze(state configs.FreezerState) error {
 	path := m.Path("freezer")
 	if m.cgroups == nil || path == "" {
 		return errors.New("cannot toggle freezer: cgroups not configured for container")
@@ -299,14 +299,9 @@ func (m *manager) Freeze(state configs.FreezerState) (Err error) {
 
 	prevState := m.cgroups.Resources.Freezer
 	m.cgroups.Resources.Freezer = state
-	defer func() {
-		if Err != nil {
-			m.cgroups.Resources.Freezer = prevState
-		}
-	}()
-
 	freezer := &FreezerGroup{}
 	if err := freezer.Set(path, m.cgroups); err != nil {
+		m.cgroups.Resources.Freezer = prevState
 		return err
 	}
 	return nil

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -354,14 +354,14 @@ func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
 }
 
 func (raw *cgroupData) path(subsystem string) (string, error) {
-	mnt, err := cgroups.FindCgroupMountpoint(raw.root, subsystem)
-	// If we didn't mount the subsystem, there is no point we make the path.
-	if err != nil {
-		return "", err
-	}
-
 	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
 	if filepath.IsAbs(raw.innerPath) {
+		mnt, err := cgroups.FindCgroupMountpoint(raw.root, subsystem)
+		// If we didn't mount the subsystem, there is no point we make the path.
+		if err != nil {
+			return "", err
+		}
+
 		// Sometimes subsystems can be mounted together as 'cpu,cpuacct'.
 		return filepath.Join(raw.root, filepath.Base(mnt), raw.innerPath), nil
 	}

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -54,8 +54,6 @@ type subsystem interface {
 	Name() string
 	// Returns the stats, as 'stats', corresponding to the cgroup under 'path'.
 	GetStats(path string, stats *cgroups.Stats) error
-	// Removes the cgroup represented by 'cgroupData'.
-	Remove(*cgroupData) error
 	// Creates and joins the cgroup represented by 'cgroupData'.
 	Apply(*cgroupData) error
 	// Set the cgroup represented by cgroup.

--- a/libcontainer/cgroups/fs/fs_test.go
+++ b/libcontainer/cgroups/fs/fs_test.go
@@ -16,11 +16,6 @@ func TestInvalidCgroupPath(t *testing.T) {
 		t.Skip("cgroup v2 is not supported")
 	}
 
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Fatalf("couldn't get cgroup root: %v", err)
-	}
-
 	testCases := []struct {
 		test               string
 		path, name, parent string
@@ -80,7 +75,7 @@ func TestInvalidCgroupPath(t *testing.T) {
 			}
 
 			// Double-check, using an actual cgroup.
-			deviceRoot := filepath.Join(root, "devices")
+			deviceRoot := filepath.Join(cgroupRoot, "devices")
 			devicePath, err := data.path("devices")
 			if err != nil {
 				t.Fatalf("couldn't get cgroup path: %v", err)

--- a/libcontainer/cgroups/fs/fs_test.go
+++ b/libcontainer/cgroups/fs/fs_test.go
@@ -15,283 +15,79 @@ func TestInvalidCgroupPath(t *testing.T) {
 	if cgroups.IsCgroup2UnifiedMode() {
 		t.Skip("cgroup v2 is not supported")
 	}
+
 	root, err := getCgroupRoot()
 	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
+		t.Fatalf("couldn't get cgroup root: %v", err)
 	}
 
-	config := &configs.Cgroup{
-		Path: "../../../../../../../../../../some/path",
+	testCases := []struct {
+		test               string
+		path, name, parent string
+	}{
+		{
+			test: "invalid cgroup path",
+			path: "../../../../../../../../../../some/path",
+		},
+		{
+			test: "invalid absolute cgroup path",
+			path: "/../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid cgroup parent",
+			parent: "../../../../../../../../../../some/path",
+			name:   "name",
+		},
+		{
+			test:   "invalid absolute cgroup parent",
+			parent: "/../../../../../../../../../../some/path",
+			name:   "name",
+		},
+		{
+			test:   "invalid cgroup name",
+			parent: "parent",
+			name:   "../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid absolute cgroup name",
+			parent: "parent",
+			name:   "/../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid cgroup name and parent",
+			parent: "../../../../../../../../../../some/path",
+			name:   "../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid absolute cgroup name and parent",
+			parent: "/../../../../../../../../../../some/path",
+			name:   "/../../../../../../../../../../some/path",
+		},
 	}
 
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			config := &configs.Cgroup{Path: tc.path, Name: tc.name, Parent: tc.parent}
 
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
+			data, err := getCgroupData(config, 0)
+			if err != nil {
+				t.Fatalf("couldn't get cgroup data: %v", err)
+			}
 
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-	}
-}
+			// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
+			if strings.HasPrefix(data.innerPath, "..") {
+				t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
+			}
 
-func TestInvalidAbsoluteCgroupPath(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
-	}
-
-	config := &configs.Cgroup{
-		Path: "/../../../../../../../../../../some/path",
-	}
-
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
-
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
-
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-	}
-}
-
-// XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
-func TestInvalidCgroupParent(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
-	}
-
-	config := &configs.Cgroup{
-		Parent: "../../../../../../../../../../some/path",
-		Name:   "name",
-	}
-
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
-
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
-
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-	}
-}
-
-// XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
-func TestInvalidAbsoluteCgroupParent(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
-	}
-
-	config := &configs.Cgroup{
-		Parent: "/../../../../../../../../../../some/path",
-		Name:   "name",
-	}
-
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
-
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
-
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-	}
-}
-
-// XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
-func TestInvalidCgroupName(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
-	}
-
-	config := &configs.Cgroup{
-		Parent: "parent",
-		Name:   "../../../../../../../../../../some/path",
-	}
-
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
-
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
-
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-	}
-
-}
-
-// XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
-func TestInvalidAbsoluteCgroupName(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
-	}
-
-	config := &configs.Cgroup{
-		Parent: "parent",
-		Name:   "/../../../../../../../../../../some/path",
-	}
-
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
-
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
-
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-	}
-}
-
-// XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
-func TestInvalidCgroupNameAndParent(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
-	}
-
-	config := &configs.Cgroup{
-		Parent: "../../../../../../../../../../some/path",
-		Name:   "../../../../../../../../../../some/path",
-	}
-
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
-
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
-
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-	}
-}
-
-// XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
-func TestInvalidAbsoluteCgroupNameAndParent(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Errorf("couldn't get cgroup root: %v", err)
-	}
-
-	config := &configs.Cgroup{
-		Parent: "/../../../../../../../../../../some/path",
-		Name:   "/../../../../../../../../../../some/path",
-	}
-
-	data, err := getCgroupData(config, 0)
-	if err != nil {
-		t.Errorf("couldn't get cgroup data: %v", err)
-	}
-
-	// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-	if strings.HasPrefix(data.innerPath, "..") {
-		t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-	}
-
-	// Double-check, using an actual cgroup.
-	deviceRoot := filepath.Join(root, "devices")
-	devicePath, err := data.path("devices")
-	if err != nil {
-		t.Errorf("couldn't get cgroup path: %v", err)
-	}
-	if !strings.HasPrefix(devicePath, deviceRoot) {
-		t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
+			// Double-check, using an actual cgroup.
+			deviceRoot := filepath.Join(root, "devices")
+			devicePath, err := data.path("devices")
+			if err != nil {
+				t.Fatalf("couldn't get cgroup path: %v", err)
+			}
+			if !strings.HasPrefix(devicePath, deviceRoot) {
+				t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
+			}
+		})
 	}
 }

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -19,12 +19,8 @@ func (s *HugetlbGroup) Name() string {
 	return "hugetlb"
 }
 
-func (s *HugetlbGroup) Apply(d *cgroupData) error {
-	_, err := d.join("hugetlb")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+func (s *HugetlbGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *HugetlbGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -37,10 +37,6 @@ func (s *HugetlbGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *HugetlbGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("hugetlb"))
-}
-
 func (s *HugetlbGroup) GetStats(path string, stats *cgroups.Stats) error {
 	hugetlbStats := cgroups.HugetlbStats{}
 	for _, pageSize := range HugePageSizes {

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -165,10 +165,6 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *MemoryGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("memory"))
-}
-
 func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
 	// Set stats from memory.stat.
 	statsFile, err := os.Open(filepath.Join(path, "memory.stat"))

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -37,11 +37,8 @@ func (s *MemoryGroup) Name() string {
 	return "memory"
 }
 
-func (s *MemoryGroup) Apply(d *cgroupData) (err error) {
-	path, err := d.path("memory")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	} else if path == "" {
+func (s *MemoryGroup) Apply(path string, d *cgroupData) (err error) {
+	if path == "" {
 		return nil
 	}
 	if memoryAssigned(d.config) {
@@ -66,11 +63,7 @@ func (s *MemoryGroup) Apply(d *cgroupData) (err error) {
 
 	// We need to join memory cgroup after set memory limits, because
 	// kmem.limit_in_bytes can only be set when the cgroup is empty.
-	_, err = d.join("memory")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+	return join(path, d.pid)
 }
 
 func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -28,13 +28,6 @@ func (s *NameGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *NameGroup) Remove(d *cgroupData) error {
-	if s.Join {
-		removePath(d.path(s.GroupName))
-	}
-	return nil
-}
-
 func (s *NameGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -16,10 +16,10 @@ func (s *NameGroup) Name() string {
 	return s.GroupName
 }
 
-func (s *NameGroup) Apply(d *cgroupData) error {
+func (s *NameGroup) Apply(path string, d *cgroupData) error {
 	if s.Join {
 		// ignore errors if the named cgroup does not exist
-		d.join(s.GroupName)
+		join(path, d.pid)
 	}
 	return nil
 }

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -35,10 +35,6 @@ func (s *NetClsGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *NetClsGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("net_cls"))
-}
-
 func (s *NetClsGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -17,12 +17,8 @@ func (s *NetClsGroup) Name() string {
 	return "net_cls"
 }
 
-func (s *NetClsGroup) Apply(d *cgroupData) error {
-	_, err := d.join("net_cls")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+func (s *NetClsGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *NetClsGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -33,10 +33,6 @@ func (s *NetPrioGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *NetPrioGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("net_prio"))
-}
-
 func (s *NetPrioGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -15,12 +15,8 @@ func (s *NetPrioGroup) Name() string {
 	return "net_prio"
 }
 
-func (s *NetPrioGroup) Apply(d *cgroupData) error {
-	_, err := d.join("net_prio")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+func (s *NetPrioGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *NetPrioGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/perf_event.go
+++ b/libcontainer/cgroups/fs/perf_event.go
@@ -14,12 +14,8 @@ func (s *PerfEventGroup) Name() string {
 	return "perf_event"
 }
 
-func (s *PerfEventGroup) Apply(d *cgroupData) error {
-	// we just want to join this group even though we don't set anything
-	if _, err := d.join("perf_event"); err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+func (s *PerfEventGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *PerfEventGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/perf_event.go
+++ b/libcontainer/cgroups/fs/perf_event.go
@@ -26,10 +26,6 @@ func (s *PerfEventGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *PerfEventGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("perf_event"))
-}
-
 func (s *PerfEventGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -44,10 +44,6 @@ func (s *PidsGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
-func (s *PidsGroup) Remove(d *cgroupData) error {
-	return removePath(d.path("pids"))
-}
-
 func (s *PidsGroup) GetStats(path string, stats *cgroups.Stats) error {
 	current, err := fscommon.GetCgroupParamUint(path, "pids.current")
 	if err != nil {

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -19,12 +19,8 @@ func (s *PidsGroup) Name() string {
 	return "pids"
 }
 
-func (s *PidsGroup) Apply(d *cgroupData) error {
-	_, err := d.join("pids")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
-	}
-	return nil
+func (s *PidsGroup) Apply(path string, d *cgroupData) error {
+	return join(path, d.pid)
 }
 
 func (s *PidsGroup) Set(path string, cgroup *configs.Cgroup) error {

--- a/libcontainer/cgroups/fs/util_test.go
+++ b/libcontainer/cgroups/fs/util_test.go
@@ -39,8 +39,7 @@ func NewCgroupTestUtil(subsystem string, t *testing.T) *cgroupTestUtil {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.root = tempDir
-	testCgroupPath := filepath.Join(d.root, subsystem)
+	testCgroupPath := filepath.Join(tempDir, subsystem)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -41,18 +41,7 @@ type subsystem interface {
 
 var errSubsystemDoesNotExist = errors.New("cgroup: subsystem does not exist")
 
-type subsystemSet []subsystem
-
-func (s subsystemSet) Get(name string) (subsystem, error) {
-	for _, ss := range s {
-		if ss.Name() == name {
-			return ss, nil
-		}
-	}
-	return nil, errSubsystemDoesNotExist
-}
-
-var legacySubsystems = subsystemSet{
+var legacySubsystems = []subsystem{
 	&fs.CpusetGroup{},
 	&fs.DevicesGroup{},
 	&fs.MemoryGroup{},
@@ -330,9 +319,9 @@ func (m *legacyManager) GetStats() (*cgroups.Stats, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	stats := cgroups.NewStats()
-	for name, path := range m.paths {
-		sys, err := legacySubsystems.Get(name)
-		if err == errSubsystemDoesNotExist || !cgroups.PathExists(path) {
+	for _, sys := range legacySubsystems {
+		path := m.paths[sys.Name()]
+		if path == "" {
 			continue
 		}
 		if err := sys.GetStats(path, stats); err != nil {

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -301,11 +301,8 @@ func (m *legacyManager) Freeze(state configs.FreezerState) error {
 	}
 	prevState := m.cgroups.Resources.Freezer
 	m.cgroups.Resources.Freezer = state
-	freezer, err := legacySubsystems.Get("freezer")
-	if err != nil {
-		return err
-	}
-	err = freezer.Set(path, m.cgroups)
+	freezer := &fs.FreezerGroup{}
+	err := freezer.Set(path, m.cgroups)
 	if err != nil {
 		m.cgroups.Resources.Freezer = prevState
 		return err
@@ -441,11 +438,8 @@ func (m *legacyManager) GetFreezerState() (configs.FreezerState, error) {
 	if !ok {
 		return configs.Undefined, nil
 	}
-	freezer, err := legacySubsystems.Get("freezer")
-	if err != nil {
-		return configs.Undefined, err
-	}
-	return freezer.(*fs.FreezerGroup).GetState(path)
+	freezer := &fs.FreezerGroup{}
+	return freezer.GetState(path)
 }
 
 func (m *legacyManager) Exists() bool {

--- a/libcontainer/cgroups/v1_utils.go
+++ b/libcontainer/cgroups/v1_utils.go
@@ -8,6 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"golang.org/x/sys/unix"
 )
 
 // Code in this source file are specific to cgroup v1,
@@ -19,6 +23,8 @@ const (
 
 var (
 	errUnified = errors.New("not implemented for cgroup v2 unified hierarchy")
+
+	defaultPrefix = "/sys/fs/cgroup"
 )
 
 type NotFoundError struct {
@@ -43,11 +49,59 @@ func IsNotFound(err error) bool {
 	return ok
 }
 
+func tryDefaultPath(cgroupPath, subsystem string) string {
+	if !strings.HasPrefix(defaultPrefix, cgroupPath) {
+		return ""
+	}
+
+	// remove possible prefix
+	subsystem = strings.TrimPrefix(subsystem, CgroupNamePrefix)
+
+	// Make sure we're still under defaultPrefix, and resolve
+	// a possible symlink (like cpu -> cpu,cpuacct).
+	path, err := securejoin.SecureJoin(defaultPrefix, subsystem)
+	if err != nil {
+		return ""
+	}
+
+	// (1) path should be a directory.
+	st, err := os.Lstat(path)
+	if err != nil || !st.IsDir() {
+		return ""
+	}
+
+	// (2) path should be a mount point.
+	pst, err := os.Lstat(filepath.Dir(path))
+	if err != nil {
+		return ""
+	}
+
+	if st.Sys().(*syscall.Stat_t).Dev == pst.Sys().(*syscall.Stat_t).Dev {
+		// parent dir has the same dev -- path is not a mount point
+		return ""
+	}
+
+	// (3) path should have 'cgroup' fs type.
+	fst := unix.Statfs_t{}
+	err = unix.Statfs(path, &fst)
+	if err != nil || fst.Type != unix.CGROUP_SUPER_MAGIC {
+		return ""
+	}
+
+	return path
+}
+
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
 func FindCgroupMountpoint(cgroupPath, subsystem string) (string, error) {
 	if IsCgroup2UnifiedMode() {
 		return "", errUnified
 	}
+
+	// Avoid parsing mountinfo by trying the default path first, if possible.
+	if path := tryDefaultPath(cgroupPath, subsystem); path != "" {
+		return path, nil
+	}
+
 	mnt, _, err := FindCgroupMountpointAndRoot(cgroupPath, subsystem)
 	return mnt, err
 }
@@ -57,9 +111,7 @@ func FindCgroupMountpointAndRoot(cgroupPath, subsystem string) (string, string, 
 		return "", "", errUnified
 	}
 
-	// We are not using mount.GetMounts() because it's super-inefficient,
-	// parsing it directly sped up x10 times because of not using Sscanf.
-	// It was one of two major performance drawbacks in container start.
+	// Avoid parsing mountinfo by checking if subsystem is valid/available
 	if !isSubsystemAvailable(subsystem) {
 		return "", "", NewNotFoundError(subsystem)
 	}


### PR DESCRIPTION
This set of patches brings down a number of times we parse /proc/self/mountinfo during container start+stop:

* with systemd: from 76 (49 after #2446) to 6 times.
* without systemd: from 116 (59 after #2446) to 16.

(there is some improvement for other operations as well but I haven't measured those)

Ideally I'd like to bring it down to less than 5 per runc run, but this is already a super good improvement.

**Update**: this is being splitted into multiple smaller PRs to facilitate easier reviewing. The following list is just for my convenience to make sure I haven't forgot anything.

- [x] cgroupv1/FindCgroupMountpoint: add a fast path | commit 38ab3b2 | PR #2499
- [x] cgroupv1/Apply: do not overuse path/getSubsystemPath | commit 89bd4c1 | PR #2494
- [x] cgroupv1/systemd: rework Apply/joinCgroups | commit 6f6c72d | PR #2494
- [x] cgroupv1/systemd: (re)use m.paths | commit 55c1ce2 | PR #2494
- [x] cgroups/fs: rm getSubsystems | commit db45ce7 | PR #2498
- [x] cgroups/fs/path: optimize | commit c7147ed | PR #2495
- [x] cgroups/fs: rm Remove method from controllers | commit 7ce1857 | PR #2498
- [x] cgroup/fs: rework Apply() | commit 576d617 | PR #2500
- [x] cgroupv1/freezer: don't use subsystemSet.Get() | commit 0bb5f5c | PR #2496
- [x] cgroups/fs/Freeze: simplify | commit cffb553 | PR #2496
- [x] cgroupv1: remove subsystemSet.Get() | commit 44a02d2 | PR #2498
- [x] cgroups/fs tests: unify TestInvalidXXXCgroupXXX | commit f78b570 | PR #2497
- [x] cgroup/fs: remove getCgroupRoot | commit 5aef675 | PR #2497

And here is the list of PRs this one was split into:
- [x] #2494 cgroups/v1: optimize path usage
- [x] #2495 libct/cgroups/fs: simple optimization
- [x] #2496 libct/cgroups/fs: simplify/speedup freezer code
- [x] #2497 libct/cgroups/fs: rm getCgroupRoot (or the alternative: #2507)
- [x] #2498 libct/cgroups/fs: code cleanups
- [x] #2499 cgroupv1/FindCgroupMountpoint: add a fast path
- [x] #2500 libct/cgroups/fs: rework Apply()