### PR TITLE
tests/integration/checkpoint.bats: fix showing errors, rm unused code

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -198,7 +198,7 @@ function simple_cr() {
   # continue to run if the migration failed at some point.
   ret=0
   __runc --criu "$CRIU" restore -d --work-path ./image-dir --image-path ./image-dir --lazy-pages test_busybox_restore <&${in_r} >&${out_w} 2>&${out_w} || ret=$?
-  grep -B 5 Error ./work-dir/restore.log || true
+  grep -B 5 Error ./image-dir/restore.log || true
   [ $ret -eq 0 ]
 
   # busybox should be back up and running


### PR DESCRIPTION
Another set of fixes to aim in debugging of https://github.com/opencontainers/runc/issues/2475.

For previous fixes, see #2476, #2509, and #2548.

Individual commits description follows

## tests/int/checkpoint: don't hide stderr

For test cases where we used pipes for container's stdin/stdout/stderr,
stderr was redirected to the same pipe as stdout, which practically
means it is lost.

These redirects to fd is needed not because we check that container is
working by writing to its stdin and reading from stdout (see
check_pipes), but also because bats redirects test stdout/stderr to a
file, which makes c/r impossible (as the file is outside of container).
This is why we can't just do something like `2>stderr.log`, and have
to do what is done in this commit.

Introduce and use another pipe for stdout, to be used for both runc run
and runc restore, so it will be shown in case of errors.

Since its handling is somewhat complicated and is used from 4 places
(2 for run, 2 for restore), separate it into a helper functions.

NOTE the code assumes that runc exits with non-zero exit code in case
there is anything that needs to be shown to a user from runc's stderr.

While at it, add error checking to runc run calls.

Hopefully, this will help debug those rare checkpoint failures in CI.

## tests/int/checkpoint: rm useless code
    
Commit 417f5ff40 added a code to close fds and kill processes, which
should have helped in an event of test case failure.
    
In fact, each test case is executed in a subshell, so
 - any variables set there can't reach teardown();
 - all the fds are closed (as the process is gone).
    
Now, I am not sure about the processes, but the code being removed
has never worked anyway, so it does not make sense to keep it.
Normally, those are waited for. In case of a test case failure,
well, the subsequent cases might fail, too.
    
Fixes: 417f5ff40dcdca

## tests/int/checkpoint.bats: fix showing logs on fail
    
This fixes the following issue with the test:
    
            not ok 12 checkpoint --lazy-pages and restore
            # (in test file tests/integration/checkpoint.bats, line 202)
            #   `[ $ret -eq 0 ]' failed
            ...
            # grep: ./work-dir/restore.log: No such file or directory
    
One might think that `--work-path ./image-dir` is a mistake, but it's
not, since `criu lazy-pages -D ./image-dir` creates a socket in
`./image-dir`, and then `criu restore --lazy-pages` expects a socket in
the work-dir.
    
Fixes: e232a71a3d8