### PR TITLE
libct/cgroups: support Cgroups.Resources.Unified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/moby/sys/mountinfo v0.1.3
 	github.com/mrunalp/fileutils v0.5.0
-	github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6
+	github.com/opencontainers/runtime-spec v1.0.3-0.20200817204227-f9c09b4ea1df
 	github.com/opencontainers/selinux v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/moby/sys/mountinfo v0.1.3 h1:KIrhRO14+AkwKvG/g2yIpNMOUVZ02xNhOw8KY1Ws
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
-github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6 h1:NhsM2gc769rVWDqJvapK37r+7+CBXI8xHhnfnt8uQsg=
-github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20200817204227-f9c09b4ea1df h1:5AW5dMFSXVH4Mg3WYe4z7ui64bK8n66IoWK8i6T4QZ8=
+github.com/opencontainers/runtime-spec v1.0.3-0.20200817204227-f9c09b4ea1df/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.6.0 h1:+bIAS/Za3q5FTwWym4fTB0vObnfCf3G/NC7K6Jx62mY=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -218,7 +218,10 @@ func (m *manager) Apply(pid int) (err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var c = m.cgroups
+	c := m.cgroups
+	if c.Resources.Unified != nil {
+		return cgroups.ErrV1NoUnified
+	}
 
 	m.paths = make(map[string]string)
 	if c.Paths != nil {
@@ -308,6 +311,9 @@ func (m *manager) Set(container *configs.Config) error {
 	// and there is no need to set any values.
 	if m.cgroups != nil && m.cgroups.Paths != nil {
 		return nil
+	}
+	if container.Cgroups.Resources.Unified != nil {
+		return cgroups.ErrV1NoUnified
 	}
 
 	m.mu.Lock()

--- a/libcontainer/cgroups/fscommon/fscommon.go
+++ b/libcontainer/cgroups/fscommon/fscommon.go
@@ -21,7 +21,7 @@ func WriteFile(dir, file, data string) error {
 		return err
 	}
 	if err := retryingWriteFile(path, []byte(data), 0700); err != nil {
-		return errors.Wrapf(err, "failed to write %q to %q", data, path)
+		return errors.Wrapf(err, "failed to write %q", data)
 	}
 	return nil
 }

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -101,6 +101,10 @@ func (m *legacyManager) Apply(pid int) error {
 		properties []systemdDbus.Property
 	)
 
+	if c.Resources.Unified != nil {
+		return cgroups.ErrV1NoUnified
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if c.Paths != nil {
@@ -341,6 +345,9 @@ func (m *legacyManager) Set(container *configs.Config) error {
 	// and there is no need to set any values.
 	if m.cgroups.Paths != nil {
 		return nil
+	}
+	if container.Cgroups.Resources.Unified != nil {
+		return cgroups.ErrV1NoUnified
 	}
 	dbusConnection, err := getDbusConnection(false)
 	if err != nil {

--- a/libcontainer/cgroups/v1_utils.go
+++ b/libcontainer/cgroups/v1_utils.go
@@ -23,7 +23,8 @@ const (
 )
 
 var (
-	errUnified = errors.New("not implemented for cgroup v2 unified hierarchy")
+	errUnified     = errors.New("not implemented for cgroup v2 unified hierarchy")
+	ErrV1NoUnified = errors.New("invalid configuration: cannot use unified on cgroup v1")
 )
 
 type NotFoundError struct {

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -127,6 +127,9 @@ type Resources struct {
 	// CpuWeight sets a proportional bandwidth limit.
 	CpuWeight uint64 `json:"cpu_weight"`
 
+	// Unified is cgroupv2-only key-value map.
+	Unified map[string]string `json:"unified"`
+
 	// SkipDevices allows to skip configuring device permissions.
 	// Used by e.g. kubelet while creating a parent cgroup (kubepods)
 	// common for many containers.

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -619,6 +619,13 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*configs.Device) (*confi
 					})
 				}
 			}
+			if len(r.Unified) > 0 {
+				// copy the map
+				c.Resources.Unified = make(map[string]string, len(r.Unified))
+				for k, v := range r.Unified {
+					c.Resources.Unified[k] = v
+				}
+			}
 		}
 	}
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -6,6 +6,7 @@ function teardown() {
     rm -f "$BATS_TMPDIR"/runc-cgroups-integration-test.json
     teardown_running_container test_cgroups_kmem
     teardown_running_container test_cgroups_permissions
+    teardown_running_container test_cgroups_group
     teardown_busybox
 }
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -7,6 +7,7 @@ function teardown() {
     teardown_running_container test_cgroups_kmem
     teardown_running_container test_cgroups_permissions
     teardown_running_container test_cgroups_group
+    teardown_running_container test_cgroups_unified
     teardown_busybox
 }
 
@@ -176,4 +177,65 @@ function setup() {
     runc exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
     [ "$status" -eq 0 ]
 #
+}
+
+@test "runc run (cgroup v1 + unified resources should fail)" {
+    requires root cgroups_v1
+
+    set_cgroups_path "$BUSYBOX_BUNDLE"
+    set_resources_limit "$BUSYBOX_BUNDLE"
+    update_config '.linux.resources.unified |= {"memory.min": "131072"}' "$BUSYBOX_BUNDLE"
+
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid configuration'* ]]
+}
+
+@test "runc run (cgroup v2 resources.unified only)" {
+    requires root cgroups_v2
+
+    set_cgroups_path "$BUSYBOX_BUNDLE"
+    update_config ' .linux.resources.unified |= {
+                      "memory.min":   "131072",
+                      "memory.low":   "524288",
+                      "memory.high": "5242880",
+                      "memory.max": "10485760",
+                      "pids.max": "99",
+                      "cpu.max": "10000 100000"
+                     }' "$BUSYBOX_BUNDLE"
+
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
+    [ "$status" -eq 0 ]
+
+    runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.min *.max *.low *.high'
+    [ "$status" -eq 0 ]
+    echo "$output"
+
+    echo "$output" | grep -q '^memory.min:131072$'
+    echo "$output" | grep -q '^memory.low:524288$'
+    echo "$output" | grep -q '^memory.high:5242880$'
+    echo "$output" | grep -q '^memory.max:10485760$'
+    echo "$output" | grep -q '^pids.max:99$'
+    echo "$output" | grep -q '^cpu.max:10000 100000$'
+}
+@test "runc run (cgroup v2 resources.unified override)" {
+    requires root cgroups_v2
+
+    set_cgroups_path "$BUSYBOX_BUNDLE"
+    update_config ' .linux.resources.memory |= {"limit": 33554432}
+                  | .linux.resources.memorySwap |= {"limit": 33554432}
+                  | .linux.resources.unified |=
+                      {"memory.min": "131072", "memory.max": "10485760" }' \
+        "$BUSYBOX_BUNDLE"
+
+    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
+    [ "$status" -eq 0 ]
+
+    runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
+    [ "$status" -eq 0 ]
+    [ "$output" = '131072' ]
+
+    runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
+    [ "$status" -eq 0 ]
+    [ "$output" = '10485760' ]
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -60,7 +60,7 @@ type Process struct {
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// LinuxCapabilities specifies the whitelist of capabilities that are kept for a process.
+// LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
 // http://man7.org/linux/man-pages/man7/capabilities.7.html
 type LinuxCapabilities struct {
 	// Bounding is the set of capabilities checked by the kernel.
@@ -354,7 +354,7 @@ type LinuxRdma struct {
 
 // LinuxResources has container runtime resource constraints
 type LinuxResources struct {
-	// Devices configures the device whitelist.
+	// Devices configures the device allowlist.
 	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
 	// Memory restriction configuration
 	Memory *LinuxMemory `json:"memory,omitempty"`
@@ -372,6 +372,8 @@ type LinuxResources struct {
 	// Limits are a set of key value pairs that define RDMA resource limits,
 	// where the key is device name and value is resource limits.
 	Rdma map[string]LinuxRdma `json:"rdma,omitempty"`
+	// Unified resources.
+	Unified map[string]string `json:"unified,omitempty"`
 }
 
 // LinuxDevice represents the mknod information for a Linux special device file
@@ -392,7 +394,8 @@ type LinuxDevice struct {
 	GID *uint32 `json:"gid,omitempty"`
 }
 
-// LinuxDeviceCgroup represents a device rule for the whitelist controller
+// LinuxDeviceCgroup represents a device rule for the devices specified to
+// the device controller
 type LinuxDeviceCgroup struct {
 	// Allow or deny
 	Allow bool `json:"allow"`
@@ -628,6 +631,7 @@ const (
 	ArchS390X       Arch = "SCMP_ARCH_S390X"
 	ArchPARISC      Arch = "SCMP_ARCH_PARISC"
 	ArchPARISC64    Arch = "SCMP_ARCH_PARISC64"
+	ArchRISCV64     Arch = "SCMP_ARCH_RISCV64"
 )
 
 // LinuxSeccompAction taken upon Seccomp rule match

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,7 +38,7 @@ github.com/moby/sys/mountinfo
 # github.com/mrunalp/fileutils v0.5.0
 ## explicit
 github.com/mrunalp/fileutils
-# github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6
+# github.com/opencontainers/runtime-spec v1.0.3-0.20200817204227-f9c09b4ea1df
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opencontainers/selinux v1.6.0


### PR DESCRIPTION
Add support for unified resource map (as per [1]), and add some test
cases for the new functionality.
    
[1] https://github.com/opencontainers/runtime-spec/pull/1040

Fixes: #2563

The biggest issue, I think, is that the mapping of the "unified" parameters
to systemd properties is not implemented, meaning there can be cases
where systemd unit settings and in-kernel cgroup settings won't agree.

I don't think it can cause any issues, but it's just doesn't look right.