### PR TITLE
libcontainer/intelrdt: remove 'omitempty' property from CMT and MBM counters

### DIFF
--- a/libcontainer/intelrdt/stats.go
+++ b/libcontainer/intelrdt/stats.go
@@ -17,15 +17,15 @@ type MemBwInfo struct {
 
 type MBMNumaNodeStats struct {
 	// The 'mbm_total_bytes' in 'container_id' group.
-	MBMTotalBytes uint64 `json:"mbm_total_bytes,omitempty"`
+	MBMTotalBytes uint64 `json:"mbm_total_bytes"`
 
 	// The 'mbm_local_bytes' in 'container_id' group.
-	MBMLocalBytes uint64 `json:"mbm_local_bytes,omitempty"`
+	MBMLocalBytes uint64 `json:"mbm_local_bytes"`
 }
 
 type CMTNumaNodeStats struct {
 	// The 'llc_occupancy' in 'container_id' group.
-	LLCOccupancy uint64 `json:"llc_occupancy,omitempty"`
+	LLCOccupancy uint64 `json:"llc_occupancy"`
 }
 
 type Stats struct {


### PR DESCRIPTION
If the values of CMT and MBM counters are zero, they will be omitted as
empty items when getting Intel RDT stats.

Remove 'omitempty' property from CMT and MBM counters to display zero
values.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>