### PR TITLE
 Optimize file-writing in libcontainer/cgroups/fs

### DIFF
--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -24,10 +24,12 @@ func (s *HugetlbGroup) Apply(path string, d *cgroupData) error {
 }
 
 func (s *HugetlbGroup) Set(path string, cgroup *configs.Cgroup) error {
-	for _, hugetlb := range cgroup.Resources.HugetlbLimit {
-		if err := fscommon.WriteFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
-			return err
-		}
+	if len(cgroup.Resources.HugetlbLimit) == 0 {
+		return nil
+	}
+	hugetlb := cgroup.Resources.HugetlbLimit[len(cgroup.Resources.HugetlbLimit)-1]
+	if err := fscommon.WriteFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
+		return err
 	}
 
 	return nil

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -20,10 +20,12 @@ func (s *NetPrioGroup) Apply(path string, d *cgroupData) error {
 }
 
 func (s *NetPrioGroup) Set(path string, cgroup *configs.Cgroup) error {
-	for _, prioMap := range cgroup.Resources.NetPrioIfpriomap {
-		if err := fscommon.WriteFile(path, "net_prio.ifpriomap", prioMap.CgroupString()); err != nil {
-			return err
-		}
+	if len(cgroup.Resources.NetPrioIfpriomap) == 0 {
+		return nil
+	}
+	prioMap := cgroup.Resources.NetPrioIfpriomap[len(cgroup.Resources.NetPrioIfpriomap)-1]
+	if err := fscommon.WriteFile(path, "net_prio.ifpriomap", prioMap.CgroupString()); err != nil {
+		return err
 	}
 
 	return nil

--- a/libcontainer/cgroups/fscommon/fscommon.go
+++ b/libcontainer/cgroups/fscommon/fscommon.go
@@ -13,10 +13,7 @@ import (
 )
 
 func WriteFile(dir, file, data string) error {
-	if dir == "" {
-		return errors.Errorf("no directory specified for %s", file)
-	}
-	path, err := securejoin.SecureJoin(dir, file)
+	path, err := joinPath(dir, file)
 	if err != nil {
 		return err
 	}
@@ -27,6 +24,15 @@ func WriteFile(dir, file, data string) error {
 }
 
 func ReadFile(dir, file string) (string, error) {
+	path, err := joinPath(dir, file)
+	if err != nil {
+		return "", err
+	}
+	data, err := ioutil.ReadFile(path)
+	return string(data), err
+}
+
+func joinPath(dir, file string) (string, error) {
 	if dir == "" {
 		return "", errors.Errorf("no directory specified for %s", file)
 	}
@@ -34,8 +40,7 @@ func ReadFile(dir, file string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadFile(path)
-	return string(data), err
+	return path, nil
 }
 
 func retryingWriteFile(filename string, data []byte, perm os.FileMode) error {


### PR DESCRIPTION
This optimizes file-writing in the `libcontainer/cgroups/fs` package, addressing #2115

Originally, I sought to optimize file manipulation by opening and closing files once outside of each for-loop, as suggested [here](https://github.com/opencontainers/runc/issues/2115#issuecomment-681317084) by @kolyshkin. 

However, this test in `libcontainer/cgroups/fs/blkio_test.go` alerted me to the fact that only the last-written values are kept:
https://github.com/opencontainers/runc/blob/09ddc63afdde16d5fb859a1d3ab010bd45f08497/libcontainer/cgroups/fs/blkio_test.go#L140-L175

So, in this PR I refactored these looping write patterns so that only the last value in each slice is written to file.

I also define a `joinPath` helper to reduce duplication between `fscommon.WriteFile()` and `fscommon.ReadFile()`