### PR TITLE
libcontainer/intelrdt: fix CMT feature check

### DIFF
--- a/libcontainer/intelrdt/cmt.go
+++ b/libcontainer/intelrdt/cmt.go
@@ -12,11 +12,13 @@ func IsCMTEnabled() bool {
 func getCMTNumaNodeStats(numaPath string) (*CMTNumaNodeStats, error) {
 	stats := &CMTNumaNodeStats{}
 
-	llcOccupancy, err := getIntelRdtParamUint(numaPath, "llc_occupancy")
-	if err != nil {
-		return nil, err
+	if enabledMonFeatures.llcOccupancy {
+		llcOccupancy, err := getIntelRdtParamUint(numaPath, "llc_occupancy")
+		if err != nil {
+			return nil, err
+		}
+		stats.LLCOccupancy = llcOccupancy
 	}
-	stats.LLCOccupancy = llcOccupancy
 
 	return stats, nil
 }


### PR DESCRIPTION
Intel RDT sub-features can be selectively disabled or enabled by kernel
command line. See "rdt=" option details in kernel document:
https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt

But Cache Monitoring Technology (CMT) feature is not correctly checked
in init() and getCMTNumaNodeStats() now. If CMT is disabled by kernel
command line (e.g., rdt=!cmt,mbmtotal,mbmlocal,l3cat,mba) while hardware
supports CMT, we may get following error when getting Intel RDT stats:
  runc run c1
  runc events c1
  ERRO[0005] container_linux.go:200: getting container's Intel RDT stats
  caused: open /sys/fs/resctrl/c1/mon_data/mon_L3_00/llc_occupancy: no
  such file or directory

Fix CMT feature check in init() and GetStats() call paths.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>