### PR TITLE
tests/centos7: add criu

### DIFF
--- a/Vagrantfile.centos7
+++ b/Vagrantfile.centos7
@@ -18,7 +18,8 @@ Vagrant.configure("2") do |config|
 
     # install yum packages
     yum install -y -q epel-release
-    yum install -y -q gcc git iptables jq libseccomp-devel make skopeo
+    (cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/adrian/criu-el7/repo/epel-7/adrian-criu-el7-epel-7.repo)
+    yum install -y -q gcc git iptables jq libseccomp-devel make skopeo criu
     yum clean all
 
     # install Go
@@ -33,8 +34,6 @@ Vagrant.configure("2") do |config|
     cd bats-core
     git checkout $BATS_VERSION
     ./install.sh /usr/local
-
-    # NOTE: criu is NOT installed. criu tests are skipped.
 
     # set PATH (NOTE: sudo without -i ignores this PATH)
     cat >> /etc/profile.d/sh.local <<EOF

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -72,7 +72,7 @@ function simple_cr() {
 
 @test "checkpoint and restore (cgroupns)" {
   # cgroupv2 already enables cgroupns so this case was tested above already
-  requires cgroups_v1
+  requires cgroups_v1 cgroupns
 
   # enable CGROUPNS
   update_config '.linux.namespaces += [{"type": "cgroup"}]'

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -286,6 +286,11 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		cgroupns)
+			if [ ! -e "/proc/self/ns/cgroup" ]; then
+				skip_me=1
+			fi
+			;;
 		cgroups_v1)
 			init_cgroup_paths
 			if [ "$CGROUP_UNIFIED" != "no" ]; then


### PR DESCRIPTION
Enable criu tests on centos 7 by using criu from Adrian's repo
(https://copr.fedorainfracloud.org/coprs/adrian/criu-el7/)
