### PR TITLE
add Go version and libseccomp version to `runc --version`

### DIFF
--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -266,3 +266,8 @@ func parseStatusFile(path string) (map[string]string, error) {
 
 	return status, nil
 }
+
+// Version returns major, minor, and micro.
+func Version() (uint, uint, uint) {
+	return libseccomp.GetLibraryVersion()
+}

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -22,3 +22,8 @@ func InitSeccomp(config *configs.Seccomp) error {
 func IsEnabled() bool {
 	return false
 }
+
+// Version returns major, minor, and micro.
+func Version() (uint, uint, uint) {
+	return 0, 0, 0
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/logs"
@@ -62,6 +63,7 @@ func main() {
 		v = append(v, fmt.Sprintf("commit: %s", gitCommit))
 	}
 	v = append(v, fmt.Sprintf("spec: %s", specs.Version))
+	v = append(v, fmt.Sprintf("go: %s", runtime.Version()))
 	app.Version = strings.Join(v, "\n")
 
 	xdgRuntimeDir := ""

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/logs"
-
+	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/sirupsen/logrus"
@@ -64,6 +64,10 @@ func main() {
 	}
 	v = append(v, fmt.Sprintf("spec: %s", specs.Version))
 	v = append(v, fmt.Sprintf("go: %s", runtime.Version()))
+	if seccomp.IsEnabled() {
+		major, minor, micro := seccomp.Version()
+		v = append(v, fmt.Sprintf("libseccomp: %d.%d.%d", major, minor, micro))
+	}
 	app.Version = strings.Join(v, "\n")
 
 	xdgRuntimeDir := ""


### PR DESCRIPTION
Printing these information would be helpful to debug runtime-related errors.

```console
$ runc --version
runc version 1.0.0-rc91+dev
commit: bdbc3b06b4690dbb29838cb8358969451f21e62e
spec: 1.0.2-dev
go: go1.14.6
libseccomp: 2.4.3
```