### PR TITLE
Remove runc default devices that overlap with spec devices.

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/runc/libcontainer/utils"
 	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/opencontainers/selinux/go-selinux/label"
 
@@ -589,6 +590,12 @@ func createDevices(config *configs.Config) error {
 	useBindMount := system.RunningInUserNS() || config.Namespaces.Contains(configs.NEWUSER)
 	oldMask := unix.Umask(0000)
 	for _, node := range config.Devices {
+
+		// The /dev/ptmx device is setup by setupPtmx()
+		if utils.CleanPath(node.Path) == "/dev/ptmx" {
+			continue
+		}
+
 		// containers running in a user namespace are not allowed to mknod
 		// devices so we can just bind mount it from the host.
 		if err := createDeviceNode(config.Rootfs, node, useBindMount); err != nil {

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	teardown_busybox
+	setup_busybox
+}
+
+function teardown() {
+	teardown_busybox
+}
+
+@test "runc run [redundant default dev]" {
+	update_config ' .linux.devices += [{"path": "/dev/tty", "type": "c", "major": 5, "minor": 0}]
+		      | .process.args |= ["ls", "-l", "/dev/tty"]'
+
+	runc run test_dev
+	[ "$status" -eq 0 ]
+
+	if [[ "$ROOTLESS" -ne 0 ]]; then
+		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"nobody".+"nogroup".+"5,".+"0".+"/dev/tty" ]]
+	else
+		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"root".+"root".+"5,".+"0".+"/dev/tty" ]]
+	fi
+}

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -11,9 +11,9 @@ function teardown() {
 	teardown_busybox
 }
 
-@test "runc run [redundant default dev]" {
+@test "runc run [redundant default /dev/tty]" {
 	update_config ' .linux.devices += [{"path": "/dev/tty", "type": "c", "major": 5, "minor": 0}]
-		      | .process.args |= ["ls", "-l", "/dev/tty"]'
+		      | .process.args |= ["ls", "-lL", "/dev/tty"]'
 
 	runc run test_dev
 	[ "$status" -eq 0 ]
@@ -23,4 +23,13 @@ function teardown() {
 	else
 		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"root".+"root".+"5,".+"0".+"/dev/tty" ]]
 	fi
+}
+
+@test "runc run [redundant default /dev/ptmx]" {
+	update_config ' .linux.devices += [{"path": "/dev/ptmx", "type": "c", "major": 5, "minor": 2}]
+		      | .process.args |= ["ls", "-lL", "/dev/ptmx"]'
+
+	runc run test_dev
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"root".+"root".+"5,".+"2".+"/dev/ptmx" ]]
 }


### PR DESCRIPTION
Runc has a set of default devices that it includes in Linux containers
(e.g., /dev/null, /dev/random, /dev/tty, etc.)

However if the container's OCI spec includes all or a subset of those same devices,
runc is currently not detecting the redundancy, causing it to create a lib
container config that has redundant device configurations.

This causes a failure in rootless mode, in particular when the /dev/tty device
has a redundant config:

container_linux.go:370: starting container process caused: process_linux.go:459: container init caused: rootfs_linux.go:70: creating device nodes caused: open /tmp/busyboxtest/rootfs/dev/tty: no such device or address"

The reason this fails in rootless mode only is that in this case runc sets up
/dev/tty not by doing mknod (it's not allowed within a user-ns) but rather by
creating a regular file under /dev/tty and bind-mounting the host's /dev/tty to
the container's /dev/tty. When this operation is done redundantly, it fails the
second time.

This change fixes this problem by ensuring runc checks for redundant devices
between the OCI spec it receives and the default devices it configures. If
a redundant device is detected, the OCI spec takes priority.

The change adds both a unit test and an integration test to verify the
behavior. Without this fix, this new integration test fails as shown above.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>