### PR TITLE
allow bind mount w/o explicit "bind" opt but w/ explicit "bind" type

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -329,6 +329,9 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 
 func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 	flags, pgflags, data, ext := parseMountOptions(m.Options)
+	if m.Type == "bind" {
+		flags |= unix.MS_BIND
+	}
 	source := m.Source
 	device := m.Type
 	if flags&unix.MS_BIND != 0 {

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -19,3 +19,12 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
 }
+
+@test "runc run [bind mount w/o explicit \"bind\" opt but w/ explicit \"bind\" type]" {
+	update_config 	' .mounts += [{"source": ".", "destination": "/tmp/bind", "type":"bind"}]
+			| .process.args |= ["ls", "/tmp/bind/config.json"]'
+
+	runc run test_bind_mount
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
+}


### PR DESCRIPTION
Previously, `{"type":"bind"}` without `{"options": ["bind"]}` was failing with ENODEV.

See https://github.com/containers/podman/issues/7652
