### PR TITLE
Add shfmt for sh and bats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ before_install:
   - sudo apt-get install -y libseccomp-dev
   - GO111MODULE=off go get -u golang.org/x/lint/golint
   - GO111MODULE=off go get -u github.com/vbatts/git-validation
+  - GO111MODULE=off go get github.com/mvdan/sh/cmd/shfmt
   - env | grep TRAVIS_
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,9 @@ validate:
 	script/validate-c
 	$(GO) vet $(MOD_VENDOR) ./...
 	shellcheck tests/integration/*.bats
+	# TODO: add shellcheck for sh files
 	shfmt -ln bats -d tests/integration/*.bats
+	shfmt -ln bash -d man/*.sh script/*.sh tests/*.sh tests/integration/*.bash
 
 ci: validate test release
 

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ validate:
 	script/validate-c
 	$(GO) vet $(MOD_VENDOR) ./...
 	shellcheck tests/integration/*.bats
+	shfmt -ln bats -d tests/integration/*.bats
 
 ci: validate test release
 

--- a/script/check-config.sh
+++ b/script/check-config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# bits of this were adapted from check_config.sh in docker 
+# bits of this were adapted from check_config.sh in docker
 # see also https://github.com/docker/docker/blob/master/contrib/check-config.sh
 
 possibleConfigs=(
@@ -202,7 +202,7 @@ flags=(
 	NF_NAT_IPV4 IP_NF_FILTER IP_NF_TARGET_MASQUERADE
 	NETFILTER_XT_MATCH_{ADDRTYPE,CONNTRACK,IPVS}
 	IP_NF_NAT NF_NAT NF_NAT_NEEDED
-	
+
 	# required for bind-mounting /dev/mqueue into containers
 	POSIX_MQUEUE
 )

--- a/script/release.sh
+++ b/script/release.sh
@@ -66,29 +66,29 @@ releasedir=""
 hashcmd=""
 while getopts "S:c:r:v:h:" opt; do
 	case "$opt" in
-		S)
-			keyid="$OPTARG"
-			;;
-		c)
-			commit="$OPTARG"
-			;;
-		r)
-			releasedir="$OPTARG"
-			;;
-		v)
-			version="$OPTARG"
-			;;
-		h)
-			hashcmd="$OPTARG"
-			;;
-		\:)
-			echo "Missing argument: -$OPTARG" >&2
-			usage
-			;;
-		\?)
-			echo "Invalid option: -$OPTARG" >&2
-			usage
-			;;
+	S)
+		keyid="$OPTARG"
+		;;
+	c)
+		commit="$OPTARG"
+		;;
+	r)
+		releasedir="$OPTARG"
+		;;
+	v)
+		version="$OPTARG"
+		;;
+	h)
+		hashcmd="$OPTARG"
+		;;
+	\:)
+		echo "Missing argument: -$OPTARG" >&2
+		usage
+		;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		usage
+		;;
 	esac
 done
 
@@ -113,10 +113,13 @@ rm -rf "$releasedir" && mkdir -p "$releasedir"
 build_project "$releasedir/$project.$goarch"
 
 # Generate new archive.
-git archive --format=tar --prefix="$project-$version/" "$commit" | xz > "$releasedir/$project.tar.xz"
+git archive --format=tar --prefix="$project-$version/" "$commit" | xz >"$releasedir/$project.tar.xz"
 
 # Generate sha256 checksums for both.
-( cd "$releasedir" ; "$hashcmd" "$project".{"$goarch",tar.xz} > "$project.$hashcmd" ; )
+(
+	cd "$releasedir"
+	"$hashcmd" "$project".{"$goarch",tar.xz} >"$project.$hashcmd"
+)
 
 # Set up the gpgflags.
 [[ "$keyid" ]] && export gpgflags="--default-key $keyid"
@@ -126,5 +129,5 @@ gpg_cansign $gpgflags || bail "Could not find suitable GPG key, skipping signing
 gpg $gpgflags --detach-sign --armor "$releasedir/$project.$goarch"
 gpg $gpgflags --detach-sign --armor "$releasedir/$project.tar.xz"
 gpg $gpgflags --clear-sign --armor \
-	--output "$releasedir/$project.$hashcmd"{.tmp,} && \
+	--output "$releasedir/$project.$hashcmd"{.tmp,} &&
 	mv "$releasedir/$project.$hashcmd"{.tmp,}

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -3,198 +3,198 @@
 load helpers
 
 function teardown() {
-    teardown_running_container test_cgroups_kmem
-    teardown_running_container test_cgroups_permissions
-    teardown_running_container test_cgroups_group
-    teardown_running_container test_cgroups_unified
-    teardown_busybox
+	teardown_running_container test_cgroups_kmem
+	teardown_running_container test_cgroups_permissions
+	teardown_running_container test_cgroups_group
+	teardown_running_container test_cgroups_unified
+	teardown_busybox
 }
 
 function setup() {
-    teardown
-    setup_busybox
+	teardown
+	setup_busybox
 }
 
 @test "runc update --kernel-memory{,-tcp} (initialized)" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    requires cgroups_kmem
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	requires cgroups_kmem
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
 
-    # Set some initial known values
-    update_config '.linux.resources.memory |= {"kernel": 16777216, "kernelTCP": 11534336}' "${BUSYBOX_BUNDLE}"
+	# Set some initial known values
+	update_config '.linux.resources.memory |= {"kernel": 16777216, "kernelTCP": 11534336}' "${BUSYBOX_BUNDLE}"
 
-    # run a detached busybox to work with
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
-    [ "$status" -eq 0 ]
+	# run a detached busybox to work with
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
+	[ "$status" -eq 0 ]
 
-    check_cgroup_value "memory.kmem.limit_in_bytes" 16777216
-    check_cgroup_value "memory.kmem.tcp.limit_in_bytes" 11534336
+	check_cgroup_value "memory.kmem.limit_in_bytes" 16777216
+	check_cgroup_value "memory.kmem.tcp.limit_in_bytes" 11534336
 
-    # update kernel memory limit
-    runc update test_cgroups_kmem --kernel-memory 50331648
-    [ "$status" -eq 0 ]
-    check_cgroup_value "memory.kmem.limit_in_bytes" 50331648
+	# update kernel memory limit
+	runc update test_cgroups_kmem --kernel-memory 50331648
+	[ "$status" -eq 0 ]
+	check_cgroup_value "memory.kmem.limit_in_bytes" 50331648
 
-    # update kernel memory tcp limit
-    runc update test_cgroups_kmem --kernel-memory-tcp 41943040
-    [ "$status" -eq 0 ]
-    check_cgroup_value "memory.kmem.tcp.limit_in_bytes" 41943040
+	# update kernel memory tcp limit
+	runc update test_cgroups_kmem --kernel-memory-tcp 41943040
+	[ "$status" -eq 0 ]
+	check_cgroup_value "memory.kmem.tcp.limit_in_bytes" 41943040
 }
 
 @test "runc update --kernel-memory (uninitialized)" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    requires cgroups_kmem
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	requires cgroups_kmem
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
 
-    # run a detached busybox to work with
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
-    [ "$status" -eq 0 ]
+	# run a detached busybox to work with
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
+	[ "$status" -eq 0 ]
 
-    # update kernel memory limit
-    runc update test_cgroups_kmem --kernel-memory 50331648
-    # Since kernel 4.6, we can update kernel memory without initialization
-    # because it's accounted by default.
-    if [[ "$KERNEL_MAJOR" -lt 4 || ( "$KERNEL_MAJOR" -eq 4 && "$KERNEL_MINOR" -le 5 ) ]]; then
-        [ ! "$status" -eq 0 ]
-    else
-        [ "$status" -eq 0 ]
-        check_cgroup_value "memory.kmem.limit_in_bytes" 50331648
-    fi
+	# update kernel memory limit
+	runc update test_cgroups_kmem --kernel-memory 50331648
+	# Since kernel 4.6, we can update kernel memory without initialization
+	# because it's accounted by default.
+	if [[ "$KERNEL_MAJOR" -lt 4 || ("$KERNEL_MAJOR" -eq 4 && "$KERNEL_MINOR" -le 5) ]]; then
+		[ ! "$status" -eq 0 ]
+	else
+		[ "$status" -eq 0 ]
+		check_cgroup_value "memory.kmem.limit_in_bytes" 50331648
+	fi
 }
 
 @test "runc create (no limits + no cgrouppath + no permission) succeeds" {
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
+	[ "$status" -eq 0 ]
 }
 
 @test "runc create (rootless + no limits + cgrouppath + no permission) fails with permission error" {
-    requires rootless
-    requires rootless_no_cgroup
-    # systemd controls the permission, so error does not happen
-    requires no_systemd
+	requires rootless
+	requires rootless_no_cgroup
+	# systemd controls the permission, so error does not happen
+	requires no_systemd
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-    [ "$status" -eq 1 ]
-    [[ ${lines[0]} == *"permission denied"* ]]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"permission denied"* ]]
 }
 
 @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error" {
-    requires rootless
-    requires rootless_no_cgroup
-    # systemd controls the permission, so error does not happen
-    requires no_systemd
+	requires rootless
+	requires rootless_no_cgroup
+	# systemd controls the permission, so error does not happen
+	requires no_systemd
 
-    set_resources_limit "$BUSYBOX_BUNDLE"
+	set_resources_limit "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-    [ "$status" -eq 1 ]
-    [[ ${lines[0]} == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] || [[ ${lines[0]} == *"cannot set pids limit: container could not join or create cgroup"* ]]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] || [[ ${lines[0]} == *"cannot set pids limit: container could not join or create cgroup"* ]]
 }
 
 @test "runc create (limits + cgrouppath + permission on the cgroup dir) succeeds" {
-   [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-    set_resources_limit "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_resources_limit "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-    [ "$status" -eq 0 ]
-    if [ "$CGROUP_UNIFIED" != "no" ]; then
-        if [ -n "${RUNC_USE_SYSTEMD}" ] ; then
-            if [ "$(id -u)" = "0" ]; then
-                check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
-            else
-                # shellcheck disable=SC2046
-                check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/user.slice/user-$(id -u).slice/cgroup.controllers)"
-            fi
-        else
-            check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"
-        fi
-    fi
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
+	[ "$status" -eq 0 ]
+	if [ "$CGROUP_UNIFIED" != "no" ]; then
+		if [ -n "${RUNC_USE_SYSTEMD}" ]; then
+			if [ "$(id -u)" = "0" ]; then
+				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
+			else
+				# shellcheck disable=SC2046
+				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/user.slice/user-$(id -u).slice/cgroup.controllers)"
+			fi
+		else
+			check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"
+		fi
+	fi
 }
 
 @test "runc exec (limits + cgrouppath + permission on the cgroup dir) succeeds" {
-   [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-    set_resources_limit "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_resources_limit "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
+	[ "$status" -eq 0 ]
 
-    runc exec test_cgroups_permissions echo "cgroups_exec"
-    [ "$status" -eq 0 ]
-    [[ ${lines[0]} == *"cgroups_exec"* ]]
+	runc exec test_cgroups_permissions echo "cgroups_exec"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == *"cgroups_exec"* ]]
 }
 
 @test "runc exec (cgroup v2 + init process in non-root cgroup) succeeds" {
-    requires root cgroups_v2
+	requires root cgroups_v2
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-    set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
+	[ "$status" -eq 0 ]
 
-    runc exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers
-    [ "$status" -eq 0 ]
-    [[ ${lines[0]} == *"memory"* ]]
+	runc exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == *"memory"* ]]
 
-    runc exec test_cgroups_group cat /proc/self/cgroup
-    [ "$status" -eq 0 ]
-    [[ ${lines[0]} == "0::/" ]]
+	runc exec test_cgroups_group cat /proc/self/cgroup
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == "0::/" ]]
 
-    runc exec test_cgroups_group mkdir /sys/fs/cgroup/foo
-    [ "$status" -eq 0 ]
+	runc exec test_cgroups_group mkdir /sys/fs/cgroup/foo
+	[ "$status" -eq 0 ]
 
-    runc exec test_cgroups_group sh -c "echo 1 > /sys/fs/cgroup/foo/cgroup.procs"
-    [ "$status" -eq 0 ]
+	runc exec test_cgroups_group sh -c "echo 1 > /sys/fs/cgroup/foo/cgroup.procs"
+	[ "$status" -eq 0 ]
 
-# the init process is now in "/foo", but an exec process can still join "/"
-# because we haven't enabled any domain controller.
-    runc exec test_cgroups_group cat /proc/self/cgroup
-    [ "$status" -eq 0 ]
-    [[ ${lines[0]} == "0::/" ]]
+	# the init process is now in "/foo", but an exec process can still join "/"
+	# because we haven't enabled any domain controller.
+	runc exec test_cgroups_group cat /proc/self/cgroup
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == "0::/" ]]
 
-# turn on a domain controller (memory)
-    runc exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
-    [ "$status" -eq 0 ]
+	# turn on a domain controller (memory)
+	runc exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
+	[ "$status" -eq 0 ]
 
-# an exec process can no longer join "/" after turning on a domain controller.
-# falls back to "/foo".
-    runc exec test_cgroups_group cat /proc/self/cgroup
-    [ "$status" -eq 0 ]
-    [[ ${lines[0]} == "0::/foo" ]]
+	# an exec process can no longer join "/" after turning on a domain controller.
+	# falls back to "/foo".
+	runc exec test_cgroups_group cat /proc/self/cgroup
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == "0::/foo" ]]
 
-# teardown: remove "/foo"
-    # shellcheck disable=SC2016
-    runc exec test_cgroups_group sh -uxc 'echo -memory > /sys/fs/cgroup/cgroup.subtree_control; for f in $(cat /sys/fs/cgroup/foo/cgroup.procs); do echo $f > /sys/fs/cgroup/cgroup.procs; done; rmdir /sys/fs/cgroup/foo'
-    runc exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
-    [ "$status" -eq 0 ]
-#
+	# teardown: remove "/foo"
+	# shellcheck disable=SC2016
+	runc exec test_cgroups_group sh -uxc 'echo -memory > /sys/fs/cgroup/cgroup.subtree_control; for f in $(cat /sys/fs/cgroup/foo/cgroup.procs); do echo $f > /sys/fs/cgroup/cgroup.procs; done; rmdir /sys/fs/cgroup/foo'
+	runc exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
+	[ "$status" -eq 0 ]
+	#
 }
 
 @test "runc run (cgroup v1 + unified resources should fail)" {
-    requires root cgroups_v1
+	requires root cgroups_v1
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-    set_resources_limit "$BUSYBOX_BUNDLE"
-    update_config '.linux.resources.unified |= {"memory.min": "131072"}' "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_resources_limit "$BUSYBOX_BUNDLE"
+	update_config '.linux.resources.unified |= {"memory.min": "131072"}' "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-    [ "$status" -ne 0 ]
-    [[ "$output" == *'invalid configuration'* ]]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
+	[ "$status" -ne 0 ]
+	[[ "$output" == *'invalid configuration'* ]]
 }
 
 @test "runc run (cgroup v2 resources.unified only)" {
-    requires root cgroups_v2
+	requires root cgroups_v2
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-    update_config ' .linux.resources.unified |= {
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	update_config ' .linux.resources.unified |= {
                       "memory.min":   "131072",
                       "memory.low":   "524288",
                       "memory.high": "5242880",
@@ -203,38 +203,38 @@ function setup() {
                       "cpu.max": "10000 100000"
                      }' "$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
+	[ "$status" -eq 0 ]
 
-    runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.min *.max *.low *.high'
-    [ "$status" -eq 0 ]
-    echo "$output"
+	runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.min *.max *.low *.high'
+	[ "$status" -eq 0 ]
+	echo "$output"
 
-    echo "$output" | grep -q '^memory.min:131072$'
-    echo "$output" | grep -q '^memory.low:524288$'
-    echo "$output" | grep -q '^memory.high:5242880$'
-    echo "$output" | grep -q '^memory.max:10485760$'
-    echo "$output" | grep -q '^pids.max:99$'
-    echo "$output" | grep -q '^cpu.max:10000 100000$'
+	echo "$output" | grep -q '^memory.min:131072$'
+	echo "$output" | grep -q '^memory.low:524288$'
+	echo "$output" | grep -q '^memory.high:5242880$'
+	echo "$output" | grep -q '^memory.max:10485760$'
+	echo "$output" | grep -q '^pids.max:99$'
+	echo "$output" | grep -q '^cpu.max:10000 100000$'
 }
 @test "runc run (cgroup v2 resources.unified override)" {
-    requires root cgroups_v2
+	requires root cgroups_v2
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-    update_config ' .linux.resources.memory |= {"limit": 33554432}
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	update_config ' .linux.resources.memory |= {"limit": 33554432}
                   | .linux.resources.memorySwap |= {"limit": 33554432}
                   | .linux.resources.unified |=
                       {"memory.min": "131072", "memory.max": "10485760" }' \
-        "$BUSYBOX_BUNDLE"
+		"$BUSYBOX_BUNDLE"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
+	[ "$status" -eq 0 ]
 
-    runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
-    [ "$status" -eq 0 ]
-    [ "$output" = '131072' ]
+	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
+	[ "$status" -eq 0 ]
+	[ "$output" = '131072' ]
 
-    runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
-    [ "$status" -eq 0 ]
-    [ "$output" = '10485760' ]
+	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
+	[ "$status" -eq 0 ]
+	[ "$output" = '10485760' ]
 }

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -3,22 +3,22 @@
 load helpers
 
 function setup() {
-  # XXX: currently criu require root containers.
-  requires criu root
+	# XXX: currently criu require root containers.
+	requires criu root
 
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
-  teardown_running_container test_busybox_restore
+	teardown_busybox
+	teardown_running_container test_busybox_restore
 }
 
 function setup_pipes() {
 	# The changes to 'terminal' are needed for running in detached mode
 	# shellcheck disable=SC2016
-	update_config 	' (.. | select(.terminal? != null)) .terminal |= false
+	update_config ' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["-c", "for i in `seq 10`; do read xxx || continue; echo ponG $xxx; done"]'
 
 	# Create three sets of pipes for __runc run.
@@ -93,28 +93,28 @@ function runc_restore_with_pipes() {
 }
 
 function simple_cr() {
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 
-  for _ in $(seq 2); do
-    # checkpoint the running container
-    runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
-    grep -B 5 Error ./work-dir/dump.log || true
-    [ "$status" -eq 0 ]
+	for _ in $(seq 2); do
+		# checkpoint the running container
+		runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
+		grep -B 5 Error ./work-dir/dump.log || true
+		[ "$status" -eq 0 ]
 
-    # after checkpoint busybox is no longer running
-    testcontainer test_busybox checkpointed
+		# after checkpoint busybox is no longer running
+		testcontainer test_busybox checkpointed
 
-    # restore from checkpoint
-    runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-    grep -B 5 Error ./work-dir/restore.log || true
-    [ "$status" -eq 0 ]
+		# restore from checkpoint
+		runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
+		grep -B 5 Error ./work-dir/restore.log || true
+		[ "$status" -eq 0 ]
 
-    # busybox should be back up and running
-    testcontainer test_busybox running
-  done
+		# busybox should be back up and running
+		testcontainer test_busybox running
+	done
 }
 
 @test "checkpoint and restore " {
@@ -122,199 +122,199 @@ function simple_cr() {
 }
 
 @test "checkpoint and restore (cgroupns)" {
-  # cgroupv2 already enables cgroupns so this case was tested above already
-  requires cgroups_v1 cgroupns
+	# cgroupv2 already enables cgroupns so this case was tested above already
+	requires cgroups_v1 cgroupns
 
-  # enable CGROUPNS
-  update_config '.linux.namespaces += [{"type": "cgroup"}]'
+	# enable CGROUPNS
+	update_config '.linux.namespaces += [{"type": "cgroup"}]'
 
-  simple_cr
+	simple_cr
 }
 
 @test "checkpoint --pre-dump and restore" {
-  setup_pipes
-  runc_run_with_pipes test_busybox
+	setup_pipes
+	runc_run_with_pipes test_busybox
 
-  #test checkpoint pre-dump
-  mkdir parent-dir
-  runc --criu "$CRIU" checkpoint --pre-dump --image-path ./parent-dir test_busybox
-  [ "$status" -eq 0 ]
+	#test checkpoint pre-dump
+	mkdir parent-dir
+	runc --criu "$CRIU" checkpoint --pre-dump --image-path ./parent-dir test_busybox
+	[ "$status" -eq 0 ]
 
-  # busybox should still be running
-  testcontainer test_busybox running
+	# busybox should still be running
+	testcontainer test_busybox running
 
-  # checkpoint the running container
-  mkdir image-dir
-  mkdir work-dir
-  runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
-  grep -B 5 Error ./work-dir/dump.log || true
-  [ "$status" -eq 0 ]
+	# checkpoint the running container
+	mkdir image-dir
+	mkdir work-dir
+	runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
+	grep -B 5 Error ./work-dir/dump.log || true
+	[ "$status" -eq 0 ]
 
-  # after checkpoint busybox is no longer running
-  testcontainer test_busybox checkpointed
+	# after checkpoint busybox is no longer running
+	testcontainer test_busybox checkpointed
 
-  runc_restore_with_pipes ./work-dir test_busybox
-  check_pipes
+	runc_restore_with_pipes ./work-dir test_busybox
+	check_pipes
 }
 
 @test "checkpoint --lazy-pages and restore" {
-  # check if lazy-pages is supported
-  run "${CRIU}" check --feature uffd-noncoop
-  if [ "$status" -eq 1 ]; then
-    skip "this criu does not support lazy migration"
-  fi
+	# check if lazy-pages is supported
+	run "${CRIU}" check --feature uffd-noncoop
+	if [ "$status" -eq 1 ]; then
+		skip "this criu does not support lazy migration"
+	fi
 
-  setup_pipes
-  runc_run_with_pipes test_busybox
+	setup_pipes
+	runc_run_with_pipes test_busybox
 
-  # checkpoint the running container
-  mkdir image-dir
-  mkdir work-dir
+	# checkpoint the running container
+	mkdir image-dir
+	mkdir work-dir
 
-  # For lazy migration we need to know when CRIU is ready to serve
-  # the memory pages via TCP.
-  exec {pipe}<> <(:)
-  # shellcheck disable=SC2094
-  exec {lazy_r}</proc/self/fd/$pipe {lazy_w}>/proc/self/fd/$pipe
-  exec {pipe}>&-
+	# For lazy migration we need to know when CRIU is ready to serve
+	# the memory pages via TCP.
+	exec {pipe}<> <(:)
+	# shellcheck disable=SC2094
+	exec {lazy_r}</proc/self/fd/$pipe {lazy_w}>/proc/self/fd/$pipe
+	exec {pipe}>&-
 
-  # TCP port for lazy migration
-  port=27277
+	# TCP port for lazy migration
+	port=27277
 
-  __runc --criu "$CRIU" checkpoint --lazy-pages --page-server 0.0.0.0:${port} --status-fd ${lazy_w} --work-path ./work-dir --image-path ./image-dir test_busybox &
-  cpt_pid=$!
+	__runc --criu "$CRIU" checkpoint --lazy-pages --page-server 0.0.0.0:${port} --status-fd ${lazy_w} --work-path ./work-dir --image-path ./image-dir test_busybox &
+	cpt_pid=$!
 
-  # wait for lazy page server to be ready
-  out=$(timeout 2 dd if=/proc/self/fd/${lazy_r} bs=1 count=1 2>/dev/null | od)
-  exec {lazy_w}>&-
-  # shellcheck disable=SC2116,SC2086
-  out=$(echo $out) # rm newlines
-  # show errors if there are any before we fail
-  grep -B5 Error ./work-dir/dump.log || true
-  # expecting \0 which od prints as
-  [ "$out" = "0000000 000000 0000001" ]
+	# wait for lazy page server to be ready
+	out=$(timeout 2 dd if=/proc/self/fd/${lazy_r} bs=1 count=1 2>/dev/null | od)
+	exec {lazy_w}>&-
+	# shellcheck disable=SC2116,SC2086
+	out=$(echo $out) # rm newlines
+	# show errors if there are any before we fail
+	grep -B5 Error ./work-dir/dump.log || true
+	# expecting \0 which od prints as
+	[ "$out" = "0000000 000000 0000001" ]
 
-  # Check if inventory.img was written
-  [ -e image-dir/inventory.img ]
+	# Check if inventory.img was written
+	[ -e image-dir/inventory.img ]
 
-  # Start CRIU in lazy-daemon mode
-  ${CRIU} lazy-pages --page-server --address 127.0.0.1 --port ${port} -D image-dir &
-  lp_pid=$!
+	# Start CRIU in lazy-daemon mode
+	${CRIU} lazy-pages --page-server --address 127.0.0.1 --port ${port} -D image-dir &
+	lp_pid=$!
 
-  # Restore lazily from checkpoint.
-  # The restored container needs a different name as the checkpointed
-  # container is not yet destroyed. It is only destroyed at that point
-  # in time when the last page is lazily transferred to the destination.
-  # Killing the CRIU on the checkpoint side will let the container
-  # continue to run if the migration failed at some point.
-  runc_restore_with_pipes ./image-dir test_busybox_restore --lazy-pages
+	# Restore lazily from checkpoint.
+	# The restored container needs a different name as the checkpointed
+	# container is not yet destroyed. It is only destroyed at that point
+	# in time when the last page is lazily transferred to the destination.
+	# Killing the CRIU on the checkpoint side will let the container
+	# continue to run if the migration failed at some point.
+	runc_restore_with_pipes ./image-dir test_busybox_restore --lazy-pages
 
-  wait $cpt_pid
+	wait $cpt_pid
 
-  wait $lp_pid
+	wait $lp_pid
 
-  check_pipes
+	check_pipes
 }
 
 @test "checkpoint and restore in external network namespace" {
-  # check if external_net_ns is supported; only with criu 3.10++
-  run "${CRIU}" check --feature external_net_ns
-  if [ "$status" -eq 1 ]; then
-    # this criu does not support external_net_ns; skip the test
-    skip "this criu does not support external network namespaces"
-  fi
+	# check if external_net_ns is supported; only with criu 3.10++
+	run "${CRIU}" check --feature external_net_ns
+	if [ "$status" -eq 1 ]; then
+		# this criu does not support external_net_ns; skip the test
+		skip "this criu does not support external network namespaces"
+	fi
 
-  # create a temporary name for the test network namespace
-  tmp=$(mktemp)
-  rm -f "$tmp"
-  ns_name=$(basename "$tmp")
-  # create network namespace
-  ip netns add "$ns_name"
-  ns_path=$(ip netns add "$ns_name" 2>&1 | sed -e 's/.*"\(.*\)".*/\1/')
-  # shellcheck disable=SC2012
-  ns_inode=$(ls -iL "$ns_path" | awk '{ print $1 }')
+	# create a temporary name for the test network namespace
+	tmp=$(mktemp)
+	rm -f "$tmp"
+	ns_name=$(basename "$tmp")
+	# create network namespace
+	ip netns add "$ns_name"
+	ns_path=$(ip netns add "$ns_name" 2>&1 | sed -e 's/.*"\(.*\)".*/\1/')
+	# shellcheck disable=SC2012
+	ns_inode=$(ls -iL "$ns_path" | awk '{ print $1 }')
 
-  # tell runc which network namespace to use
-  update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+	# tell runc which network namespace to use
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
 
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 
-  for _ in $(seq 2); do
-    # checkpoint the running container; this automatically tells CRIU to
-    # handle the network namespace defined in config.json as an external
-    runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
-    grep -B 5 Error ./work-dir/dump.log || true
-    [ "$status" -eq 0 ]
+	for _ in $(seq 2); do
+		# checkpoint the running container; this automatically tells CRIU to
+		# handle the network namespace defined in config.json as an external
+		runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
+		grep -B 5 Error ./work-dir/dump.log || true
+		[ "$status" -eq 0 ]
 
-    # after checkpoint busybox is no longer running
-    testcontainer test_busybox checkpointed
+		# after checkpoint busybox is no longer running
+		testcontainer test_busybox checkpointed
 
-    # restore from checkpoint; this should restore the container into the existing network namespace
-    runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-    grep -B 5 Error ./work-dir/restore.log || true
-    [ "$status" -eq 0 ]
+		# restore from checkpoint; this should restore the container into the existing network namespace
+		runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
+		grep -B 5 Error ./work-dir/restore.log || true
+		[ "$status" -eq 0 ]
 
-    # busybox should be back up and running
-    testcontainer test_busybox running
+		# busybox should be back up and running
+		testcontainer test_busybox running
 
-    # container should be running in same network namespace as before
-    pid=$(__runc state test_busybox | jq '.pid')
-    ns_inode_new=$(readlink /proc/"$pid"/ns/net | sed -e 's/.*\[\(.*\)\]/\1/')
-    echo "old network namespace inode $ns_inode"
-    echo "new network namespace inode $ns_inode_new"
-    [ "$ns_inode" -eq "$ns_inode_new" ]
-  done
-  ip netns del "$ns_name"
+		# container should be running in same network namespace as before
+		pid=$(__runc state test_busybox | jq '.pid')
+		ns_inode_new=$(readlink /proc/"$pid"/ns/net | sed -e 's/.*\[\(.*\)\]/\1/')
+		echo "old network namespace inode $ns_inode"
+		echo "new network namespace inode $ns_inode_new"
+		[ "$ns_inode" -eq "$ns_inode_new" ]
+	done
+	ip netns del "$ns_name"
 }
 
 @test "checkpoint and restore with container specific CRIU config" {
-  tmp=$(mktemp /tmp/runc-criu-XXXXXX.conf)
-  # This is the file we write to /etc/criu/default.conf
-  tmplog1=$(mktemp /tmp/runc-criu-log-XXXXXX.log)
-  unlink "$tmplog1"
-  tmplog1=$(basename "$tmplog1")
-  # That is the actual configuration file to be used
-  tmplog2=$(mktemp /tmp/runc-criu-log-XXXXXX.log)
-  unlink "$tmplog2"
-  tmplog2=$(basename "$tmplog2")
-  # This adds the annotation 'org.criu.config' to set a container
-  # specific CRIU config file.
-  update_config '.annotations += {"org.criu.config": "'"$tmp"'"}'
+	tmp=$(mktemp /tmp/runc-criu-XXXXXX.conf)
+	# This is the file we write to /etc/criu/default.conf
+	tmplog1=$(mktemp /tmp/runc-criu-log-XXXXXX.log)
+	unlink "$tmplog1"
+	tmplog1=$(basename "$tmplog1")
+	# That is the actual configuration file to be used
+	tmplog2=$(mktemp /tmp/runc-criu-log-XXXXXX.log)
+	unlink "$tmplog2"
+	tmplog2=$(basename "$tmplog2")
+	# This adds the annotation 'org.criu.config' to set a container
+	# specific CRIU config file.
+	update_config '.annotations += {"org.criu.config": "'"$tmp"'"}'
 
-  # Tell CRIU to use another configuration file
-  mkdir -p /etc/criu
-  echo "log-file=$tmplog1" > /etc/criu/default.conf
-  # Make sure the RPC defined configuration file overwrites the previous
-  echo "log-file=$tmplog2" > "$tmp"
+	# Tell CRIU to use another configuration file
+	mkdir -p /etc/criu
+	echo "log-file=$tmplog1" >/etc/criu/default.conf
+	# Make sure the RPC defined configuration file overwrites the previous
+	echo "log-file=$tmplog2" >"$tmp"
 
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 
-  # checkpoint the running container
-  runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
-  grep -B 5 Error ./work-dir/dump.log || true
-  [ "$status" -eq 0 ]
-  ! test -f ./work-dir/"$tmplog1"
-  test -f ./work-dir/"$tmplog2"
+	# checkpoint the running container
+	runc --criu "$CRIU" checkpoint --work-path ./work-dir test_busybox
+	grep -B 5 Error ./work-dir/dump.log || true
+	[ "$status" -eq 0 ]
+	! test -f ./work-dir/"$tmplog1"
+	test -f ./work-dir/"$tmplog2"
 
-  # after checkpoint busybox is no longer running
-  testcontainer test_busybox checkpointed
+	# after checkpoint busybox is no longer running
+	testcontainer test_busybox checkpointed
 
-  test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
-  # restore from checkpoint
-  runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-  grep -B 5 Error ./work-dir/restore.log || true
-  [ "$status" -eq 0 ]
-  ! test -f ./work-dir/"$tmplog1"
-  test -f ./work-dir/"$tmplog2"
+	test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
+	# restore from checkpoint
+	runc --criu "$CRIU" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
+	grep -B 5 Error ./work-dir/restore.log || true
+	[ "$status" -eq 0 ]
+	! test -f ./work-dir/"$tmplog1"
+	test -f ./work-dir/"$tmplog2"
 
-  # busybox should be back up and running
-  testcontainer test_busybox running
-  unlink "$tmp"
-  test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
+	# busybox should be back up and running
+	testcontainer test_busybox running
+	unlink "$tmp"
+	test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
 }

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -3,87 +3,87 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "runc create" {
-  runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox created
+	testcontainer test_busybox created
 
-  # start the command
-  runc start test_busybox
-  [ "$status" -eq 0 ]
+	# start the command
+	runc start test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 }
 
 @test "runc create exec" {
-  runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox created
+	testcontainer test_busybox created
 
-  runc exec test_busybox true
-  [ "$status" -eq 0 ]
+	runc exec test_busybox true
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox created
+	testcontainer test_busybox created
 
-  # start the command
-  runc start test_busybox
-  [ "$status" -eq 0 ]
+	# start the command
+	runc start test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 }
 
 @test "runc create --pid-file" {
-  runc create --pid-file pid.txt --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	runc create --pid-file pid.txt --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox created
+	testcontainer test_busybox created
 
-  # check pid.txt was generated
-  [ -e pid.txt ]
+	# check pid.txt was generated
+	[ -e pid.txt ]
 
-  run cat pid.txt
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	run cat pid.txt
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
 
-  # start the command
-  runc start test_busybox
-  [ "$status" -eq 0 ]
+	# start the command
+	runc start test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 }
 
 @test "runc create --pid-file with new CWD" {
-  # create pid_file directory as the CWD
-  run mkdir pid_file
-  [ "$status" -eq 0 ]
-  run cd pid_file
-  [ "$status" -eq 0 ]
+	# create pid_file directory as the CWD
+	run mkdir pid_file
+	[ "$status" -eq 0 ]
+	run cd pid_file
+	[ "$status" -eq 0 ]
 
-  runc create --pid-file pid.txt -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET"  test_busybox
-  [ "$status" -eq 0 ]
+	runc create --pid-file pid.txt -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox created
+	testcontainer test_busybox created
 
-  # check pid.txt was generated
-  [ -e pid.txt ]
+	# check pid.txt was generated
+	[ -e pid.txt ]
 
-  run cat pid.txt
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	run cat pid.txt
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
 
-  # start the command
-  runc start test_busybox
-  [ "$status" -eq 0 ]
+	# start the command
+	runc start test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 }

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -3,79 +3,79 @@
 load helpers
 
 function setup() {
-  teardown_hello
-  setup_hello
+	teardown_hello
+	setup_hello
 }
 
 function teardown() {
-  teardown_hello
+	teardown_hello
 }
 
 @test "global --debug" {
-  # run hello-world
-  runc --debug run test_hello
-  echo "${output}"
-  [ "$status" -eq 0 ]
+	# run hello-world
+	runc --debug run test_hello
+	echo "${output}"
+	[ "$status" -eq 0 ]
 
-  # check expected debug output was sent to stderr
-  [[ "${output}" == *"level=debug"* ]]
-  [[ "${output}" == *"nsexec started"* ]]
-  [[ "${output}" == *"child process in init()"* ]]
+	# check expected debug output was sent to stderr
+	[[ "${output}" == *"level=debug"* ]]
+	[[ "${output}" == *"nsexec started"* ]]
+	[[ "${output}" == *"child process in init()"* ]]
 }
 
 @test "global --debug to --log" {
-  # run hello-world
-  runc --log log.out --debug run test_hello
-  [ "$status" -eq 0 ]
+	# run hello-world
+	runc --log log.out --debug run test_hello
+	[ "$status" -eq 0 ]
 
-  # check output does not include debug info
-  [[ "${output}" != *"level=debug"* ]]
+	# check output does not include debug info
+	[[ "${output}" != *"level=debug"* ]]
 
-  # check log.out was generated
-  [ -e log.out ]
+	# check log.out was generated
+	[ -e log.out ]
 
-  # check expected debug output was sent to log.out
-  run cat log.out
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"level=debug"* ]]
-  [[ "${output}" == *"nsexec started"* ]]
-  [[ "${output}" == *"child process in init()"* ]]
+	# check expected debug output was sent to log.out
+	run cat log.out
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"level=debug"* ]]
+	[[ "${output}" == *"nsexec started"* ]]
+	[[ "${output}" == *"child process in init()"* ]]
 }
 
 @test "global --debug to --log --log-format 'text'" {
-  # run hello-world
-  runc --log log.out --log-format "text" --debug run test_hello
-  [ "$status" -eq 0 ]
+	# run hello-world
+	runc --log log.out --log-format "text" --debug run test_hello
+	[ "$status" -eq 0 ]
 
-  # check output does not include debug info
-  [[ "${output}" != *"level=debug"* ]]
+	# check output does not include debug info
+	[[ "${output}" != *"level=debug"* ]]
 
-  # check log.out was generated
-  [ -e log.out ]
+	# check log.out was generated
+	[ -e log.out ]
 
-  # check expected debug output was sent to log.out
-  run cat log.out
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"level=debug"* ]]
-  [[ "${output}" == *"nsexec started"* ]]
-  [[ "${output}" == *"child process in init()"* ]]
+	# check expected debug output was sent to log.out
+	run cat log.out
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"level=debug"* ]]
+	[[ "${output}" == *"nsexec started"* ]]
+	[[ "${output}" == *"child process in init()"* ]]
 }
 
 @test "global --debug to --log --log-format 'json'" {
-  # run hello-world
-  runc --log log.out --log-format "json" --debug run test_hello
-  [ "$status" -eq 0 ]
+	# run hello-world
+	runc --log log.out --log-format "json" --debug run test_hello
+	[ "$status" -eq 0 ]
 
-  # check output does not include debug info
-  [[ "${output}" != *"level=debug"* ]]
+	# check output does not include debug info
+	[[ "${output}" != *"level=debug"* ]]
 
-  # check log.out was generated
-  [ -e log.out ]
+	# check log.out was generated
+	[ -e log.out ]
 
-  # check expected debug output was sent to log.out
-  run cat log.out
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *'"level":"debug"'* ]]
-  [[ "${output}" == *"nsexec started"* ]]
-  [[ "${output}" == *"child process in init()"* ]]
+	# check expected debug output was sent to log.out
+	run cat log.out
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *'"level":"debug"'* ]]
+	[[ "${output}" == *"nsexec started"* ]]
+	[[ "${output}" == *"child process in init()"* ]]
 }

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -3,78 +3,78 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
-  teardown_running_container testbusyboxdelete
+	teardown_busybox
+	teardown_running_container testbusyboxdelete
 }
 
 @test "runc delete" {
-  runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
-  [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
+	[ "$status" -eq 0 ]
 
-  testcontainer testbusyboxdelete running
+	testcontainer testbusyboxdelete running
 
-  runc kill testbusyboxdelete KILL
-  [ "$status" -eq 0 ]
-  retry 10 1 eval "__runc state testbusyboxdelete | grep -q 'stopped'"
+	runc kill testbusyboxdelete KILL
+	[ "$status" -eq 0 ]
+	retry 10 1 eval "__runc state testbusyboxdelete | grep -q 'stopped'"
 
-  runc delete testbusyboxdelete
-  [ "$status" -eq 0 ]
+	runc delete testbusyboxdelete
+	[ "$status" -eq 0 ]
 
-  runc state testbusyboxdelete
-  [ "$status" -ne 0 ]
+	runc state testbusyboxdelete
+	[ "$status" -ne 0 ]
 
-  run find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d
-  [ "$status" -eq 0 ]
-  [ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
+	run find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d
+	[ "$status" -eq 0 ]
+	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 
 @test "runc delete --force" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  # force delete test_busybox
-  runc delete --force test_busybox
+	# force delete test_busybox
+	runc delete --force test_busybox
 
-  runc state test_busybox
-  [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 }
 
 @test "runc delete --force ignore not exist" {
-  runc delete --force notexists
-  [ "$status" -eq 0 ]
+	runc delete --force notexists
+	[ "$status" -eq 0 ]
 }
 
 @test "runc delete --force in cgroupv1 with subcgroups" {
-  requires cgroups_v1 root cgroupns
-  set_cgroups_path "$BUSYBOX_BUNDLE"
-  set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
-  # enable cgroupns
-  update_config '.linux.namespaces += [{"type": "cgroup"}]'
+	requires cgroups_v1 root cgroupns
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
+	# enable cgroupns
+	update_config '.linux.namespaces += [{"type": "cgroup"}]'
 
-  local subsystems="memory freezer"
+	local subsystems="memory freezer"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-    testcontainer test_busybox running
+	testcontainer test_busybox running
 
-    __runc exec -d test_busybox sleep 1d
+	__runc exec -d test_busybox sleep 1d
 
-    # find the pid of sleep
-    pid=$(__runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
-    [[ ${pid} =~ [0-9]+ ]]
+	# find the pid of sleep
+	pid=$(__runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
+	[[ ${pid} =~ [0-9]+ ]]
 
-    # create a sub-cgroup
-    cat <<EOF | runc exec test_busybox sh
+	# create a sub-cgroup
+	cat <<EOF | runc exec test_busybox sh
 set -e -u -x
 for s in ${subsystems}; do
   cd /sys/fs/cgroup/\$s
@@ -84,47 +84,47 @@ for s in ${subsystems}; do
   cat tasks
 done
 EOF
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ [0-9]+ ]]
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ [0-9]+ ]]
 
-    for s in ${subsystems}; do
-      name=CGROUP_${s^^}
-      eval path=\$"${name}"/foo
-      # shellcheck disable=SC2154
-      [ -d "${path}" ] || fail "test failed to create memory sub-cgroup ($path not found)"
-    done
+	for s in ${subsystems}; do
+		name=CGROUP_${s^^}
+		eval path=\$"${name}"/foo
+		# shellcheck disable=SC2154
+		[ -d "${path}" ] || fail "test failed to create memory sub-cgroup ($path not found)"
+	done
 
-    runc delete --force test_busybox
+	runc delete --force test_busybox
 
-    runc state test_busybox
-    [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 
-    run find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d
-    [ "$status" -eq 0 ]
-    [ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
+	run find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d
+	[ "$status" -eq 0 ]
+	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 
 @test "runc delete --force in cgroupv2 with subcgroups" {
-  requires cgroups_v2 root
-  set_cgroups_path "$BUSYBOX_BUNDLE"
-  set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
+	requires cgroups_v2 root
+	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  # create a sub process
-  __runc exec -d test_busybox sleep 1d
+	# create a sub process
+	__runc exec -d test_busybox sleep 1d
 
-  # find the pid of sleep
-  pid=$(__runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
-  [[ ${pid} =~ [0-9]+ ]]
+	# find the pid of sleep
+	pid=$(__runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
+	[[ ${pid} =~ [0-9]+ ]]
 
-  # create subcgroups
-  cat <<EOF > nest.sh
+	# create subcgroups
+	cat <<EOF >nest.sh
   set -e -u -x
   cd /sys/fs/cgroup
   echo +pids > cgroup.subtree_control
@@ -134,19 +134,19 @@ EOF
   echo ${pid} > cgroup.threads
   cat cgroup.threads
 EOF
-  runc exec test_busybox sh < nest.sh
-  [ "$status" -eq 0 ]
-  [[ "$output" =~ [0-9]+ ]]
+	runc exec test_busybox sh <nest.sh
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ [0-9]+ ]]
 
-  # check create subcgroups success
-  [ -d "$CGROUP_PATH"/foo ]
+	# check create subcgroups success
+	[ -d "$CGROUP_PATH"/foo ]
 
-  # force delete test_busybox
-  runc delete --force test_busybox
+	# force delete test_busybox
+	runc delete --force test_busybox
 
-  runc state test_busybox
-  [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 
-  # check delete subcgroups success
-  [ ! -d "$CGROUP_PATH"/foo ]
+	# check delete subcgroups success
+	[ ! -d "$CGROUP_PATH"/foo ]
 }

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -3,140 +3,140 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "events --stats" {
-  # XXX: currently cgroups require root containers.
-  requires root
-  init_cgroup_paths
+	# XXX: currently cgroups require root containers.
+	requires root
+	init_cgroup_paths
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # generate stats
-  runc events --stats test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
-  [[ "${lines[0]}" == *"data"* ]]
+	# generate stats
+	runc events --stats test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
+	[[ "${lines[0]}" == *"data"* ]]
 }
 
 @test "events --interval default" {
-  # XXX: currently cgroups require root containers.
-  requires root
-  init_cgroup_paths
+	# XXX: currently cgroups require root containers.
+	requires root
+	init_cgroup_paths
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # spawn two sub processes (shells)
-  # the first sub process is an event logger that sends stats events to events.log
-  # the second sub process waits for an event that includes test_busybox then
-  # kills the test_busybox container which causes the event logger to exit
-  (__runc events test_busybox > events.log) &
-  (
-    retry 10 1 eval "grep -q 'test_busybox' events.log"
-    teardown_running_container test_busybox
-  ) &
-  wait # wait for the above sub shells to finish
+	# spawn two sub processes (shells)
+	# the first sub process is an event logger that sends stats events to events.log
+	# the second sub process waits for an event that includes test_busybox then
+	# kills the test_busybox container which causes the event logger to exit
+	(__runc events test_busybox >events.log) &
+	(
+		retry 10 1 eval "grep -q 'test_busybox' events.log"
+		teardown_running_container test_busybox
+	) &
+	wait # wait for the above sub shells to finish
 
-  [ -e events.log ]
+	[ -e events.log ]
 
-  run cat events.log
-  [ "$status" -eq 0 ]
-  [[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
-  [[ "${lines[0]}" == *"data"* ]]
+	run cat events.log
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
+	[[ "${lines[0]}" == *"data"* ]]
 }
 
 @test "events --interval 1s" {
-  # XXX: currently cgroups require root containers.
-  requires root
-  init_cgroup_paths
+	# XXX: currently cgroups require root containers.
+	requires root
+	init_cgroup_paths
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # spawn two sub processes (shells)
-  # the first sub process is an event logger that sends stats events to events.log once a second
-  # the second sub process tries 3 times for an event that incudes test_busybox
-  # pausing 1s between each attempt then kills the test_busybox container which
-  # causes the event logger to exit
-  (__runc events --interval 1s test_busybox > events.log) &
-  (
-    retry 3 1 eval "grep -q 'test_busybox' events.log"
-    teardown_running_container test_busybox
-  ) &
-  wait # wait for the above sub shells to finish
+	# spawn two sub processes (shells)
+	# the first sub process is an event logger that sends stats events to events.log once a second
+	# the second sub process tries 3 times for an event that incudes test_busybox
+	# pausing 1s between each attempt then kills the test_busybox container which
+	# causes the event logger to exit
+	(__runc events --interval 1s test_busybox >events.log) &
+	(
+		retry 3 1 eval "grep -q 'test_busybox' events.log"
+		teardown_running_container test_busybox
+	) &
+	wait # wait for the above sub shells to finish
 
-  [ -e events.log ]
+	[ -e events.log ]
 
-  run eval "grep -q 'test_busybox' events.log"
-  [ "$status" -eq 0 ]
+	run eval "grep -q 'test_busybox' events.log"
+	[ "$status" -eq 0 ]
 }
 
 @test "events --interval 100ms" {
-  # XXX: currently cgroups require root containers.
-  requires root
-  init_cgroup_paths
+	# XXX: currently cgroups require root containers.
+	requires root
+	init_cgroup_paths
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  #prove there is no carry over of events.log from a prior test
-  [ ! -e events.log ]
+	#prove there is no carry over of events.log from a prior test
+	[ ! -e events.log ]
 
-  # spawn two sub processes (shells)
-  # the first sub process is an event logger that sends stats events to events.log once every 100ms
-  # the second sub process tries 3 times for an event that incudes test_busybox
-  # pausing 100s between each attempt then kills the test_busybox container which
-  # causes the event logger to exit
-  (__runc events --interval 100ms test_busybox > events.log) &
-  (
-    retry 3 0.100 eval "grep -q 'test_busybox' events.log"
-    teardown_running_container test_busybox
-  ) &
-  wait # wait for the above sub shells to finish
+	# spawn two sub processes (shells)
+	# the first sub process is an event logger that sends stats events to events.log once every 100ms
+	# the second sub process tries 3 times for an event that incudes test_busybox
+	# pausing 100s between each attempt then kills the test_busybox container which
+	# causes the event logger to exit
+	(__runc events --interval 100ms test_busybox >events.log) &
+	(
+		retry 3 0.100 eval "grep -q 'test_busybox' events.log"
+		teardown_running_container test_busybox
+	) &
+	wait # wait for the above sub shells to finish
 
-  [ -e events.log ]
+	[ -e events.log ]
 
-  run eval "grep -q 'test_busybox' events.log"
-  [ "$status" -eq 0 ]
+	run eval "grep -q 'test_busybox' events.log"
+	[ "$status" -eq 0 ]
 }
 
 @test "events oom" {
-  # XXX: currently cgroups require root containers.
-  requires root cgroups_swap
-  init_cgroup_paths
+	# XXX: currently cgroups require root containers.
+	requires root cgroups_swap
+	init_cgroup_paths
 
-  # we need the container to hit OOM, so disable swap
-  update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}' "${BUSYBOX_BUNDLE}"
+	# we need the container to hit OOM, so disable swap
+	update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}' "${BUSYBOX_BUNDLE}"
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # spawn two sub processes (shells)
-  # the first sub process is an event logger that sends stats events to events.log
-  # the second sub process exec a memory hog process to cause a oom condition
-  # and waits for an oom event
-  (__runc events test_busybox > events.log) &
-  (
-    retry 10 1 eval "grep -q 'test_busybox' events.log"
-    # shellcheck disable=SC2016
-    __runc exec -d test_busybox sh -c 'test=$(dd if=/dev/urandom ibs=5120k)'
-    retry 10 1 eval "grep -q 'oom' events.log"
-    __runc delete -f test_busybox
-  ) &
-  wait # wait for the above sub shells to finish
+	# spawn two sub processes (shells)
+	# the first sub process is an event logger that sends stats events to events.log
+	# the second sub process exec a memory hog process to cause a oom condition
+	# and waits for an oom event
+	(__runc events test_busybox >events.log) &
+	(
+		retry 10 1 eval "grep -q 'test_busybox' events.log"
+		# shellcheck disable=SC2016
+		__runc exec -d test_busybox sh -c 'test=$(dd if=/dev/urandom ibs=5120k)'
+		retry 10 1 eval "grep -q 'oom' events.log"
+		__runc delete -f test_busybox
+	) &
+	wait # wait for the above sub shells to finish
 
-  grep -q '{"type":"oom","id":"test_busybox"}' events.log
+	grep -q '{"type":"oom","id":"test_busybox"}' events.log
 }

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -3,138 +3,138 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "runc exec" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc exec test_busybox echo Hello from exec
-  [ "$status" -eq 0 ]
-  echo text echoed = "'""${output}""'"
-  [[ "${output}" == *"Hello from exec"* ]]
+	runc exec test_busybox echo Hello from exec
+	[ "$status" -eq 0 ]
+	echo text echoed = "'""${output}""'"
+	[[ "${output}" == *"Hello from exec"* ]]
 }
 
 @test "runc exec --pid-file" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc exec --pid-file pid.txt test_busybox echo Hello from exec
-  [ "$status" -eq 0 ]
-  echo text echoed = "'""${output}""'"
-  [[ "${output}" == *"Hello from exec"* ]]
+	runc exec --pid-file pid.txt test_busybox echo Hello from exec
+	[ "$status" -eq 0 ]
+	echo text echoed = "'""${output}""'"
+	[[ "${output}" == *"Hello from exec"* ]]
 
-  # check pid.txt was generated
-  [ -e pid.txt ]
+	# check pid.txt was generated
+	[ -e pid.txt ]
 
-  run cat pid.txt
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ [0-9]+ ]]
-  [[ ${lines[0]} != $(__runc state test_busybox | jq '.pid') ]]
+	run cat pid.txt
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ [0-9]+ ]]
+	[[ ${lines[0]} != $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec --pid-file with new CWD" {
-  # create pid_file directory as the CWD
-  run mkdir pid_file
-  [ "$status" -eq 0 ]
-  run cd pid_file
-  [ "$status" -eq 0 ]
+	# create pid_file directory as the CWD
+	run mkdir pid_file
+	[ "$status" -eq 0 ]
+	run cd pid_file
+	[ "$status" -eq 0 ]
 
-  # run busybox detached
-  runc run -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc exec --pid-file pid.txt test_busybox echo Hello from exec
-  [ "$status" -eq 0 ]
-  echo text echoed = "'""${output}""'"
-  [[ "${output}" == *"Hello from exec"* ]]
+	runc exec --pid-file pid.txt test_busybox echo Hello from exec
+	[ "$status" -eq 0 ]
+	echo text echoed = "'""${output}""'"
+	[[ "${output}" == *"Hello from exec"* ]]
 
-  # check pid.txt was generated
-  [ -e pid.txt ]
+	# check pid.txt was generated
+	[ -e pid.txt ]
 
-  run cat pid.txt
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ [0-9]+ ]]
-  [[ ${lines[0]} != $(__runc state test_busybox | jq '.pid') ]]
+	run cat pid.txt
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ [0-9]+ ]]
+	[[ ${lines[0]} != $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec ls -la" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc exec test_busybox ls -la
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} == *"total"* ]]
-  [[ ${lines[1]} == *"."* ]]
-  [[ ${lines[2]} == *".."* ]]
+	runc exec test_busybox ls -la
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == *"total"* ]]
+	[[ ${lines[1]} == *"."* ]]
+	[[ ${lines[2]} == *".."* ]]
 }
 
 @test "runc exec ls -la with --cwd" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc exec --cwd /bin test_busybox pwd
-  [ "$status" -eq 0 ]
-  [[ ${output} == "/bin"* ]]
+	runc exec --cwd /bin test_busybox pwd
+	[ "$status" -eq 0 ]
+	[[ ${output} == "/bin"* ]]
 }
 
 @test "runc exec --env" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc exec --env RUNC_EXEC_TEST=true test_busybox env
-  [ "$status" -eq 0 ]
+	runc exec --env RUNC_EXEC_TEST=true test_busybox env
+	[ "$status" -eq 0 ]
 
-  [[ ${output} == *"RUNC_EXEC_TEST=true"* ]]
+	[[ ${output} == *"RUNC_EXEC_TEST=true"* ]]
 }
 
 @test "runc exec --user" {
-  # --user can't work in rootless containers that don't have idmap.
-  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	# --user can't work in rootless containers that don't have idmap.
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc exec --user 1000:1000 test_busybox id
-  [ "$status" -eq 0 ]
+	runc exec --user 1000:1000 test_busybox id
+	[ "$status" -eq 0 ]
 
-  [[ "${output}" == "uid=1000 gid=1000"* ]]
+	[[ "${output}" == "uid=1000 gid=1000"* ]]
 }
 
 @test "runc exec --additional-gids" {
-  requires root
+	requires root
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  wait_for_container 15 1 test_busybox
+	wait_for_container 15 1 test_busybox
 
-  runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
-  [ "$status" -eq 0 ]
+	runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
+	[ "$status" -eq 0 ]
 
-  [[ ${output} == "1000 100 65534" ]]
+	[[ ${output} == "1000 100 65534" ]]
 }
 
 @test "runc exec --preserve-fds" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  run bash -c "cat hello > preserve-fds.test; exec 3<preserve-fds.test; $RUNC ${RUNC_USE_SYSTEMD:+--systemd-cgroup} --log /proc/self/fd/2 --root $ROOT exec --preserve-fds=1 test_busybox cat /proc/self/fd/3"
-  [ "$status" -eq 0 ]
+	run bash -c "cat hello > preserve-fds.test; exec 3<preserve-fds.test; $RUNC ${RUNC_USE_SYSTEMD:+--systemd-cgroup} --log /proc/self/fd/2 --root $ROOT exec --preserve-fds=1 test_busybox cat /proc/self/fd/3"
+	[ "$status" -eq 0 ]
 
-  [[ "${output}" == *"hello"* ]]
+	[[ "${output}" == *"hello"* ]]
 }

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -3,85 +3,85 @@
 load helpers
 
 @test "runc -h" {
-  runc -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ NAME:+ ]]
-  [[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
+	runc -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ NAME:+ ]]
+	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 
-  runc --help
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ NAME:+ ]]
-  [[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
+	runc --help
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ NAME:+ ]]
+	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 }
 
 @test "runc command -h" {
-  runc checkpoint -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ checkpoint+ ]]
+	runc checkpoint -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ checkpoint+ ]]
 
-  runc delete -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ delete+ ]]
+	runc delete -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ delete+ ]]
 
-  runc events -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ events+ ]]
+	runc events -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ events+ ]]
 
-  runc exec -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ exec+ ]]
+	runc exec -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ exec+ ]]
 
-  runc kill -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ kill+ ]]
+	runc kill -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ kill+ ]]
 
-  runc list -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ NAME:+ ]]
-  [[ ${lines[1]} =~ runc\ list+ ]]
+	runc list -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ NAME:+ ]]
+	[[ ${lines[1]} =~ runc\ list+ ]]
 
-  runc list --help
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ NAME:+ ]]
-  [[ ${lines[1]} =~ runc\ list+ ]]
+	runc list --help
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ NAME:+ ]]
+	[[ ${lines[1]} =~ runc\ list+ ]]
 
-  runc pause -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ pause+ ]]
+	runc pause -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ pause+ ]]
 
-  runc restore -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ restore+ ]]
+	runc restore -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ restore+ ]]
 
-  runc resume -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ resume+ ]]
+	runc resume -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ resume+ ]]
 
-  # We don't use runc_spec here, because we're just testing the help page.
-  runc spec -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ spec+ ]]
+	# We don't use runc_spec here, because we're just testing the help page.
+	runc spec -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ spec+ ]]
 
-  runc start -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ start+ ]]
+	runc start -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ start+ ]]
 
-  runc run -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ run+ ]]
+	runc run -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ run+ ]]
 
-  runc state -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ state+ ]]
+	runc state -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ state+ ]]
 
-  runc update -h
-  [ "$status" -eq 0 ]
-  [[ ${lines[1]} =~ runc\ update+ ]]
+	runc update -h
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ runc\ update+ ]]
 
 }
 
 @test "runc foo -h" {
-  runc foo -h
-  [ "$status" -ne 0 ]
-  [[ "${output}" == *"No help topic for 'foo'"* ]]
+	runc foo -h
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"No help topic for 'foo'"* ]]
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -17,7 +17,7 @@ BUSYBOX_IMAGE="$BATS_TMPDIR/busybox.tar"
 BUSYBOX_BUNDLE="$BATS_TMPDIR/busyboxtest"
 
 # hello-world in tar format
-HELLO_FILE=`get_hello`
+HELLO_FILE=$(get_hello)
 HELLO_IMAGE="$TESTDATA/$HELLO_FILE"
 HELLO_BUNDLE="$BATS_TMPDIR/hello-world"
 
@@ -95,11 +95,11 @@ function update_config() {
 # a rootless configuration.
 function runc_rootless_idmap() {
 	bundle="${1:-.}"
-	update_config 	' .mounts |= map((select(.type == "devpts") | .options += ["gid=5"]) // .)
+	update_config ' .mounts |= map((select(.type == "devpts") | .options += ["gid=5"]) // .)
 			| .linux.uidMappings += [{"hostID": '"$ROOTLESS_UIDMAP_START"', "containerID": 1000, "size": '"$ROOTLESS_UIDMAP_LENGTH"'}]
 			| .linux.gidMappings += [{"hostID": '"$ROOTLESS_GIDMAP_START"', "containerID": 100, "size": 1}]
-			| .linux.gidMappings += [{"hostID": '"$(($ROOTLESS_GIDMAP_START+10))"', "containerID": 1, "size": 20}]
-			| .linux.gidMappings += [{"hostID": '"$(($ROOTLESS_GIDMAP_START+100))"', "containerID": 1000, "size": '"$(($ROOTLESS_GIDMAP_LENGTH-1000))"'}]' $bundle
+			| .linux.gidMappings += [{"hostID": '"$(($ROOTLESS_GIDMAP_START + 10))"', "containerID": 1, "size": 20}]
+			| .linux.gidMappings += [{"hostID": '"$(($ROOTLESS_GIDMAP_START + 100))"', "containerID": 1000, "size": '"$(($ROOTLESS_GIDMAP_LENGTH - 1000))"'}]' $bundle
 }
 
 # Shortcut to add empty resources as part of a rootless configuration.
@@ -122,7 +122,7 @@ function init_cgroup_paths() {
 	# init once
 	test -n "$CGROUP_UNIFIED" && return
 
-	if [ -n "${RUNC_USE_SYSTEMD}" ] ; then
+	if [ -n "${RUNC_USE_SYSTEMD}" ]; then
 		SD_UNIT_NAME="runc-cgroups-integration-test.scope"
 		if [ $(id -u) = "0" ]; then
 			REL_CGROUPS_PATH="/machine.slice/$SD_UNIT_NAME"
@@ -144,13 +144,15 @@ function init_cgroup_paths() {
 		#   it's quite hard to test.
 		# - freezer (since kernel 5.2) we can auto-detect by looking for the
 		#   "cgroup.freeze" file a *non-root* cgroup.
-		CGROUP_SUBSYSTEMS=$(cat /sys/fs/cgroup/cgroup.controllers; echo devices)
+		CGROUP_SUBSYSTEMS=$(
+			cat /sys/fs/cgroup/cgroup.controllers
+			echo devices
+		)
 		CGROUP_BASE_PATH=/sys/fs/cgroup
 		CGROUP_PATH=${CGROUP_BASE_PATH}${REL_CGROUPS_PATH}
 
 		# Find any cgroup.freeze files...
-		if [ -n "$(find "$CGROUP_BASE_PATH" -type f -name "cgroup.freeze" -print -quit)" ]
-		then
+		if [ -n "$(find "$CGROUP_BASE_PATH" -type f -name "cgroup.freeze" -print -quit)" ]; then
 			CGROUP_SUBSYSTEMS+=" freezer"
 		fi
 	else
@@ -177,7 +179,7 @@ function check_cgroup_value() {
 	source=$1
 	expected=$2
 
-	if [ "x$CGROUP_UNIFIED" = "xyes" ] ; then
+	if [ "x$CGROUP_UNIFIED" = "xyes" ]; then
 		cgroup=$CGROUP_PATH
 	else
 		ctrl=${source%%.*}
@@ -427,7 +429,7 @@ function setup_busybox() {
 		BUSYBOX_IMAGE="/testdata/busybox.tar"
 	fi
 	if [ ! -e $BUSYBOX_IMAGE ]; then
-		curl -o $BUSYBOX_IMAGE -sSL `get_busybox`
+		curl -o $BUSYBOX_IMAGE -sSL $(get_busybox)
 	fi
 	tar --exclude './dev/*' -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
 	cd "$BUSYBOX_BUNDLE"

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -9,16 +9,16 @@ HOOKLIBCC=librunc-hooks-create-container.so
 LIBPATH="$DEBIAN_BUNDLE/rootfs/lib/"
 
 function setup() {
-	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &> /dev/null || true
-	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &> /dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &>/dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &>/dev/null || true
 
 	teardown_debian
 	setup_debian
 }
 
 function teardown() {
-	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &> /dev/null || true
-	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &> /dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &>/dev/null || true
+	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &>/dev/null || true
 
 	rm -f $HOOKLIBCR.1.0.0 $HOOKLIBCC.1.0.0
 	teardown_debian
@@ -35,12 +35,13 @@ function teardown() {
 	current_pwd="$(pwd)"
 
 	# To mount $HOOKLIBCR we need to do that in the container namespace
-	create_runtime_hook=$(cat <<-EOF
-		pid=\$(cat - | jq -r '.pid')
-		touch "$LIBPATH/$HOOKLIBCR.1.0.0"
-		nsenter -m \$ns -t \$pid mount --bind "$current_pwd/$HOOKLIBCR.1.0.0" "$LIBPATH/$HOOKLIBCR.1.0.0"
-EOF
-)
+	create_runtime_hook=$(
+		cat <<-EOF
+			pid=\$(cat - | jq -r '.pid')
+			touch "$LIBPATH/$HOOKLIBCR.1.0.0"
+			nsenter -m \$ns -t \$pid mount --bind "$current_pwd/$HOOKLIBCR.1.0.0" "$LIBPATH/$HOOKLIBCR.1.0.0"
+		EOF
+	)
 
 	create_container_hook="touch ./lib/$HOOKLIBCC.1.0.0 && mount --bind $current_pwd/$HOOKLIBCC.1.0.0 ./lib/$HOOKLIBCC.1.0.0"
 
@@ -49,7 +50,7 @@ EOF
 		.hooks |= . + {"createContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_container_hook]}]} |
 		.hooks |= . + {"startContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", "ldconfig"]}]} |
 		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' "$DEBIAN_BUNDLE"/config.json)
-	echo "${CONFIG}" > config.json
+	echo "${CONFIG}" >config.json
 
 	runc run test_debian
 	[ "$status" -eq 0 ]

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -3,32 +3,31 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
-
 @test "kill detached busybox" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  runc kill test_busybox KILL
-  [ "$status" -eq 0 ]
+	runc kill test_busybox KILL
+	[ "$status" -eq 0 ]
 
-  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
 
-  # we should ensure kill work after the container stopped
-  runc kill -a test_busybox 0
-  [ "$status" -eq 0 ]
+	# we should ensure kill work after the container stopped
+	runc kill -a test_busybox 0
+	[ "$status" -eq 0 ]
 
-  runc delete test_busybox
-  [ "$status" -eq 0 ]
+	runc delete test_busybox
+	[ "$status" -eq 0 ]
 }

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -3,54 +3,54 @@
 load helpers
 
 function setup() {
-  teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
-  teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
-  teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
-  teardown_busybox
-  setup_busybox
+	teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
+	teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
+	teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
-  teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
-  teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
-  teardown_busybox
+	teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
+	teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
+	teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
+	teardown_busybox
 }
 
 @test "list" {
-  # run a few busyboxes detached
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
-  [ "$status" -eq 0 ]
+	# run a few busyboxes detached
+	ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
+	[ "$status" -eq 0 ]
 
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
-  [ "$status" -eq 0 ]
+	ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
+	[ "$status" -eq 0 ]
 
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
-  [ "$status" -eq 0 ]
+	ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
+	[ "$status" -eq 0 ]
 
-  ROOT=$HELLO_BUNDLE runc list
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
-  [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-  [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-  [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	ROOT=$HELLO_BUNDLE runc list
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
+	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 
-  ROOT=$HELLO_BUNDLE runc list -q
-  [ "$status" -eq 0 ]
-  [[ "${lines[0]}" == "test_box1" ]]
-  [[ "${lines[1]}" == "test_box2" ]]
-  [[ "${lines[2]}" == "test_box3" ]]
+	ROOT=$HELLO_BUNDLE runc list -q
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == "test_box1" ]]
+	[[ "${lines[1]}" == "test_box2" ]]
+	[[ "${lines[2]}" == "test_box3" ]]
 
-  ROOT=$HELLO_BUNDLE runc list --format table
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
-  [[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-  [[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-  [[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	ROOT=$HELLO_BUNDLE runc list --format table
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
+	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 
-  ROOT=$HELLO_BUNDLE runc list --format json
-  [ "$status" -eq 0 ]
-  [[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-  [[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-  [[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
+	ROOT=$HELLO_BUNDLE runc list --format json
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
+	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
+	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
 }

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -8,7 +8,7 @@ function setup() {
 
 	# Create fake rootfs.
 	mkdir rootfs/testdir
-	echo "Forbidden information!" > rootfs/testfile
+	echo "Forbidden information!" >rootfs/testfile
 
 	# add extra masked paths
 	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir", "/testfile"]'

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -13,7 +13,7 @@ function teardown() {
 }
 
 @test "runc run [bind mount]" {
-	update_config 	' .mounts += [{"source": ".", "destination": "/tmp/bind", "options": ["bind"]}]
+	update_config ' .mounts += [{"source": ".", "destination": "/tmp/bind", "options": ["bind"]}]
 			| .process.args |= ["ls", "/tmp/bind/config.json"]'
 
 	runc run test_bind_mount

--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -3,10 +3,10 @@ get_busybox() {
 	case $(go env GOARCH) in
 	arm64)
 		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/glibc/busybox.tar.xz'
-	;;
+		;;
 	*)
 		echo 'https://github.com/docker-library/busybox/raw/dist-amd64/glibc/busybox.tar.xz'
-	;;
+		;;
 	esac
 }
 
@@ -14,10 +14,10 @@ get_hello() {
 	case $(go env GOARCH) in
 	arm64)
 		echo 'hello-world-aarch64.tar'
-	;;
+		;;
 	*)
 		echo 'hello-world.tar'
-	;;
+		;;
 	esac
 }
 
@@ -30,10 +30,10 @@ get_and_extract_debian() {
 	case $(go env GOARCH) in
 	arm64)
 		skopeo copy docker://arm64v8/debian:buster "oci:$debian"
-	;;
+		;;
 	*)
 		skopeo copy docker://amd64/debian:buster "oci:$debian"
-	;;
+		;;
 	esac
 
 	args="$([ -z "${ROOTLESS_TESTPATH+x}" ] && echo "--rootless")"

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -3,78 +3,76 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "runc pause and resume" {
-  if [[ "$ROOTLESS" -ne 0 ]]
-  then
-    requires rootless_cgroup
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-  fi
-  requires cgroups_freezer
+	if [[ "$ROOTLESS" -ne 0 ]]; then
+		requires rootless_cgroup
+		set_cgroups_path "$BUSYBOX_BUNDLE"
+	fi
+	requires cgroups_freezer
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 
-  # pause busybox
-  runc pause test_busybox
-  [ "$status" -eq 0 ]
+	# pause busybox
+	runc pause test_busybox
+	[ "$status" -eq 0 ]
 
-  # test state of busybox is paused
-  testcontainer test_busybox paused
+	# test state of busybox is paused
+	testcontainer test_busybox paused
 
-  # resume busybox
-  runc resume test_busybox
-  [ "$status" -eq 0 ]
+	# resume busybox
+	runc resume test_busybox
+	[ "$status" -eq 0 ]
 
-  # test state of busybox is back to running
-  testcontainer test_busybox running
+	# test state of busybox is back to running
+	testcontainer test_busybox running
 }
 
 @test "runc pause and resume with nonexist container" {
-  if [[ "$ROOTLESS" -ne 0 ]]
-  then
-    requires rootless_cgroup
-    set_cgroups_path "$BUSYBOX_BUNDLE"
-  fi
-  requires cgroups_freezer
+	if [[ "$ROOTLESS" -ne 0 ]]; then
+		requires rootless_cgroup
+		set_cgroups_path "$BUSYBOX_BUNDLE"
+	fi
+	requires cgroups_freezer
 
-  # run test_busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run test_busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 
-  # pause test_busybox and nonexistent container
-  runc pause test_busybox
-  [ "$status" -eq 0 ]
-  runc pause nonexistent
-  [ "$status" -ne 0 ]
+	# pause test_busybox and nonexistent container
+	runc pause test_busybox
+	[ "$status" -eq 0 ]
+	runc pause nonexistent
+	[ "$status" -ne 0 ]
 
-  # test state of test_busybox is paused
-  testcontainer test_busybox paused
+	# test state of test_busybox is paused
+	testcontainer test_busybox paused
 
-  # resume test_busybox and nonexistent container
-  runc resume test_busybox
-  [ "$status" -eq 0 ]
-  runc resume nonexistent
-  [ "$status" -ne 0 ]
+	# resume test_busybox and nonexistent container
+	runc resume test_busybox
+	[ "$status" -eq 0 ]
+	runc resume nonexistent
+	[ "$status" -ne 0 ]
 
-  # test state of test_busybox is back to running
-  testcontainer test_busybox running
+	# test state of test_busybox is back to running
+	testcontainer test_busybox running
 
-  # delete test_busybox
-  runc delete --force test_busybox
+	# delete test_busybox
+	runc delete --force test_busybox
 
-  runc state test_busybox
-  [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 }

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -3,84 +3,84 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "ps" {
-  # ps is not supported, it requires cgroups
-  requires root
+	# ps is not supported, it requires cgroups
+	requires root
 
-  # start busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# start busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  runc ps test_busybox
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
-  [[ "${lines[1]}" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
+	runc ps test_busybox
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
+	[[ "${lines[1]}" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
 }
 
 @test "ps -f json" {
-  # ps is not supported, it requires cgroups
-  requires root
+	# ps is not supported, it requires cgroups
+	requires root
 
-  # start busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# start busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  runc ps -f json test_busybox
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ [0-9]+ ]]
+	runc ps -f json test_busybox
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ [0-9]+ ]]
 }
 
 @test "ps -e -x" {
-  # ps is not supported, it requires cgroups
-  requires root
+	# ps is not supported, it requires cgroups
+	requires root
 
-  # start busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# start busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  runc ps test_busybox -e -x
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
-  [[ "${lines[1]}" =~ [0-9]+ ]]
+	runc ps test_busybox -e -x
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
+	[[ "${lines[1]}" =~ [0-9]+ ]]
 }
 
 @test "ps after the container stopped" {
-  # ps requires cgroups
-  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-  set_cgroups_path "$BUSYBOX_BUNDLE"
+	# ps requires cgroups
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	set_cgroups_path "$BUSYBOX_BUNDLE"
 
-  # start busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# start busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  runc ps test_busybox
-  [ "$status" -eq 0 ]
+	runc ps test_busybox
+	[ "$status" -eq 0 ]
 
-  runc kill test_busybox KILL
-  [ "$status" -eq 0 ]
+	runc kill test_busybox KILL
+	[ "$status" -eq 0 ]
 
-  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
 
-  runc ps test_busybox
-  [ "$status" -eq 0 ]
+	runc ps test_busybox
+	[ "$status" -eq 0 ]
 }

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -3,48 +3,48 @@
 load helpers
 
 function setup() {
-  teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
-  teardown_busybox
-  setup_busybox
+	teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
-  teardown_busybox
+	teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
+	teardown_busybox
 }
 
 @test "global --root" {
-  # run busybox detached using $HELLO_BUNDLE for state
-  ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_dotbox
-  [ "$status" -eq 0 ]
+	# run busybox detached using $HELLO_BUNDLE for state
+	ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_dotbox
+	[ "$status" -eq 0 ]
 
-  # run busybox detached in default root
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached in default root
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  runc state test_busybox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
+	runc state test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"running"* ]]
 
-  ROOT=$HELLO_BUNDLE runc state test_dotbox
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"running"* ]]
+	ROOT=$HELLO_BUNDLE runc state test_dotbox
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"running"* ]]
 
-  ROOT=$HELLO_BUNDLE runc state test_busybox
-  [ "$status" -ne 0 ]
+	ROOT=$HELLO_BUNDLE runc state test_busybox
+	[ "$status" -ne 0 ]
 
-  runc state test_dotbox
-  [ "$status" -ne 0 ]
+	runc state test_dotbox
+	[ "$status" -ne 0 ]
 
-  runc kill test_busybox KILL
-  [ "$status" -eq 0 ]
-  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
-  runc delete test_busybox
-  [ "$status" -eq 0 ]
+	runc kill test_busybox KILL
+	[ "$status" -eq 0 ]
+	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	runc delete test_busybox
+	[ "$status" -eq 0 ]
 
-  ROOT=$HELLO_BUNDLE runc kill test_dotbox KILL
-  [ "$status" -eq 0 ]
-  retry 10 1 eval "ROOT='$HELLO_BUNDLE' __runc state test_dotbox | grep -q 'stopped'"
-  ROOT=$HELLO_BUNDLE runc delete test_dotbox
-  [ "$status" -eq 0 ]
+	ROOT=$HELLO_BUNDLE runc kill test_dotbox KILL
+	[ "$status" -eq 0 ]
+	retry 10 1 eval "ROOT='$HELLO_BUNDLE' __runc state test_dotbox | grep -q 'stopped'"
+	ROOT=$HELLO_BUNDLE runc delete test_dotbox
+	[ "$status" -eq 0 ]
 }

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -25,11 +25,11 @@ function teardown() {
 
 	SPEC_VERSION=$(awk '$1 == "github.com/opencontainers/runtime-spec" {print $2}' "$BATS_TEST_DIRNAME"/../../go.mod)
 	# Will look like this when not pinned to specific tag: "v0.0.0-20190207185410-29686dbc5559", otherwise "v1.0.0"
-	SPEC_COMMIT=$(cut -d "-" -f 3 <<< "$SPEC_VERSION")
+	SPEC_COMMIT=$(cut -d "-" -f 3 <<<"$SPEC_VERSION")
 	SPEC_REF=$([[ -z "$SPEC_COMMIT" ]] && echo "$SPEC_VERSION" || echo "$SPEC_COMMIT")
 
 	git clone https://github.com/opencontainers/runtime-spec.git
-	( cd runtime-spec && git reset --hard "$SPEC_REF" )
+	(cd runtime-spec && git reset --hard "$SPEC_REF")
 	SCHEMA='runtime-spec/schema/config-schema.json'
 	[ -e "$SCHEMA" ]
 

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -3,29 +3,29 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "runc start" {
-  runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox created
+	testcontainer test_busybox created
 
-  # start container test_busybox
-  runc start test_busybox
-  [ "$status" -eq 0 ]
+	# start container test_busybox
+	runc start test_busybox
+	[ "$status" -eq 0 ]
 
-  testcontainer test_busybox running
+	testcontainer test_busybox running
 
-  # delete test_busybox
-  runc delete --force test_busybox
+	# delete test_busybox
+	runc delete --force test_busybox
 
-  runc state test_busybox
-  [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 }

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -3,74 +3,74 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "runc run detached" {
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 }
 
 @test "runc run detached ({u,g}id != 0)" {
-  # cannot start containers as another user in rootless setup without idmap
-  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	# cannot start containers as another user in rootless setup without idmap
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
-  # replace "uid": 0 with "uid": 1000
-  # and do a similar thing for gid.
-  update_config ' (.. | select(.uid? == 0)) .uid |= 1000
+	# replace "uid": 0 with "uid": 1000
+	# and do a similar thing for gid.
+	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 }
 
 @test "runc run detached --pid-file" {
-  # run busybox detached
-  runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  # check pid.txt was generated
-  [ -e pid.txt ]
+	# check pid.txt was generated
+	[ -e pid.txt ]
 
-  run cat pid.txt
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	run cat pid.txt
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc run detached --pid-file with new CWD" {
-  # create pid_file directory as the CWD
-  run mkdir pid_file
-  [ "$status" -eq 0 ]
-  run cd pid_file
-  [ "$status" -eq 0 ]
+	# create pid_file directory as the CWD
+	run mkdir pid_file
+	[ "$status" -eq 0 ]
+	run cd pid_file
+	[ "$status" -eq 0 ]
 
-  # run busybox detached
-  runc run --pid-file pid.txt -d  -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run --pid-file pid.txt -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  # check pid.txt was generated
-  [ -e pid.txt ]
+	# check pid.txt was generated
+	[ -e pid.txt ]
 
-  run cat pid.txt
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	run cat pid.txt
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
 }

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -3,62 +3,62 @@
 load helpers
 
 function setup() {
-  teardown_hello
-  setup_hello
+	teardown_hello
+	setup_hello
 }
 
 function teardown() {
-  teardown_hello
+	teardown_hello
 }
 
 @test "runc run" {
-  # run hello-world
-  runc run test_hello
-  [ "$status" -eq 0 ]
+	# run hello-world
+	runc run test_hello
+	[ "$status" -eq 0 ]
 
-  # check expected output
-  [[ "${output}" == *"Hello"* ]]
+	# check expected output
+	[[ "${output}" == *"Hello"* ]]
 }
 
 @test "runc run ({u,g}id != 0)" {
-  # cannot start containers as another user in rootless setup without idmap
-  [[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	# cannot start containers as another user in rootless setup without idmap
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
 
-  # replace "uid": 0 with "uid": 1000
-  # and do a similar thing for gid.
-  update_config ' (.. | select(.uid? == 0)) .uid |= 1000
+	# replace "uid": 0 with "uid": 1000
+	# and do a similar thing for gid.
+	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-  # run hello-world
-  runc run test_hello
-  [ "$status" -eq 0 ]
+	# run hello-world
+	runc run test_hello
+	[ "$status" -eq 0 ]
 
-  # check expected output
-  [[ "${output}" == *"Hello"* ]]
+	# check expected output
+	[[ "${output}" == *"Hello"* ]]
 }
 
 @test "runc run with rootfs set to ." {
-  cp config.json rootfs/.
-  rm config.json
-  cd rootfs
-  update_config '(.. | select(. == "rootfs")) |= "."'
+	cp config.json rootfs/.
+	rm config.json
+	cd rootfs
+	update_config '(.. | select(. == "rootfs")) |= "."'
 
-  # run hello-world
-  runc run test_hello
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"Hello"* ]]
+	# run hello-world
+	runc run test_hello
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Hello"* ]]
 }
 
 @test "runc run --pid-file" {
-  # run hello-world
-  runc run --pid-file pid.txt test_hello
-  [ "$status" -eq 0 ]
-  [[ "${output}" == *"Hello"* ]]
+	# run hello-world
+	runc run --pid-file pid.txt test_hello
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Hello"* ]]
 
-  # check pid.txt was generated
-  [ -e pid.txt ]
+	# check pid.txt was generated
+	[ -e pid.txt ]
 
-  run cat pid.txt
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ [0-9]+ ]]
+	run cat pid.txt
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ [0-9]+ ]]
 }

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -3,64 +3,64 @@
 load helpers
 
 function setup() {
-  teardown_busybox
-  setup_busybox
+	teardown_busybox
+	setup_busybox
 }
 
 function teardown() {
-  teardown_busybox
+	teardown_busybox
 }
 
 @test "state (kill + delete)" {
-  runc state test_busybox
-  [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  runc kill test_busybox KILL
-  [ "$status" -eq 0 ]
+	runc kill test_busybox KILL
+	[ "$status" -eq 0 ]
 
-  # wait for busybox to be in the destroyed state
-  retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	# wait for busybox to be in the destroyed state
+	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
 
-  # delete test_busybox
-  runc delete test_busybox
-  [ "$status" -eq 0 ]
+	# delete test_busybox
+	runc delete test_busybox
+	[ "$status" -eq 0 ]
 
-  runc state test_busybox
-  [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 }
 
 @test "state (pause + resume)" {
-  # XXX: pause and resume require cgroups.
-  requires root
+	# XXX: pause and resume require cgroups.
+	requires root
 
-  runc state test_busybox
-  [ "$status" -ne 0 ]
+	runc state test_busybox
+	[ "$status" -ne 0 ]
 
-  # run busybox detached
-  runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-  [ "$status" -eq 0 ]
+	# run busybox detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
 
-  # check state
-  testcontainer test_busybox running
+	# check state
+	testcontainer test_busybox running
 
-  # pause busybox
-  runc pause test_busybox
-  [ "$status" -eq 0 ]
+	# pause busybox
+	runc pause test_busybox
+	[ "$status" -eq 0 ]
 
-  # test state of busybox is paused
-  testcontainer test_busybox paused
+	# test state of busybox is paused
+	testcontainer test_busybox paused
 
-  # resume busybox
-  runc resume test_busybox
-  [ "$status" -eq 0 ]
+	# resume busybox
+	runc resume test_busybox
+	[ "$status" -eq 0 ]
 
-  # test state of busybox is back to running
-  testcontainer test_busybox running
+	# test state of busybox is back to running
+	testcontainer test_busybox running
 }

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -15,7 +15,7 @@ function teardown() {
 	# stty size fails without a tty
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "stty size"]'
 	# note that stdout/stderr are already redirected by bats' run
-	runc run test_busybox < /dev/null
+	runc run test_busybox </dev/null
 	[ "$status" -eq 0 ]
 }
 
@@ -57,7 +57,7 @@ function teardown() {
 	# and do a similar thing for gid.
 	# Replace sh script with stat.
 	# shellcheck disable=SC2016
-	update_config 	' (.. | select(.uid? == 0)) .uid |= 1000
+	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 			| (.. | select(.gid? == 0)) .gid |= 100
 			| (.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
@@ -77,7 +77,7 @@ function teardown() {
 	testcontainer test_busybox running
 
 	# note that stdout/stderr are already redirected by bats' run
-	runc exec -t test_busybox sh -c "stty size" < /dev/null
+	runc exec -t test_busybox sh -c "stty size" </dev/null
 	[ "$status" -eq 0 ]
 }
 
@@ -125,7 +125,7 @@ function teardown() {
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
 	# shellcheck disable=SC2016
-	update_config 	' (.. | select(.uid? == 0)) .uid |= 1000
+	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 			| (.. | select(.gid? == 0)) .gid |= 100'
 
 	# run busybox detached
@@ -154,7 +154,8 @@ function teardown() {
 	# make sure we're running
 	testcontainer test_busybox running
 
-	tty_info_with_consize_size=$( cat <<EOF
+	tty_info_with_consize_size=$(
+		cat <<EOF
 {
     "terminal": true,
     "consoleSize": {
@@ -172,7 +173,7 @@ EOF
 	)
 
 	# run the exec
-	runc exec -t --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" -p <( echo "$tty_info_with_consize_size" ) test_busybox
+	runc exec -t --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" -p <(echo "$tty_info_with_consize_size") test_busybox
 	[ "$status" -eq 0 ]
 
 	# check the pid was generated
@@ -181,7 +182,8 @@ EOF
 	#wait user process to finish
 	timeout 1 tail --pid="$(head -n 1 pid.txt)" -f /dev/null
 
-	tty_info=$( cat <<EOF
+	tty_info=$(
+		cat <<EOF
 {
     "args": [
 	"/bin/cat",
@@ -193,7 +195,7 @@ EOF
 	)
 
 	# run the exec
-	runc exec -t -p <( echo "$tty_info" ) test_busybox
+	runc exec -t -p <(echo "$tty_info") test_busybox
 	[ "$status" -eq 0 ]
 
 	# test tty width and height against original process.json
@@ -203,7 +205,7 @@ EOF
 @test "runc create [terminal=false]" {
 	# Disable terminal creation.
 	# Replace sh script with sleep.
-	update_config 	' (.. | select(.terminal? != null)) .terminal |= false
+	update_config ' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["sleep", "1000s"]
 			| del(.. | select(.? == "sh"))'
 
@@ -225,7 +227,7 @@ EOF
 	# Disable terminal creation.
 	# Replace sh script with sleep.
 
-	update_config   ' (.. | select(.terminal? != null)) .terminal |= false
+	update_config ' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["sleep", "1000s"]
 			| del(.. | select(.? == "sh"))'
 
@@ -245,7 +247,7 @@ EOF
 @test "runc run -d [terminal=false]" {
 	# Disable terminal creation.
 	# Replace sh script with sleep.
-	update_config 	' (.. | select(.terminal? != null)) .terminal |= false
+	update_config ' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["sleep", "1000s"]
 			| del(.. | select(.? == "sh"))'
 

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -3,20 +3,20 @@
 load helpers
 
 function teardown() {
-    rm -f "$BATS_TMPDIR"/runc-cgroups-integration-test.json
-    teardown_running_container test_update
-    teardown_running_container test_update_rt
-    teardown_busybox
+	rm -f "$BATS_TMPDIR"/runc-cgroups-integration-test.json
+	teardown_running_container test_update
+	teardown_running_container test_update_rt
+	teardown_busybox
 }
 
 function setup() {
-    teardown
-    setup_busybox
+	teardown
+	setup_busybox
 
-    set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path "$BUSYBOX_BUNDLE"
 
-    # Set some initial known values
-    update_config 	' .linux.resources.memory |= {"limit": 33554432, "reservation": 25165824}
+	# Set some initial known values
+	update_config ' .linux.resources.memory |= {"limit": 33554432, "reservation": 25165824}
 			| .linux.resources.cpu |= {"shares": 100, "quota": 500000, "period": 1000000, "cpus": "0"}
 			| .linux.resources.pids |= {"limit": 20}' "${BUSYBOX_BUNDLE}"
 }
@@ -24,146 +24,146 @@ function setup() {
 # Tests whatever limits are (more or less) common between cgroup
 # v1 and v2: memory/swap, pids, and cpuset.
 @test "update cgroup v1/v2 common limits" {
-    [[ "$ROOTLESS" -ne 0 && -z "$RUNC_USE_SYSTEMD" ]] && requires rootless_cgroup
-    if [[ "$ROOTLESS" -ne 0 && -n "$RUNC_USE_SYSTEMD" ]]; then
-        file="/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers"
-        # NOTE: delegation of cpuset requires systemd >= 244 (Fedora >= 32, Ubuntu >= 20.04).
-        for f in memory pids cpuset; do
-            if grep -qwv $f "$file"; then
-                skip "$f is not enabled in $file"
-            fi
-        done
-    fi
-    init_cgroup_paths
+	[[ "$ROOTLESS" -ne 0 && -z "$RUNC_USE_SYSTEMD" ]] && requires rootless_cgroup
+	if [[ "$ROOTLESS" -ne 0 && -n "$RUNC_USE_SYSTEMD" ]]; then
+		file="/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers"
+		# NOTE: delegation of cpuset requires systemd >= 244 (Fedora >= 32, Ubuntu >= 20.04).
+		for f in memory pids cpuset; do
+			if grep -qwv $f "$file"; then
+				skip "$f is not enabled in $file"
+			fi
+		done
+	fi
+	init_cgroup_paths
 
-    # run a few busyboxes detached
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-    [ "$status" -eq 0 ]
+	# run a few busyboxes detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
 
-    # Set a few variables to make the code below work for both v1 and v2
-    case $CGROUP_UNIFIED in
-    no)
-        MEM_LIMIT="memory.limit_in_bytes"
-        SD_MEM_LIMIT="MemoryLimit"
-        MEM_RESERVE="memory.soft_limit_in_bytes"
-        SD_MEM_RESERVE="unsupported"
-        MEM_SWAP="memory.memsw.limit_in_bytes"
-        SD_MEM_SWAP="unsupported"
-        SYSTEM_MEM=$(cat "${CGROUP_MEMORY_BASE_PATH}/${MEM_LIMIT}")
-        HAVE_SWAP="no"
-        if [ -f "${CGROUP_MEMORY_BASE_PATH}/${MEM_SWAP}" ]; then
-            HAVE_SWAP="yes"
-        fi
-        ;;
-    yes)
-        MEM_LIMIT="memory.max"
-        SD_MEM_LIMIT="MemoryMax"
-        MEM_RESERVE="memory.low"
-        SD_MEM_RESERVE="MemoryLow"
-        MEM_SWAP="memory.swap.max"
-        SD_MEM_SWAP="MemorySwapMax"
-        SYSTEM_MEM="max"
-        HAVE_SWAP="yes"
-        ;;
-    esac
-    SD_UNLIMITED="infinity"
-    SD_VERSION=$(systemctl --version | awk '{print $2; exit}')
-    if [ "$SD_VERSION" -lt 227 ]; then
-        SD_UNLIMITED="18446744073709551615"
-    fi
+	# Set a few variables to make the code below work for both v1 and v2
+	case $CGROUP_UNIFIED in
+	no)
+		MEM_LIMIT="memory.limit_in_bytes"
+		SD_MEM_LIMIT="MemoryLimit"
+		MEM_RESERVE="memory.soft_limit_in_bytes"
+		SD_MEM_RESERVE="unsupported"
+		MEM_SWAP="memory.memsw.limit_in_bytes"
+		SD_MEM_SWAP="unsupported"
+		SYSTEM_MEM=$(cat "${CGROUP_MEMORY_BASE_PATH}/${MEM_LIMIT}")
+		HAVE_SWAP="no"
+		if [ -f "${CGROUP_MEMORY_BASE_PATH}/${MEM_SWAP}" ]; then
+			HAVE_SWAP="yes"
+		fi
+		;;
+	yes)
+		MEM_LIMIT="memory.max"
+		SD_MEM_LIMIT="MemoryMax"
+		MEM_RESERVE="memory.low"
+		SD_MEM_RESERVE="MemoryLow"
+		MEM_SWAP="memory.swap.max"
+		SD_MEM_SWAP="MemorySwapMax"
+		SYSTEM_MEM="max"
+		HAVE_SWAP="yes"
+		;;
+	esac
+	SD_UNLIMITED="infinity"
+	SD_VERSION=$(systemctl --version | awk '{print $2; exit}')
+	if [ "$SD_VERSION" -lt 227 ]; then
+		SD_UNLIMITED="18446744073709551615"
+	fi
 
-    # check that initial values were properly set
-    check_cgroup_value "cpuset.cpus" 0
-    if [[ "$CGROUP_UNIFIED" = "yes" ]] && ! grep -qw memory "$CGROUP_PATH/cgroup.controllers"; then
-    # This happen on containerized environment because "echo +memory > /sys/fs/cgroup/cgroup.subtree_control" fails with EINVAL
-        skip "memory controller not available"
-    fi
-    check_cgroup_value $MEM_LIMIT 33554432
-    check_systemd_value $SD_MEM_LIMIT 33554432
+	# check that initial values were properly set
+	check_cgroup_value "cpuset.cpus" 0
+	if [[ "$CGROUP_UNIFIED" = "yes" ]] && ! grep -qw memory "$CGROUP_PATH/cgroup.controllers"; then
+		# This happen on containerized environment because "echo +memory > /sys/fs/cgroup/cgroup.subtree_control" fails with EINVAL
+		skip "memory controller not available"
+	fi
+	check_cgroup_value $MEM_LIMIT 33554432
+	check_systemd_value $SD_MEM_LIMIT 33554432
 
-    check_cgroup_value $MEM_RESERVE 25165824
-    check_systemd_value $SD_MEM_RESERVE 25165824
+	check_cgroup_value $MEM_RESERVE 25165824
+	check_systemd_value $SD_MEM_RESERVE 25165824
 
-    check_cgroup_value "pids.max" 20
-    check_systemd_value "TasksMax" 20
+	check_cgroup_value "pids.max" 20
+	check_systemd_value "TasksMax" 20
 
-    # update cpuset if supported (i.e. we're running on a multicore cpu)
-    cpu_count=$(grep -c '^processor' /proc/cpuinfo)
-    if [ "$cpu_count" -gt 1 ]; then
-        runc update test_update --cpuset-cpus "1"
-        [ "$status" -eq 0 ]
-        check_cgroup_value "cpuset.cpus" 1
-    fi
+	# update cpuset if supported (i.e. we're running on a multicore cpu)
+	cpu_count=$(grep -c '^processor' /proc/cpuinfo)
+	if [ "$cpu_count" -gt 1 ]; then
+		runc update test_update --cpuset-cpus "1"
+		[ "$status" -eq 0 ]
+		check_cgroup_value "cpuset.cpus" 1
+	fi
 
-    # update memory limit
-    runc update test_update --memory 67108864
-    [ "$status" -eq 0 ]
-    check_cgroup_value $MEM_LIMIT 67108864
-    check_systemd_value $SD_MEM_LIMIT 67108864
+	# update memory limit
+	runc update test_update --memory 67108864
+	[ "$status" -eq 0 ]
+	check_cgroup_value $MEM_LIMIT 67108864
+	check_systemd_value $SD_MEM_LIMIT 67108864
 
-    runc update test_update --memory 50M
-    [ "$status" -eq 0 ]
-    check_cgroup_value $MEM_LIMIT 52428800
-    check_systemd_value $SD_MEM_LIMIT 52428800
+	runc update test_update --memory 50M
+	[ "$status" -eq 0 ]
+	check_cgroup_value $MEM_LIMIT 52428800
+	check_systemd_value $SD_MEM_LIMIT 52428800
 
-    # update memory soft limit
-    runc update test_update --memory-reservation 33554432
-    [ "$status" -eq 0 ]
-    check_cgroup_value "$MEM_RESERVE" 33554432
-    check_systemd_value "$SD_MEM_RESERVE" 33554432
+	# update memory soft limit
+	runc update test_update --memory-reservation 33554432
+	[ "$status" -eq 0 ]
+	check_cgroup_value "$MEM_RESERVE" 33554432
+	check_systemd_value "$SD_MEM_RESERVE" 33554432
 
-    # Run swap memory tests if swap is available
-    if [ "$HAVE_SWAP" = "yes" ]; then
-        # try to remove memory swap limit
-        runc update test_update --memory-swap -1
-        [ "$status" -eq 0 ]
-        check_cgroup_value "$MEM_SWAP" $SYSTEM_MEM
-        check_systemd_value "$SD_MEM_SWAP" $SD_UNLIMITED
+	# Run swap memory tests if swap is available
+	if [ "$HAVE_SWAP" = "yes" ]; then
+		# try to remove memory swap limit
+		runc update test_update --memory-swap -1
+		[ "$status" -eq 0 ]
+		check_cgroup_value "$MEM_SWAP" $SYSTEM_MEM
+		check_systemd_value "$SD_MEM_SWAP" $SD_UNLIMITED
 
-        # update memory swap
-        if [ "$CGROUP_UNIFIED" = "yes" ]; then
-            # for cgroupv2, memory and swap can only be set together
-            runc update test_update --memory 52428800 --memory-swap 96468992
-            [ "$status" -eq 0 ]
-            # for cgroupv2, swap is a separate limit (it does not include mem)
-            check_cgroup_value "$MEM_SWAP" $((96468992-52428800))
-            check_systemd_value "$SD_MEM_SWAP" $((96468992-52428800))
-        else
-            runc update test_update --memory-swap 96468992
-            [ "$status" -eq 0 ]
-            check_cgroup_value "$MEM_SWAP" 96468992
-            check_systemd_value "$SD_MEM_SWAP" 96468992
-        fi
-    fi
+		# update memory swap
+		if [ "$CGROUP_UNIFIED" = "yes" ]; then
+			# for cgroupv2, memory and swap can only be set together
+			runc update test_update --memory 52428800 --memory-swap 96468992
+			[ "$status" -eq 0 ]
+			# for cgroupv2, swap is a separate limit (it does not include mem)
+			check_cgroup_value "$MEM_SWAP" $((96468992 - 52428800))
+			check_systemd_value "$SD_MEM_SWAP" $((96468992 - 52428800))
+		else
+			runc update test_update --memory-swap 96468992
+			[ "$status" -eq 0 ]
+			check_cgroup_value "$MEM_SWAP" 96468992
+			check_systemd_value "$SD_MEM_SWAP" 96468992
+		fi
+	fi
 
-    # try to remove memory limit
-    runc update test_update --memory -1
-    [ "$status" -eq 0 ]
+	# try to remove memory limit
+	runc update test_update --memory -1
+	[ "$status" -eq 0 ]
 
-    # check memory limit is gone
-    check_cgroup_value $MEM_LIMIT $SYSTEM_MEM
-    check_systemd_value $SD_MEM_LIMIT $SD_UNLIMITED
+	# check memory limit is gone
+	check_cgroup_value $MEM_LIMIT $SYSTEM_MEM
+	check_systemd_value $SD_MEM_LIMIT $SD_UNLIMITED
 
-    # check swap memory limited is gone
-    if [ "$HAVE_SWAP" = "yes" ]; then
-        check_cgroup_value $MEM_SWAP $SYSTEM_MEM
-        check_systemd_value "$SD_MEM_SWAP" $SD_UNLIMITED
-    fi
+	# check swap memory limited is gone
+	if [ "$HAVE_SWAP" = "yes" ]; then
+		check_cgroup_value $MEM_SWAP $SYSTEM_MEM
+		check_systemd_value "$SD_MEM_SWAP" $SD_UNLIMITED
+	fi
 
-    # update pids limit
-    runc update test_update --pids-limit 10
-    [ "$status" -eq 0 ]
-    check_cgroup_value "pids.max" 10
-    check_systemd_value "TasksMax" 10
+	# update pids limit
+	runc update test_update --pids-limit 10
+	[ "$status" -eq 0 ]
+	check_cgroup_value "pids.max" 10
+	check_systemd_value "TasksMax" 10
 
-    # unlimited
-    runc update test_update --pids-limit -1
-    [ "$status" -eq 0 ]
-    check_cgroup_value "pids.max" max
-    check_systemd_value "TasksMax" $SD_UNLIMITED
+	# unlimited
+	runc update test_update --pids-limit -1
+	[ "$status" -eq 0 ]
+	check_cgroup_value "pids.max" max
+	check_systemd_value "TasksMax" $SD_UNLIMITED
 
-    # Revert to the test initial value via json on stdin
-    runc update  -r - test_update <<EOF
+	# Revert to the test initial value via json on stdin
+	runc update -r - test_update <<EOF
 {
   "memory": {
     "limit": 33554432,
@@ -180,35 +180,35 @@ function setup() {
   }
 }
 EOF
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpuset.cpus" 0
+	[ "$status" -eq 0 ]
+	check_cgroup_value "cpuset.cpus" 0
 
-    check_cgroup_value $MEM_LIMIT 33554432
-    check_systemd_value $SD_MEM_LIMIT 33554432
+	check_cgroup_value $MEM_LIMIT 33554432
+	check_systemd_value $SD_MEM_LIMIT 33554432
 
-    check_cgroup_value $MEM_RESERVE 25165824
-    check_systemd_value $SD_MEM_RESERVE 25165824
+	check_cgroup_value $MEM_RESERVE 25165824
+	check_systemd_value $SD_MEM_RESERVE 25165824
 
-    check_cgroup_value "pids.max" 20
-    check_systemd_value "TasksMax" 20
+	check_cgroup_value "pids.max" 20
+	check_systemd_value "TasksMax" 20
 
-    # redo all the changes at once
-    runc update test_update \
-        --cpu-period 900000 --cpu-quota 600000 --cpu-share 200 \
-        --memory 67108864 --memory-reservation 33554432 \
-        --pids-limit 10
-    [ "$status" -eq 0 ]
-    check_cgroup_value $MEM_LIMIT 67108864
-    check_systemd_value $SD_MEM_LIMIT 67108864
+	# redo all the changes at once
+	runc update test_update \
+		--cpu-period 900000 --cpu-quota 600000 --cpu-share 200 \
+		--memory 67108864 --memory-reservation 33554432 \
+		--pids-limit 10
+	[ "$status" -eq 0 ]
+	check_cgroup_value $MEM_LIMIT 67108864
+	check_systemd_value $SD_MEM_LIMIT 67108864
 
-    check_cgroup_value $MEM_RESERVE 33554432
-    check_systemd_value $SD_MEM_RESERVE 33554432
+	check_cgroup_value $MEM_RESERVE 33554432
+	check_systemd_value $SD_MEM_RESERVE 33554432
 
-    check_cgroup_value "pids.max" 10
-    check_systemd_value "TasksMax" 10
+	check_cgroup_value "pids.max" 10
+	check_systemd_value "TasksMax" 10
 
-    # reset to initial test value via json file
-    cat << EOF > "$BATS_TMPDIR"/runc-cgroups-integration-test.json
+	# reset to initial test value via json file
+	cat <<EOF >"$BATS_TMPDIR"/runc-cgroups-integration-test.json
 {
   "memory": {
     "limit": 33554432,
@@ -226,94 +226,94 @@ EOF
 }
 EOF
 
-    runc update  -r "$BATS_TMPDIR"/runc-cgroups-integration-test.json test_update
-    [ "$status" -eq 0 ]
-    check_cgroup_value "cpuset.cpus" 0
+	runc update -r "$BATS_TMPDIR"/runc-cgroups-integration-test.json test_update
+	[ "$status" -eq 0 ]
+	check_cgroup_value "cpuset.cpus" 0
 
-    check_cgroup_value $MEM_LIMIT 33554432
-    check_systemd_value $SD_MEM_LIMIT 33554432
+	check_cgroup_value $MEM_LIMIT 33554432
+	check_systemd_value $SD_MEM_LIMIT 33554432
 
-    check_cgroup_value $MEM_RESERVE 25165824
-    check_systemd_value $SD_MEM_RESERVE 25165824
+	check_cgroup_value $MEM_RESERVE 25165824
+	check_systemd_value $SD_MEM_RESERVE 25165824
 
-    check_cgroup_value "pids.max" 20
-    check_systemd_value "TasksMax" 20
+	check_cgroup_value "pids.max" 20
+	check_systemd_value "TasksMax" 20
 }
 
 function check_cpu_quota() {
-    local quota=$1
-    local period=$2
-    local sd_quota=$3
+	local quota=$1
+	local period=$2
+	local sd_quota=$3
 
-    if [ "$CGROUP_UNIFIED" = "yes" ]; then
-        if [ "$quota" = "-1" ]; then
-            quota="max"
-        fi
-        check_cgroup_value "cpu.max" "$quota $period"
-    else
-        check_cgroup_value "cpu.cfs_quota_us" $quota
-        check_cgroup_value "cpu.cfs_period_us" "$period"
-    fi
-    # systemd values are the same for v1 and v2
-    check_systemd_value "CPUQuotaPerSecUSec" "$sd_quota"
+	if [ "$CGROUP_UNIFIED" = "yes" ]; then
+		if [ "$quota" = "-1" ]; then
+			quota="max"
+		fi
+		check_cgroup_value "cpu.max" "$quota $period"
+	else
+		check_cgroup_value "cpu.cfs_quota_us" $quota
+		check_cgroup_value "cpu.cfs_period_us" "$period"
+	fi
+	# systemd values are the same for v1 and v2
+	check_systemd_value "CPUQuotaPerSecUSec" "$sd_quota"
 
-    # CPUQuotaPeriodUSec requires systemd >= v242
-    [ "$(systemd_version)" -lt 242 ] && return
+	# CPUQuotaPeriodUSec requires systemd >= v242
+	[ "$(systemd_version)" -lt 242 ] && return
 
-    local sd_period=$(( period/1000 ))ms
-    [ "$sd_period" = "1000ms" ] && sd_period="1s"
-    local sd_infinity=""
-    # 100ms is the default value, and if not set, shown as infinity
-    [ "$sd_period" = "100ms" ] && sd_infinity="infinity"
-    check_systemd_value "CPUQuotaPeriodUSec" $sd_period $sd_infinity
+	local sd_period=$((period / 1000))ms
+	[ "$sd_period" = "1000ms" ] && sd_period="1s"
+	local sd_infinity=""
+	# 100ms is the default value, and if not set, shown as infinity
+	[ "$sd_period" = "100ms" ] && sd_infinity="infinity"
+	check_systemd_value "CPUQuotaPeriodUSec" $sd_period $sd_infinity
 }
 
 function check_cpu_shares() {
-    local shares=$1
+	local shares=$1
 
-    if [ "$CGROUP_UNIFIED" = "yes" ]; then
-        local weight=$((1 + ((shares - 2) * 9999) / 262142))
-        check_cgroup_value "cpu.weight" $weight
-        check_systemd_value "CPUWeight" $weight
-    else
-        check_cgroup_value "cpu.shares" "$shares"
-        check_systemd_value "CPUShares" "$shares"
-    fi
+	if [ "$CGROUP_UNIFIED" = "yes" ]; then
+		local weight=$((1 + ((shares - 2) * 9999) / 262142))
+		check_cgroup_value "cpu.weight" $weight
+		check_systemd_value "CPUWeight" $weight
+	else
+		check_cgroup_value "cpu.shares" "$shares"
+		check_systemd_value "CPUShares" "$shares"
+	fi
 }
 
 @test "update cgroup cpu limits" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    # run a few busyboxes detached
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-    [ "$status" -eq 0 ]
+	# run a few busyboxes detached
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
 
-    # check that initial values were properly set
-    check_cpu_quota 500000 1000000 "500ms"
-    check_cpu_shares 100
+	# check that initial values were properly set
+	check_cpu_quota 500000 1000000 "500ms"
+	check_cpu_shares 100
 
-    # update cpu period
-    runc update test_update --cpu-period 900000
-    [ "$status" -eq 0 ]
-    check_cpu_quota 500000 900000 "560ms"
+	# update cpu period
+	runc update test_update --cpu-period 900000
+	[ "$status" -eq 0 ]
+	check_cpu_quota 500000 900000 "560ms"
 
-    # update cpu quota
-    runc update test_update --cpu-quota 600000
-    [ "$status" -eq 0 ]
-    check_cpu_quota 600000 900000 "670ms"
+	# update cpu quota
+	runc update test_update --cpu-quota 600000
+	[ "$status" -eq 0 ]
+	check_cpu_quota 600000 900000 "670ms"
 
-    # remove cpu quota
-    runc update test_update --cpu-quota -1
-    [ "$status" -eq 0 ]
-    check_cpu_quota -1 900000 "infinity"
+	# remove cpu quota
+	runc update test_update --cpu-quota -1
+	[ "$status" -eq 0 ]
+	check_cpu_quota -1 900000 "infinity"
 
-    # update cpu-shares
-    runc update test_update --cpu-share 200
-    [ "$status" -eq 0 ]
-    check_cpu_shares 200
+	# update cpu-shares
+	runc update test_update --cpu-share 200
+	[ "$status" -eq 0 ]
+	check_cpu_shares 200
 
-    # Revert to the test initial value via json on stding
-    runc update  -r - test_update <<EOF
+	# Revert to the test initial value via json on stding
+	runc update -r - test_update <<EOF
 {
   "cpu": {
     "shares": 100,
@@ -322,23 +322,23 @@ function check_cpu_shares() {
   }
 }
 EOF
-    [ "$status" -eq 0 ]
-    check_cpu_quota 500000 1000000 "500ms"
+	[ "$status" -eq 0 ]
+	check_cpu_quota 500000 1000000 "500ms"
 
-    # redo all the changes at once
-    runc update test_update \
-        --cpu-period 900000 --cpu-quota 600000 --cpu-share 200
-    [ "$status" -eq 0 ]
-    check_cpu_quota 600000 900000 "670ms"
-    check_cpu_shares 200
+	# redo all the changes at once
+	runc update test_update \
+		--cpu-period 900000 --cpu-quota 600000 --cpu-share 200
+	[ "$status" -eq 0 ]
+	check_cpu_quota 600000 900000 "670ms"
+	check_cpu_shares 200
 
-    # remove cpu quota and reset the period
-    runc update test_update --cpu-quota -1 --cpu-period 100000
-    [ "$status" -eq 0 ]
-    check_cpu_quota -1 100000 "infinity"
+	# remove cpu quota and reset the period
+	runc update test_update --cpu-quota -1 --cpu-period 100000
+	[ "$status" -eq 0 ]
+	check_cpu_quota -1 100000 "infinity"
 
-    # reset to initial test value via json file
-    cat << EOF > "$BATS_TMPDIR"/runc-cgroups-integration-test.json
+	# reset to initial test value via json file
+	cat <<EOF >"$BATS_TMPDIR"/runc-cgroups-integration-test.json
 {
   "cpu": {
     "shares": 100,
@@ -348,110 +348,110 @@ EOF
 }
 EOF
 
-    runc update  -r "$BATS_TMPDIR"/runc-cgroups-integration-test.json test_update
-    [ "$status" -eq 0 ]
-    check_cpu_quota 500000 1000000 "500ms"
-    check_cpu_shares 100
+	runc update -r "$BATS_TMPDIR"/runc-cgroups-integration-test.json test_update
+	[ "$status" -eq 0 ]
+	check_cpu_quota 500000 1000000 "500ms"
+	check_cpu_shares 100
 }
 
 @test "set cpu period with no quota" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    update_config '.linux.resources.cpu |= { "period": 1000000 }' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= { "period": 1000000 }' "${BUSYBOX_BUNDLE}"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
 
-    check_cpu_quota -1 1000000 "infinity"
+	check_cpu_quota -1 1000000 "infinity"
 }
 
 @test "set cpu quota with no period" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    update_config '.linux.resources.cpu |= { "quota": 5000 }' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= { "quota": 5000 }' "${BUSYBOX_BUNDLE}"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-    [ "$status" -eq 0 ]
-    check_cpu_quota 5000 100000 "50ms"
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
+	check_cpu_quota 5000 100000 "50ms"
 }
 
 @test "update cpu period with no previous period/quota set" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    update_config '.linux.resources.cpu |= {}' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= {}' "${BUSYBOX_BUNDLE}"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
 
-    # update the period alone, no old values were set
-    runc update --cpu-period 50000 test_update
-    [ "$status" -eq 0 ]
-    check_cpu_quota -1 50000 "infinity"
+	# update the period alone, no old values were set
+	runc update --cpu-period 50000 test_update
+	[ "$status" -eq 0 ]
+	check_cpu_quota -1 50000 "infinity"
 }
 
 @test "update cpu quota with no previous period/quota set" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-    update_config '.linux.resources.cpu |= {}' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= {}' "${BUSYBOX_BUNDLE}"
 
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-    [ "$status" -eq 0 ]
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
 
-    # update the quota alone, no old values were set
-    runc update --cpu-quota 30000 test_update
-    [ "$status" -eq 0 ]
-    check_cpu_quota 30000 100000 "300ms"
+	# update the quota alone, no old values were set
+	runc update --cpu-quota 30000 test_update
+	[ "$status" -eq 0 ]
+	check_cpu_quota 30000 100000 "300ms"
 }
 
 @test "update rt period and runtime" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    requires cgroups_v1 cgroups_rt no_systemd
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	requires cgroups_v1 cgroups_rt no_systemd
 
-    # By default, "${CGROUP_CPU}/cpu.rt_runtime_us" is set to 0, which inhibits
-    # setting the container's realtimeRuntime. (#2046)
-    #
-    # When $CGROUP_CPU is "/sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/test-cgroup",
-    # we write the values of /sys/fs/cgroup/cpu,cpuacct/cpu.rt_{period,runtime}_us to:
-    # - sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/cpu.rt_{period,runtime}_us
-    # - sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/test-cgroup/cpu.rt_{period,runtime}_us
-    #
-    # Typically period=1000000 runtime=950000 .
-    #
-    # TODO: support systemd
-    mkdir -p "$CGROUP_CPU"
-    local root_period root_runtime
-    root_period=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us")
-    root_runtime=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_runtime_us")
-    # the following IFS magic sets dirs=("runc-cgroups-integration-test" "test-cgroup")
-    IFS='/' read -r -a dirs <<< "${CGROUP_CPU//${CGROUP_CPU_BASE_PATH}/}"
-    for (( i = 0; i < ${#dirs[@]}; i++ )); do
-        local target="$CGROUP_CPU_BASE_PATH"
-        for (( j = 0; j <= i; j++ )); do
-            target="${target}/${dirs[$j]}"
-        done
-        target_period="${target}/cpu.rt_period_us"
-        echo "Writing ${root_period} to ${target_period}"
-        echo "$root_period" > "$target_period"
-        target_runtime="${target}/cpu.rt_runtime_us"
-        echo "Writing ${root_runtime} to ${target_runtime}"
-        echo "$root_runtime" > "$target_runtime"
-    done
+	# By default, "${CGROUP_CPU}/cpu.rt_runtime_us" is set to 0, which inhibits
+	# setting the container's realtimeRuntime. (#2046)
+	#
+	# When $CGROUP_CPU is "/sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/test-cgroup",
+	# we write the values of /sys/fs/cgroup/cpu,cpuacct/cpu.rt_{period,runtime}_us to:
+	# - sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/cpu.rt_{period,runtime}_us
+	# - sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/test-cgroup/cpu.rt_{period,runtime}_us
+	#
+	# Typically period=1000000 runtime=950000 .
+	#
+	# TODO: support systemd
+	mkdir -p "$CGROUP_CPU"
+	local root_period root_runtime
+	root_period=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us")
+	root_runtime=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_runtime_us")
+	# the following IFS magic sets dirs=("runc-cgroups-integration-test" "test-cgroup")
+	IFS='/' read -r -a dirs <<<"${CGROUP_CPU//${CGROUP_CPU_BASE_PATH}/}"
+	for ((i = 0; i < ${#dirs[@]}; i++)); do
+		local target="$CGROUP_CPU_BASE_PATH"
+		for ((j = 0; j <= i; j++)); do
+			target="${target}/${dirs[$j]}"
+		done
+		target_period="${target}/cpu.rt_period_us"
+		echo "Writing ${root_period} to ${target_period}"
+		echo "$root_period" >"$target_period"
+		target_runtime="${target}/cpu.rt_runtime_us"
+		echo "Writing ${root_runtime} to ${target_runtime}"
+		echo "$root_runtime" >"$target_runtime"
+	done
 
-    # run a detached busybox
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update_rt
-    [ "$status" -eq 0 ]
+	# run a detached busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update_rt
+	[ "$status" -eq 0 ]
 
-    runc update  -r - test_update_rt <<EOF
+	runc update -r - test_update_rt <<EOF
 {
   "cpu": {
     "realtimeRuntime": 500001
   }
 }
 EOF
-    check_cgroup_value "cpu.rt_period_us" "$root_period"
-    check_cgroup_value "cpu.rt_runtime_us" 500001
+	check_cgroup_value "cpu.rt_period_us" "$root_period"
+	check_cgroup_value "cpu.rt_runtime_us" 500001
 
-    runc update  -r - test_update_rt <<EOF
+	runc update -r - test_update_rt <<EOF
 {
   "cpu": {
     "realtimePeriod": 800001,
@@ -459,77 +459,76 @@ EOF
   }
 }
 EOF
-    check_cgroup_value "cpu.rt_period_us" 800001
-    check_cgroup_value "cpu.rt_runtime_us" 500001
+	check_cgroup_value "cpu.rt_period_us" 800001
+	check_cgroup_value "cpu.rt_runtime_us" 500001
 
-    runc update test_update_rt --cpu-rt-period 900001 --cpu-rt-runtime 600001
+	runc update test_update_rt --cpu-rt-period 900001 --cpu-rt-runtime 600001
 
-    check_cgroup_value "cpu.rt_period_us" 900001
-    check_cgroup_value "cpu.rt_runtime_us" 600001
+	check_cgroup_value "cpu.rt_period_us" 900001
+	check_cgroup_value "cpu.rt_runtime_us" 600001
 }
 
 @test "update devices [minimal transition rules]" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    # This test currently only makes sense on cgroupv1.
-    requires cgroups_v1
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	# This test currently only makes sense on cgroupv1.
+	requires cgroups_v1
 
-    # Run a basic shell script that tries to write to /dev/null. If "runc
-    # update" makes use of minimal transition rules, updates should not cause
-    # writes to fail at any point.
-    update_config '.process.args |= ["sh", "-c", "while true; do echo >/dev/null; done"]'
+	# Run a basic shell script that tries to write to /dev/null. If "runc
+	# update" makes use of minimal transition rules, updates should not cause
+	# writes to fail at any point.
+	update_config '.process.args |= ["sh", "-c", "while true; do echo >/dev/null; done"]'
 
-    # Set up a temporary console socket and recvtty so we can get the stdio.
-    TMP_RECVTTY_DIR="$(mktemp -d "$BATS_TMPDIR/runc-tmp-recvtty.XXXXXX")"
-    TMP_RECVTTY_PID="$TMP_RECVTTY_DIR/recvtty.pid"
-    TMP_CONSOLE_SOCKET="$TMP_RECVTTY_DIR/console.sock"
-    CONTAINER_OUTPUT="$TMP_RECVTTY_DIR/output"
-    ("$RECVTTY" --no-stdin --pid-file "$TMP_RECVTTY_PID" \
-                --mode single "$TMP_CONSOLE_SOCKET" &>"$CONTAINER_OUTPUT" ) &
-    retry 10 0.1 [ -e "$TMP_CONSOLE_SOCKET" ]
+	# Set up a temporary console socket and recvtty so we can get the stdio.
+	TMP_RECVTTY_DIR="$(mktemp -d "$BATS_TMPDIR/runc-tmp-recvtty.XXXXXX")"
+	TMP_RECVTTY_PID="$TMP_RECVTTY_DIR/recvtty.pid"
+	TMP_CONSOLE_SOCKET="$TMP_RECVTTY_DIR/console.sock"
+	CONTAINER_OUTPUT="$TMP_RECVTTY_DIR/output"
+	("$RECVTTY" --no-stdin --pid-file "$TMP_RECVTTY_PID" \
+		--mode single "$TMP_CONSOLE_SOCKET" &>"$CONTAINER_OUTPUT") &
+	retry 10 0.1 [ -e "$TMP_CONSOLE_SOCKET" ]
 
-    # Run the container in the background.
-    runc run -d --console-socket "$TMP_CONSOLE_SOCKET" test_update
-    cat "$CONTAINER_OUTPUT"
-    [ "$status" -eq 0 ]
+	# Run the container in the background.
+	runc run -d --console-socket "$TMP_CONSOLE_SOCKET" test_update
+	cat "$CONTAINER_OUTPUT"
+	[ "$status" -eq 0 ]
 
-    # Trigger an update. This update doesn't actually change the device rules,
-    # but it will trigger the devices cgroup code to reapply the current rules.
-    # We trigger the update a few times to make sure we hit the race.
-    for _ in {1..12}
-    do
-        # TODO: Update "runc update" so we can change the device rules.
-        runc update --pids-limit 30 test_update
-        [ "$status" -eq 0 ]
-    done
+	# Trigger an update. This update doesn't actually change the device rules,
+	# but it will trigger the devices cgroup code to reapply the current rules.
+	# We trigger the update a few times to make sure we hit the race.
+	for _ in {1..12}; do
+		# TODO: Update "runc update" so we can change the device rules.
+		runc update --pids-limit 30 test_update
+		[ "$status" -eq 0 ]
+	done
 
-    # Kill recvtty.
-    kill -9 "$(<"$TMP_RECVTTY_PID")"
+	# Kill recvtty.
+	kill -9 "$(<"$TMP_RECVTTY_PID")"
 
-    # There should've been no output from the container.
-    cat "$CONTAINER_OUTPUT"
-    [ -z "$(<"$CONTAINER_OUTPUT")" ]
+	# There should've been no output from the container.
+	cat "$CONTAINER_OUTPUT"
+	[ -z "$(<"$CONTAINER_OUTPUT")" ]
 }
 
 @test "update paused container" {
-    [[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-    requires cgroups_freezer
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	requires cgroups_freezer
 
-    # Run the container in the background.
-    runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-    [ "$status" -eq 0 ]
+	# Run the container in the background.
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
 
-    # Pause the container.
-    runc pause test_update
-    [ "$status" -eq 0 ]
+	# Pause the container.
+	runc pause test_update
+	[ "$status" -eq 0 ]
 
-    # Trigger an unrelated update.
-    runc update --pids-limit 30 test_update
-    [ "$status" -eq 0 ]
+	# Trigger an unrelated update.
+	runc update --pids-limit 30 test_update
+	[ "$status" -eq 0 ]
 
-    # The container should still be paused.
-    testcontainer test_update paused
+	# The container should still be paused.
+	testcontainer test_update paused
 
-    # Resume the container.
-    runc resume test_update
-    [ "$status" -eq 0 ]
+	# Resume the container.
+	runc resume test_update
+	[ "$status" -eq 0 ]
 }

--- a/tests/integration/version.bats
+++ b/tests/integration/version.bats
@@ -3,9 +3,9 @@
 load helpers
 
 @test "runc version" {
-  runc -v
-  [ "$status" -eq 0 ]
-  [[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
-  [[ ${lines[1]} =~ commit:+ ]]
-  [[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]
+	runc -v
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
+	[[ ${lines[1]} =~ commit:+ ]]
+	[[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]
 }


### PR DESCRIPTION
### 1.     tests/integration/*.bats: reformat with shfmt
    
Various bats tests use various types of indentation (about half
is tabs, the rest is 2 spaces, 4 spaces, etc.).
    
Let's bring it to one style (tabs) using recently added
shfmt support for bats files (see https://github.com/mvdan/sh/issues/600).
    
This commit is brought to you by
    
    shfmt -ln bats -w tests/integration/*.bats

### 2. CI: add shfmt for bats

Note that you need a very recent shfmt (such as
https://github.com/mvdan/sh/commit/08ecaf9adf4bb75).

### 3. *.sh: use shfmt
    
I played with shfmt options (-bn, -ci, -sr) a bit trying to minimize
the patch generated (and also because I don't have a strong preference
on these matters), and it appears to be that the patch size is about the
same nevertheless, so I chose no options.
    
This commit is brought to you by
    
    shfmt -ln bash -w man/*.sh script/*.sh tests/*.sh tests/integration/*.bash

### 4. CI: add shfmt for sh files

Fixes: https://github.com/opencontainers/runc/issues/2396