### PR TITLE
rootfs: handle github.com/moby/sys/mountinfo deficiency

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -829,8 +829,11 @@ func msMoveRoot(rootfs string) error {
 	mountinfos, err := mountinfo.GetMounts(func(info *mountinfo.Info) (skip, stop bool) {
 		// Collect every sysfs and procfs filesystem, except for those which
 		// are non-full mounts or are inside the rootfs of the container.
-		if info.Root != "/" ||
-			(info.FSType != "proc" && info.FSType != "sysfs") ||
+		//
+		// NOTE: We cannot do the root check here because of an implementation
+		// detail of github.com/moby/sys/mountinfo -- see
+		// <https://github.com/moby/sys/pull/50> for the fix and details.
+		if (info.FSType != "proc" && info.FSType != "sysfs") ||
 			strings.HasPrefix(info.Mountpoint, rootfs) {
 			skip = true
 		}

--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	teardown_busybox
+	setup_busybox
+}
+
+function teardown() {
+	teardown_busybox
+}
+
+@test "runc run --no-pivot must not expose bare /proc" {
+	requires root
+
+	update_config '.process.args |= ["unshare", "-mrpf", "sh", "-euxc", "mount -t proc none /proc && echo h > /proc/sysrq-trigger"]'
+
+	runc run --no-pivot test_no_pivot
+	[ "$status" -eq 1 ]
+	[[ ${lines[*]} == *"mount: permission denied"* ]]
+}


### PR DESCRIPTION
github.com/moby/sys/mountinfo doesn't fill the Root field of
mountinfo.Info when calling filter functions, meaning that the change in
commit b8bf57281298 ("rootfs: handle nested procfs mounts for MS_MOVE")
regressed the security hardening.

While this is being fixed upstream in [1], just remove this info.Root
optimisation because the ENOENT check is actually sufficient to fix the
original issue.

[1]: https://github.com/moby/sys/pull/50

Closes #2654
Reported-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>