### PR TITLE
Makefile: fix go vet/fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ dbuild: runcimage
 		$(RUNC_IMAGE) make clean all
 
 lint:
-	$(GO) vet ./...
-	$(GO) fmt ./...
+	$(GO) vet $(MOD_VENDOR) ./...
+	$(GO) fmt $(MOD_VENDOR) ./...
 
 man:
 	man/md2man-all.sh
@@ -120,7 +120,7 @@ clean:
 validate:
 	script/validate-gofmt
 	script/validate-c
-	$(GO) vet ./...
+	$(GO) vet $(MOD_VENDOR) ./...
 
 ci: validate test release
 


### PR DESCRIPTION
_separated from #2538_

I have noticed that `go vet` from golang 1.13 ignores the vendor/
subdir, downloading all the modules when invoked in Travis CI env.

As the other go commands, in 1.13 it needs explicit -mod=vendor
flag, so let's provide one.

PS once golang 1.13 is unsupported, we will drop it.