### PR TITLE
libcontainer: prefer bytes.TrimSpace() over strings.TrimSpace()

### DIFF
--- a/libcontainer/cgroups/fs2/create.go
+++ b/libcontainer/cgroups/fs2/create.go
@@ -105,7 +105,7 @@ func CreateCgroupPath(path string, c *configs.Cgroup) (Err error) {
 			}
 			cgTypeFile := filepath.Join(current, "cgroup.type")
 			cgType, _ := ioutil.ReadFile(cgTypeFile)
-			switch strings.TrimSpace(string(cgType)) {
+			switch string(bytes.TrimSpace(cgType)) {
 			// If the cgroup is in an invalid mode (usually this means there's an internal
 			// process in the cgroup tree, because we created a cgroup under an
 			// already-populated-by-other-processes cgroup), then we have to error out if
@@ -128,7 +128,7 @@ func CreateCgroupPath(path string, c *configs.Cgroup) (Err error) {
 				fallthrough
 			case "threaded":
 				if containsDomainController(c) {
-					return fmt.Errorf("cannot enter cgroupv2 %q with domain controllers -- it is in %s mode", current, strings.TrimSpace(string(cgType)))
+					return fmt.Errorf("cannot enter cgroupv2 %q with domain controllers -- it is in %s mode", current, string(bytes.TrimSpace(cgType)))
 				}
 			}
 		}

--- a/libcontainer/cgroups/fs2/defaultpath_test.go
+++ b/libcontainer/cgroups/fs2/defaultpath_test.go
@@ -33,8 +33,8 @@ func TestParseCgroupFromReader(t *testing.T) {
 	for s, expected := range cases {
 		g, err := parseCgroupFromReader(strings.NewReader(s))
 		if expected != "" {
-			if string(g) != expected {
-				t.Errorf("expected %q, got %q", expected, string(g))
+			if g != expected {
+				t.Errorf("expected %q, got %q", expected, g)
 			}
 			if err != nil {
 				t.Error(err)

--- a/libcontainer/cgroups/fscommon/utils.go
+++ b/libcontainer/cgroups/fscommon/utils.go
@@ -79,5 +79,5 @@ func GetCgroupParamString(path, file string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(string(contents)), nil
+	return strings.TrimSpace(contents), nil
 }

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -3,6 +3,7 @@
 package libcontainer
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -304,7 +305,7 @@ func setupUser(config *initConfig) error {
 	// There's nothing we can do about /etc/group entries, so we silently
 	// ignore setting groups here (since the user didn't explicitly ask us to
 	// set the group).
-	allowSupGroups := !config.RootlessEUID && strings.TrimSpace(string(setgroups)) != "deny"
+	allowSupGroups := !config.RootlessEUID && string(bytes.TrimSpace(setgroups)) != "deny"
 
 	if allowSupGroups {
 		suppGroups := append(execUser.Sgids, addGroups...)

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1087,7 +1087,7 @@ func TestSysctl(t *testing.T) {
 	// Wait for process
 	waitProcess(&pconfig, t)
 
-	shmmniOutput := strings.TrimSpace(string(stdout.Bytes()))
+	shmmniOutput := string(bytes.TrimSpace(stdout.Bytes()))
 	if shmmniOutput != "8192" {
 		t.Fatalf("kernel.shmmni property expected to be 8192, but is %s", shmmniOutput)
 	}
@@ -1221,7 +1221,7 @@ func TestOomScoreAdj(t *testing.T) {
 
 	// Wait for process
 	waitProcess(&pconfig, t)
-	outputOomScoreAdj := strings.TrimSpace(string(stdout.Bytes()))
+	outputOomScoreAdj := string(bytes.TrimSpace(stdout.Bytes()))
 
 	// Check that the oom_score_adj matches the value that was set as part of config.
 	if outputOomScoreAdj != strconv.Itoa(*config.OomScoreAdj) {
@@ -1624,7 +1624,7 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 
 	// Check if mount is visible on host or not.
 	out, err := exec.Command("findmnt", "-n", "-f", "-oTARGET", dir2host).CombinedOutput()
-	outtrim := strings.TrimSpace(string(out))
+	outtrim := string(bytes.TrimSpace(out))
 	if err != nil {
 		t.Logf("findmnt error %q: %q", err, outtrim)
 	}

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1629,7 +1629,7 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 		t.Logf("findmnt error %q: %q", err, outtrim)
 	}
 
-	if string(outtrim) != dir2host {
+	if outtrim != dir2host {
 		t.Fatalf("Mount in container on %s did not propagate to host on %s. finmnt output=%s", dir2cont, dir2host, outtrim)
 	}
 }

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -4,6 +4,7 @@ package intelrdt
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -375,7 +376,7 @@ func getIntelRdtParamUint(path, file string) (uint64, error) {
 		return 0, err
 	}
 
-	res, err := parseUint(strings.TrimSpace(string(contents)), 10, 64)
+	res, err := parseUint(string(bytes.TrimSpace(contents)), 10, 64)
 	if err != nil {
 		return res, fmt.Errorf("unable to parse %q as a uint from file %q", string(contents), fileName)
 	}
@@ -389,7 +390,7 @@ func getIntelRdtParamString(path, file string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(string(contents)), nil
+	return string(bytes.TrimSpace(contents)), nil
 }
 
 func writeFile(dir, file, data string) error {

--- a/libcontainer/logs/logs_linux_test.go
+++ b/libcontainer/logs/logs_linux_test.go
@@ -19,8 +19,8 @@ func TestLoggingToFile(t *testing.T) {
 	logToLogWriter(t, logW, `{"level": "info","msg":"kitten"}`)
 
 	logFileContent := waitForLogContent(t, logFile)
-	if !strings.Contains(string(logFileContent), "kitten") {
-		t.Fatalf("%s does not contain kitten", string(logFileContent))
+	if !strings.Contains(logFileContent, "kitten") {
+		t.Fatalf("%s does not contain kitten", logFileContent)
 	}
 }
 
@@ -32,8 +32,8 @@ func TestLogForwardingDoesNotStopOnJsonDecodeErr(t *testing.T) {
 	logToLogWriter(t, logW, "invalid-json-with-kitten")
 
 	logFileContent := waitForLogContent(t, logFile)
-	if !strings.Contains(string(logFileContent), "failed to decode") {
-		t.Fatalf("%q does not contain decoding error", string(logFileContent))
+	if !strings.Contains(logFileContent, "failed to decode") {
+		t.Fatalf("%q does not contain decoding error", logFileContent)
 	}
 
 	truncateLogFile(t, logFile)
@@ -41,8 +41,8 @@ func TestLogForwardingDoesNotStopOnJsonDecodeErr(t *testing.T) {
 	logToLogWriter(t, logW, `{"level": "info","msg":"puppy"}`)
 
 	logFileContent = waitForLogContent(t, logFile)
-	if !strings.Contains(string(logFileContent), "puppy") {
-		t.Fatalf("%s does not contain puppy", string(logFileContent))
+	if !strings.Contains(logFileContent, "puppy") {
+		t.Fatalf("%s does not contain puppy", logFileContent)
 	}
 }
 
@@ -54,8 +54,8 @@ func TestLogForwardingDoesNotStopOnLogLevelParsingErr(t *testing.T) {
 	logToLogWriter(t, logW, `{"level": "alert","msg":"puppy"}`)
 
 	logFileContent := waitForLogContent(t, logFile)
-	if !strings.Contains(string(logFileContent), "failed to parse log level") {
-		t.Fatalf("%q does not contain log level parsing error", string(logFileContent))
+	if !strings.Contains(logFileContent, "failed to parse log level") {
+		t.Fatalf("%q does not contain log level parsing error", logFileContent)
 	}
 
 	truncateLogFile(t, logFile)
@@ -63,8 +63,8 @@ func TestLogForwardingDoesNotStopOnLogLevelParsingErr(t *testing.T) {
 	logToLogWriter(t, logW, `{"level": "info","msg":"puppy"}`)
 
 	logFileContent = waitForLogContent(t, logFile)
-	if !strings.Contains(string(logFileContent), "puppy") {
-		t.Fatalf("%s does not contain puppy", string(logFileContent))
+	if !strings.Contains(logFileContent, "puppy") {
+		t.Fatalf("%s does not contain puppy", logFileContent)
 	}
 }
 
@@ -75,8 +75,8 @@ func TestLogForwardingStopsAfterClosingTheWriter(t *testing.T) {
 	logToLogWriter(t, logW, `{"level": "info","msg":"sync"}`)
 
 	logFileContent := waitForLogContent(t, logFile)
-	if !strings.Contains(string(logFileContent), "sync") {
-		t.Fatalf("%q does not contain sync message", string(logFileContent))
+	if !strings.Contains(logFileContent, "sync") {
+		t.Fatalf("%q does not contain sync message", logFileContent)
 	}
 
 	logW.Close()

--- a/libcontainer/network_linux.go
+++ b/libcontainer/network_linux.go
@@ -3,11 +3,11 @@
 package libcontainer
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/types"
@@ -79,7 +79,7 @@ func readSysfsNetworkStats(ethInterface, statsFile string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	return strconv.ParseUint(string(bytes.TrimSpace(data)), 10, 64)
 }
 
 // loopback is a network strategy that provides a basic loopback device


### PR DESCRIPTION
Perform trimming before converting to a string, which should be somewhat more performant.

There may be more cases where we could process variables as byte before converting to strings; see https://medium.com/go-walkthrough/go-walkthrough-bytes-strings-packages-499be9f4b5bd

Also removed some unneeded conversions, caught by my IDE