### PR TITLE
cgroup2: fix `runc update --cpu-quota` w/o `--cpu-period`

### DIFF
--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -4,17 +4,21 @@ package fs2
 
 import (
 	"bufio"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/pkg/errors"
 )
 
 func isCpuSet(cgroup *configs.Cgroup) bool {
-	return cgroup.Resources.CpuWeight != 0 || cgroup.Resources.CpuMax != ""
+	return cgroup.Resources.CpuWeight != 0 || cgroup.Resources.CpuQuota != 0 || cgroup.Resources.CpuPeriod != 0
 }
 
 func setCpu(dirPath string, cgroup *configs.Cgroup) error {
@@ -29,15 +33,56 @@ func setCpu(dirPath string, cgroup *configs.Cgroup) error {
 		}
 	}
 
-	// NOTE: .CpuQuota and .CpuPeriod are not used here. Conversion is the caller's responsibility.
-	if cgroup.Resources.CpuMax != "" {
-		if err := fscommon.WriteFile(dirPath, "cpu.max", cgroup.Resources.CpuMax); err != nil {
+	// Convert .CpuQuota and .CpuPeriod into "cpu.max".
+	// Conversion requires the previous value of "cpu.max"
+	prevCpuMaxBytes, err := ioutil.ReadFile(filepath.Join(dirPath, "cpu.max"))
+	if err != nil {
+		return err
+	}
+	cpuMax, err := ConvertCPUQuotaCPUPeriodToCgroupV2Value(
+		strings.TrimSpace(string(prevCpuMaxBytes)),
+		cgroup.Resources.CpuQuota, cgroup.Resources.CpuPeriod)
+	if err != nil {
+		return err
+	}
+	if cpuMax != "" {
+		if err := fscommon.WriteFile(dirPath, "cpu.max", cpuMax); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
+
+// ConvertCPUQuotaCPUPeriodToCgroupV2Value generates cpu.max string.
+func ConvertCPUQuotaCPUPeriodToCgroupV2Value(prevCpuMax string, quota int64, period uint64) (string, error) {
+	if quota == 0 && period == 0 {
+		return prevCpuMax, nil
+	}
+
+	prevPair := strings.Fields(prevCpuMax)
+	if len(prevPair) < 2 {
+		return "", errors.Errorf("bad cpu.max: %q", prevCpuMax)
+	}
+	// prevQuotaStr is either a positive decimal integer or "max"
+	prevQuotaStr := prevPair[0]
+	prevPeriodStr := prevPair[1]
+	prevPeriod, err := strconv.Atoi(prevPeriodStr)
+	if err != nil {
+		return "", errors.Errorf("bad cpu.max: %q", prevCpuMax)
+	}
+
+	if period == 0 {
+		period = uint64(prevPeriod)
+	}
+	if quota < 0 {
+		return fmt.Sprintf("max %d", period), nil
+	}
+	if quota == 0 {
+		return fmt.Sprintf("%s %d", prevQuotaStr, period), nil
+	}
+	return fmt.Sprintf("%d %d", quota, period), nil
+}
+
 func statCpu(dirPath string, stats *cgroups.Stats) error {
 	f, err := os.Open(filepath.Join(dirPath, "cpu.stat"))
 	if err != nil {

--- a/libcontainer/cgroups/fs2/cpu_test.go
+++ b/libcontainer/cgroups/fs2/cpu_test.go
@@ -1,0 +1,114 @@
+package fs2
+
+import (
+	"testing"
+)
+
+func TestConvertCPUQuotaCPUPeriodToCgroupV2Value(t *testing.T) {
+	cases := []struct {
+		current  string
+		quota    int64
+		period   uint64
+		expected string
+	}{
+		// quota = 0, period = 0
+		{
+			current:  "12345 123456",
+			quota:    0,
+			period:   0,
+			expected: "12345 123456",
+		},
+		{
+			current:  "max 123456",
+			quota:    0,
+			period:   0,
+			expected: "max 123456",
+		},
+		// quota = -1, period = 0
+		{
+			current:  "12345 123456",
+			quota:    -1,
+			period:   0,
+			expected: "max 123456",
+		},
+		{
+			current:  "max 123456",
+			quota:    -1,
+			period:   0,
+			expected: "max 123456",
+		},
+		// quota = -1, period > 0
+		{
+			current:  "12345 123456",
+			quota:    -1,
+			period:   5000,
+			expected: "max 5000",
+		},
+		{
+			current:  "max 123456",
+			quota:    -1,
+			period:   5000,
+			expected: "max 5000",
+		},
+		// quota > 0, period = 0
+		{
+			current:  "12345 123456",
+			quota:    1000,
+			period:   0,
+			expected: "1000 123456",
+		},
+		{
+			current:  "max 123456",
+			quota:    1000,
+			period:   0,
+			expected: "1000 123456",
+		},
+		// quota > 0, period > 0
+		{
+			current:  "12345 123456",
+			quota:    1000,
+			period:   5000,
+			expected: "1000 5000",
+		},
+		{
+			current:  "max 123456",
+			quota:    1000,
+			period:   5000,
+			expected: "1000 5000",
+		},
+		// quota = 0, period > 0
+		{
+			current:  "12345 123456",
+			quota:    0,
+			period:   5000,
+			expected: "12345 5000",
+		},
+		{
+			current:  "max 123456",
+			quota:    0,
+			period:   5000,
+			expected: "max 5000",
+		},
+		// invalid
+		{
+			current:  "",
+			quota:    1000,
+			period:   5000,
+			expected: "",
+		},
+	}
+	for i, c := range cases {
+		got, err := ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.current, c.quota, c.period)
+		if c.expected == "" && err == nil {
+			t.Errorf("%d: expected error (c=%+v)", i, c)
+			continue
+		}
+		if c.expected != "" && err != nil {
+			t.Errorf("%d: unexpected error: %+v (c=%+v)", i, err, c)
+			continue
+		}
+		if got != c.expected {
+			t.Errorf("%d: expected %q, got %q (c=%+v)", i, c.expected, got, c)
+		}
+	}
+}

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -593,21 +593,6 @@ func ConvertCPUSharesToCgroupV2Value(cpuShares uint64) uint64 {
 	return (1 + ((cpuShares-2)*9999)/262142)
 }
 
-// ConvertCPUQuotaCPUPeriodToCgroupV2Value generates cpu.max string.
-func ConvertCPUQuotaCPUPeriodToCgroupV2Value(quota int64, period uint64) string {
-	if quota <= 0 && period == 0 {
-		return ""
-	}
-	if period == 0 {
-		// This default value is documented in https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
-		period = 100000
-	}
-	if quota <= 0 {
-		return fmt.Sprintf("max %d", period)
-	}
-	return fmt.Sprintf("%d %d", quota, period)
-}
-
 // ConvertMemorySwapToCgroupV2Value converts MemorySwap value from OCI spec
 // for use by cgroup v2 drivers. A conversion is needed since Resources.MemorySwap
 // is defined as memory+swap combined, while in cgroup v2 swap is a separate value.

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -456,52 +456,6 @@ func TestConvertCPUSharesToCgroupV2Value(t *testing.T) {
 		}
 	}
 }
-
-func TestConvertCPUQuotaCPUPeriodToCgroupV2Value(t *testing.T) {
-	cases := []struct {
-		quota    int64
-		period   uint64
-		expected string
-	}{
-		{
-			quota:    0,
-			period:   0,
-			expected: "",
-		},
-		{
-			quota:    -1,
-			period:   0,
-			expected: "",
-		},
-		{
-			quota:    1000,
-			period:   5000,
-			expected: "1000 5000",
-		},
-		{
-			quota:    0,
-			period:   5000,
-			expected: "max 5000",
-		},
-		{
-			quota:    -1,
-			period:   5000,
-			expected: "max 5000",
-		},
-		{
-			quota:    1000,
-			period:   0,
-			expected: "1000 100000",
-		},
-	}
-	for _, c := range cases {
-		got := ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.quota, c.period)
-		if got != c.expected {
-			t.Errorf("expected ConvertCPUQuotaCPUPeriodToCgroupV2Value(%d, %d) to be %s, got %s", c.quota, c.period, c.expected, got)
-		}
-	}
-}
-
 func TestConvertMemorySwapToCgroupV2Value(t *testing.T) {
 	cases := []struct {
 		memswap, memory int64

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -127,6 +127,6 @@ type Resources struct {
 	// CpuWeight sets a proportional bandwidth limit.
 	CpuWeight uint64 `json:"cpu_weight"`
 
-	// CpuMax sets she maximum bandwidth limit (format: max period).
-	CpuMax string `json:"cpu_max"`
+	// CpuMax is converted from CpuQuota and CpuPeriod.
+	// Specifying CpuMax directly is not supported currently.
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -532,8 +532,6 @@ func CreateCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
 				if r.CPU.Period != nil {
 					c.Resources.CpuPeriod = *r.CPU.Period
 				}
-				//CpuMax is used for cgroupv2 and should be converted
-				c.Resources.CpuMax = cgroups.ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.Resources.CpuQuota, c.Resources.CpuPeriod)
 
 				if r.CPU.RealtimeRuntime != nil {
 					c.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime

--- a/update.go
+++ b/update.go
@@ -258,8 +258,6 @@ other options are ignored.
 		config.Cgroups.Resources.CpuShares = *r.CPU.Shares
 		//CpuWeight is used for cgroupv2 and should be converted
 		config.Cgroups.Resources.CpuWeight = cgroups.ConvertCPUSharesToCgroupV2Value(*r.CPU.Shares)
-		//CpuMax is used for cgroupv2 and should be converted
-		config.Cgroups.Resources.CpuMax = cgroups.ConvertCPUQuotaCPUPeriodToCgroupV2Value(*r.CPU.Quota, *r.CPU.Period)
 		config.Cgroups.Resources.CpuRtPeriod = *r.CPU.RealtimePeriod
 		config.Cgroups.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
 		config.Cgroups.Resources.CpusetCpus = r.CPU.Cpus


### PR DESCRIPTION
Fix #2456

`ConvertCPUQuotaCPUPeriodToCgroupV2Value()` is now called in the fs2 manager, not in the CLI module, because the conversion requires statting the previous "cpu.max" value.

related test: `TestUpdateCPUQuota` of Moby: https://github.com/moby/moby/blob/89382f2f20745b9e63bed6c066f104980dff4396/integration/container/update_linux_test.go#L86
