### PR TITLE
Fix .travis.yml warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: bionic
 language: go
+os: linux
 go:
   - 1.14.x
   - 1.13.x
@@ -7,7 +8,7 @@ go:
 cache:
   directories:
   - /home/travis/.vagrant.d/boxes
-matrix:
+jobs:
   include:
     - go: 1.14.x
       name: "verify-dependencies"
@@ -55,7 +56,6 @@ matrix:
 go_import_path: github.com/opencontainers/runc
 
 # `make ci` uses Docker.
-sudo: required
 services:
   - docker
 


### PR DESCRIPTION
Travis reports following warnings which are fixed with this commit.
```
   root: deprecated key sudo (The key `sudo` has no effect anymore.)
   root: missing os, using the default linux
   root: key matrix is an alias for jobs, using jobs
```