### PR TITLE
runc run: fix removing cgroups on error; improve logging on error

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2050,8 +2050,9 @@ func ignoreTerminateErrors(err error) error {
 		return nil
 	}
 	s := err.Error()
-	switch {
-	case strings.Contains(s, "process already finished"), strings.Contains(s, "Wait was already called"):
+	if strings.Contains(s, "signal: killed") ||
+		strings.Contains(s, "process already finished") ||
+		strings.Contains(s, "Wait was already called") {
 		return nil
 	}
 	return err

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -363,10 +363,6 @@ func (c *linuxContainer) start(process *Process) error {
 	}
 	parent.forwardChildLogs()
 	if err := parent.start(); err != nil {
-		// terminate the process to ensure that it properly is reaped.
-		if err := ignoreTerminateErrors(parent.terminate()); err != nil {
-			logrus.Warn(err)
-		}
 		return newSystemErrorWithCause(err, "starting container process")
 	}
 

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -86,9 +86,9 @@ func (p *setnsProcess) signal(sig os.Signal) error {
 	return unix.Kill(p.pid(), s)
 }
 
-func (p *setnsProcess) start() (err error) {
+func (p *setnsProcess) start() (retErr error) {
 	defer p.messageSockPair.parent.Close()
-	err = p.cmd.Start()
+	err := p.cmd.Start()
 	// close the write-side of the pipes (controlled by child)
 	p.messageSockPair.child.Close()
 	p.logFilePair.child.Close()
@@ -100,7 +100,7 @@ func (p *setnsProcess) start() (err error) {
 			return newSystemErrorWithCause(err, "copying bootstrap data to pipe")
 		}
 	}
-	if err = p.execSetns(); err != nil {
+	if err := p.execSetns(); err != nil {
 		return newSystemErrorWithCause(err, "executing setns process")
 	}
 	if len(p.cgroupPaths) > 0 {

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -79,7 +79,7 @@ function setup() {
 
     runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
     [ "$status" -eq 1 ]
-    [[ ${lines[1]} == *"permission denied"* ]]
+    [[ ${lines[0]} == *"permission denied"* ]]
 }
 
 @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error" {
@@ -92,7 +92,7 @@ function setup() {
 
     runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
     [ "$status" -eq 1 ]
-    [[ ${lines[1]} == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] || [[ ${lines[1]} == *"cannot set pids limit: container could not join or create cgroup"* ]]
+    [[ ${lines[0]} == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] || [[ ${lines[0]} == *"cannot set pids limit: container could not join or create cgroup"* ]]
 }
 
 @test "runc create (limits + cgrouppath + permission on the cgroup dir) succeeds" {


### PR DESCRIPTION
### 1. libct/(*initProcess).start: fix removing cgroups on error

In case cgroup configuration is invalid (some parameters can't be set
etc.), p.manager.Set fails, the error is returned, and then we try to
remove cgroups (by calling p.manager.Destroy) in a defer.
    
The problem is, the container init is not yet killed (as it is killed in
the caller, i.e. (*linuxContainer).start), so cgroup removal fails like
this:
    
> time="2020-09-26T07:46:25Z" level=warning msg="Failed to remove cgroup (will retry)" error="rmdir /sys/fs/cgroup/net_cls,net_prio/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod28ce6e74_694c_4b77_a953_dc01e182ac76.slice/crio-f6984c5eeb6c6b49ff3f036bdcb9ded317b3d0b2469ebbb35705442a2afd98c2.scope: device or resource busy"
> ...
> time="2020-09-26T07:46:27Z" level=error msg="Failed to remove cgroup" error="rmdir /sys/fs/cgroup/net_cls,net_prio/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod28ce6e74_694c_4b77_a953_dc01e182ac76.slice/crio-f6984c5eeb6c6b49ff3f036bdcb9ded317b3d0b2469ebbb35705442a2afd98c2.scope: device or resource busy"

This can also be seen when running `TestCpuShares` (from libcontainer/integration) on a cgroup v1 system (see any PR's CI on CentOS 7 vagrant box).
    
The above is repeated for every controller, and looks quite scary.

To fix, move the init termination to the above-mentioned defer.

Do the same for `(*setnsProcess).start()` for uniformity (and
to not call terminate() twice).

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1883640

### 2. libcontainer/ignoreTerminateError: ignore SIGKILL

When we call terminate(), we kill the process, and wait
returns the error indicating the process was killed.
This is exactly what we expect here, so there is no reason
to treat it as an error.

Before this patch, when a container with invalid cgroup parameters is started:

> time="2020-09-23T22:01:51Z" level=warning msg="signal: killed"
    
With this patch, the useless warning is gone.
    
NOTE this change breaks a couple of integration test cases, since they were
expecting a particular message in the second line, and now due to
"signal: killed" removed it's in the first line. Fix those, too.
