### PR TITLE
Makefile: disable kernel memory accounting on RHEL 7 3.10 kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ ifeq ($(shell $(GO) env GOOS),linux)
 		endif
 	endif
 endif
+
+# Disable kmem if building on RHEL7 (kernel 3.10.0 el7)
+ifneq ($(shell uname -r | grep '^3\.10\.0.*\.el7\.'),)
+	BUILDTAGS += nokmem
+endif
+
 GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
 	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \

--- a/README.md
+++ b/README.md
@@ -61,16 +61,19 @@ sudo make install
 with some of them enabled by default (see `BUILDTAGS` in top-level `Makefile`).
 
 To change build tags from the default, set the `BUILDTAGS` variable for make,
-e.g.
+e.g. to disable `seccomp` and enable `nokmem`, run:
 
 ```bash
-make BUILDTAGS='seccomp'
+make BUILDTAGS="nokmem"
 ```
 
 | Build Tag | Feature                            | Enabled by default | Dependency |
 |-----------|------------------------------------|--------------------|------------|
 | seccomp   | Syscall filtering                  | yes                | libseccomp |
-| nokmem    | disable kernel memory accounting   | no                 | <none>     |
+| nokmem    | disable kernel memory accounting   | usually not        | _none_     |
+
+**Note** `nokmem` build tag is now auto-set by the Makefile in case
+the running kernel version looks like one from RHEL7 (3.10.0-\*.el7.)
 
 The following build tags were used earlier, but are now obsoleted:
  - **apparmor** (since runc v1.0.0-rc93 the feature is always enabled)

--- a/libcontainer/cgroups/fs/kmem.go
+++ b/libcontainer/cgroups/fs/kmem.go
@@ -13,7 +13,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const cgroupKernelMemoryLimit = "memory.kmem.limit_in_bytes"
+const (
+	kmemDisabled            = false
+	cgroupKernelMemoryLimit = "memory.kmem.limit_in_bytes"
+)
 
 func EnableKernelMemoryAccounting(path string) error {
 	// Ensure that kernel memory is available in this kernel build. If it

--- a/libcontainer/cgroups/fs/kmem_disabled.go
+++ b/libcontainer/cgroups/fs/kmem_disabled.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 )
 
+const kmemDisabled = true
+
 func EnableKernelMemoryAccounting(path string) error {
 	return nil
 }

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -191,6 +191,9 @@ func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
 }
 
 func TestMemorySetKernelMemory(t *testing.T) {
+	if kmemDisabled {
+		t.Skip("kernel memory limits are disabled")
+	}
 	helper := NewCgroupTestUtil("memory", t)
 	defer helper.cleanup()
 
@@ -219,6 +222,9 @@ func TestMemorySetKernelMemory(t *testing.T) {
 }
 
 func TestMemorySetKernelMemoryTCP(t *testing.T) {
+	if kmemDisabled {
+		t.Skip("kernel memory limits are disabled")
+	}
 	helper := NewCgroupTestUtil("memory", t)
 	defer helper.cleanup()
 

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -685,6 +685,9 @@ func testRunWithKernelMemory(t *testing.T, systemd bool) {
 	if cgroups.IsCgroup2UnifiedMode() {
 		t.Skip("cgroup v2 does not support kernel memory limit")
 	}
+	if kmemDisabled {
+		t.Skip("kernel memory is disabled in this runc build")
+	}
 
 	rootfs, err := newRootfs()
 	ok(t, err)

--- a/libcontainer/integration/kmem_disabled_test.go
+++ b/libcontainer/integration/kmem_disabled_test.go
@@ -1,0 +1,5 @@
+// +build linux,nokmem
+
+package integration
+
+const kmemDisabled = true

--- a/libcontainer/integration/kmem_test.go
+++ b/libcontainer/integration/kmem_test.go
@@ -1,0 +1,5 @@
+// +build linux,!nokmem
+
+package integration
+
+const kmemDisabled = false

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -318,6 +318,10 @@ function requires() {
 			if [ ! -e "${CGROUP_MEMORY_BASE_PATH}/memory.kmem.limit_in_bytes" ]; then
 				skip_me=1
 			fi
+			if uname -r | grep -q '^3\.10\.0.*\.el7\.'; then
+				# In RHEL7 kernel, kmem is broken so runc disables it.
+				skip_me=1
+			fi
 			;;
 		cgroups_rt)
 			init_cgroup_paths


### PR DESCRIPTION
Kernel-memory accounting is known to be broken on RHEL 7 kernels. This patch automatically disables kernel-memory accounting when building on a 3.10 kernel.

The original behavior is preserved if a custom BUILDTAGS is passed;

    make BUILDTAGS='seccomp selinux' ...

I recalled we had a similar patch in Moby (https://github.com/moby/moby/commit/8972aa9350d52e4a7e58242447b7a9d2f0c27f37), and thought I'd might as well upstream this.

Also note that https://github.com/moby/moby/pull/41254#issue-456148870

> Kernel memory limit is not supported on cgroup v2. Even on cgroup v1, kernel memory limit (kmem.limit_in_bytes) has been deprecated since kernel 5.4. https://github.com/torvalds/linux/commit/0158115f702b0ba208ab0b5adf44cae99b3ebcc7

So perhaps either add a similar check for kernel 5.4+, or disabling kmem by default, and making it an opt-on could make sense (@AkihiroSuda wdyt?)