### PR TITLE
support CAP_PERFMON, CAP_BPF, and CAP_CHECKPOINT_RESTORE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.1
 	github.com/sirupsen/logrus v1.6.0
-	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	// NOTE: urfave/cli must be <= v1.22.1 due to a regression: https://github.com/urfave/cli/issues/1092
 	github.com/urfave/cli v1.22.1
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/moby/sys/mountinfo v0.1.3 h1:KIrhRO14+AkwKvG/g2yIpNMOUVZ02xNhOw8KY1Ws
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976 h1:aZQToFSLH8ejFeSkTc3r3L4dPImcj7Ib/KgmkQqbGGg=
 github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
-github.com/opencontainers/runtime-spec v1.0.3-0.20200710190001-3e4195d92445 h1:y8cfsJRmn8g3VkM4IDpusKSgMUZEXhudm/BuYANLozE=
-github.com/opencontainers/runtime-spec v1.0.3-0.20200710190001-3e4195d92445/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6 h1:NhsM2gc769rVWDqJvapK37r+7+CBXI8xHhnfnt8uQsg=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.6.0 h1:+bIAS/Za3q5FTwWym4fTB0vObnfCf3G/NC7K6Jx62mY=
@@ -57,8 +55,8 @@ github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
-github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=

--- a/vendor/github.com/syndtr/gocapability/capability/enum.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum.go
@@ -41,7 +41,9 @@ const (
 //go:generate go run enumgen/gen.go
 type Cap int
 
-// POSIX-draft defined capabilities.
+// POSIX-draft defined capabilities and Linux extensions.
+//
+// Defined in https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
 const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
 	// overrides the restriction of changing file ownership and group
@@ -187,6 +189,7 @@ const (
 	// arbitrary SCSI commands
 	// Allow setting encryption key on loopback filesystem
 	// Allow setting zone reclaim policy
+	// Allow everything under CAP_BPF and CAP_PERFMON for backward compatibility
 	CAP_SYS_ADMIN = Cap(21)
 
 	// Allow use of reboot()
@@ -211,6 +214,7 @@ const (
 	// Allow more than 64hz interrupts from the real-time clock
 	// Override max number of consoles on console allocation
 	// Override max number of keymaps
+	// Control memory reclaim behavior
 	CAP_SYS_RESOURCE = Cap(24)
 
 	// Allow manipulation of system clock
@@ -256,8 +260,45 @@ const (
 	// Allow preventing system suspends
 	CAP_BLOCK_SUSPEND = Cap(36)
 
-	// Allow reading audit messages from the kernel
+	// Allow reading the audit log via multicast netlink socket
 	CAP_AUDIT_READ = Cap(37)
+
+	// Allow system performance and observability privileged operations
+	// using perf_events, i915_perf and other kernel subsystems
+	CAP_PERFMON = Cap(38)
+
+	// CAP_BPF allows the following BPF operations:
+	// - Creating all types of BPF maps
+	// - Advanced verifier features
+	//   - Indirect variable access
+	//   - Bounded loops
+	//   - BPF to BPF function calls
+	//   - Scalar precision tracking
+	//   - Larger complexity limits
+	//   - Dead code elimination
+	//   - And potentially other features
+	// - Loading BPF Type Format (BTF) data
+	// - Retrieve xlated and JITed code of BPF programs
+	// - Use bpf_spin_lock() helper
+	//
+	// CAP_PERFMON relaxes the verifier checks further:
+	// - BPF progs can use of pointer-to-integer conversions
+	// - speculation attack hardening measures are bypassed
+	// - bpf_probe_read to read arbitrary kernel memory is allowed
+	// - bpf_trace_printk to print kernel memory is allowed
+	//
+	// CAP_SYS_ADMIN is required to use bpf_probe_write_user.
+	//
+	// CAP_SYS_ADMIN is required to iterate system wide loaded
+	// programs, maps, links, BTFs and convert their IDs to file descriptors.
+	//
+	// CAP_PERFMON and CAP_BPF are required to load tracing programs.
+	// CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
+	CAP_BPF = Cap(39)
+
+	// Allow checkpoint/restore related operations.
+	// Introduced in kernel 5.9
+	CAP_CHECKPOINT_RESTORE = Cap(40)
 )
 
 var (

--- a/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
@@ -80,6 +80,12 @@ func (c Cap) String() string {
 		return "block_suspend"
 	case CAP_AUDIT_READ:
 		return "audit_read"
+	case CAP_PERFMON:
+		return "perfmon"
+	case CAP_BPF:
+		return "bpf"
+	case CAP_CHECKPOINT_RESTORE:
+		return "checkpoint_restore"
 	}
 	return "unknown"
 }
@@ -125,5 +131,8 @@ func List() []Cap {
 		CAP_WAKE_ALARM,
 		CAP_BLOCK_SUSPEND,
 		CAP_AUDIT_READ,
+		CAP_PERFMON,
+		CAP_BPF,
+		CAP_CHECKPOINT_RESTORE,
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.6.0
 ## explicit
 github.com/sirupsen/logrus
-# github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+# github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 ## explicit
 github.com/syndtr/gocapability/capability
 # github.com/urfave/cli v1.22.1


### PR DESCRIPTION
CAP_PERFMON and CAP_BPF were introduced in kernel 5.8: https://kernelnewbies.org/Linux_5.8#Introduce_CAP_BPF_and_CAP_PERFMON_security_capabilities

CAP_CHECKPOINT_RESTORE was merged on the master recently and will be available in the next version of the kernel. https://github.com/torvalds/linux/commit/124ea650d3072b005457faed69909221c2905a1f
