### PR TITLE
Fix run/exec with terminal: true in case stdin is not a terminal

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -12,16 +12,17 @@ import (
 	"github.com/containerd/console"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/pkg/errors"
 )
 
 type tty struct {
-	epoller   *console.Epoller
-	console   *console.EpollConsole
-	stdin     console.Console
-	closers   []io.Closer
-	postStart []io.Closer
-	wg        sync.WaitGroup
-	consoleC  chan error
+	epoller     *console.Epoller
+	console     *console.EpollConsole
+	hostConsole console.Console
+	closers     []io.Closer
+	postStart   []io.Closer
+	wg          sync.WaitGroup
+	consoleC    chan error
 }
 
 func (t *tty) copyIO(w io.Writer, r io.ReadCloser) {
@@ -71,6 +72,37 @@ func inheritStdio(process *libcontainer.Process) error {
 	return nil
 }
 
+func (t *tty) initHostConsole() error {
+	// Usually all three (stdin, stdout, and stderr) streams are open to
+	// the terminal, but they might be redirected, so try them all.
+	for _, s := range []*os.File{os.Stderr, os.Stdout, os.Stdin} {
+		c, err := console.ConsoleFromFile(s)
+		switch err {
+		case nil:
+			t.hostConsole = c
+			return nil
+		case console.ErrNotAConsole:
+			continue
+		default:
+			// should not happen
+			return errors.Wrap(err, "unable to get console")
+		}
+	}
+	// If all streams are redirected, but we still have a controlling
+	// terminal, it can be obtained by opening /dev/tty.
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		return err
+	}
+	c, err := console.ConsoleFromFile(tty)
+	if err != nil {
+		return errors.Wrap(err, "unable to get console")
+	}
+
+	t.hostConsole = c
+	return nil
+}
+
 func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) (Err error) {
 	f, err := utils.RecvFd(socket)
 	if err != nil {
@@ -99,18 +131,13 @@ func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) (Err error
 	t.wg.Add(1)
 	go t.copyIO(os.Stdout, epollConsole)
 
-	// set raw mode to stdin and also handle interrupt
-	stdin, err := console.ConsoleFromFile(os.Stdin)
-	if err != nil {
-		return err
-	}
-	if err := stdin.SetRaw(); err != nil {
+	// Set raw mode for the controlling terminal.
+	if err := t.hostConsole.SetRaw(); err != nil {
 		return fmt.Errorf("failed to set the terminal from the stdin: %v", err)
 	}
-	go handleInterrupt(stdin)
+	go handleInterrupt(t.hostConsole)
 
 	t.epoller = epoller
-	t.stdin = stdin
 	t.console = epollConsole
 	t.closers = []io.Closer{epollConsole}
 	return nil
@@ -156,15 +183,15 @@ func (t *tty) Close() error {
 	for _, c := range t.closers {
 		c.Close()
 	}
-	if t.stdin != nil {
-		t.stdin.Reset()
+	if t.hostConsole != nil {
+		t.hostConsole.Reset()
 	}
 	return nil
 }
 
 func (t *tty) resize() error {
-	if t.console == nil {
+	if t.console == nil || t.hostConsole == nil {
 		return nil
 	}
-	return t.console.ResizeFrom(console.Current())
+	return t.console.ResizeFrom(t.hostConsole)
 }

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -157,6 +157,9 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, det
 		process.Stderr = nil
 		t := &tty{}
 		if !detach {
+			if err := t.initHostConsole(); err != nil {
+				return nil, err
+			}
 			parent, child, err := utils.NewSockPair("console")
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This fixes the following failure (and the likes):

```    
sudo runc run -b bundle ctr </dev/null
WARN[0000] exit status 2
ERRO[0000] container_linux.go:367: starting container process caused: process_linux.go:459: container init caused:
```
    
The "exit status 2" with no error message is caused by SIGHUP
which is sent to init by the kernel when we are losing the
controlling terminal. If we choose to ignore that, we get
the same result, this time caused by panic in console.Current(),
which is addressed by [1].
    
Otherwise, the issue here is simple: the code assumes stdin
is opened to a terminal, and fails to work otherwise. Some
standard Linux tools (e.g. stty, top) do the same (modulo panic),
while some others (reset, tput) use the trick of trying
all the three std streams (starting with stderr as it is least likely
to be redirected), and if all three fails, open /dev/tty.
    
This commit does a similar thing (see `initHostConsole`).
    
It also replaces the call to console.Current(), which may panic
(see [1]), by reusing the t.hostConsole.
    
Finally, a couple of simple test cases are added.

Alas, I'm not sure how to automate the test case when runc is
run without a controlling terminal. I have reproduced it manually:

```console
[root@kir-rhat runc]# cat /root/runme 
cd /home/kir/go/src/github.com/opencontainers/runc
./runc run -b tst xxx-$$
echo $?
[root@kir-rhat runc]# ssh -T root@localhost ./runme
time="2020-07-31T18:51:55-07:00" level=error msg="open /dev/tty: no such device or address"
1
[root@kir-rhat runc]# 
```
(which is much better than mysterious "container init caused" error, right?)
    
[1] https://github.com/containerd/console/pull/37

Fixes: https://github.com/opencontainers/runc/issues/2485