### PR TITLE
Replace sed with jq for more readable json manipulation in tests

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -21,15 +21,7 @@ function setup() {
     set_cgroups_path "$BUSYBOX_BUNDLE"
 
     # Set some initial known values
-    DATA=$(cat <<-EOF
-    "memory": {
-        "kernel": 16777216,
-        "kernelTCP": 11534336
-    },
-EOF
-    )
-    DATA=$(echo ${DATA} | sed 's/\n/\\n/g')
-    sed -i "s/\(\"resources\": {\)/\1\n${DATA}/" ${BUSYBOX_BUNDLE}/config.json
+    update_config '.linux.resources.memory |= {"kernel": 16777216, "kernelTCP": 11534336}' ${BUSYBOX_BUNDLE}
 
     # run a detached busybox to work with
     runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_kmem

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -118,16 +118,7 @@ function teardown() {
   init_cgroup_paths
   
   # we need the container to hit OOM, so disable swap
-  # ("swap" here is actually memory+swap)
-  DATA=$(cat <<EOF
-  "memory": {
-    "limit": 33554432,
-    "swap": 33554432
-  },
-EOF
-  )
-  DATA=$(echo ${DATA} | sed 's/\n/\\n/g')
-  sed -i "s/\(\"resources\": {\)/\1\n${DATA}/" ${BUSYBOX_BUNDLE}/config.json
+  update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}' ${BUSYBOX_BUNDLE}
 
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -11,7 +11,7 @@ function setup() {
 	echo "Forbidden information!" > rootfs/testfile
 
 	# add extra masked paths
-	sed -i 's;"maskedPaths": \[;"maskedPaths": \["/testdir","/testfile",;g' config.json
+	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir", "/testfile"]' 
 }
 
 function teardown() {

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -12,8 +12,8 @@ function teardown() {
 }
 
 @test "runc run [bind mount]" {
-	CONFIG=$(jq '.mounts |= . + [{"source": ".", "destination": "/tmp/bind", "options": ["bind"]}] | .process.args = ["ls", "/tmp/bind/config.json"]' config.json)
-	echo "${CONFIG}" >config.json
+	update_config 	' .mounts += [{"source": ".", "destination": "/tmp/bind", "options": ["bind"]}] 
+			| .process.args |= ["ls", "/tmp/bind/config.json"]' 
 
 	runc run test_bind_mount
 	[ "$status" -eq 0 ]

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -37,7 +37,7 @@ function teardown() {
   [[ "${output}" == *"sh"* ]]
 
   # change the default args parameter from sh to hello
-  sed -i 's;"sh";"/hello";' config.json
+  update_config '(.. | select(.? == "sh")) |= "/hello"'
 
   # ensure the generated spec works by running hello-world
   runc run test_hello
@@ -58,7 +58,7 @@ function teardown() {
   [ -e "$HELLO_BUNDLE"/config.json ]
 
   # change the default args parameter from sh to hello
-  sed -i 's;"sh";"/hello";' "$HELLO_BUNDLE"/config.json
+  update_config '(.. | select(.? == "sh")) |= "/hello"' $HELLO_BUNDLE
 
   # ensure the generated spec works by running hello-world
   runc run --bundle "$HELLO_BUNDLE" test_hello

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -26,8 +26,8 @@ function teardown() {
 
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.
-  sed -i 's;"uid": 0;"uid": 1000;g' config.json
-  sed -i 's;"gid": 0;"gid": 100;g' config.json
+  update_config ' (.. | select(.uid? == 0)) .uid |= 1000
+		| (.. | select(.gid? == 0)) .gid |= 100' 
 
   # run busybox detached
   runc run -d --console-socket $CONSOLE_SOCKET test_busybox

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -26,8 +26,8 @@ function teardown() {
 
   # replace "uid": 0 with "uid": 1000
   # and do a similar thing for gid.
-  sed -i 's;"uid": 0;"uid": 1000;g' config.json
-  sed -i 's;"gid": 0;"gid": 100;g' config.json
+  update_config ' (.. | select(.uid? == 0)) .uid |= 1000	
+		| (.. | select(.gid? == 0)) .gid |= 100' 
 
   # run hello-world
   runc run test_hello
@@ -41,7 +41,7 @@ function teardown() {
   cp config.json rootfs/.
   rm config.json
   cd rootfs
-  sed -i 's;"rootfs";".";' config.json
+  update_config '(.. | select(. == "rootfs")) |= "."'
 
   # run hello-world
   runc run test_hello

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -16,28 +16,9 @@ function setup() {
     set_cgroups_path "$BUSYBOX_BUNDLE"
 
     # Set some initial known values
-    DATA=$(cat <<EOF
-    "memory": {
-        "limit": 33554432,
-        "reservation": 25165824
-    },
-    "cpu": {
-        "shares": 100,
-        "quota": 500000,
-        "period": 1000000,
-        "cpus": "0"
-    },
-    "pids": {
-        "limit": 20
-    }
-EOF
-    )
-    DATA=$(echo ${DATA} | sed 's/\n/\\n/g')
-    if grep -qw \"resources\" ${BUSYBOX_BUNDLE}/config.json; then
-        sed -i "s/\(\"resources\": {\)/\1\n${DATA},/" ${BUSYBOX_BUNDLE}/config.json
-    else
-        sed -i "s/\(\"linux\": {\)/\1\n\"resources\": {${DATA}},/" ${BUSYBOX_BUNDLE}/config.json
-    fi
+    update_config 	' .linux.resources.memory |= {"limit": 33554432, "reservation": 25165824}
+			| .linux.resources.cpu |= {"shares": 100, "quota": 500000, "period": 1000000, "cpus": "0"}
+			| .linux.resources.pids |= {"limit": 20}' ${BUSYBOX_BUNDLE}
 }
 
 # Tests whatever limits are (more or less) common between cgroup
@@ -321,8 +302,7 @@ EOF
     # Run a basic shell script that tries to write to /dev/null. If "runc
     # update" makes use of minimal transition rules, updates should not cause
     # writes to fail at any point.
-    jq '.process.args = ["sh", "-c", "while true; do echo >/dev/null; done"]' config.json > config.json.tmp
-    mv config.json{.tmp,}
+    update_config '.process.args |= ["sh", "-c", "while true; do echo >/dev/null; done"]' 
 
     # Set up a temporary console socket and recvtty so we can get the stdio.
     TMP_RECVTTY_DIR="$(mktemp -d "$BATS_TMPDIR/runc-tmp-recvtty.XXXXXX")"


### PR DESCRIPTION
Signed-off-by: John Hwang <John.F.Hwang@gmail.com>

Replaced sed in /tests/integration with jq for json manipulation.

An assumption I made in this refactor is that order of elements in an array doesn't matter. 

Also, I translated a few lines literally because I'm unsure of the nature of config.json.
ex) there is a recursive search for the key "gid" and "uid" because I'm unsure of whether they occur on multiple lines of a config.json, or just at the .process.user field.

Closes #2417