### PR TITLE
libcontainer/intelrdt: IntelRdtManager refactoring

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -149,11 +149,7 @@ func RootlessCgroupfs(l *LinuxFactory) error {
 // create and manage Intel RDT resources (e.g., L3 cache, memory bandwidth).
 func IntelRdtFs(l *LinuxFactory) error {
 	l.NewIntelRdtManager = func(config *configs.Config, id string, path string) intelrdt.Manager {
-		return &intelrdt.IntelRdtManager{
-			Config: config,
-			Id:     id,
-			Path:   path,
-		}
+		return intelrdt.NewManager(config, id, path)
 	}
 	return nil
 }

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -165,18 +165,18 @@ type Manager interface {
 }
 
 // This implements interface Manager
-type IntelRdtManager struct {
+type intelRdtManager struct {
 	mu     sync.Mutex
-	Config *configs.Config
-	Id     string
-	Path   string
+	config *configs.Config
+	id     string
+	path   string
 }
 
 func NewManager(config *configs.Config, id string, path string) Manager {
-	return &IntelRdtManager{
-		Config: config,
-		Id:     id,
-		Path:   path,
+	return &intelRdtManager{
+		config: config,
+		id:     id,
+		path:   path,
 	}
 }
 
@@ -542,51 +542,51 @@ func GetIntelRdtPath(id string) (string, error) {
 }
 
 // Applies Intel RDT configuration to the process with the specified pid
-func (m *IntelRdtManager) Apply(pid int) (err error) {
+func (m *intelRdtManager) Apply(pid int) (err error) {
 	// If intelRdt is not specified in config, we do nothing
-	if m.Config.IntelRdt == nil {
+	if m.config.IntelRdt == nil {
 		return nil
 	}
-	d, err := getIntelRdtData(m.Config, pid)
+	d, err := getIntelRdtData(m.config, pid)
 	if err != nil && !IsNotFound(err) {
 		return err
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	path, err := d.join(m.Id)
+	path, err := d.join(m.id)
 	if err != nil {
 		return err
 	}
 
-	m.Path = path
+	m.path = path
 	return nil
 }
 
 // Destroys the Intel RDT 'container_id' group
-func (m *IntelRdtManager) Destroy() error {
+func (m *intelRdtManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if err := os.RemoveAll(m.GetPath()); err != nil {
 		return err
 	}
-	m.Path = ""
+	m.path = ""
 	return nil
 }
 
 // Returns Intel RDT path to save in a state file and to be able to
 // restore the object later
-func (m *IntelRdtManager) GetPath() string {
-	if m.Path == "" {
-		m.Path, _ = GetIntelRdtPath(m.Id)
+func (m *intelRdtManager) GetPath() string {
+	if m.path == "" {
+		m.path, _ = GetIntelRdtPath(m.id)
 	}
-	return m.Path
+	return m.path
 }
 
 // Returns statistics for Intel RDT
-func (m *IntelRdtManager) GetStats() (*Stats, error) {
+func (m *intelRdtManager) GetStats() (*Stats, error) {
 	// If intelRdt is not specified in config
-	if m.Config.IntelRdt == nil {
+	if m.config.IntelRdt == nil {
 		return nil, nil
 	}
 
@@ -668,7 +668,7 @@ func (m *IntelRdtManager) GetStats() (*Stats, error) {
 }
 
 // Set Intel RDT "resource control" filesystem as configured.
-func (m *IntelRdtManager) Set(container *configs.Config) error {
+func (m *intelRdtManager) Set(container *configs.Config) error {
 	// About L3 cache schema:
 	// It has allocation bitmasks/values for L3 cache on each socket,
 	// which contains L3 cache id and capacity bitmask (CBM).

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -172,6 +172,14 @@ type IntelRdtManager struct {
 	Path   string
 }
 
+func NewManager(config *configs.Config, id string, path string) Manager {
+	return &IntelRdtManager{
+		Config: config,
+		Id:     id,
+		Path:   path,
+	}
+}
+
 const (
 	IntelRdtTasks = "tasks"
 )

--- a/libcontainer/intelrdt/intelrdt_test.go
+++ b/libcontainer/intelrdt/intelrdt_test.go
@@ -26,10 +26,7 @@ func TestIntelRdtSetL3CacheSchema(t *testing.T) {
 	})
 
 	helper.IntelRdtData.config.IntelRdt.L3CacheSchema = l3CacheSchemeAfter
-	intelrdt := &IntelRdtManager{
-		Config: helper.IntelRdtData.config,
-		Path:   helper.IntelRdtPath,
-	}
+	intelrdt := NewManager(helper.IntelRdtData.config, "", helper.IntelRdtPath)
 	if err := intelrdt.Set(helper.IntelRdtData.config); err != nil {
 		t.Fatal(err)
 	}
@@ -64,10 +61,7 @@ func TestIntelRdtSetMemBwSchema(t *testing.T) {
 	})
 
 	helper.IntelRdtData.config.IntelRdt.MemBwSchema = memBwSchemeAfter
-	intelrdt := &IntelRdtManager{
-		Config: helper.IntelRdtData.config,
-		Path:   helper.IntelRdtPath,
-	}
+	intelrdt := NewManager(helper.IntelRdtData.config, "", helper.IntelRdtPath)
 	if err := intelrdt.Set(helper.IntelRdtData.config); err != nil {
 		t.Fatal(err)
 	}
@@ -102,10 +96,7 @@ func TestIntelRdtSetMemBwScSchema(t *testing.T) {
 	})
 
 	helper.IntelRdtData.config.IntelRdt.MemBwSchema = memBwScSchemeAfter
-	intelrdt := &IntelRdtManager{
-		Config: helper.IntelRdtData.config,
-		Path:   helper.IntelRdtPath,
-	}
+	intelrdt := NewManager(helper.IntelRdtData.config, "", helper.IntelRdtPath)
 	if err := intelrdt.Set(helper.IntelRdtData.config); err != nil {
 		t.Fatal(err)
 	}

--- a/update.go
+++ b/update.go
@@ -317,11 +317,7 @@ other options are ignored.
 					return err
 				}
 				config.IntelRdt = &configs.IntelRdt{}
-				intelRdtManager := intelrdt.IntelRdtManager{
-					Config: &config,
-					Id:     container.ID(),
-					Path:   state.IntelRdtPath,
-				}
+				intelRdtManager := intelrdt.NewManager(&config, container.ID(), state.IntelRdtPath)
 				if err := intelRdtManager.Apply(state.InitProcessPid); err != nil {
 					return err
 				}


### PR DESCRIPTION
This is a set of patches for IntelRdtManager refactoring. 
It is similar to part of the cgroup refactoring in #2387.

No functional change.
Please review commits one by one.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>