### PR TITLE
cleancode: adjust and make it more readability

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -335,35 +335,28 @@ func (l *LinuxFactory) Type() string {
 // StartInitialization loads a container by opening the pipe fd from the parent to read the configuration and state
 // This is a low level implementation detail of the reexec and should not be consumed externally
 func (l *LinuxFactory) StartInitialization() (err error) {
-	var (
-		pipefd, fifofd int
-		consoleSocket  *os.File
-		envInitPipe    = os.Getenv("_LIBCONTAINER_INITPIPE")
-		envFifoFd      = os.Getenv("_LIBCONTAINER_FIFOFD")
-		envConsole     = os.Getenv("_LIBCONTAINER_CONSOLE")
-	)
-
 	// Get the INITPIPE.
-	pipefd, err = strconv.Atoi(envInitPipe)
+	envInitPipe := os.Getenv("_LIBCONTAINER_INITPIPE")
+	pipefd, err := strconv.Atoi(envInitPipe)
 	if err != nil {
 		return fmt.Errorf("unable to convert _LIBCONTAINER_INITPIPE=%s to int: %s", envInitPipe, err)
 	}
-
-	var (
-		pipe = os.NewFile(uintptr(pipefd), "pipe")
-		it   = initType(os.Getenv("_LIBCONTAINER_INITTYPE"))
-	)
+	pipe := os.NewFile(uintptr(pipefd), "pipe")
 	defer pipe.Close()
 
 	// Only init processes have FIFOFD.
-	fifofd = -1
+	fifofd := -1
+	envInitType := os.Getenv("_LIBCONTAINER_INITTYPE")
+	it := initType(envInitType)
 	if it == initStandard {
+		envFifoFd := os.Getenv("_LIBCONTAINER_FIFOFD")
 		if fifofd, err = strconv.Atoi(envFifoFd); err != nil {
 			return fmt.Errorf("unable to convert _LIBCONTAINER_FIFOFD=%s to int: %s", envFifoFd, err)
 		}
 	}
 
-	if envConsole != "" {
+	var consoleSocket *os.File
+	if envConsole := os.Getenv("_LIBCONTAINER_CONSOLE"); envConsole != "" {
 		console, err := strconv.Atoi(envConsole)
 		if err != nil {
 			return fmt.Errorf("unable to convert _LIBCONTAINER_CONSOLE=%s to int: %s", envConsole, err)


### PR DESCRIPTION
Tiny adjust `LinuxFactory.StartInitialization()` method, I think this may be more readability and clean. 

First, get environment variables are together in `var` statement at the head of the method.  The init order are also consistent with the variable declaration.

And second, `it, pipe, consoleSocket, fifofd` are the args for `i, err := newContainerInit(it, pipe, consoleSocket, fifofd)` 

Signed-off-by: Jeff Zvier <zvier20@gmail.com>