### PR TITLE
(*initProcess).start: rm second Apply

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -346,16 +346,7 @@ func (p *initProcess) start() (retErr error) {
 		return newSystemErrorWithCausef(err, "getting pipe fds for pid %d", childPid)
 	}
 	p.setExternalDescriptors(fds)
-	// Do this before syncing with child so that no children
-	// can escape the cgroup
-	if err := p.manager.Apply(childPid); err != nil {
-		return newSystemErrorWithCause(err, "applying cgroup configuration for process")
-	}
-	if p.intelRdtManager != nil {
-		if err := p.intelRdtManager.Apply(childPid); err != nil {
-			return newSystemErrorWithCause(err, "applying Intel RDT configuration for process")
-		}
-	}
+
 	// Now it's time to setup cgroup namesapce
 	if p.config.Config.Namespaces.Contains(configs.NEWCGROUP) && p.config.Config.Namespaces.PathOf(configs.NEWCGROUP) == "" {
 		if _, err := p.messageSockPair.parent.Write([]byte{createCgroupns}); err != nil {


### PR DESCRIPTION
Commit df3fa115f adds a second call to cgroupManager.Apply() method in
order to add a second pid to the cgroup.

While I admit I don't understand the reason why it was added
(even after reading #1916, #1184, and #1884), it seems that
going through all the steps (configure cgroup parameters, figure
out paths to all controllers, create a systemd unit) twice is excessive
and should not be done.

More to say, even merely adding the child pid to the same cgroup seems
redundant, as we added the parent pid to the cgroup before sending the
data to the child (runc init process), and it waits for the data before
doing clone(), so its children will be in the same cgroup anyway.

Needs a very careful review.