### PR TITLE
libcontainer: remove `removePath` from cgroups

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -427,16 +427,6 @@ func join(path string, pid int) error {
 	return cgroups.WriteCgroupProc(path, pid)
 }
 
-func removePath(p string, err error) error {
-	if err != nil {
-		return err
-	}
-	if p != "" {
-		return os.RemoveAll(p)
-	}
-	return nil
-}
-
 func (m *manager) GetPaths() map[string]string {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
`removePath` is unused as below and lint check is failed
https://github.com/opencontainers/runc/commit/11fb94965cab5b2a54da9dca50d0e36d0ee36ef0

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>