### PR TITLE
libct/cgroups/fs: simplify/speedup freezer code

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -298,7 +298,7 @@ func (m *manager) Set(container *configs.Config) error {
 
 // Freeze toggles the container's freezer cgroup depending on the state
 // provided
-func (m *manager) Freeze(state configs.FreezerState) (Err error) {
+func (m *manager) Freeze(state configs.FreezerState) error {
 	path := m.Path("freezer")
 	if m.cgroups == nil || path == "" {
 		return errors.New("cannot toggle freezer: cgroups not configured for container")
@@ -306,14 +306,9 @@ func (m *manager) Freeze(state configs.FreezerState) (Err error) {
 
 	prevState := m.cgroups.Resources.Freezer
 	m.cgroups.Resources.Freezer = state
-	defer func() {
-		if Err != nil {
-			m.cgroups.Resources.Freezer = prevState
-		}
-	}()
-
 	freezer := &FreezerGroup{}
 	if err := freezer.Set(path, m.cgroups); err != nil {
+		m.cgroups.Resources.Freezer = prevState
 		return err
 	}
 	return nil

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -312,10 +312,7 @@ func (m *manager) Freeze(state configs.FreezerState) (Err error) {
 		}
 	}()
 
-	freezer, err := m.getSubsystems().Get("freezer")
-	if err != nil {
-		return err
-	}
+	freezer := &FreezerGroup{}
 	if err := freezer.Set(path, m.cgroups); err != nil {
 		return err
 	}
@@ -418,13 +415,12 @@ func (m *manager) GetCgroups() (*configs.Cgroup, error) {
 
 func (m *manager) GetFreezerState() (configs.FreezerState, error) {
 	dir := m.Path("freezer")
-	freezer, err := m.getSubsystems().Get("freezer")
-
 	// If the container doesn't have the freezer cgroup, say it's undefined.
-	if err != nil || dir == "" {
+	if dir == "" {
 		return configs.Undefined, nil
 	}
-	return freezer.(*FreezerGroup).GetState(dir)
+	freezer := &FreezerGroup{}
+	return freezer.GetState(dir)
 }
 
 func (m *manager) Exists() bool {

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -319,10 +319,7 @@ func (m *legacyManager) Freeze(state configs.FreezerState) error {
 	}
 	prevState := m.cgroups.Resources.Freezer
 	m.cgroups.Resources.Freezer = state
-	freezer, err := legacySubsystems.Get("freezer")
-	if err != nil {
-		return err
-	}
+	freezer := &fs.FreezerGroup{}
 	err = freezer.Set(path, m.cgroups)
 	if err != nil {
 		m.cgroups.Resources.Freezer = prevState
@@ -458,11 +455,8 @@ func (m *legacyManager) GetFreezerState() (configs.FreezerState, error) {
 	if err != nil && !cgroups.IsNotFound(err) {
 		return configs.Undefined, err
 	}
-	freezer, err := legacySubsystems.Get("freezer")
-	if err != nil {
-		return configs.Undefined, err
-	}
-	return freezer.(*fs.FreezerGroup).GetState(path)
+	freezer := &fs.FreezerGroup{}
+	return freezer.GetState(path)
 }
 
 func (m *legacyManager) Exists() bool {


### PR DESCRIPTION
_this is separated out from https://github.com/opencontainers/runc/pull/2438 in order to make review easier_

Make things faster and code more readable by simplification and code removal.

Please see individual commits for details.