### PR TITLE
libct/cgroups/readProcsFile: return an error if read failed

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -138,7 +138,7 @@ func readProcsFile(file string) ([]int, error) {
 			out = append(out, pid)
 		}
 	}
-	return out, nil
+	return out, s.Err()
 }
 
 // ParseCgroupFile parses the given cgroup file, typically /proc/self/cgroup


### PR DESCRIPTION
Not sure why but the errors from scanner were ignored. Such errors
can happen if open(2) has succeeded but the subsequent read(2) fails.
