### PR TITLE
Add shellcheck to bats files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ validate:
 	script/validate-gofmt
 	script/validate-c
 	$(GO) vet $(MOD_VENDOR) ./...
+	shellcheck tests/integration/*.bats
 
 ci: validate test release
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -170,6 +170,7 @@ function setup() {
     [[ ${lines[0]} == "0::/foo" ]]
 
 # teardown: remove "/foo"
+    # shellcheck disable=SC2016
     runc exec test_cgroups_group sh -uxc 'echo -memory > /sys/fs/cgroup/cgroup.subtree_control; for f in $(cat /sys/fs/cgroup/foo/cgroup.procs); do echo $f > /sys/fs/cgroup/cgroup.procs; done; rmdir /sys/fs/cgroup/foo'
     runc exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
     [ "$status" -eq 0 ]

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -3,7 +3,7 @@
 load helpers
 
 function teardown() {
-    rm -f $BATS_TMPDIR/runc-cgroups-integration-test.json
+    rm -f "$BATS_TMPDIR"/runc-cgroups-integration-test.json
     teardown_running_container test_cgroups_kmem
     teardown_running_container test_cgroups_permissions
     teardown_busybox
@@ -21,10 +21,10 @@ function setup() {
     set_cgroups_path "$BUSYBOX_BUNDLE"
 
     # Set some initial known values
-    update_config '.linux.resources.memory |= {"kernel": 16777216, "kernelTCP": 11534336}' ${BUSYBOX_BUNDLE}
+    update_config '.linux.resources.memory |= {"kernel": 16777216, "kernelTCP": 11534336}' "${BUSYBOX_BUNDLE}"
 
     # run a detached busybox to work with
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_kmem
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
     [ "$status" -eq 0 ]
 
     check_cgroup_value "memory.kmem.limit_in_bytes" 16777216
@@ -48,7 +48,7 @@ function setup() {
     set_cgroups_path "$BUSYBOX_BUNDLE"
 
     # run a detached busybox to work with
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_kmem
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
     [ "$status" -eq 0 ]
 
     # update kernel memory limit
@@ -64,7 +64,7 @@ function setup() {
 }
 
 @test "runc create (no limits + no cgrouppath + no permission) succeeds" {
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_permissions
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
     [ "$status" -eq 0 ]
 }
 
@@ -76,7 +76,7 @@ function setup() {
 
     set_cgroups_path "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_permissions
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
     [ "$status" -eq 1 ]
     [[ ${lines[1]} == *"permission denied"* ]]
 }
@@ -89,7 +89,7 @@ function setup() {
 
     set_resources_limit "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_permissions
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
     [ "$status" -eq 1 ]
     [[ ${lines[1]} == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] || [[ ${lines[1]} == *"cannot set pids limit: container could not join or create cgroup"* ]]
 }
@@ -100,7 +100,7 @@ function setup() {
     set_cgroups_path "$BUSYBOX_BUNDLE"
     set_resources_limit "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_permissions
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
     [ "$status" -eq 0 ]
     if [ "$CGROUP_UNIFIED" != "no" ]; then
         if [ -n "${RUNC_USE_SYSTEMD}" ] ; then
@@ -121,7 +121,7 @@ function setup() {
     set_cgroups_path "$BUSYBOX_BUNDLE"
     set_resources_limit "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_permissions
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
     [ "$status" -eq 0 ]
 
     runc exec test_cgroups_permissions echo "cgroups_exec"
@@ -135,7 +135,7 @@ function setup() {
     set_cgroups_path "$BUSYBOX_BUNDLE"
     set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket $CONSOLE_SOCKET test_cgroups_group
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
     [ "$status" -eq 0 ]
 
     runc exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -104,9 +104,10 @@ function setup() {
     [ "$status" -eq 0 ]
     if [ "$CGROUP_UNIFIED" != "no" ]; then
         if [ -n "${RUNC_USE_SYSTEMD}" ] ; then
-            if [ $(id -u) = "0" ]; then
+            if [ "$(id -u)" = "0" ]; then
                 check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
             else
+                # shellcheck disable=SC2046
                 check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/user.slice/user-$(id -u).slice/cgroup.controllers)"
             fi
         else

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -55,7 +55,7 @@ function setup() {
     runc update test_cgroups_kmem --kernel-memory 50331648
     # Since kernel 4.6, we can update kernel memory without initialization
     # because it's accounted by default.
-    if [ "$KERNEL_MAJOR" -lt 4 ] || [ "$KERNEL_MAJOR" -eq 4 -a "$KERNEL_MINOR" -le 5 ]; then
+    if [[ "$KERNEL_MAJOR" -lt 4 || ( "$KERNEL_MAJOR" -eq 4 && "$KERNEL_MINOR" -le 5 ) ]]; then
         [ ! "$status" -eq 0 ]
     else
         [ "$status" -eq 0 ]

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -59,6 +59,7 @@ function simple_cr() {
 
   testcontainer test_busybox running
 
+  # shellcheck disable=SC2034
   for i in `seq 2`; do
     # checkpoint the running container
     runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
@@ -158,6 +159,7 @@ function simple_cr() {
   # For lazy migration we need to know when CRIU is ready to serve
   # the memory pages via TCP.
   exec {pipe}<> <(:)
+  # shellcheck disable=SC2094
   exec {lazy_r}</proc/self/fd/$pipe {lazy_w}>/proc/self/fd/$pipe
   exec {pipe}>&-
   FDS_TO_CLOSE+=($lazy_r $lazy_w)
@@ -169,6 +171,7 @@ function simple_cr() {
   # wait for lazy page server to be ready
   out=$(timeout 2 dd if=/proc/self/fd/${lazy_r} bs=1 count=1 2>/dev/null | od)
   exec {lazy_w}>&-
+  # shellcheck disable=SC2116,SC2086
   out=$(echo $out) # rm newlines
   # show errors if there are any before we fail
   grep -B5 Error ./work-dir/dump.log || true
@@ -224,7 +227,7 @@ function simple_cr() {
   # create network namespace
   ip netns add $ns_name
   ns_path=`ip netns add $ns_name 2>&1 | sed -e 's/.*"\(.*\)".*/\1/'`
-
+  # shellcheck disable=SC2012
   ns_inode=`ls -iL $ns_path | awk '{ print $1 }'`
 
   # tell runc which network namespace to use
@@ -235,6 +238,7 @@ function simple_cr() {
 
   testcontainer test_busybox running
 
+  # shellcheck disable=SC2034
   for i in `seq 2`; do
     # checkpoint the running container; this automatically tells CRIU to
     # handle the network namespace defined in config.json as an external

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -41,6 +41,7 @@ function setup_pipes() {
 	exec {in_r}</proc/self/fd/$pipe
 	exec {in_w}>/proc/self/fd/$pipe
 	exec {pipe}>&-
+	# shellcheck disable=SC2206
 	FDS_TO_CLOSE=($in_r $in_w $out_r $out_w)
 }
 
@@ -162,10 +163,12 @@ function simple_cr() {
   # shellcheck disable=SC2094
   exec {lazy_r}</proc/self/fd/$pipe {lazy_w}>/proc/self/fd/$pipe
   exec {pipe}>&-
+  # shellcheck disable=SC2206
   FDS_TO_CLOSE+=($lazy_r $lazy_w)
 
   __runc --criu "$CRIU" checkpoint --lazy-pages --page-server 0.0.0.0:${port} --status-fd ${lazy_w} --work-path ./work-dir --image-path ./image-dir test_busybox &
   cpt_pid=$!
+  # shellcheck disable=SC2206
   PIDS_TO_KILL=($cpt_pid)
 
   # wait for lazy page server to be ready
@@ -184,6 +187,7 @@ function simple_cr() {
   # Start CRIU in lazy-daemon mode
   ${CRIU} lazy-pages --page-server --address 127.0.0.1 --port ${port} -D image-dir &
   lp_pid=$!
+  # shellcheck disable=SC2206
   PIDS_TO_KILL+=($lp_pid)
 
   # Restore lazily from checkpoint.

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -63,7 +63,7 @@ function simple_cr() {
   for i in `seq 2`; do
     # checkpoint the running container
     runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
-    cat ./work-dir/dump.log | grep -B 5 Error || true
+    grep -B 5 Error ./work-dir/dump.log || true
     [ "$status" -eq 0 ]
 
     # after checkpoint busybox is no longer running
@@ -71,7 +71,7 @@ function simple_cr() {
 
     # restore from checkpoint
     runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket $CONSOLE_SOCKET test_busybox
-    cat ./work-dir/restore.log | grep -B 5 Error || true
+    grep -B 5 Error ./work-dir/restore.log || true
     [ "$status" -eq 0 ]
 
     # busybox should be back up and running
@@ -113,7 +113,7 @@ function simple_cr() {
   mkdir image-dir
   mkdir work-dir
   runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
-  cat ./work-dir/dump.log | grep -B 5 Error || true
+  grep -B 5 Error ./work-dir/dump.log || true
   [ "$status" -eq 0 ]
 
   # after checkpoint busybox is no longer running
@@ -122,7 +122,7 @@ function simple_cr() {
   # restore from checkpoint
   ret=0
   __runc --criu "$CRIU" restore -d --work-path ./work-dir --image-path ./image-dir test_busybox <&${in_r} >&${out_w} 2>&${out_w} || ret=$?
-  cat ./work-dir/restore.log | grep -B 5 Error || true
+  grep -B 5 Error ./work-dir/restore.log || true
   [ $ret -eq 0 ]
 
   # busybox should be back up and running
@@ -194,7 +194,7 @@ function simple_cr() {
   # continue to run if the migration failed at some point.
   ret=0
   __runc --criu "$CRIU" restore -d --work-path ./image-dir --image-path ./image-dir --lazy-pages test_busybox_restore <&${in_r} >&${out_w} 2>&${out_w} || ret=$?
-  cat ./work-dir/restore.log | grep -B 5 Error || true
+  grep -B 5 Error ./work-dir/restore.log || true
   [ $ret -eq 0 ]
 
   # busybox should be back up and running
@@ -243,9 +243,7 @@ function simple_cr() {
     # checkpoint the running container; this automatically tells CRIU to
     # handle the network namespace defined in config.json as an external
     runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
-    # if you are having problems getting criu to work uncomment the following dump:
-    #cat /run/opencontainer/containers/test_busybox/criu.work/dump.log
-    cat ./work-dir/dump.log | grep -B 5 Error || true
+    grep -B 5 Error ./work-dir/dump.log || true
     [ "$status" -eq 0 ]
 
     # after checkpoint busybox is no longer running
@@ -253,7 +251,7 @@ function simple_cr() {
 
     # restore from checkpoint; this should restore the container into the existing network namespace
     runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket $CONSOLE_SOCKET test_busybox
-    cat ./work-dir/restore.log | grep -B 5 Error || true
+    grep -B 5 Error ./work-dir/restore.log || true
     [ "$status" -eq 0 ]
 
     # busybox should be back up and running
@@ -296,7 +294,7 @@ function simple_cr() {
 
   # checkpoint the running container
   runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
-  cat ./work-dir/dump.log | grep -B 5 Error || true
+  grep -B 5 Error ./work-dir/dump.log || true
   [ "$status" -eq 0 ]
   ! test -f ./work-dir/$tmplog1
   test -f ./work-dir/$tmplog2
@@ -307,7 +305,7 @@ function simple_cr() {
   test -f ./work-dir/$tmplog2 && unlink ./work-dir/$tmplog2
   # restore from checkpoint
   runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket $CONSOLE_SOCKET test_busybox
-  cat ./work-dir/restore.log | grep -B 5 Error || true
+  grep -B 5 Error ./work-dir/restore.log || true
   [ "$status" -eq 0 ]
   ! test -f ./work-dir/$tmplog1
   test -f ./work-dir/$tmplog2

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -27,6 +27,7 @@ function teardown() {
 
 function setup_pipes() {
 	# The changes to 'terminal' are needed for running in detached mode
+	# shellcheck disable=SC2016
 	update_config 	' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["-c", "for i in `seq 10`; do read xxx || continue; echo ponG $xxx; done"]'
 

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -12,7 +12,7 @@ function teardown() {
 }
 
 @test "runc create" {
-  runc create --console-socket $CONSOLE_SOCKET test_busybox
+  runc create --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created
@@ -25,7 +25,7 @@ function teardown() {
 }
 
 @test "runc create exec" {
-  runc create --console-socket $CONSOLE_SOCKET test_busybox
+  runc create --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created
@@ -43,7 +43,7 @@ function teardown() {
 }
 
 @test "runc create --pid-file" {
-  runc create --pid-file pid.txt --console-socket $CONSOLE_SOCKET test_busybox
+  runc create --pid-file pid.txt --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created
@@ -69,7 +69,7 @@ function teardown() {
   run cd pid_file
   [ "$status" -eq 0 ]
 
-  runc create --pid-file pid.txt -b $BUSYBOX_BUNDLE --console-socket $CONSOLE_SOCKET  test_busybox
+  runc create --pid-file pid.txt -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET"  test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -82,7 +82,7 @@ function teardown() {
   echo ${pid} > cgroup.threads
   cat cgroup.threads
 EOF
-  cat nest.sh | runc exec test_busybox sh
+  runc exec test_busybox sh < nest.sh
   [ "$status" -eq 0 ]
   [[ "$output" =~ [0-9]+ ]]
 

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -12,7 +12,7 @@ function teardown() {
 }
 
 @test "runc delete" {
-  runc run -d --console-socket $CONSOLE_SOCKET testbusyboxdelete
+  runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
   [ "$status" -eq 0 ]
 
   testcontainer testbusyboxdelete running
@@ -34,7 +34,7 @@ function teardown() {
 
 @test "runc delete --force" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -58,7 +58,7 @@ function teardown() {
   set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -87,7 +87,7 @@ EOF
   [[ "$output" =~ [0-9]+ ]]
 
   # check create subcgroups success
-  [ -d $CGROUP_PATH/foo ]
+  [ -d "$CGROUP_PATH"/foo ]
 
   # force delete test_busybox
   runc delete --force test_busybox
@@ -96,5 +96,5 @@ EOF
   [ "$status" -ne 0 ]
 
   # check delete subcgroups success
-  [ ! -d $CGROUP_PATH/foo ]
+  [ ! -d "$CGROUP_PATH"/foo ]
 }

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -131,6 +131,7 @@ function teardown() {
   (__runc events test_busybox > events.log) &
   (
     retry 10 1 eval "grep -q 'test_busybox' events.log"
+    # shellcheck disable=SC2016
     __runc exec -d test_busybox sh -c 'test=$(dd if=/dev/urandom ibs=5120k)'
     retry 10 1 eval "grep -q 'oom' events.log"
     __runc delete -f test_busybox

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -17,7 +17,7 @@ function teardown() {
   init_cgroup_paths
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # generate stats
@@ -33,7 +33,7 @@ function teardown() {
   init_cgroup_paths
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # spawn two sub processes (shells)
@@ -61,7 +61,7 @@ function teardown() {
   init_cgroup_paths
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # spawn two sub processes (shells)
@@ -88,7 +88,7 @@ function teardown() {
   init_cgroup_paths
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   #prove there is no carry over of events.log from a prior test
@@ -118,10 +118,10 @@ function teardown() {
   init_cgroup_paths
 
   # we need the container to hit OOM, so disable swap
-  update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}' ${BUSYBOX_BUNDLE}
+  update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}' "${BUSYBOX_BUNDLE}"
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # spawn two sub processes (shells)

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc exec" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc exec test_busybox echo Hello from exec
@@ -24,7 +24,7 @@ function teardown() {
 
 @test "runc exec --pid-file" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc exec --pid-file pid.txt test_busybox echo Hello from exec
@@ -49,7 +49,7 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # run busybox detached
-  runc run -d -b $BUSYBOX_BUNDLE --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc exec --pid-file pid.txt test_busybox echo Hello from exec
@@ -68,7 +68,7 @@ function teardown() {
 
 @test "runc exec ls -la" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc exec test_busybox ls -la
@@ -80,7 +80,7 @@ function teardown() {
 
 @test "runc exec ls -la with --cwd" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc exec --cwd /bin test_busybox pwd
@@ -90,7 +90,7 @@ function teardown() {
 
 @test "runc exec --env" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc exec --env RUNC_EXEC_TEST=true test_busybox env
@@ -104,7 +104,7 @@ function teardown() {
   [[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc exec --user 1000:1000 test_busybox id
@@ -117,7 +117,7 @@ function teardown() {
   requires root
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   wait_for_container 15 1 test_busybox
@@ -130,7 +130,7 @@ function teardown() {
 
 @test "runc exec --preserve-fds" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   run bash -c "cat hello > preserve-fds.test; exec 3<preserve-fds.test; $RUNC ${RUNC_USE_SYSTEMD:+--systemd-cgroup} --log /proc/self/fd/2 --root $ROOT exec --preserve-fds=1 test_busybox cat /proc/self/fd/3"

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -39,7 +39,8 @@ function teardown() {
 		pid=\$(cat - | jq -r '.pid')
 		touch "$LIBPATH/$HOOKLIBCR.1.0.0"
 		nsenter -m \$ns -t \$pid mount --bind "$current_pwd/$HOOKLIBCR.1.0.0" "$LIBPATH/$HOOKLIBCR.1.0.0"
-	EOF)
+EOF
+)
 
 	create_container_hook="touch ./lib/$HOOKLIBCC.1.0.0 && mount --bind $current_pwd/$HOOKLIBCC.1.0.0 ./lib/$HOOKLIBCC.1.0.0"
 

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -9,16 +9,16 @@ HOOKLIBCC=librunc-hooks-create-container.so
 LIBPATH="$DEBIAN_BUNDLE/rootfs/lib/"
 
 function setup() {
-	umount $LIBPATH/$HOOKLIBCR.1.0.0 &> /dev/null || true
-	umount $LIBPATH/$HOOKLIBCC.1.0.0 &> /dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &> /dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &> /dev/null || true
 
 	teardown_debian
 	setup_debian
 }
 
 function teardown() {
-	umount $LIBPATH/$HOOKLIBCR.1.0.0 &> /dev/null || true
-	umount $LIBPATH/$HOOKLIBCC.1.0.0 &> /dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &> /dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &> /dev/null || true
 
 	rm -f $HOOKLIBCR.1.0.0 $HOOKLIBCC.1.0.0
 	teardown_debian
@@ -48,15 +48,15 @@ EOF
 		.hooks |= . + {"createRuntime": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_runtime_hook]}]} |
 		.hooks |= . + {"createContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_container_hook]}]} |
 		.hooks |= . + {"startContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", "ldconfig"]}]} |
-		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' $DEBIAN_BUNDLE/config.json)
+		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' "$DEBIAN_BUNDLE"/config.json)
 	echo "${CONFIG}" > config.json
 
 	runc run test_debian
 	[ "$status" -eq 0 ]
 
 	echo "Checking create-runtime library"
-	echo $output | grep $HOOKLIBCR
+	echo "$output" | grep $HOOKLIBCR
 
 	echo "Checking create-container library"
-	echo $output | grep $HOOKLIBCC
+	echo "$output" | grep $HOOKLIBCC
 }

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -14,7 +14,7 @@ function teardown() {
 
 @test "kill detached busybox" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -3,29 +3,29 @@
 load helpers
 
 function setup() {
-  teardown_running_container_inroot test_box1 $HELLO_BUNDLE
-  teardown_running_container_inroot test_box2 $HELLO_BUNDLE
-  teardown_running_container_inroot test_box3 $HELLO_BUNDLE
+  teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
+  teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
+  teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
   teardown_busybox
   setup_busybox
 }
 
 function teardown() {
-  teardown_running_container_inroot test_box1 $HELLO_BUNDLE
-  teardown_running_container_inroot test_box2 $HELLO_BUNDLE
-  teardown_running_container_inroot test_box3 $HELLO_BUNDLE
+  teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
+  teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
+  teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
   teardown_busybox
 }
 
 @test "list" {
   # run a few busyboxes detached
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box1
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
   [ "$status" -eq 0 ]
 
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box2
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
   [ "$status" -eq 0 ]
 
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_box3
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
   [ "$status" -eq 0 ]
 
   ROOT=$HELLO_BUNDLE runc list

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -20,7 +20,7 @@ function teardown() {
 
 @test "mask paths [file]" {
 	# run busybox detached
-	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	runc exec test_busybox cat /testfile
@@ -38,7 +38,7 @@ function teardown() {
 
 @test "mask paths [directory]" {
 	# run busybox detached
-	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	runc exec test_busybox ls /testdir

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -17,5 +17,5 @@ function teardown() {
 
 	runc run test_bind_mount
 	[ "$status" -eq 0 ]
-	[[ "${lines[0]}" =~ '/tmp/bind/config.json' ]]
+	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
 }

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -20,7 +20,7 @@ function teardown() {
   requires cgroups_freezer
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox running
@@ -49,7 +49,7 @@ function teardown() {
   requires cgroups_freezer
 
   # run test_busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox running

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -16,7 +16,7 @@ function teardown() {
   requires root
 
   # start busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -33,7 +33,7 @@ function teardown() {
   requires root
 
   # start busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -49,7 +49,7 @@ function teardown() {
   requires root
 
   # start busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -67,7 +67,7 @@ function teardown() {
   set_cgroups_path "$BUSYBOX_BUNDLE"
 
   # start busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -3,23 +3,23 @@
 load helpers
 
 function setup() {
-  teardown_running_container_inroot test_dotbox $HELLO_BUNDLE
+  teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
   teardown_busybox
   setup_busybox
 }
 
 function teardown() {
-  teardown_running_container_inroot test_dotbox $HELLO_BUNDLE
+  teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
   teardown_busybox
 }
 
 @test "global --root" {
   # run busybox detached using $HELLO_BUNDLE for state
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket $CONSOLE_SOCKET test_dotbox
+  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_dotbox
   [ "$status" -eq 0 ]
 
   # run busybox detached in default root
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   runc state test_busybox

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -55,7 +55,7 @@ function teardown() {
   [ -e "$HELLO_BUNDLE"/config.json ]
 
   # change the default args parameter from sh to hello
-  update_config '(.. | select(.? == "sh")) |= "/hello"' $HELLO_BUNDLE
+  update_config '(.. | select(.? == "sh")) |= "/hello"' "$HELLO_BUNDLE"
 
   # ensure the generated spec works by running hello-world
   runc run --bundle "$HELLO_BUNDLE" test_hello
@@ -69,12 +69,12 @@ function teardown() {
   run git clone https://github.com/opencontainers/runtime-spec.git src/runtime-spec
   [ "$status" -eq 0 ]
 
-  SPEC_VERSION=$(grep 'github.com/opencontainers/runtime-spec' ${TESTDIR}/../../go.mod | cut -d ' ' -f 2)
+  SPEC_VERSION=$(grep 'github.com/opencontainers/runtime-spec' "${TESTDIR}"/../../go.mod | cut -d ' ' -f 2)
 
   # Will look like this when not pinned to spesific tag: "v0.0.0-20190207185410-29686dbc5559", otherwise "v1.0.0"
-  SPEC_COMMIT=$(cut -d "-" -f 3 <<< $SPEC_VERSION)
+  SPEC_COMMIT=$(cut -d "-" -f 3 <<< "$SPEC_VERSION")
 
-  SPEC_REF=$([[ -z "$SPEC_COMMIT" ]] && echo $SPEC_VERSION || echo $SPEC_COMMIT)
+  SPEC_REF=$([[ -z "$SPEC_COMMIT" ]] && echo "$SPEC_VERSION" || echo "$SPEC_COMMIT")
 
   run bash -c "cd src/runtime-spec && git reset --hard ${SPEC_REF}"
 

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -4,18 +4,15 @@ load helpers
 
 function setup() {
   # initial cleanup in case a prior test exited and did not cleanup
-  cd "$INTEGRATION_ROOT"
-  run rm -f -r "$HELLO_BUNDLE"
+  rm -rf "$HELLO_BUNDLE"
 
   # setup hello-world for spec generation testing
-  run mkdir "$HELLO_BUNDLE"
-  run mkdir "$HELLO_BUNDLE"/rootfs
-  run tar -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
+  mkdir -p "$HELLO_BUNDLE"/rootfs
+  tar -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
 }
 
 function teardown() {
-  cd "$INTEGRATION_ROOT"
-  run rm -f -r "$HELLO_BUNDLE"
+  rm -rf "$HELLO_BUNDLE"
 }
 
 @test "spec generation cwd" {

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -12,7 +12,7 @@ function teardown() {
 }
 
 @test "runc start" {
-  runc create --console-socket $CONSOLE_SOCKET test_busybox
+  runc create --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   testcontainer test_busybox created

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc run detached" {
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -30,7 +30,7 @@ function teardown() {
 		| (.. | select(.gid? == 0)) .gid |= 100' 
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -39,7 +39,7 @@ function teardown() {
 
 @test "runc run detached --pid-file" {
   # run busybox detached
-  runc run --pid-file pid.txt -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -61,7 +61,7 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   # run busybox detached
-  runc run --pid-file pid.txt -d  -b $BUSYBOX_BUNDLE --console-socket $CONSOLE_SOCKET test_busybox
+  runc run --pid-file pid.txt -d  -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -16,7 +16,7 @@ function teardown() {
   [ "$status" -ne 0 ]
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state
@@ -44,7 +44,7 @@ function teardown() {
   [ "$status" -ne 0 ]
 
   # run busybox detached
-  runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
   [ "$status" -eq 0 ]
 
   # check state

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -152,7 +152,7 @@ EOF
 	[ -e pid.txt ]
 
 	#wait user process to finish
-	timeout 1 tail --pid=$(head -n 1 pid.txt) -f /dev/null
+	timeout 1 tail --pid="$(head -n 1 pid.txt)" -f /dev/null
 
 	tty_info=$( cat <<EOF
 {

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -13,7 +13,8 @@ function teardown() {
 
 @test "runc run [tty ptsname]" {
 	# Replace sh script with readlink.
-	update_config '(.. | select(.[]? == "sh")) += ["-c", "for file in /proc/self/fd/[012]; do readlink $file; done"]' 
+	# shellcheck disable=SC2016
+	update_config '(.. | select(.[]? == "sh")) += ["-c", "for file in /proc/self/fd/[012]; do readlink $file; done"]'
 
 	# run busybox
 	runc run test_busybox
@@ -29,7 +30,8 @@ function teardown() {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
 	# Replace sh script with stat.
-	update_config '(.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]' 
+	# shellcheck disable=SC2016
+	update_config '(.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
 	# run busybox
 	runc run test_busybox
@@ -46,7 +48,8 @@ function teardown() {
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
 	# Replace sh script with stat.
-	update_config 	' (.. | select(.uid? == 0)) .uid |= 1000 
+	# shellcheck disable=SC2016
+	update_config 	' (.. | select(.uid? == 0)) .uid |= 1000
 			| (.. | select(.gid? == 0)) .gid |= 100
 			| (.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
@@ -67,7 +70,8 @@ function teardown() {
 	testcontainer test_busybox running
 
 	# run the exec
-    runc exec -t test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
+	# shellcheck disable=SC2016
+	runc exec -t test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ /dev/pts/+ ]]
 	[[ ${lines[1]} =~ /dev/pts/+ ]]
@@ -87,7 +91,8 @@ function teardown() {
 	testcontainer test_busybox running
 
 	# run the exec
-    runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
+	# shellcheck disable=SC2016
+	runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ 0 ]]
 	[[ ${lines[1]} =~ 5 ]]
@@ -99,8 +104,9 @@ function teardown() {
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
+	# shellcheck disable=SC2016
 	update_config 	' (.. | select(.uid? == 0)) .uid |= 1000
-  			| (.. | select(.gid? == 0)) .gid |= 100' 
+			| (.. | select(.gid? == 0)) .gid |= 100'
 
 	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
@@ -110,6 +116,7 @@ function teardown() {
 	testcontainer test_busybox running
 
 	# run the exec
+	# shellcheck disable=SC2016
 	runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ 1000 ]]
@@ -197,7 +204,7 @@ EOF
 @test "runc run [terminal=false]" {
 	# Disable terminal creation.
 	# Replace sh script with sleep.
-	
+
 	update_config   ' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["sleep", "1000s"]
 			| del(.. | select(.? == "sh"))'
@@ -219,7 +226,7 @@ EOF
 	# Disable terminal creation.
 	# Replace sh script with sleep.
 	update_config 	' (.. | select(.terminal? != null)) .terminal |= false
-			| (.. | select(.[]? == "sh")) += ["sleep", "1000s"] 
+			| (.. | select(.[]? == "sh")) += ["sleep", "1000s"]
 			| del(.. | select(.? == "sh"))'
 
 	# Make sure that the handling of detached IO is done properly. See #1354.

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -60,7 +60,7 @@ function teardown() {
 
 @test "runc exec [tty ptsname]" {
 	# run busybox detached
-	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	# make sure we're running
@@ -80,7 +80,7 @@ function teardown() {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
 	# run busybox detached
-	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	# make sure we're running
@@ -103,7 +103,7 @@ function teardown() {
   			| (.. | select(.gid? == 0)) .gid |= 100' 
 
 	# run busybox detached
-	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	# make sure we're running
@@ -121,7 +121,7 @@ function teardown() {
 	update_config '(.. | select(.readonly? != null)) .readonly |= false'
 
 	# run busybox detached
-	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	# make sure we're running
@@ -145,7 +145,7 @@ EOF
 	)
 
 	# run the exec
-	runc exec -t --pid-file pid.txt -d --console-socket $CONSOLE_SOCKET -p <( echo $tty_info_with_consize_size ) test_busybox
+	runc exec -t --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" -p <( echo "$tty_info_with_consize_size" ) test_busybox
 	[ "$status" -eq 0 ]
 
 	# check the pid was generated
@@ -166,7 +166,7 @@ EOF
 	)
 
 	# run the exec
-	runc exec -t -p <( echo $tty_info ) test_busybox
+	runc exec -t -p <( echo "$tty_info" ) test_busybox
 	[ "$status" -eq 0 ]
 
 	# test tty width and height against original process.json

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -419,8 +419,9 @@ EOF
     #
     # TODO: support systemd
     mkdir -p "$CGROUP_CPU"
-    local root_period=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us")
-    local root_runtime=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_runtime_us")
+    local root_period root_runtime
+    root_period=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us")
+    root_runtime=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_runtime_us")
     # the following IFS magic sets dirs=("runc-cgroups-integration-test" "test-cgroup")
     IFS='/' read -r -a dirs <<< $(echo ${CGROUP_CPU} | sed -e s@^${CGROUP_CPU_BASE_PATH}/@@)
     for (( i = 0; i < ${#dirs[@]}; i++ )); do

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -423,7 +423,7 @@ EOF
     root_period=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us")
     root_runtime=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_runtime_us")
     # the following IFS magic sets dirs=("runc-cgroups-integration-test" "test-cgroup")
-    IFS='/' read -r -a dirs <<< $(echo ${CGROUP_CPU} | sed -e s@^${CGROUP_CPU_BASE_PATH}/@@)
+    IFS='/' read -r -a dirs <<< "${CGROUP_CPU//${CGROUP_CPU_BASE_PATH}/}"
     for (( i = 0; i < ${#dirs[@]}; i++ )); do
         local target="$CGROUP_CPU_BASE_PATH"
         for (( j = 0; j <= i; j++ )); do


### PR DESCRIPTION
This PR
 - fixes (or adds annotations to ignore) all the shellcheck warnings for .bats files;
 - add shellcheck to the CI cycle.

TODO (not in this PR):
 - fix shellcheck warnings for helpers.bash

~~This currently includes #2548; I'll rebase once it's merged.~~ rebased