### PR TITLE
Convert root path to absolute on create command

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,6 +141,9 @@ func main() {
 				fatal(err)
 			}
 		}
+		if err := reviseRootDir(context); err != nil {
+			return err
+		}
 		return logs.ConfigureLogging(createLogConfig(context))
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -92,6 +92,21 @@ func revisePidFile(context *cli.Context) error {
 	return context.Set("pid-file", pidFile)
 }
 
+// reviseRootDir convert the root to absolute path
+func reviseRootDir(context *cli.Context) error {
+	root := context.GlobalString("root")
+	if root == "" {
+		return nil
+	}
+
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+
+	return context.GlobalSet("root", root)
+}
+
 // parseBoolOrAuto returns (nil, nil) if s is empty or "auto"
 func parseBoolOrAuto(s string) (*bool, error) {
 	if s == "" || strings.ToLower(s) == "auto" {


### PR DESCRIPTION
Converting relative root path to absolute, so flag is relative to the current directory.

```
runc --root myroot state a
{
  "ociVersion": "1.0.2-dev",
  "id": "a",
  "pid": 403514,
  "status": "created",
  "bundle": "/root/container/mybundle",
  "rootfs": "/root/container/mybundle/rootfs",
  "created": "2020-10-03T02:04:11.259347723Z",
  "owner": ""
}
````

Fixes #2613