### PR TITLE
Fixing some lint issues

### DIFF
--- a/contrib/cmd/recvtty/recvtty.go
+++ b/contrib/cmd/recvtty/recvtty.go
@@ -105,7 +105,9 @@ func handleSingle(path string, noStdin bool) error {
 	if err != nil {
 		return err
 	}
-	console.ClearONLCR(c.Fd())
+	if err := console.ClearONLCR(c.Fd()); err != nil {
+		return err
+	}
 
 	// Copy from our stdio to the master fd.
 	quitChan := make(chan struct{})

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -374,7 +374,6 @@ func systemdVersion(conn *systemdDbus.Conn) (int, error) {
 		}
 
 		version, versionErr = systemdVersionAtoi(verStr)
-		return
 	})
 
 	return version, versionErr

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -228,7 +228,7 @@ func checkHostNs(sysctlConfig string, path string) error {
 		return fmt.Errorf("could not check that %q is a symlink: %v", path, err)
 	}
 
-	if symLink == false {
+	if !symLink {
 		// The provided namespace is not a symbolic link,
 		// it is not the host namespace.
 		return nil

--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -22,7 +22,9 @@ func TestValidate(t *testing.T) {
 
 func TestValidateWithInvalidRootfs(t *testing.T) {
 	dir := "rootfs"
-	os.Symlink("/var", dir)
+	if err := os.Symlink("/var", dir); err != nil {
+		t.Fatal(err)
+	}
 	defer os.Remove(dir)
 
 	config := &configs.Config{

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1528,7 +1528,7 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 
 	buf := make([]byte, 10*4096)
 	oob := make([]byte, 4096)
-	for true {
+	for {
 		n, oobn, _, _, err := criuClientCon.ReadMsgUnix(buf, oob)
 		if req.Opts != nil && req.Opts.StatusFd != nil {
 			// Close status_fd as soon as we got something back from criu,

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -235,7 +235,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 		t.Fatal(err)
 	}
 
-	process, err = os.FindProcess(pid)
+	_, err = os.FindProcess(pid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 		t.Fatal(s.String(), pid)
 	}
 
-	output := string(stdout.Bytes())
+	output := stdout.String()
 	if !strings.Contains(output, "Hello!") {
 		t.Fatal("Did not restore the pipe correctly:", output)
 	}

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -279,10 +279,10 @@ func TestEnter(t *testing.T) {
 	waitProcess(&pconfig, t)
 
 	// Check that both processes live in the same pidns
-	pidns := string(stdout.Bytes())
+	pidns := stdout.String()
 	ok(t, err)
 
-	pidns2 := string(stdout2.Bytes())
+	pidns2 := stdout2.String()
 	ok(t, err)
 
 	if pidns != pidns2 {
@@ -325,7 +325,7 @@ func TestProcessEnv(t *testing.T) {
 	// Wait for process
 	waitProcess(&pconfig, t)
 
-	outputEnv := string(stdout.Bytes())
+	outputEnv := stdout.String()
 
 	// Check that the environment has the key/value pair we added
 	if !strings.Contains(outputEnv, "FOO=BAR") {
@@ -964,7 +964,7 @@ func TestPassExtraFiles(t *testing.T) {
 
 	waitProcess(&process, t)
 
-	out := string(stdout.Bytes())
+	out := stdout.String()
 	// fd 5 is the directory handle for /proc/$$/fd
 	if out != "0 1 2 3 4 5" {
 		t.Fatalf("expected to have the file descriptors '0 1 2 3 4 5' passed to init, got '%s'", out)
@@ -1501,7 +1501,7 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 	mountPropagated = false
 	dir2cont = filepath.Join(dir1cont, filepath.Base(dir2host))
 
-	propagationInfo := string(stdout2.Bytes())
+	propagationInfo := stdout2.String()
 	lines := strings.Split(propagationInfo, "\n")
 	for _, l := range lines {
 		linefields := strings.Split(l, " ")
@@ -1892,7 +1892,7 @@ func TestTmpfsCopyUp(t *testing.T) {
 	// Wait for process
 	waitProcess(&pconfig, t)
 
-	outputLs := string(stdout.Bytes())
+	outputLs := stdout.String()
 
 	// Check that the ls output has /etc/passwd
 	if !strings.Contains(outputLs, "/etc/passwd") {

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -226,7 +226,6 @@ func init() {
 	if strings.HasPrefix(os.Args[0], "nsenter-") {
 		os.Exit(0)
 	}
-	return
 }
 
 func newPipe() (parent *os.File, child *os.File, err error) {

--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -49,7 +49,7 @@ var archs = map[string]string{
 // Attempting to convert a string that is not a valid operator results in an
 // error.
 func ConvertStringToOperator(in string) (configs.Operator, error) {
-	if op, ok := operators[in]; ok == true {
+	if op, ok := operators[in]; ok {
 		return op, nil
 	}
 	return 0, fmt.Errorf("string %s is not a valid operator for seccomp", in)
@@ -62,7 +62,7 @@ func ConvertStringToOperator(in string) (configs.Operator, error) {
 // Attempting to convert a string that is not a valid action results in an
 // error.
 func ConvertStringToAction(in string) (configs.Action, error) {
-	if act, ok := actions[in]; ok == true {
+	if act, ok := actions[in]; ok {
 		return act, nil
 	}
 	return 0, fmt.Errorf("string %s is not a valid action for seccomp", in)
@@ -70,7 +70,7 @@ func ConvertStringToAction(in string) (configs.Action, error) {
 
 // ConvertStringToArch converts a string into a Seccomp comparison arch.
 func ConvertStringToArch(in string) (string, error) {
-	if arch, ok := archs[in]; ok == true {
+	if arch, ok := archs[in]; ok {
 		return arch, nil
 	}
 	return "", fmt.Errorf("string %s is not a valid arch for seccomp", in)

--- a/libcontainer/user/user_test.go
+++ b/libcontainer/user/user_test.go
@@ -463,7 +463,7 @@ this is just some garbage data
 			t.Errorf("Parse(%#v) has error %v", test, err)
 			continue
 		}
-		sort.Sort(sort.IntSlice(gids))
+		sort.Ints(gids)
 		if !reflect.DeepEqual(gids, test.expected) {
 			t.Errorf("Gids(%v), expect %v from groups %v", gids, test.expected, test.groups)
 		}
@@ -499,7 +499,7 @@ func TestGetAdditionalGroupsNumeric(t *testing.T) {
 			t.Errorf("Parse(%#v) has error %v", test, err)
 			continue
 		}
-		sort.Sort(sort.IntSlice(gids))
+		sort.Ints(gids)
 		if !reflect.DeepEqual(gids, test.expected) {
 			t.Errorf("Gids(%v), expect %v from groups %v", gids, test.expected, test.groups)
 		}

--- a/libcontainer/utils/utils_test.go
+++ b/libcontainer/utils/utils_test.go
@@ -32,7 +32,9 @@ func TestSearchLabels(t *testing.T) {
 
 func TestResolveRootfs(t *testing.T) {
 	dir := "rootfs"
-	os.Mkdir(dir, 0600)
+	if err := os.Mkdir(dir, 0600); err != nil {
+		t.Fatal(err)
+	}
 	defer os.Remove(dir)
 
 	path, err := ResolveRootfs(dir)
@@ -51,7 +53,9 @@ func TestResolveRootfs(t *testing.T) {
 func TestResolveRootfsWithSymlink(t *testing.T) {
 	dir := "rootfs"
 	tmpDir, _ := filepath.EvalSymlinks(os.TempDir())
-	os.Symlink(tmpDir, dir)
+	if err := os.Symlink(tmpDir, dir); err != nil {
+		t.Fatal(err)
+	}
 	defer os.Remove(dir)
 
 	path, err := ResolveRootfs(dir)

--- a/notify_socket.go
+++ b/notify_socket.go
@@ -162,7 +162,10 @@ func (n *notifySocket) run(pid1 int) error {
 
 			// now we can inform systemd to use pid1 as the pid to monitor
 			newPid := "MAINPID=" + strconv.Itoa(pid1)
-			client.Write([]byte(newPid + "\n"))
+			_, err := client.Write([]byte(newPid + "\n"))
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 	}

--- a/tty.go
+++ b/tty.go
@@ -112,7 +112,10 @@ func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) (Err error
 	if err != nil {
 		return err
 	}
-	console.ClearONLCR(cons.Fd())
+	err = console.ClearONLCR(cons.Fd())
+	if err != nil {
+		return err
+	}
 	epoller, err := console.NewEpoller()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixing some issues from https://github.com/opencontainers/runc/issues/2627

contrib/cmd/recvtty/recvtty.go:108:20: Error return value of `console.ClearONLCR` is not checked (errcheck)

libcontainer/cgroups/systemd/common.go:377:3: S1023: redundant `return` statement (gosimple)

libcontainer/configs/validate/validator.go:231:5: S1002: should omit comparison to bool constant, can be simplified to `!symLink` (gosimple)

libcontainer/container_linux.go:1531:2: S1006: should use for {} instead of for true {} (gosimple)

libcontainer/integration/checkpoint_test.go:238:2: SA4006: this value of `process` is never used (staticcheck)

libcontainer/integration/checkpoint_test.go:258:12: S1030: should use stdout.String() instead of string(stdout.Bytes()) (gosimple)

libcontainer/integration/exec_test.go:282:11: S1030: should use stdout.String() instead of string(stdout.Bytes()) (gosimple)

libcontainer/integration/exec_test.go:285:12: S1030: should use stdout2.String() instead of string(stdout2.Bytes()) (gosimple)

libcontainer/integration/exec_test.go:328:15: S1030: should use stdout.String() instead of string(stdout.Bytes()) (gosimple)

libcontainer/integration/exec_test.go:1504:21: S1030: should use stdout2.String() instead of string(stdout2.Bytes()) 
(gosimple)

libcontainer/nsenter/nsenter_test.go:229:2: S1023: redundant `return` statement (gosimple)

libcontainer/seccomp/config.go:65:29: S1002: should omit comparison to bool constant, can be simplified to `ok` (gosimple)

libcontainer/seccomp/config.go:73:28: S1002: should omit comparison to bool constant, can be simplified to `ok` (gosimple)

libcontainer/user/user_test.go:466:3: S1032: should use sort.Ints(...) instead of sort.Sort(sort.IntSlice(...)) (gosimple)

libcontainer/user/user_test.go:502:3: S1032: should use sort.Ints(...) instead of sort.Sort(sort.IntSlice(...)) (gosimple)

notify_socket.go:165:16: Error return value of `client.Write` is not checked (errcheck)