### PR TITLE
libcontainer/intelrdt: adjust the file mode

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -413,7 +413,7 @@ func writeFile(dir, file, data string) error {
 	if dir == "" {
 		return fmt.Errorf("no such directory for %s", file)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, file), []byte(data+"\n"), 0700); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dir, file), []byte(data+"\n"), 0o600); err != nil {
 		return fmt.Errorf("failed to write %v to %v: %v", data, file, err)
 	}
 	return nil
@@ -520,7 +520,7 @@ func WriteIntelRdtTasks(dir string, pid int) error {
 
 	// Don't attach any pid if -1 is specified as a pid
 	if pid != -1 {
-		if err := ioutil.WriteFile(filepath.Join(dir, IntelRdtTasks), []byte(strconv.Itoa(pid)), 0700); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(dir, IntelRdtTasks), []byte(strconv.Itoa(pid)), 0o600); err != nil {
 			return fmt.Errorf("failed to write %v to %v: %v", pid, IntelRdtTasks, err)
 		}
 	}
@@ -763,7 +763,7 @@ func (m *intelRdtManager) Set(container *configs.Config) error {
 
 func (raw *intelRdtData) join(id string) (string, error) {
 	path := filepath.Join(raw.root, id)
-	if err := os.MkdirAll(path, 0755); err != nil {
+	if err := os.MkdirAll(path, 0o755); err != nil {
 		return "", NewLastCmdError(err)
 	}
 

--- a/libcontainer/intelrdt/util_test.go
+++ b/libcontainer/intelrdt/util_test.go
@@ -45,7 +45,7 @@ func NewIntelRdtTestUtil(t *testing.T) *intelRdtTestUtil {
 	}
 
 	// Ensure the full mock Intel RDT "resource control" filesystem path exists
-	err = os.MkdirAll(testIntelRdtPath, 0755)
+	err = os.MkdirAll(testIntelRdtPath, 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit adjusts the file mode to use the latest golang style
and also changes the file mode value in accordance with default.

This commit is related to https://github.com/opencontainers/runc/pull/2625

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>