### PR TITLE
shellcheck CI files

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -61,8 +61,7 @@ function simple_cr() {
 
   testcontainer test_busybox running
 
-  # shellcheck disable=SC2034
-  for i in $(seq 2); do
+  for _ in $(seq 2); do
     # checkpoint the running container
     runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
     grep -B 5 Error ./work-dir/dump.log || true
@@ -243,8 +242,7 @@ function simple_cr() {
 
   testcontainer test_busybox running
 
-  # shellcheck disable=SC2034
-  for i in $(seq 2); do
+  for _ in $(seq 2); do
     # checkpoint the running container; this automatically tells CRIU to
     # handle the network namespace defined in config.json as an external
     runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -61,7 +61,7 @@ function teardown() {
 
   local subsystems="memory freezer"
 
-    runc run -d --console-socket $CONSOLE_SOCKET test_busybox
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
     [ "$status" -eq 0 ]
 
     testcontainer test_busybox running
@@ -88,9 +88,9 @@ EOF
 
     for s in ${subsystems}; do
       name=CGROUP_${s^^}
-      eval path=\$${name}/foo
-      echo $path
-      [ -d ${path} ] || fail "test failed to create memory sub-cgroup"
+      eval path=\$"${name}"/foo
+      # shellcheck disable=SC2154
+      [ -d "${path}" ] || fail "test failed to create memory sub-cgroup ($path not found)"
     done
 
     runc delete --force test_busybox

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -61,7 +61,6 @@ function teardown() {
 
   local subsystems="memory freezer"
 
-  for i in $(seq 1); do
     runc run -d --console-socket $CONSOLE_SOCKET test_busybox
     [ "$status" -eq 0 ]
 
@@ -102,8 +101,6 @@ EOF
     run find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d
     [ "$status" -eq 0 ]
     [ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
-
-  done
 }
 
 @test "runc delete --force in cgroupv2 with subcgroups" {


### PR DESCRIPTION
#### 1. tests/int/delete.bats: fix shellcheck warnings.

Those are caused by merging #2506 after #2549 without a rebase.
Fixes: #2559 

The failures were:

```
In tests/integration/delete.bats line 64:
  for i in $(seq 1); do
  ^-^ SC2034: i appears unused. Verify use (or export if used externally).


In tests/integration/delete.bats line 65:
    runc run -d --console-socket $CONSOLE_SOCKET test_busybox
                                 ^-------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
    runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox


In tests/integration/delete.bats line 92:
      eval path=\$${name}/foo
                  ^-----^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
      eval path=\$"${name}"/foo


In tests/integration/delete.bats line 93:
      echo $path
           ^---^ SC2154: path is referenced but not assigned.
           ^---^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
      echo "$path"


In tests/integration/delete.bats line 94:
      [ -d ${path} ] || fail "test failed to create memory sub-cgroup"
           ^-----^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
      [ -d "${path}" ] || fail "test failed to create memory sub-cgroup"


In tests/integration/tty.bats line 73:
	runc run -d --console-socket $CONSOLE_SOCKET test_busybox
                                     ^-------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- i appears unused. Verify use (or ...
  https://www.shellcheck.net/wiki/SC2154 -- path is referenced but not assign...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

#### 2. tests/int: alt fix for shellcheck SC2034

Instead of ignoring it, use a throwaway variable `_`
(yes, just like in Go).

