### PR TITLE
libcontainer/integration: fix cgroupv1 + systemd tests

### DIFF
--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -267,7 +267,7 @@ func (m *legacyManager) joinCgroups(pid int) error {
 }
 
 func getSubsystemPath(c *configs.Cgroup, subsystem string) (string, error) {
-	mountpoint, err := cgroups.FindCgroupMountpoint(c.Path, subsystem)
+	mountpoint, err := cgroups.FindCgroupMountpoint("", subsystem)
 	if err != nil {
 		return "", err
 	}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -406,7 +406,10 @@ func (m *legacyManager) Set(container *configs.Config) error {
 
 func enableKmem(c *configs.Cgroup) error {
 	path, err := getSubsystemPath(c, "memory")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer"
-	"github.com/opencontainers/runc/libcontainer/configs"
-
-	"golang.org/x/sys/unix"
 )
 
 func showFile(t *testing.T, fname string) error {
@@ -76,20 +73,10 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-
-	if userns {
-		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
-		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
-		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
-	} else {
-		config.Mounts = append(config.Mounts, &configs.Mount{
-			Destination: "/sys/fs/cgroup",
-			Device:      "cgroup",
-			Flags:       defaultMountFlags | unix.MS_RDONLY,
-		})
-	}
-
+	config := newTemplateConfig(&tParam{
+		rootfs: rootfs,
+		userns: userns,
+	})
 	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
 
 	if err != nil {

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -76,7 +76,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	if userns {
 		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -514,7 +514,10 @@ func testFreeze(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(&tParam{
+		rootfs:  rootfs,
+		systemd: systemd,
+	})
 	container, err := newContainerWithName("test", config)
 	ok(t, err)
 	defer container.Destroy()
@@ -571,10 +574,10 @@ func testCpuShares(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	if systemd {
-		config.Cgroups.Parent = "system.slice"
-	}
+	config := newTemplateConfig(&tParam{
+		rootfs:  rootfs,
+		systemd: systemd,
+	})
 	config.Cgroups.Resources.CpuShares = 1
 
 	_, _, err = runContainer(config, "", "ps")
@@ -603,10 +606,10 @@ func testPids(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	if systemd {
-		config.Cgroups.Parent = "system.slice"
-	}
+	config := newTemplateConfig(&tParam{
+		rootfs:  rootfs,
+		systemd: systemd,
+	})
 	config.Cgroups.Resources.PidsLimit = -1
 
 	// Running multiple processes.
@@ -689,10 +692,10 @@ func testRunWithKernelMemory(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	if systemd {
-		config.Cgroups.Parent = "system.slice"
-	}
+	config := newTemplateConfig(&tParam{
+		rootfs:  rootfs,
+		systemd: systemd,
+	})
 	config.Cgroups.Resources.KernelMemory = 52428800
 
 	_, _, err = runContainer(config, "", "ps")
@@ -723,10 +726,10 @@ func testCgroupResourcesUnifiedErrorOnV1(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	if systemd {
-		config.Cgroups.Parent = "system.slice"
-	}
+	config := newTemplateConfig(&tParam{
+		rootfs:  rootfs,
+		systemd: systemd,
+	})
 	config.Cgroups.Resources.Unified = map[string]string{
 		"memory.min": "10240",
 	}
@@ -758,13 +761,13 @@ func testCgroupResourcesUnified(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(&tParam{
+		rootfs:  rootfs,
+		systemd: systemd,
+	})
 	config.Cgroups.Resources.Memory = 536870912     // 512M
 	config.Cgroups.Resources.MemorySwap = 536870912 // 512M, i.e. no swap
 	config.Namespaces.Add(configs.NEWCGROUP, "")
-	if systemd {
-		config.Cgroups.Parent = "system.slice"
-	}
 
 	testCases := []struct {
 		name     string

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -40,7 +40,7 @@ func testExecPS(t *testing.T, userns bool) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	if userns {
 		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
@@ -77,7 +77,7 @@ func TestIPCPrivate(t *testing.T) {
 	l, err := os.Readlink("/proc/1/ns/ipc")
 	ok(t, err)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	buffers, exitCode, err := runContainer(config, "", "readlink", "/proc/self/ns/ipc")
 	ok(t, err)
 
@@ -102,7 +102,7 @@ func TestIPCHost(t *testing.T) {
 	l, err := os.Readlink("/proc/1/ns/ipc")
 	ok(t, err)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Namespaces.Remove(configs.NEWIPC)
 	buffers, exitCode, err := runContainer(config, "", "readlink", "/proc/self/ns/ipc")
 	ok(t, err)
@@ -128,7 +128,7 @@ func TestIPCJoinPath(t *testing.T) {
 	l, err := os.Readlink("/proc/1/ns/ipc")
 	ok(t, err)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Namespaces.Add(configs.NEWIPC, "/proc/1/ns/ipc")
 
 	buffers, exitCode, err := runContainer(config, "", "readlink", "/proc/self/ns/ipc")
@@ -152,7 +152,7 @@ func TestIPCBadPath(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Namespaces.Add(configs.NEWIPC, "/proc/1/ns/ipcc")
 
 	_, _, err = runContainer(config, "", "true")
@@ -182,7 +182,7 @@ func testRlimit(t *testing.T, userns bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	if userns {
 		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
@@ -212,7 +212,7 @@ func TestEnter(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	container, err := newContainerWithName("test", config)
 	ok(t, err)
@@ -299,7 +299,7 @@ func TestProcessEnv(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	container, err := newContainerWithName("test", config)
 	ok(t, err)
@@ -347,7 +347,7 @@ func TestProcessEmptyCaps(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Capabilities = nil
 
 	container, err := newContainerWithName("test", config)
@@ -396,7 +396,7 @@ func TestProcessCaps(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	container, err := newContainerWithName("test", config)
 	ok(t, err)
@@ -464,7 +464,7 @@ func TestAdditionalGroups(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	container, err := newContainerWithName("test", config)
 	ok(t, err)
@@ -518,7 +518,7 @@ func testFreeze(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	container, err := newContainerWithName("test", config)
 	ok(t, err)
 	defer container.Destroy()
@@ -575,7 +575,7 @@ func testCpuShares(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	if systemd {
 		config.Cgroups.Parent = "system.slice"
 	}
@@ -607,7 +607,7 @@ func testPids(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	if systemd {
 		config.Cgroups.Parent = "system.slice"
 	}
@@ -693,7 +693,7 @@ func testRunWithKernelMemory(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	if systemd {
 		config.Cgroups.Parent = "system.slice"
 	}
@@ -727,7 +727,7 @@ func testCgroupResourcesUnifiedErrorOnV1(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	if systemd {
 		config.Cgroups.Parent = "system.slice"
 	}
@@ -762,7 +762,7 @@ func testCgroupResourcesUnified(t *testing.T, systemd bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Cgroups.Resources.Memory = 536870912     // 512M
 	config.Cgroups.Resources.MemorySwap = 536870912 // 512M, i.e. no swap
 	config.Namespaces.Add(configs.NEWCGROUP, "")
@@ -870,7 +870,7 @@ func TestContainerState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Namespaces = configs.Namespaces([]configs.Namespace{
 		{Type: configs.NEWNS},
 		{Type: configs.NEWUTS},
@@ -931,7 +931,7 @@ func TestPassExtraFiles(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	container, err := newContainerWithName("test", config)
 	if err != nil {
@@ -1006,7 +1006,7 @@ func TestMountCmds(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Mounts = append(config.Mounts, &configs.Mount{
 		Source:      tmpDir,
 		Destination: "/tmp",
@@ -1063,7 +1063,7 @@ func TestSysctl(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Sysctl = map[string]string{
 		"kernel.shmmni": "8192",
 	}
@@ -1100,7 +1100,7 @@ func TestMountCgroupRO(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	config.Mounts = append(config.Mounts, &configs.Mount{
 		Destination: "/sys/fs/cgroup",
@@ -1149,7 +1149,7 @@ func TestMountCgroupRW(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	config.Mounts = append(config.Mounts, &configs.Mount{
 		Destination: "/sys/fs/cgroup",
@@ -1200,7 +1200,7 @@ func TestOomScoreAdj(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.OomScoreAdj = ptrInt(200)
 
 	container, err := newContainerWithName("test", config)
@@ -1242,7 +1242,7 @@ func TestHook(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	expectedBundle := bundle
 	config.Labels = append(config.Labels, "bundle="+expectedBundle)
 
@@ -1388,7 +1388,7 @@ func TestSTDIOPermissions(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	buffers, exitCode, err := runContainer(config, "", "sh", "-c", "echo hi > /dev/stderr")
 	ok(t, err)
 	if exitCode != 0 {
@@ -1421,7 +1421,7 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	config.RootPropagation = unix.MS_SLAVE | unix.MS_REC
 
@@ -1537,7 +1537,7 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.RootPropagation = unix.MS_PRIVATE
 
 	// Bind mount a volume
@@ -1646,7 +1646,7 @@ func TestPIDHost(t *testing.T) {
 	l, err := os.Readlink("/proc/1/ns/pid")
 	ok(t, err)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Namespaces.Remove(configs.NEWPID)
 	buffers, exitCode, err := runContainer(config, "", "readlink", "/proc/self/ns/pid")
 	ok(t, err)
@@ -1669,7 +1669,7 @@ func TestInitJoinPID(t *testing.T) {
 	defer remove(rootfs)
 
 	// Execute a long-running container
-	container1, err := newContainer(newTemplateConfig(rootfs))
+	container1, err := newContainer(newTemplateConfig(&tParam{rootfs: rootfs}))
 	ok(t, err)
 	defer container1.Destroy()
 
@@ -1693,7 +1693,7 @@ func TestInitJoinPID(t *testing.T) {
 	pidns1 := state1.NamespacePaths[configs.NEWPID]
 
 	// Run a container inside the existing pidns but with different cgroups
-	config2 := newTemplateConfig(rootfs)
+	config2 := newTemplateConfig(&tParam{rootfs: rootfs})
 	config2.Namespaces.Add(configs.NEWPID, pidns1)
 	config2.Cgroups.Path = "integration/test2"
 	container2, err := newContainerWithName("testCT2", config2)
@@ -1772,7 +1772,7 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 	defer remove(rootfs)
 
 	// Execute a long-running container
-	config1 := newTemplateConfig(rootfs)
+	config1 := newTemplateConfig(&tParam{rootfs: rootfs})
 	config1.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config1.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config1.Namespaces = append(config1.Namespaces, configs.Namespace{Type: configs.NEWUSER})
@@ -1805,7 +1805,7 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs2)
 
-	config2 := newTemplateConfig(rootfs2)
+	config2 := newTemplateConfig(&tParam{rootfs: rootfs2})
 	config2.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config2.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config2.Namespaces.Add(configs.NEWNET, netns1)
@@ -1865,7 +1865,7 @@ func TestTmpfsCopyUp(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 
 	config.Mounts = append(config.Mounts, &configs.Mount{
 		Source:      "tmpfs",
@@ -1915,7 +1915,7 @@ func TestCGROUPPrivate(t *testing.T) {
 	l, err := os.Readlink("/proc/1/ns/cgroup")
 	ok(t, err)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Namespaces.Add(configs.NEWCGROUP, "")
 	buffers, exitCode, err := runContainer(config, "", "readlink", "/proc/self/ns/cgroup")
 	ok(t, err)
@@ -1944,7 +1944,7 @@ func TestCGROUPHost(t *testing.T) {
 	l, err := os.Readlink("/proc/1/ns/cgroup")
 	ok(t, err)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	buffers, exitCode, err := runContainer(config, "", "readlink", "/proc/self/ns/cgroup")
 	ok(t, err)
 

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -91,12 +91,10 @@ func testExecInRlimit(t *testing.T, userns bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	if userns {
-		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
-		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
-		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
-	}
+	config := newTemplateConfig(&tParam{
+		rootfs: rootfs,
+		userns: userns,
+	})
 
 	container, err := newContainer(config)
 	ok(t, err)
@@ -557,10 +555,10 @@ func TestExecInUserns(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
-	config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
-	config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
+	config := newTemplateConfig(&tParam{
+		rootfs: rootfs,
+		userns: true,
+	})
 	container, err := newContainer(config)
 	ok(t, err)
 	defer container.Destroy()

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -25,7 +25,7 @@ func TestExecIn(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	container, err := newContainer(config)
 	ok(t, err)
 	defer container.Destroy()
@@ -91,7 +91,7 @@ func testExecInRlimit(t *testing.T, userns bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	if userns {
 		config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 		config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
@@ -152,7 +152,7 @@ func TestExecInAdditionalGroups(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	container, err := newContainer(config)
 	ok(t, err)
 	defer container.Destroy()
@@ -209,7 +209,7 @@ func TestExecInError(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	container, err := newContainer(config)
 	ok(t, err)
 	defer container.Destroy()
@@ -262,7 +262,7 @@ func TestExecInTTY(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	container, err := newContainer(config)
 	ok(t, err)
 	defer container.Destroy()
@@ -359,7 +359,7 @@ func TestExecInEnvironment(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	container, err := newContainer(config)
 	ok(t, err)
 	defer container.Destroy()
@@ -421,7 +421,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	container, err := newContainer(config)
 	if err != nil {
 		t.Fatal(err)
@@ -505,7 +505,7 @@ func TestExecInOomScoreAdj(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.OomScoreAdj = ptrInt(200)
 	container, err := newContainer(config)
 	ok(t, err)
@@ -557,7 +557,7 @@ func TestExecInUserns(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.UidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config.GidMappings = []configs.IDMap{{HostID: 0, ContainerID: 0, Size: 1000}}
 	config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -25,7 +25,7 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 
 	errnoRet := uint(syscall.ESRCH)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -95,7 +95,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -164,7 +164,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -226,7 +226,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -304,7 +304,7 @@ func TestSeccompPermitWriteMultipleConditions(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -359,7 +359,7 @@ func TestSeccompDenyWriteMultipleConditions(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -409,7 +409,7 @@ func TestSeccompMultipleConditionSameArgDeniesStdout(t *testing.T) {
 	defer remove(rootfs)
 
 	// Prevent writing to both stdout and stderr
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -457,7 +457,7 @@ func TestSeccompMultipleConditionSameArgDeniesStderr(t *testing.T) {
 	defer remove(rootfs)
 
 	// Prevent writing to both stdout and stderr
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -16,17 +16,21 @@ var standardEnvironment = []string{
 
 const defaultMountFlags = unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV
 
+type tParam struct {
+	rootfs string
+}
+
 // newTemplateConfig returns a base template for running a container
 //
 // it uses a network strategy of just setting a loopback interface
 // and the default setup for devices
-func newTemplateConfig(rootfs string) *configs.Config {
+func newTemplateConfig(p *tParam) *configs.Config {
 	var allowedDevices []*configs.DeviceRule
 	for _, device := range specconv.AllowedDevices {
 		allowedDevices = append(allowedDevices, &device.DeviceRule)
 	}
 	return &configs.Config{
-		Rootfs: rootfs,
+		Rootfs: p.rootfs,
 		Capabilities: &configs.Capabilities{
 			Bounding: []string{
 				"CAP_CHOWN",


### PR DESCRIPTION
Commit f57bb2fe3db set it to /sys/fs/cgroup which is somewhat confusing
as now tests create cgroups that look like this on the filesystem:

 - /sys/fs/cgroup/memory/sys/fs/cgroup
 - /sys/fs/cgroup/devices/sys/fs/cgroup
 ... etc.

but it worked!

It seems that some(?) tests were still not working properly with systemd because of invalid configuration.

Similar to what libcontainer/specconv does, add the functionality to set proper cgroup parameters for systemd.
This fixes all the tests.

Fixes: #2473

----

This PR also fixes the root cause of the breakage, which calls for
a separate story to be told. Gather around, kids, let me tell it to you.

Commit a1d5398afa91b0cb10 ("Respect container's cgroup path") added a
`cgroupPath` argument to `FindCgroupMountpoint` to make runc/libcontainer
work in a custom multitenant environment with multiple cgroup mount
points.

It also added passing `c.Path` as an argument to `FindCgroupMountpoint`
for systemd (v1) controller:

https://github.com/opencontainers/runc/blob/0a9af3949f66117a66ee0edf121b0c132b223128/libcontainer/cgroups/systemd/v1.go#L270

This change is wrong for two reasons:

1. systemd controller do not use `c.Path` at all (and `c.Path` is never set
   by `specconv`) -- instead, it uses `Name` and `Parent` fields.

2. `c.Path`, if set, is not absolute -- it is relative to `/sys/fs/cgroup`
   -- but it is used as an absolute path here.

Now, as `c.Path` is never set, the change did not result in any breakage,
and this code sit quietly for some time. The issue might not have been
discovered -- until we started running libcontainer/integration tests
in a CentOS 7 VM, which resulted in a following weird error:

> FAIL: TestPidsSystemd: utils_test.go:55: exec_test.go:630: unexpected error: container_linux.go:353: starting container process caused: process_linux.go:326: applying cgroup configuration for process caused: mountpoint for devices not found

The error was "fixed" in commit f57bb2fe3dbe8 by changing the tests'
cgroups Path to be "/sys/fs/cgroup/". This indeed fixed the issue, but
resulted in creation of cgroup directories like `/sys/fs/cgroup/memory/sys/fs/cgroup`,
`/sys/fs/cgroup/devices/sys/fs/cgroup` and so on.

So, revert the change to avoid confusion.

----

A bonus story for you.

Commit 27d3dd3df35 ("don't fail when subsystem not mounted") added
ignoring "not found" error to enableKmem, and as a result the function
now tries to call Mkdir with an empty path, which results in a weird
error message. For example, this is a failure from a
libcontainer/integration test:

> === RUN   TestRunWithKernelMemorySystemd
>    exec_test.go:704: runContainer failed with kernel memory limit: container_linux.go:370: starting container process caused: process_linux.go:327: applying cgroup configuration for process caused: mkdir : no such file or directory

I am not entirely sure if it is a good idea to silently ignore set
limits, but at least let's fix the error handling.