### PR TITLE
CI: add golangci-lint via github actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # must be specified without patch version
+          version: v1.31
+
+          # Only show new issues for a pull request.
+          only-new-issues: true


### PR DESCRIPTION
It is set to only check the new code, so this should help maintainers to see any new issues introduced by PRs.

To see the example how it works, check https://github.com/kolyshkin/runc/pull/1

Fixes: #2617