### PR TITLE
rootless: allow /dev/{tty,ptmx} to be present in linux.devices

### DIFF
--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -231,3 +231,10 @@ EOF
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
 }
+
+@test "runc run [tty and ptmx in devices (#2450)]" {
+	update_config '.process.terminal=true | .process.args=["true"] | .linux.devices = [{"path":"/dev/tty","type":"c","major":5,"minor":0,"fileMode":8630},{"path":"/dev/ptmx","type":"c","major":5,"minor":2,"fileMode":8630}]'
+	# run busybox
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Fix #2450

Previously, rootless runc was failing when `.linux.devices` contains an entry for either `/dev/tty` or `/dev/ptmx`.

`/dev/tty`: `ENXIO` (no such device or address)
```console
$ rootlesskit runc run foo
WARN[0000] signal: killed                               
ERRO[0000] container_linux.go:353: starting container process caused: process_linux.go:459: container init caused: rootfs_linux.go:70: creating device nodes caused: open /home/suda/tmp/runctest/rootfs/dev/tty: no such device or address 
[rootlesskit:child ] error: command [runc run foo] exited: exit status 1
[rootlesskit:parent] error: child exited: exit status 1
```

`/dev/ptmx`: `EBUSY` (device or resource busy)
```console
$ rootlesskit runc run foo
WARN[0000] signal: killed                               
ERRO[0000] container_linux.go:353: starting container process caused: process_linux.go:459: container init caused: rootfs_linux.go:73: setting up ptmx caused: remove /home/suda/tmp/runctest/rootfs/dev/ptmx: device or resource busy 
[rootlesskit:child ] error: command [runc run foo] exited: exit status 1
[rootlesskit:parent] error: child exited: exit status 1
```