### PR TITLE
Update bash completion to support systemd-cgroup

### DIFF
--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -224,6 +224,7 @@ _runc_runc() {
 		--help
 		--version -v
 		--debug
+		--systemd-cgroup
 	"
 	local options_with_args="
 		--log


### PR DESCRIPTION
This setting cannot complete `--systemd-cgroup` currently.
This is a minor fix and I think it is easy to review.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>