### PR TITLE
Kill processes in cgroup even if process Wait fails

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -511,14 +511,11 @@ func (p *initProcess) start() (retErr error) {
 
 func (p *initProcess) wait() (*os.ProcessState, error) {
 	err := p.cmd.Wait()
-	if err != nil {
-		return p.cmd.ProcessState, err
-	}
 	// we should kill all processes in cgroup when init is died if we use host PID namespace
 	if p.sharePidns {
 		signalAllProcesses(p.manager, unix.SIGKILL)
 	}
-	return p.cmd.ProcessState, nil
+	return p.cmd.ProcessState, err
 }
 
 func (p *initProcess) terminate() error {


### PR DESCRIPTION
If the cgroup's init process doesn't complete successfully, Wait returns a
non-nil error. We should still kill all the processes in the cgroup in that
case, if process namespace is shared. Otherwise, it may result in process leak.

Fixes #2632

Signed-off-by: Chaitanya Bandi <kbandi@cs.stonybrook.edu>