### PR TITLE
tests/int: fix wrt busybox's nogroup->nobody change

### DIFF
--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -13,23 +13,23 @@ function teardown() {
 
 @test "runc run [redundant default /dev/tty]" {
 	update_config ' .linux.devices += [{"path": "/dev/tty", "type": "c", "major": 5, "minor": 0}]
-		      | .process.args |= ["ls", "-lL", "/dev/tty"]'
+		      | .process.args |= ["ls", "-lLn", "/dev/tty"]'
 
 	runc run test_dev
 	[ "$status" -eq 0 ]
 
 	if [[ "$ROOTLESS" -ne 0 ]]; then
-		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"nobody".+"nogroup".+"5,".+"0".+"/dev/tty" ]]
+		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"65534".+"65534".+"5,".+"0".+"/dev/tty" ]]
 	else
-		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"root".+"root".+"5,".+"0".+"/dev/tty" ]]
+		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"0".+"0".+"5,".+"0".+"/dev/tty" ]]
 	fi
 }
 
 @test "runc run [redundant default /dev/ptmx]" {
 	update_config ' .linux.devices += [{"path": "/dev/ptmx", "type": "c", "major": 5, "minor": 2}]
-		      | .process.args |= ["ls", "-lL", "/dev/ptmx"]'
+		      | .process.args |= ["ls", "-lLn", "/dev/ptmx"]'
 
 	runc run test_dev
 	[ "$status" -eq 0 ]
-	[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"root".+"root".+"5,".+"2".+"/dev/ptmx" ]]
+	[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"0".+"0".+"5,".+"2".+"/dev/ptmx" ]]
 }

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -122,10 +122,10 @@ function teardown() {
 
   wait_for_container 15 1 test_busybox
 
-  runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id
+  runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
   [ "$status" -eq 0 ]
 
-  [[ ${output} == "uid=1000 gid=1000 groups=100(users),65534(nogroup)" ]]
+  [[ ${output} == "1000 100 65534" ]]
 }
 
 @test "runc exec --preserve-fds" {


### PR DESCRIPTION
Apparently, newer busybox image changed "nogroup" group name to "nobody",
breaking a few test cases that depended on the name.

Fix those tests by switching to numeric IDs.

### 1. tests/int: fix runc exec --preserve-fds

This test started to fail, as it expected the output from
`id` to be

	uid=1000 gid=1000 groups=100(users),65534(nogroup)

while the actual output is now

	uid=1000 gid=1000 groups=100(users),65534(nobody)

Apparently, busybox image changed group name.

As we're only interested in ids, not names, and to fix the test,
let's use `id -G`.

### 2. tests/int/dev.bats: fixes for new busybox

These tests expect group name to be "nogroup", while recent busybox
changed that to "nobody".

Use numeric uids/gids to fix.
