### PR TITLE
libcontainer/system: remove deprecated GetProcessStartTime

### DIFF
--- a/libcontainer/system/proc.go
+++ b/libcontainer/system/proc.go
@@ -71,16 +71,6 @@ func Stat(pid int) (stat Stat_t, err error) {
 	return parseStat(string(bytes))
 }
 
-// GetProcessStartTime is deprecated.  Use Stat(pid) and
-// Stat_t.StartTime instead.
-func GetProcessStartTime(pid int) (string, error) {
-	stat, err := Stat(pid)
-	if err != nil {
-		return "", err
-	}
-	return strconv.FormatUint(stat.StartTime, 10), nil
-}
-
 func parseStat(data string) (stat Stat_t, err error) {
 	// From proc(5), field 2 could contain space and is inside `(` and `)`.
 	// The following is an example:


### PR DESCRIPTION
As noticed in https://github.com/opencontainers/runc/pull/2612#discussion_r497636110, GetProcessStartTime was deprecated over three Years ago in 439eaa3584402d239297f278cc1f22c08dbdcc17 (https://github.com/opencontainers/runc/pull/1489), so we may as well remove it now.
