### PR TITLE
tests/fedora32: retry dnf

### DIFF
--- a/Vagrantfile.centos7
+++ b/Vagrantfile.centos7
@@ -12,6 +12,8 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
   end
   config.vm.provision "shell", inline: <<-SHELL
+    set -e -u -o pipefail
+
     # configuration
     GO_VERSION="1.13.11"
     BATS_VERSION="v1.2.0"

--- a/Vagrantfile.fedora32
+++ b/Vagrantfile.fedora32
@@ -13,13 +13,18 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
   end
   config.vm.provision "shell", inline: <<-SHELL
-    cat << EOF | dnf -y shell
+    set -e -u -o pipefail
+    # Work around dnf mirror failures by retrying a few times
+    for i in $(seq 0 2); do
+      sleep $i
+      cat << EOF | dnf -y shell && break
 config exclude kernel,kernel-core
 config install_weak_deps false
 update
 install iptables gcc make golang-go libseccomp-devel bats jq git-core criu skopeo
 ts run
 EOF
+    done
     dnf clean all
 
     # Add a user for rootless tests


### PR DESCRIPTION
Fedora mirrors are not very stable recently, leading to CI failures
(seen in multiple recent PRs) that usually look like this:

> sudo: make: command not found

In fact it's caused by dnf failure to read metadata from mirrors:

> Errors during downloading metadata for repository 'updates':
>     Downloading successful, but checksum doesn't match. Calculated: <....>
> Error: Failed to download metadata for repo 'updates': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried

The error went undetected due to lack of exit code check.

This PR:
 - adds `set -e -u -o pipefail` so the script will fail early (and do the same for centos7 vagrantfile);
 - adds a retry loop with a sleep around dnf invocation.
