### PR TITLE
allow customizable PREFIX variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CONTAINER_ENGINE := docker
 GO := go
 
-PREFIX := $(DESTDIR)/usr/local
+PREFIX ?= $(DESTDIR)/usr/local
 BINDIR := $(PREFIX)/sbin
 MANDIR := $(PREFIX)/share/man
 


### PR DESCRIPTION
This change would let me specify my own PREFIX so that I can reuse
Makefile targets for building rpm packages.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@mrunalp @cyphar PTAL