### PR TITLE
libcontainer: move capabilities to separate package

### DIFF
--- a/libcontainer/capabilities/capabilities.go
+++ b/libcontainer/capabilities/capabilities.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package libcontainer
+package capabilities
 
 import (
 	"fmt"
@@ -24,10 +24,11 @@ func init() {
 	}
 }
 
-func newContainerCapList(capConfig *configs.Capabilities) (*containerCapabilities, error) {
+// New creates a new Caps from the given Capabilities config.
+func New(capConfig *configs.Capabilities) (*Caps, error) {
 	var (
 		err  error
-		caps containerCapabilities
+		caps Caps
 	)
 
 	if caps.bounding, err = capSlice(capConfig.Bounding); err != nil {
@@ -66,7 +67,8 @@ func capSlice(caps []string) ([]capability.Cap, error) {
 	return out, nil
 }
 
-type containerCapabilities struct {
+// Caps holds the capabilities for a container.
+type Caps struct {
 	pid         capability.Capabilities
 	bounding    []capability.Cap
 	effective   []capability.Cap
@@ -76,14 +78,14 @@ type containerCapabilities struct {
 }
 
 // ApplyBoundingSet sets the capability bounding set to those specified in the whitelist.
-func (c *containerCapabilities) ApplyBoundingSet() error {
+func (c *Caps) ApplyBoundingSet() error {
 	c.pid.Clear(capability.BOUNDS)
 	c.pid.Set(capability.BOUNDS, c.bounding...)
 	return c.pid.Apply(capability.BOUNDS)
 }
 
 // Apply sets all the capabilities for the current process in the config.
-func (c *containerCapabilities) ApplyCaps() error {
+func (c *Caps) ApplyCaps() error {
 	c.pid.Clear(allCapabilityTypes)
 	c.pid.Set(capability.BOUNDS, c.bounding...)
 	c.pid.Set(capability.PERMITTED, c.permitted...)

--- a/libcontainer/capabilities/capabilities_unsupported.go
+++ b/libcontainer/capabilities/capabilities_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package capabilities

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -13,9 +13,8 @@ import (
 	"strings"
 	"unsafe"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/containerd/console"
+	"github.com/opencontainers/runc/libcontainer/capabilities"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"
@@ -25,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 type initType string
@@ -129,13 +129,13 @@ func finalizeNamespace(config *initConfig) error {
 		return errors.Wrap(err, "close exec fds")
 	}
 
-	capabilities := &configs.Capabilities{}
+	caps := &configs.Capabilities{}
 	if config.Capabilities != nil {
-		capabilities = config.Capabilities
+		caps = config.Capabilities
 	} else if config.Config.Capabilities != nil {
-		capabilities = config.Config.Capabilities
+		caps = config.Config.Capabilities
 	}
-	w, err := newContainerCapList(capabilities)
+	w, err := capabilities.New(caps)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I had these changes open in the branch I used for https://github.com/opencontainers/runc/pull/2595. TBH, I don't exactly recall why I made these changes, but I guess because it's slightly cleaner to have it in a separate package (similar to cgroups, devices, apparmor, etc all being separate).

I'm not super-attached to it, so feel free to close if you don't like this change, but thought I'd push it to give the opportunity to review 😅 


@kolyshkin @AkihiroSuda 