### PR TITLE
Paths nits

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -264,7 +264,7 @@ func (m *manager) Set(container *configs.Config) error {
 // Freeze toggles the container's freezer cgroup depending on the state
 // provided
 func (m *manager) Freeze(state configs.FreezerState) (Err error) {
-	path := m.GetPaths()["freezer"]
+	path := m.Path("freezer")
 	if m.cgroups == nil || path == "" {
 		return errors.New("cannot toggle freezer: cgroups not configured for container")
 	}
@@ -382,8 +382,7 @@ func (m *manager) GetCgroups() (*configs.Cgroup, error) {
 }
 
 func (m *manager) GetFreezerState() (configs.FreezerState, error) {
-	paths := m.GetPaths()
-	dir := paths["freezer"]
+	dir := m.Path("freezer")
 	freezer, err := m.getSubsystems().Get("freezer")
 
 	// If the container doesn't have the freezer cgroup, say it's undefined.

--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -393,5 +393,5 @@ func (m *manager) GetFreezerState() (configs.FreezerState, error) {
 }
 
 func (m *manager) Exists() bool {
-	return cgroups.PathExists(m.paths["devices"])
+	return cgroups.PathExists(m.Path("devices"))
 }

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -112,6 +112,8 @@ func (m *legacyManager) Apply(pid int) error {
 		properties []systemdDbus.Property
 	)
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if c.Paths != nil {
 		paths := make(map[string]string)
 		for name, path := range c.Paths {
@@ -465,5 +467,5 @@ func (m *legacyManager) GetFreezerState() (configs.FreezerState, error) {
 }
 
 func (m *legacyManager) Exists() bool {
-	return cgroups.PathExists(m.paths["devices"])
+	return cgroups.PathExists(m.Path("devices"))
 }

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -51,12 +51,8 @@ func (m *mockCgroupManager) Destroy() error {
 }
 
 func (m *mockCgroupManager) Exists() bool {
-	paths := m.GetPaths()
-	if paths != nil {
-		_, err := os.Lstat(paths["devices"])
-		return err == nil
-	}
-	return false
+	_, err := os.Lstat(m.Path("devices"))
+	return err == nil
 }
 
 func (m *mockCgroupManager) GetPaths() map[string]string {


### PR DESCRIPTION
This is a fixup for 

1. using `GetPaths()` instead of `Path()`
2. accessing `m.paths` map without lock

mostly introduced by #2338 and #2391.