### PR TITLE
fix redundant source code copy issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,5 +95,3 @@ ENV DEBIAN_ROOTFS /debian
 RUN mkdir -p "${DEBIAN_ROOTFS}"
 RUN . tests/integration/multi-arch.bash \
     && get_and_extract_debian "$DEBIAN_ROOTFS"
-
-COPY . .


### PR DESCRIPTION
There is a -v flag to unittest, integration, rootlessintegration tests inside container in Makefile.
IMO, it do not have to copy source code to container.

Signed-off-by: Xiaodong Liu <liuxiaodong@loongson.cn>