### PR TITLE
travis: add multi-arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,20 @@ matrix:
         - sudo ssh default -t 'sudo -i make -C /vagrant localintegration RUNC_USE_SYSTEMD=1'
         # FIXME: rootless is skipped because of EPERM on writing cgroup.procs
         # - sudo ssh default -t 'sudo -i make -C /vagrant localrootlessintegration'
-
+    - go: 1.13.x
+      name: "multi-arch"
+      arch:
+       - arm64
+       - ppc64le
+       - s390x
+      before_install:
+        - sudo apt-get install -y jq
+      script:
+        - make all
+        - sudo PATH="$PATH" make localintegration
   allow_failures:
     - go: tip
+    - name: "multi-arch"
 
 go_import_path: github.com/opencontainers/runc
 
@@ -72,4 +83,5 @@ before_install:
 script:
   - git-validation -run DCO,short-subject -v
   - make
-  - make clean ci cross
+  - make clean ci
+  - make cross

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,9 @@ ARG CRIU_VERSION=v3.14
 FROM golang:${GO_VERSION}-buster
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN dpkg --add-architecture armel \
-    && dpkg --add-architecture armhf \
-    && dpkg --add-architecture arm64 \
-    && dpkg --add-architecture ppc64el \
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
-        crossbuild-essential-arm64 \
-        crossbuild-essential-armel \
-        crossbuild-essential-armhf \
-        crossbuild-essential-ppc64el \
         curl \
         gawk \
         iptables \
@@ -28,10 +20,6 @@ RUN dpkg --add-architecture armel \
         libprotobuf-c-dev \
         libprotobuf-dev \
         libseccomp-dev \
-        libseccomp-dev:arm64 \
-        libseccomp-dev:armel \
-        libseccomp-dev:armhf \
-        libseccomp-dev:ppc64el \
         libseccomp2 \
         pkg-config \
         protobuf-c-compiler \
@@ -41,6 +29,27 @@ RUN dpkg --add-architecture armel \
         uidmap \
     && apt-get clean \
     && rm -rf /var/cache/apt /var/lib/apt/lists/*;
+
+# Install cross-compilation dependencies only on amd64
+RUN [ $(uname -m) = amd64 ] \
+    && dpkg --add-architecture armel \
+    && dpkg --add-architecture armhf \
+    && dpkg --add-architecture arm64 \
+    && dpkg --add-architecture ppc64el \
+    && dpkg --add-architecture s390x \
+    && apt-get install -y --no-install-recommends \
+        crossbuild-essential-arm64 \
+        crossbuild-essential-armel \
+        crossbuild-essential-armhf \
+        crossbuild-essential-ppc64el \
+        crossbuild-essential-s390x \
+        libseccomp-dev:arm64 \
+        libseccomp-dev:armel \
+        libseccomp-dev:armhf \
+        libseccomp-dev:ppc64el \
+        libseccomp-dev:s390x \
+   || true
+
 
 # Add a dummy user for the rootless integration tests. While runC does
 # not require an entry in /etc/passwd to operate, one of the tests uses

--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -4,6 +4,12 @@ get_busybox(){
 	arm64)
 		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/glibc/busybox.tar.xz'
 	;;
+	s390x)
+		echo 'https://github.com/docker-library/busybox/raw/dist-s390x/glibc/busybox.tar.xz'
+	;;
+	ppc64le)
+		echo 'https://github.com/docker-library/busybox/raw/dist-ppc64le/glibc/busybox.tar.xz'
+	;;
 	*)
 		echo 'https://github.com/docker-library/busybox/raw/dist-amd64/glibc/busybox.tar.xz'
 	;;
@@ -15,6 +21,12 @@ get_hello(){
         arm64)
                 echo 'hello-world-aarch64.tar'
         ;;
+	s390x)
+		echo 'hello-world-s390x.tar'
+	;;
+	ppc64le)
+		echo 'hello-world-ppc64le.tar'
+	;;
         *)
                 echo 'hello-world.tar'
         ;;


### PR DESCRIPTION
Enable running the tests on arm64, ppc64le and s390x.

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>