### PR TITLE
fix TestPidsSystemd and TestRunWithKernelMemorySystemd test error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,7 @@ matrix:
       script:
         # kernel 3.10 (frankenized), systemd 219
         - sudo ssh default 'rpm -q centos-release kernel systemd'
-        # FIXME: the following unit tests are skipped (TESTFLAGS=-short):
-        #        FAIL: TestPidsSystemd: utils_test.go:55: exec_test.go:630: unexpected error: container_linux.go:353: starting container process caused: process_linux.go:326: applying cgroup configuration for process caused: mountpoint for devices not found
-        #        FAIL: TestRunWithKernelMemorySystemd: exec_test.go:713: runContainer failed with kernel memory limit: container_linux.go:353: starting container process caused: process_linux.go:326: applying cgroup configuration for process caused: mkdir : no such file or directory
-        - sudo ssh default -t 'sudo -i make -C /vagrant localunittest TESTFLAGS=-short'
+        - sudo ssh default -t 'sudo -i make -C /vagrant localunittest'
         - sudo ssh default -t 'sudo -i make -C /vagrant localintegration'
         - sudo ssh default -t 'sudo -i make -C /vagrant localintegration RUNC_USE_SYSTEMD=1'
         # FIXME: rootless is skipped because of EPERM on writing cgroup.procs

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -117,7 +117,7 @@ func newTemplateConfig(rootfs string) *configs.Config {
 			{Type: configs.NEWNET},
 		}),
 		Cgroups: &configs.Cgroup{
-			Path: "integration/test",
+			Path: "/sys/fs/cgroup/",
 			Resources: &configs.Resources{
 				MemorySwappiness: nil,
 				Devices:          allowedDevices,


### PR DESCRIPTION
Test command : `make localunittest`
Test logs:
 ```
FAIL: TestPidsSystemd (0.08s)
    utils_test.go:55: exec_test.go:630: unexpected error: container_linux.go:353: starting container process caused: process_linux.go:326: applying cgroup configuration for process caused: mountpoint for devices not found
FAIL: TestRunWithKernelMemorySystemd (0.07s)
    exec_test.go:713: runContainer failed with kernel memory limit: container_linux.go:353: starting container process caused: process_linux.go:326: applying cgroup configuration for process caused: mkdir : no such file or directory
```
Root cause:
TestPidsSystemd: The  cgroup root path is  `integration/test` when the test container is stating. The devices subsystem can not find under this root path, then casue apply cgroup error. The code show as following,
https://github.com/opencontainers/runc/blob/3cb1909c70f16c36fcbc88f48fab7907eed7b1fc/libcontainer/cgroups/systemd/v1.go#L274

TestRunWithKernelMemorySystemd: The root cause is same as the TestPidsSystemd. But it leads to `mkdir ""`, when system want to set "KernelMemory" property. See the code as  following,
https://github.com/opencontainers/runc/blob/3cb1909c70f16c36fcbc88f48fab7907eed7b1fc/libcontainer/cgroups/systemd/v1.go#L431

Signed-off-by: Xiaodong Liu <liuxiaodong@loongson.cn>