### PR TITLE
setFreezer: explicitly return nil

### DIFF
--- a/libcontainer/cgroups/fs2/freezer.go
+++ b/libcontainer/cgroups/fs2/freezer.go
@@ -19,7 +19,7 @@ func setFreezer(dirPath string, state configs.FreezerState) error {
 		// freeze the container (since without the freezer cgroup, that's a
 		// no-op).
 		if state == configs.Undefined || state == configs.Thawed {
-			err = nil
+			return nil
 		}
 		return errors.Wrap(err, "freezer not supported")
 	}


### PR DESCRIPTION
`errors.Wrap(err, "some error")` returns `nil` if `err` is `nil`, so it's slightly clearer to just return early than to set the error to `nil` and call `errors.Wrap()`. This is also somewhat defensive in case we decide to replace `errors.Wrap()` for golang's native `%w` wrapping.
