### PR TITLE
cgroups/systemd: add setting CPUQuotaPeriod prop

### DIFF
--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -68,7 +68,7 @@ var legacySubsystems = subsystemSet{
 	&fs.NameGroup{GroupName: "name=systemd"},
 }
 
-func genV1ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error) {
+func genV1ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
 	r := c.Resources
 
@@ -88,7 +88,7 @@ func genV1ResourcesProperties(c *configs.Cgroup) ([]systemdDbus.Property, error)
 			newProp("CPUShares", r.CpuShares))
 	}
 
-	addCpuQuota(&properties, r.CpuQuota, r.CpuPeriod)
+	addCpuQuota(conn, &properties, r.CpuQuota, r.CpuPeriod)
 
 	if r.BlkioWeight != 0 {
 		properties = append(properties,
@@ -165,7 +165,11 @@ func (m *legacyManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("DefaultDependencies", false))
 
-	resourcesProperties, err := genV1ResourcesProperties(c)
+	dbusConnection, err := getDbusConnection(false)
+	if err != nil {
+		return err
+	}
+	resourcesProperties, err := genV1ResourcesProperties(c, dbusConnection)
 	if err != nil {
 		return err
 	}
@@ -180,10 +184,6 @@ func (m *legacyManager) Apply(pid int) error {
 		}
 	}
 
-	dbusConnection, err := getDbusConnection(false)
-	if err != nil {
-		return err
-	}
 	if err := startUnit(dbusConnection, unitName, properties); err != nil {
 		return err
 	}
@@ -368,7 +368,11 @@ func (m *legacyManager) Set(container *configs.Config) error {
 	if m.cgroups.Paths != nil {
 		return nil
 	}
-	properties, err := genV1ResourcesProperties(container.Cgroups)
+	dbusConnection, err := getDbusConnection(false)
+	if err != nil {
+		return err
+	}
+	properties, err := genV1ResourcesProperties(container.Cgroups, dbusConnection)
 	if err != nil {
 		return err
 	}
@@ -393,11 +397,6 @@ func (m *legacyManager) Set(container *configs.Config) error {
 		logrus.Infof("freeze container before SetUnitProperties failed: %v", err)
 	}
 
-	dbusConnection, err := getDbusConnection(false)
-	if err != nil {
-		_ = m.Freeze(targetFreezerState)
-		return err
-	}
 	if err := dbusConnection.SetUnitProperties(getUnitName(container.Cgroups), true, properties...); err != nil {
 		_ = m.Freeze(targetFreezerState)
 		return err

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -250,8 +250,18 @@ function check_cpu_quota() {
         check_cgroup_value "cpu.cfs_quota_us" $quota
         check_cgroup_value "cpu.cfs_period_us" $period
     fi
-    # systemd value is the same for v1 and v2
+    # systemd values are the same for v1 and v2
     check_systemd_value "CPUQuotaPerSecUSec" $sd_quota
+
+    # CPUQuotaPeriodUSec requires systemd >= v242
+    [ "$(systemd_version)" -lt 242 ] && return
+
+    local sd_period=$(( period/1000 ))ms
+    [ "$sd_period" = "1000ms" ] && sd_period="1s"
+    local sd_infinity=""
+    # 100ms is the default value, and if not set, shown as infinity
+    [ "$sd_period" = "100ms" ] && sd_infinity="infinity"
+    check_systemd_value "CPUQuotaPeriodUSec" $sd_period $sd_infinity
 }
 
 function check_cpu_shares() {


### PR DESCRIPTION
_This is currently based on and includes #2458 and will be rebased once that one is merged. Please only review the last commit._

For some reason, runc systemd drivers (both v1 and v2) never set
systemd unit property named `CPUQuotaPeriod` (known as
`CPUQuotaPeriodUSec` on dbus and in `systemctl show` output).

Set it, and add a check to all the integration tests. The check is less
than trivial because, when not set, the value is shown as "infinity" but
when set to the same (default) value, shown as "100ms", so in case we
expect 100ms (period = 100000 us), we have to _also_ check for
"infinity".

Fixes https://github.com/opencontainers/runc/issues/2465