### PR TITLE
travis: don't hardcode golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@ dist: bionic
 language: go
 os: linux
 go:
-  - 1.14.x
-  - 1.13.x
+  - stable
+  - oldstable
   - tip
 cache:
   directories:
   - /home/travis/.vagrant.d/boxes
 jobs:
   include:
-    - go: 1.14.x
+    - go: stable
       name: "verify-dependencies"
       script:
         - make verify-dependencies
-    - go: 1.13.x
+    - go: oldstable
       name: "cgroup-systemd"
       env:
         - RUNC_USE_SYSTEMD=1

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ dbuild: runcimage
 		$(RUNC_IMAGE) make clean all
 
 lint:
-	$(GO) vet ./...
-	$(GO) fmt ./...
+	$(GO) vet $(MOD_VENDOR) ./...
+	$(GO) fmt $(MOD_VENDOR) ./...
 
 man:
 	man/md2man-all.sh
@@ -120,7 +120,7 @@ clean:
 validate:
 	script/validate-gofmt
 	script/validate-c
-	$(GO) vet ./...
+	$(GO) vet $(MOD_VENDOR) ./...
 
 ci: validate test release
 


### PR DESCRIPTION
Golang is supporting two minor releases (currently 1.14.x and 1.13.x),
and thus once a new minor release is out, the oldest supported one
becomes unsupported (e.g. when 1.15 is out, 1.13 becomes unsupported).

Instead of hardcoding golang versions, let's specify "stable" and
"oldstable" (which currently equals to 1.14.x and 1.13.x). This way,
we'll be sure we're testing stuff using up to date and supported golang
releases.

This was not possible before due to:
 - https://github.com/travis-ci/gimme/issues/179
 - https://github.com/travis-ci/gimme/issues/185

but apparently it's finally fixed. Hooray!

Previous discussion on the topic:
 * https://github.com/opencontainers/runc/pull/2239#discussion_r393100037

Also, add `-mod=vendor` to `go fmt` and `go vet` since it's required
for go 1.13 to honor vendor subdir. This should speed up CI a little bit.