### PR TITLE
integration tests fixes for no swap ctrl case

### DIFF
--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -112,11 +112,11 @@ function teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "events oom " {
+@test "events oom" {
   # XXX: currently cgroups require root containers.
-  requires root
+  requires root cgroups_swap
   init_cgroup_paths
-  
+
   # we need the container to hit OOM, so disable swap
   # ("swap" here is actually memory+swap)
   DATA=$(cat <<EOF

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -257,6 +257,12 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		cgroups_swap)
+			init_cgroup_paths
+			if [ $CGROUP_UNIFIED = "no" -a ! -e "${CGROUP_MEMORY_BASE_PATH}/memory.memsw.limit_in_bytes" ]; then
+				skip_me=1
+			fi
+			;;
 		cgroups_v1)
 			init_cgroup_paths
 			if [ "$CGROUP_UNIFIED" != "no" ]; then

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -69,6 +69,10 @@ EOF
         MEM_SWAP="memory.memsw.limit_in_bytes"
         SD_MEM_SWAP="unsupported"
         SYSTEM_MEM=$(cat "${CGROUP_MEMORY_BASE_PATH}/${MEM_LIMIT}")
+        HAVE_SWAP="no"
+        if [ -f "${CGROUP_MEMORY_BASE_PATH}/${MEM_SWAP}" ]; then
+            HAVE_SWAP="yes"
+        fi
         ;;
     yes)
         MEM_LIMIT="memory.max"
@@ -78,7 +82,7 @@ EOF
         MEM_SWAP="memory.swap.max"
         SD_MEM_SWAP="MemorySwapMax"
         SYSTEM_MEM="max"
-        CGROUP_MEMORY=$CGROUP_PATH
+        HAVE_SWAP="yes"
         ;;
     esac
     SD_UNLIMITED="infinity"
@@ -124,7 +128,7 @@ EOF
     check_systemd_value "$SD_MEM_RESERVE" 33554432
 
     # Run swap memory tests if swap is available
-    if [ -f "$CGROUP_MEMORY/$MEM_SWAP" ]; then
+    if [ "$HAVE_SWAP" = "yes" ]; then
         # try to remove memory swap limit
         runc update test_update --memory-swap -1
         [ "$status" -eq 0 ]
@@ -156,7 +160,7 @@ EOF
     check_systemd_value $SD_MEM_LIMIT $SD_UNLIMITED
 
     # check swap memory limited is gone
-    if [ -f "$CGROUP_MEMORY/$MEM_SWAP" ]; then
+    if [ "$HAVE_SWAP" = "yes" ]; then
         check_cgroup_value $MEM_SWAP $SYSTEM_MEM
         check_systemd_value "$SD_MEM_SWAP" $SD_UNLIMITED
     fi

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -69,7 +69,6 @@ EOF
         MEM_SWAP="memory.memsw.limit_in_bytes"
         SD_MEM_SWAP="unsupported"
         SYSTEM_MEM=$(cat "${CGROUP_MEMORY_BASE_PATH}/${MEM_LIMIT}")
-        SYSTEM_MEM_SWAP=$(cat "${CGROUP_MEMORY_BASE_PATH}/$MEM_SWAP")
         ;;
     yes)
         MEM_LIMIT="memory.max"
@@ -79,7 +78,6 @@ EOF
         MEM_SWAP="memory.swap.max"
         SD_MEM_SWAP="MemorySwapMax"
         SYSTEM_MEM="max"
-        SYSTEM_MEM_SWAP="max"
         CGROUP_MEMORY=$CGROUP_PATH
         ;;
     esac
@@ -130,7 +128,7 @@ EOF
         # try to remove memory swap limit
         runc update test_update --memory-swap -1
         [ "$status" -eq 0 ]
-        check_cgroup_value "$MEM_SWAP" $SYSTEM_MEM_SWAP
+        check_cgroup_value "$MEM_SWAP" $SYSTEM_MEM
         check_systemd_value "$SD_MEM_SWAP" $SD_UNLIMITED
 
         # update memory swap


### PR DESCRIPTION
I ran the integration tests on an Ubuntu 19.04 host. To my surprise, I got two failures that this PR addresses. Both are caused by the fact that the memory.memsw control is turned off by default in Ubuntu 19.04 kernel (you need to add `swapaccount=1` to enable it).

The fixes are:

### 1. tests/int/update: fix for no swap case
    
In case memory+swap cgroup control is not available, the test case fails:

```    
# not ok 78 update cgroup v1/v2 common limits
# (in test file tests/integration/update.bats, line 72)
#   `SYSTEM_MEM_SWAP=$(cat "${CGROUP_MEMORY_BASE_PATH}/$MEM_SWAP")' failed
```
    
The fix is to reuse `SYSTEM_MEM` since the "unlimited" value is the same for mem and mem+swap.

### 2. Simplify mem+swap presence check

For v2, mem+swap is always present. For v1, check it once and set a
variable which is used below.

This also removes CGROUP_MEMORY for v2 case since it's no longer used.

### 3. tests/int/events: skip oom test if no swap
  
In case swap cgroup control is not available, the "event oom" test gives
the following error:

```
# not ok 30 events oom
# (in test file tests/integration/events.bats, line 134)
#   `[ "$status" -eq 0 ]' failed
# <....>
# runc run -d --console-socket /tmp/console.sock test_busybox (status=1):
# time="2020-05-29T02:10:20Z" level=warning msg="signal: killed"
# time="2020-05-29T02:10:20Z" level=error msg="container_linux.go:353: starting container process caused: process_linux.go:437: container init caused: process_linux.go:403: setting cgroup config for procHooks process caused: failed to write \"33554432\" to \"/sys/fs/cgroup/memory/test_busybox/memory.memsw.limit_in_bytes\": open /sys/fs/cgroup/memory/test_busybox/memory.memsw.limit_in_bytes: permission denied"
```

When I try to run the test without setting the swap limit, the shell
process is still getting killed, but the test hangs. I am not sure what
the reason is, but realistically this test is hard to perform without
the swap limit, so let's require cgroup swap for it.
