### PR TITLE
Cpu quota fixes, try II

### DIFF
--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -14,24 +14,35 @@ import (
 )
 
 func isCpuSet(cgroup *configs.Cgroup) bool {
-	return cgroup.Resources.CpuWeight != 0 || cgroup.Resources.CpuMax != ""
+	return cgroup.Resources.CpuWeight != 0 || cgroup.Resources.CpuQuota != 0 || cgroup.Resources.CpuPeriod != 0
 }
 
 func setCpu(dirPath string, cgroup *configs.Cgroup) error {
 	if !isCpuSet(cgroup) {
 		return nil
 	}
+	r := cgroup.Resources
 
 	// NOTE: .CpuShares is not used here. Conversion is the caller's responsibility.
-	if cgroup.Resources.CpuWeight != 0 {
-		if err := fscommon.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(cgroup.Resources.CpuWeight, 10)); err != nil {
+	if r.CpuWeight != 0 {
+		if err := fscommon.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(r.CpuWeight, 10)); err != nil {
 			return err
 		}
 	}
 
-	// NOTE: .CpuQuota and .CpuPeriod are not used here. Conversion is the caller's responsibility.
-	if cgroup.Resources.CpuMax != "" {
-		if err := fscommon.WriteFile(dirPath, "cpu.max", cgroup.Resources.CpuMax); err != nil {
+	if r.CpuQuota != 0 || r.CpuPeriod != 0 {
+		str := "max"
+		if r.CpuQuota > 0 {
+			str = strconv.FormatInt(r.CpuQuota, 10)
+		}
+		period := r.CpuPeriod
+		if period == 0 {
+			// This default value is documented in
+			// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
+			period = 100000
+		}
+		str += " " + strconv.FormatUint(period, 10)
+		if err := fscommon.WriteFile(dirPath, "cpu.max", str); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -71,35 +71,36 @@ var legacySubsystems = subsystemSet{
 
 func genV1ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
+	r := c.Resources
 
-	deviceProperties, err := generateDeviceProperties(c.Resources.Devices)
+	deviceProperties, err := generateDeviceProperties(r.Devices)
 	if err != nil {
 		return nil, err
 	}
 	properties = append(properties, deviceProperties...)
 
-	if c.Resources.Memory != 0 {
+	if r.Memory != 0 {
 		properties = append(properties,
-			newProp("MemoryLimit", uint64(c.Resources.Memory)))
+			newProp("MemoryLimit", uint64(r.Memory)))
 	}
 
-	if c.Resources.CpuShares != 0 {
+	if r.CpuShares != 0 {
 		properties = append(properties,
-			newProp("CPUShares", c.Resources.CpuShares))
+			newProp("CPUShares", r.CpuShares))
 	}
 
 	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
-	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
+	if r.CpuQuota != 0 && r.CpuPeriod != 0 {
 		// corresponds to USEC_INFINITY in systemd
 		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
 		// always setting a property value ensures we can apply a quota and remove it later
 		cpuQuotaPerSecUSec := uint64(math.MaxUint64)
-		if c.Resources.CpuQuota > 0 {
+		if r.CpuQuota > 0 {
 			// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
 			// (integer percentage of CPU) internally.  This means that if a fractional percent of
 			// CPU is indicated by Resources.CpuQuota, we need to round up to the nearest
 			// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
-			cpuQuotaPerSecUSec = uint64(c.Resources.CpuQuota*1000000) / c.Resources.CpuPeriod
+			cpuQuotaPerSecUSec = uint64(r.CpuQuota*1000000) / r.CpuPeriod
 			if cpuQuotaPerSecUSec%10000 != 0 {
 				cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
 			}
@@ -108,15 +109,15 @@ func genV1ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
 	}
 
-	if c.Resources.BlkioWeight != 0 {
+	if r.BlkioWeight != 0 {
 		properties = append(properties,
-			newProp("BlockIOWeight", uint64(c.Resources.BlkioWeight)))
+			newProp("BlockIOWeight", uint64(r.BlkioWeight)))
 	}
 
-	if c.Resources.PidsLimit > 0 || c.Resources.PidsLimit == -1 {
+	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
 			newProp("TasksAccounting", true),
-			newProp("TasksMax", uint64(c.Resources.PidsLimit)))
+			newProp("TasksMax", uint64(r.PidsLimit)))
 	}
 
 	return properties, nil

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -3,7 +3,6 @@
 package systemd
 
 import (
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -73,25 +72,7 @@ func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("CPUWeight", r.CpuWeight))
 	}
 
-	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
-	if r.CpuQuota != 0 && r.CpuPeriod != 0 {
-		// corresponds to USEC_INFINITY in systemd
-		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
-		// always setting a property value ensures we can apply a quota and remove it later
-		cpuQuotaPerSecUSec := uint64(math.MaxUint64)
-		if r.CpuQuota > 0 {
-			// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
-			// (integer percentage of CPU) internally.  This means that if a fractional percent of
-			// CPU is indicated by Resources.CpuQuota, we need to round up to the nearest
-			// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
-			cpuQuotaPerSecUSec = uint64(r.CpuQuota*1000000) / r.CpuPeriod
-			if cpuQuotaPerSecUSec%10000 != 0 {
-				cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
-			}
-		}
-		properties = append(properties,
-			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
-	}
+	addCpuQuota(&properties, r.CpuQuota, r.CpuPeriod)
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -37,28 +37,29 @@ func NewUnifiedManager(config *configs.Cgroup, path string, rootless bool) cgrou
 
 func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
+	r := c.Resources
 
 	// NOTE: This is of questionable correctness because we insert our own
 	//       devices eBPF program later. Two programs with identical rules
 	//       aren't the end of the world, but it is a bit concerning. However
 	//       it's unclear if systemd removes all eBPF programs attached when
 	//       doing SetUnitProperties...
-	deviceProperties, err := generateDeviceProperties(c.Resources.Devices)
+	deviceProperties, err := generateDeviceProperties(r.Devices)
 	if err != nil {
 		return nil, err
 	}
 	properties = append(properties, deviceProperties...)
 
-	if c.Resources.Memory != 0 {
+	if r.Memory != 0 {
 		properties = append(properties,
-			newProp("MemoryMax", uint64(c.Resources.Memory)))
+			newProp("MemoryMax", uint64(r.Memory)))
 	}
-	if c.Resources.MemoryReservation != 0 {
+	if r.MemoryReservation != 0 {
 		properties = append(properties,
-			newProp("MemoryLow", uint64(c.Resources.MemoryReservation)))
+			newProp("MemoryLow", uint64(r.MemoryReservation)))
 	}
 
-	swap, err := cgroups.ConvertMemorySwapToCgroupV2Value(c.Resources.MemorySwap, c.Resources.Memory)
+	swap, err := cgroups.ConvertMemorySwapToCgroupV2Value(r.MemorySwap, r.Memory)
 	if err != nil {
 		return nil, err
 	}
@@ -67,23 +68,23 @@ func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("MemorySwapMax", uint64(swap)))
 	}
 
-	if c.Resources.CpuWeight != 0 {
+	if r.CpuWeight != 0 {
 		properties = append(properties,
-			newProp("CPUWeight", c.Resources.CpuWeight))
+			newProp("CPUWeight", r.CpuWeight))
 	}
 
 	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
-	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
+	if r.CpuQuota != 0 && r.CpuPeriod != 0 {
 		// corresponds to USEC_INFINITY in systemd
 		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
 		// always setting a property value ensures we can apply a quota and remove it later
 		cpuQuotaPerSecUSec := uint64(math.MaxUint64)
-		if c.Resources.CpuQuota > 0 {
+		if r.CpuQuota > 0 {
 			// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
 			// (integer percentage of CPU) internally.  This means that if a fractional percent of
 			// CPU is indicated by Resources.CpuQuota, we need to round up to the nearest
 			// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
-			cpuQuotaPerSecUSec = uint64(c.Resources.CpuQuota*1000000) / c.Resources.CpuPeriod
+			cpuQuotaPerSecUSec = uint64(r.CpuQuota*1000000) / r.CpuPeriod
 			if cpuQuotaPerSecUSec%10000 != 0 {
 				cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
 			}
@@ -92,13 +93,13 @@ func genV2ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
 	}
 
-	if c.Resources.PidsLimit > 0 || c.Resources.PidsLimit == -1 {
+	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
 			newProp("TasksAccounting", true),
-			newProp("TasksMax", uint64(c.Resources.PidsLimit)))
+			newProp("TasksMax", uint64(r.PidsLimit)))
 	}
 
-	// ignore c.Resources.KernelMemory
+	// ignore r.KernelMemory
 
 	return properties, nil
 }

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -593,21 +593,6 @@ func ConvertCPUSharesToCgroupV2Value(cpuShares uint64) uint64 {
 	return (1 + ((cpuShares-2)*9999)/262142)
 }
 
-// ConvertCPUQuotaCPUPeriodToCgroupV2Value generates cpu.max string.
-func ConvertCPUQuotaCPUPeriodToCgroupV2Value(quota int64, period uint64) string {
-	if quota <= 0 && period == 0 {
-		return ""
-	}
-	if period == 0 {
-		// This default value is documented in https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
-		period = 100000
-	}
-	if quota <= 0 {
-		return fmt.Sprintf("max %d", period)
-	}
-	return fmt.Sprintf("%d %d", quota, period)
-}
-
 // ConvertMemorySwapToCgroupV2Value converts MemorySwap value from OCI spec
 // for use by cgroup v2 drivers. A conversion is needed since Resources.MemorySwap
 // is defined as memory+swap combined, while in cgroup v2 swap is a separate value.

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -457,51 +457,6 @@ func TestConvertCPUSharesToCgroupV2Value(t *testing.T) {
 	}
 }
 
-func TestConvertCPUQuotaCPUPeriodToCgroupV2Value(t *testing.T) {
-	cases := []struct {
-		quota    int64
-		period   uint64
-		expected string
-	}{
-		{
-			quota:    0,
-			period:   0,
-			expected: "",
-		},
-		{
-			quota:    -1,
-			period:   0,
-			expected: "",
-		},
-		{
-			quota:    1000,
-			period:   5000,
-			expected: "1000 5000",
-		},
-		{
-			quota:    0,
-			period:   5000,
-			expected: "max 5000",
-		},
-		{
-			quota:    -1,
-			period:   5000,
-			expected: "max 5000",
-		},
-		{
-			quota:    1000,
-			period:   0,
-			expected: "1000 100000",
-		},
-	}
-	for _, c := range cases {
-		got := ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.quota, c.period)
-		if got != c.expected {
-			t.Errorf("expected ConvertCPUQuotaCPUPeriodToCgroupV2Value(%d, %d) to be %s, got %s", c.quota, c.period, c.expected, got)
-		}
-	}
-}
-
 func TestConvertMemorySwapToCgroupV2Value(t *testing.T) {
 	cases := []struct {
 		memswap, memory int64

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -126,7 +126,4 @@ type Resources struct {
 
 	// CpuWeight sets a proportional bandwidth limit.
 	CpuWeight uint64 `json:"cpu_weight"`
-
-	// CpuMax sets she maximum bandwidth limit (format: max period).
-	CpuMax string `json:"cpu_max"`
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -532,9 +532,6 @@ func CreateCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
 				if r.CPU.Period != nil {
 					c.Resources.CpuPeriod = *r.CPU.Period
 				}
-				//CpuMax is used for cgroupv2 and should be converted
-				c.Resources.CpuMax = cgroups.ConvertCPUQuotaCPUPeriodToCgroupV2Value(c.Resources.CpuQuota, c.Resources.CpuPeriod)
-
 				if r.CPU.RealtimeRuntime != nil {
 					c.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
 				}

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -236,54 +236,62 @@ EOF
     check_systemd_value "TasksMax" 20
 }
 
-@test "update cgroup v1 cpu limits" {
+function check_cpu_quota() {
+    local quota=$1
+    local period=$2
+    local sd_quota=$3
+
+    if [ "$CGROUP_UNIFIED" = "yes" ]; then
+        if [ "$quota" = "-1" ]; then
+            quota="max"
+        fi
+        check_cgroup_value "cpu.max" "$quota $period"
+    else
+        check_cgroup_value "cpu.cfs_quota_us" $quota
+        check_cgroup_value "cpu.cfs_period_us" $period
+    fi
+    # systemd value is the same for v1 and v2
+    check_systemd_value "CPUQuotaPerSecUSec" $sd_quota
+}
+
+function check_cpu_shares() {
+    local shares=$1
+
+    if [ "$CGROUP_UNIFIED" = "yes" ]; then
+        local weight=$((1 + ((shares - 2) * 9999) / 262142))
+        check_cgroup_value "cpu.weight" $weight
+        check_systemd_value "CPUWeight" $weight
+    else
+        check_cgroup_value "cpu.shares" $shares
+        check_systemd_value "CPUShares" $shares
+    fi
+}
+
+@test "update cgroup cpu limits" {
     [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    requires cgroups_v1
 
     # run a few busyboxes detached
     runc run -d --console-socket $CONSOLE_SOCKET test_update
     [ "$status" -eq 0 ]
 
     # check that initial values were properly set
-    check_cgroup_value "cpu.cfs_period_us" 1000000
-    check_cgroup_value "cpu.cfs_quota_us" 500000
-    check_systemd_value "CPUQuotaPerSecUSec" 500ms
+    check_cpu_quota 500000 1000000 "500ms"
+    check_cpu_shares 100
 
-    check_cgroup_value "cpu.shares" 100
-    check_systemd_value "CPUShares" 100
+    # update cpu period
+    runc update test_update --cpu-period 900000
+    [ "$status" -eq 0 ]
+    check_cpu_quota 500000 900000 "560ms"
 
-    # systemd driver does not allow to update quota and period separately
-    if [ -z "$RUNC_USE_SYSTEMD" ]; then
-        # update cpu period
-        runc update test_update --cpu-period 900000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_period_us" 900000
-
-        # update cpu quota
-        runc update test_update --cpu-quota 600000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_quota_us" 600000
-    else
-        # update cpu quota
-        runc update test_update --cpu-quota 600000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_quota_us" 600000
-        # this is currently broken
-        #check_systemd_value "CPUQuotaPerSecUSec" 600ms
-
-        # update cpu quota and period together
-        runc update test_update --cpu-period 900000 --cpu-quota 600000
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpu.cfs_period_us" 900000
-        check_cgroup_value "cpu.cfs_quota_us" 600000
-        check_systemd_value "CPUQuotaPerSecUSec" 670ms
-    fi
+    # update cpu quota
+    runc update test_update --cpu-quota 600000
+    [ "$status" -eq 0 ]
+    check_cpu_quota 600000 900000 "670ms"
 
     # update cpu-shares
     runc update test_update --cpu-share 200
     [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.shares" 200
-    check_systemd_value "CPUShares" 200
+    check_cpu_shares 200
 
     # Revert to the test initial value via json on stding
     runc update  -r - test_update <<EOF
@@ -296,23 +304,14 @@ EOF
 }
 EOF
     [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_period_us" 1000000
-    check_cgroup_value "cpu.cfs_quota_us" 500000
-    check_systemd_value "CPUQuotaPerSecUSec" 500ms
-
-    check_cgroup_value "cpu.shares" 100
-    check_systemd_value "CPUShares" 100
+    check_cpu_quota 500000 1000000 "500ms"
 
     # redo all the changes at once
     runc update test_update \
         --cpu-period 900000 --cpu-quota 600000 --cpu-share 200
     [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_period_us" 900000
-    check_cgroup_value "cpu.cfs_quota_us" 600000
-    check_systemd_value "CPUQuotaPerSecUSec" 670ms
-
-    check_cgroup_value "cpu.shares" 200
-    check_systemd_value "CPUShares" 200
+    check_cpu_quota 600000 900000 "670ms"
+    check_cpu_shares 200
 
     # reset to initial test value via json file
     cat << EOF > $BATS_TMPDIR/runc-cgroups-integration-test.json
@@ -327,12 +326,8 @@ EOF
 
     runc update  -r $BATS_TMPDIR/runc-cgroups-integration-test.json test_update
     [ "$status" -eq 0 ]
-    check_cgroup_value "cpu.cfs_period_us" 1000000
-    check_cgroup_value "cpu.cfs_quota_us" 500000
-    check_systemd_value "CPUQuotaPerSecUSec" 500ms
-
-    check_cgroup_value "cpu.shares" 100
-    check_systemd_value "CPUShares" 100
+    check_cpu_quota 500000 1000000 "500ms"
+    check_cpu_shares 100
 }
 
 @test "update rt period and runtime" {

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -288,6 +288,11 @@ function check_cpu_shares() {
     [ "$status" -eq 0 ]
     check_cpu_quota 600000 900000 "670ms"
 
+    # remove cpu quota
+    runc update test_update --cpu-quota -1
+    [ "$status" -eq 0 ]
+    check_cpu_quota -1 900000 "infinity"
+
     # update cpu-shares
     runc update test_update --cpu-share 200
     [ "$status" -eq 0 ]
@@ -312,6 +317,11 @@ EOF
     [ "$status" -eq 0 ]
     check_cpu_quota 600000 900000 "670ms"
     check_cpu_shares 200
+
+    # remove cpu quota and reset the period
+    runc update test_update --cpu-quota -1 --cpu-period 100000
+    [ "$status" -eq 0 ]
+    check_cpu_quota -1 100000 "infinity"
 
     # reset to initial test value via json file
     cat << EOF > $BATS_TMPDIR/runc-cgroups-integration-test.json

--- a/update.go
+++ b/update.go
@@ -258,8 +258,6 @@ other options are ignored.
 		config.Cgroups.Resources.CpuShares = *r.CPU.Shares
 		//CpuWeight is used for cgroupv2 and should be converted
 		config.Cgroups.Resources.CpuWeight = cgroups.ConvertCPUSharesToCgroupV2Value(*r.CPU.Shares)
-		//CpuMax is used for cgroupv2 and should be converted
-		config.Cgroups.Resources.CpuMax = cgroups.ConvertCPUQuotaCPUPeriodToCgroupV2Value(*r.CPU.Quota, *r.CPU.Period)
 		config.Cgroups.Resources.CpuRtPeriod = *r.CPU.RealtimePeriod
 		config.Cgroups.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
 		config.Cgroups.Resources.CpusetCpus = r.CPU.Cpus


### PR DESCRIPTION
_this is loosely based on https://github.com/opencontainers/runc/pull/2428 but I am trying to make things right this time_

Seting CPU quota and period independently does not make much sense, but historically runc allowed it and this needs to be supported to not break compatibility.

This PR fixes the following issues:

### 1. Issue https://github.com/opencontainers/runc/issues/2456

systemd/v1, systemd/v2 and fs2 cgroup drivers reset the period to default 100000 during `runc update` if it is not set explicitly. This makes the behavior inconsistent with the one when fs driver is used (it leaves the period at the old value).

The issue is fixed by reusing the old (previously set) value for period/quota, if a new period/quota is not specified during the update.

### 2. Issue https://github.com/opencontainers/runc/issues/2464

systemd/v1, systemd/v2 and fs2 cgroup drivers ignore the CPU period during start/run, if CPU quota is not set. The fs (v1) driver sets the period.

~~The issue is fixed by rejecting the configuration where quota is not set but the period is set during start. **NOTE:** this can bring some backward compatibility issues but I consider the chances are low.~~

Issue fixed by
 - changing the AND to OR in checking whether the CPU quota values should be applied, and
 - using defaults for both quota and period if those are not set (default quota is unlimited, default period is 100000).

### 3. Issue https://github.com/opencontainers/runc/issues/2463

systemd v2 driver ignores --cpu-quota during update if CPU period was not set.

Fixed by adding the default period to `addCpuQuota`

### Other changes

In addition, this PR enables CPU quota and CPU shares tests for v2, adds unlimited quota tests, and some corner test cases to cover all the issues above.

Fixes: #2456, #2463, #2464.