### PR TITLE
Rootless systemd dbus friendlier error

### DIFF
--- a/docs/cgroup-v2.md
+++ b/docs/cgroup-v2.md
@@ -24,6 +24,13 @@ On cgroup v2 hosts, it is highly recommended to run runc with the systemd cgroup
 
 The recommended systemd version is 244 or later. Older systemd does not support delegation of `cpuset` controller.
 
+Make sure you also have the `dbus-user-session` (Debian/Ubuntu) or `dbus-daemon` (CentOS/Fedora) package installed, and that `dbus` is running. On Debian-flavored distros, this can be accomplished like so:
+
+```console
+$ sudo apt install -y dbus-user-session
+$ systemctl --user start dbus
+```
+
 ## Rootless
 On cgroup v2 hosts, rootless runc can talk to systemd to get cgroup permissions to be delegated.
 

--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -102,5 +102,5 @@ func DetectUserDbusSessionBusAddress() (string, error) {
 			return strings.TrimPrefix(s, "DBUS_SESSION_BUS_ADDRESS="), nil
 		}
 	}
-	return "", errors.New("could not detect DBUS_SESSION_BUS_ADDRESS from `systemctl --user --no-pager show-environment`")
+	return "", errors.New("could not detect DBUS_SESSION_BUS_ADDRESS from `systemctl --user --no-pager show-environment`. Make sure you have installed the dbus-user-session or dbus-daemon package and then run: `systemctl --user start dbus`")
 }


### PR DESCRIPTION
Closes #2582 

This PR adds a more helpful error message when `$DBUS_SESSION_BUS_ADDRESS` does not exist. I've tried to make the error message itself distro-agnostic but in the docs I've used the example in the issue.

Signed-off-by: Aos Dabbagh <aosdab@gmail.com>