### PR TITLE
systemd: parse systemdVersion when only an int is returned

### DIFF
--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -1,0 +1,32 @@
+package systemd
+
+import (
+	"testing"
+)
+
+func TestSystemdVersion(t *testing.T) {
+	var systemdVersionTests = []struct {
+		verStr      string
+		expectedVer int
+		expectErr   bool
+	}{
+		{`"219"`, 219, false},
+		{`"v245.4-1.fc32"`, 245, false},
+		{`"241-1"`, 241, false},
+		{`"v241-1"`, 241, false},
+		{"NaN", 0, true},
+		{"", 0, true},
+	}
+	for _, sdTest := range systemdVersionTests {
+		ver, err := systemdVersionAtoi(sdTest.verStr)
+		if !sdTest.expectErr && err != nil {
+			t.Errorf("systemdVersionAtoi(%s); want nil; got %v", sdTest.verStr, err)
+		}
+		if sdTest.expectErr && err == nil {
+			t.Errorf("systemdVersionAtoi(%s); wanted failure; got nil", sdTest.verStr)
+		}
+		if ver != sdTest.expectedVer {
+			t.Errorf("systemdVersionAtoi(%s); want %d; got %d", sdTest.verStr, sdTest.expectedVer, ver)
+		}
+	}
+}


### PR DESCRIPTION
there have been cases observed where instead of `v$VER.0-$OS` the systemdVersion returned is just `$VER`. handle this case

Signed-off-by: Peter Hunt <pehunt@redhat.com>