### PR TITLE
Makefile: fix vendor and verify-dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,8 @@ validate:
 ci: validate test release
 
 vendor:
-	export GO111MODULE=on \
-	$(GO) mod tidy && \
-	$(GO) mod vendor && \
+	$(GO) mod tidy
+	$(GO) mod vendor
 	$(GO) mod verify
 
 verify-dependencies: vendor


### PR DESCRIPTION
Commit a08ab87fe added these targets. Alas, the `go mod tidy` never
worked. Here is the relevant part of the `vendor` target in `Makefile`:

https://github.com/opencontainers/runc/blob/892477ca26638b214dc79150a09ba3565b93137d/Makefile#L128-L130

which is essentially

```bash
export GO111MODULE=on $(GO) mod tidy && ...
```
which exports a bunch of variables, such as `go`, `mod`, and `tidy`
(or would export those if they existed), but does not run `go mod tidy`.

The fix would be to add a semicolon after the `export` statement,
but since `GO111MODULE` is not really needed here (maybe some older
golang versions needed it?), let's just drop it.

With this dropped, && does not make any sense, so drop it, too.

NOTE that if someone tries

        GO111MODULE=off make vendor

it will fail, but I guess it is expected.

