### PR TITLE
vendor: bump mountinfo to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/golang/protobuf v1.4.2
-	github.com/moby/sys/mountinfo v0.3.1
+	github.com/moby/sys/mountinfo v0.4.0
 	github.com/mrunalp/fileutils v0.5.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200817204227-f9c09b4ea1df
 	github.com/opencontainers/selinux v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/moby/sys/mountinfo v0.3.1 h1:R+C9GycEzoR3GdwQ7mANRhJORnVDJiRkf0JMY82MeI0=
-github.com/moby/sys/mountinfo v0.3.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
+github.com/moby/sys/mountinfo v0.4.0 h1:1KInV3Huv18akCu58V7lzNlt+jFmqlu1EaErnEHE/VM=
+github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200817204227-f9c09b4ea1df h1:5AW5dMFSXVH4Mg3WYe4z7ui64bK8n66IoWK8i6T4QZ8=

--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	teardown_busybox
+	setup_busybox
+}
+
+function teardown() {
+	teardown_busybox
+}
+
+@test "runc run --no-pivot must not expose bare /proc" {
+	requires root
+
+	update_config '.process.args |= ["unshare", "-mrpf", "sh", "-euxc", "mount -t proc none /proc && echo h > /proc/sysrq-trigger"]'
+
+	runc run --no-pivot test_no_pivot
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"mount: permission denied"* ]]
+}

--- a/vendor/github.com/moby/sys/mountinfo/doc.go
+++ b/vendor/github.com/moby/sys/mountinfo/doc.go
@@ -15,11 +15,8 @@
 // parse filters while reading mountinfo. A filter can skip some entries, or stop
 // processing the rest of the file once the needed information is found.
 //
-// For mountinfo filters that accept path as an argument, the path must be:
-//  - absolute;
-//  - having all symlinks resolved;
-//  - being cleaned.
-//
+// For mountinfo filters that accept path as an argument, the path must be absolute,
+// having all symlinks resolved, and being cleaned (i.e. no extra slashes or dots).
 // One way to achieve all of the above is to employ filepath.Abs followed by
 // filepath.EvalSymlinks (the latter calls filepath.Clean on the result so
 // there is no need to explicitly call filepath.Clean).
@@ -28,20 +25,20 @@
 // of the cases where mountinfo should not be parsed:
 //
 // 1. Before performing a mount. Usually, this is not needed, but if required (say to
-//    prevent over-mounts), to check whether a directory is mounted, call os.Lstat
-//    on it and its parent directory, and compare their st.Sys().(*syscall.Stat_t).Dev
-//    fields -- if they differ, then the directory is the mount point. NOTE this does
-//    not work for bind mounts. Optionally, the filesystem type can also be checked
-//    by calling unix.Statfs and checking the Type field (i.e. filesystem type).
+// prevent over-mounts), to check whether a directory is mounted, call os.Lstat
+// on it and its parent directory, and compare their st.Sys().(*syscall.Stat_t).Dev
+// fields -- if they differ, then the directory is the mount point. NOTE this does
+// not work for bind mounts. Optionally, the filesystem type can also be checked
+// by calling unix.Statfs and checking the Type field (i.e. filesystem type).
 //
 // 2. After performing a mount. If there is no error returned, the mount succeeded;
-//    checking the mount table for a new mount is redundant and expensive.
+// checking the mount table for a new mount is redundant and expensive.
 //
 // 3. Before performing an unmount. It is more efficient to do an unmount and ignore
-//    a specific error (EINVAL) which tells the directory is not mounted.
+// a specific error (EINVAL) which tells the directory is not mounted.
 //
 // 4. After performing an unmount. If there is no error returned, the unmount succeeded.
 //
 // 5. To find the mount point root of a specific directory. You can perform os.Stat()
-//    on the directory and traverse up until the Dev field of a parent directory differs.
+// on the directory and traverse up until the Dev field of a parent directory differs.
 package mountinfo

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
@@ -6,12 +6,12 @@ import "strings"
 // used to filter out mountinfo entries we're not interested in,
 // and/or stop further processing if we found what we wanted.
 //
-// It takes a pointer to the Info struct (not fully populated,
-// currently only Mountpoint, FSType, Source, and (on Linux)
-// VFSOptions are filled in), and returns two booleans:
+// It takes a pointer to the Info struct (fully populated with all available
+// fields on the GOOS platform), and returns two booleans:
 //
-//  - skip: true if the entry should be skipped
-//  - stop: true if parsing should be stopped after the entry
+// skip: true if the entry should be skipped;
+//
+// stop: true if parsing should be stopped after the entry.
 type FilterFunc func(*Info) (skip, stop bool)
 
 // PrefixFilter discards all entries whose mount points
@@ -36,8 +36,8 @@ func SingleEntryFilter(mp string) FilterFunc {
 // ParentsFilter returns all entries whose mount points
 // can be parents of a path specified, discarding others.
 //
-// For example, given `/var/lib/docker/something`, entries
-// like `/var/lib/docker`, `/var` and `/` are returned.
+// For example, given /var/lib/docker/something, entries
+// like /var/lib/docker, /var and / are returned.
 func ParentsFilter(path string) FilterFunc {
 	return func(m *Info) (bool, bool) {
 		skip := !strings.HasPrefix(path, m.Mountpoint)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/godbus/dbus/v5
 # github.com/golang/protobuf v1.4.2
 ## explicit
 github.com/golang/protobuf/proto
-# github.com/moby/sys/mountinfo v0.3.1
+# github.com/moby/sys/mountinfo v0.4.0
 ## explicit
 github.com/moby/sys/mountinfo
 # github.com/mrunalp/fileutils v0.5.0


### PR DESCRIPTION
Release notes:
- https://github.com/moby/sys/releases/tag/mountinfo%2Fv0.4.0

In particular, this fixes a regression introduced in commit b8bf572812 (PR #2647)
which checked the `mountinfo.Root` field in a `FilterFunc`, while `Root` was
not (yet) set when calling the filter.

Also add "runc run --no-pivot must not expose bare /proc" test by @AkihiroSuda
to prevent future regressions like this one.

Closes: #2655 