### PR TITLE
tests/int/checkpoint: fds and pids cleanup

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -144,9 +144,6 @@ function simple_cr() {
 
   setup_pipes
 
-  # This should not be necessary: https://github.com/checkpoint-restore/criu/issues/575
-  update_config '(.. | select(.readonly? != null)) .readonly |= false'
-
   # TCP port for lazy migration
   port=27277
 


### PR DESCRIPTION
1. Do not use hardcoded fd numbers, instead relying on bash feature of
   assigning an fd to a variable.

   This looks very weird, but the rule of thumb here is:
   - if this is `exec`, use `{var}` (i.e. no `$`);
   - otherwise, use as normal (`$var` or `${var}`).

2. Add killing the background processes and closing the fds to teardown.
   This is helpful in case of a test failure, in order to not affect the
   subsequent tests. Found in https://github.com/opencontainers/runc/pull/2507#issuecomment-655034055

3. Drop removing readonly flag for lazy cpt tests, it is no longer required
   (see https://github.com/checkpoint-restore/criu/pull/1033, https://github.com/checkpoint-restore/criu/issues/575)