### PR TITLE
libcontainer/cgroups: use const for templates

### DIFF
--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -18,7 +18,7 @@ const (
 	hugetlbFailcnt          = "100\n"
 )
 
-var (
+const (
 	usage    = "hugetlb.%s.usage_in_bytes"
 	limit    = "hugetlb.%s.limit_in_bytes"
 	maxUsage = "hugetlb.%s.max_usage_in_bytes"


### PR DESCRIPTION
The names of these templates overlapped with some local variables, which made reading the code somewhat confusing.

Changing them to a const, given that these were not updated anywere.
