### PR TITLE
tests/integration: rm excessive run use; fix exec --preserve-fds test

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -43,8 +43,7 @@ function check_pipes() {
 	echo Ping >&${in_w}
 	exec {in_w}>&-
 	exec {out_w}>&-
-	run cat <&${out_r}
-	[ "$status" -eq 0 ]
+	output=$(cat <&${out_r})
 	[[ "${output}" == *"ponG Ping"* ]]
 }
 
@@ -159,8 +158,7 @@ function simple_cr() {
 
 @test "checkpoint --lazy-pages and restore" {
 	# check if lazy-pages is supported
-	run "${CRIU}" check --feature uffd-noncoop
-	if [ "$status" -eq 1 ]; then
+	if ! "${CRIU}" check --feature uffd-noncoop; then
 		skip "this criu does not support lazy migration"
 	fi
 
@@ -218,8 +216,7 @@ function simple_cr() {
 
 @test "checkpoint and restore in external network namespace" {
 	# check if external_net_ns is supported; only with criu 3.10++
-	run "${CRIU}" check --feature external_net_ns
-	if [ "$status" -eq 1 ]; then
+	if ! "${CRIU}" check --feature external_net_ns; then
 		# this criu does not support external_net_ns; skip the test
 		skip "this criu does not support external network namespaces"
 	fi

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -51,9 +51,7 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	run cat pid.txt
-	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	[[ $(cat pid.txt) == $(__runc state test_busybox | jq '.pid') ]]
 
 	# start the command
 	runc start test_busybox
@@ -64,10 +62,8 @@ function teardown() {
 
 @test "runc create --pid-file with new CWD" {
 	# create pid_file directory as the CWD
-	run mkdir pid_file
-	[ "$status" -eq 0 ]
-	run cd pid_file
-	[ "$status" -eq 0 ]
+	mkdir pid_file
+	cd pid_file
 
 	runc create --pid-file pid.txt -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
@@ -77,9 +73,7 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	run cat pid.txt
-	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	[[ $(cat pid.txt) == $(__runc state test_busybox | jq '.pid') ]]
 
 	# start the command
 	runc start test_busybox

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -35,8 +35,7 @@ function teardown() {
 	[ -e log.out ]
 
 	# check expected debug output was sent to log.out
-	run cat log.out
-	[ "$status" -eq 0 ]
+	output=$(cat log.out)
 	[[ "${output}" == *"level=debug"* ]]
 	[[ "${output}" == *"nsexec started"* ]]
 	[[ "${output}" == *"child process in init()"* ]]
@@ -54,8 +53,7 @@ function teardown() {
 	[ -e log.out ]
 
 	# check expected debug output was sent to log.out
-	run cat log.out
-	[ "$status" -eq 0 ]
+	output=$(cat log.out)
 	[[ "${output}" == *"level=debug"* ]]
 	[[ "${output}" == *"nsexec started"* ]]
 	[[ "${output}" == *"child process in init()"* ]]
@@ -73,8 +71,7 @@ function teardown() {
 	[ -e log.out ]
 
 	# check expected debug output was sent to log.out
-	run cat log.out
-	[ "$status" -eq 0 ]
+	output=$(cat log.out)
 	[[ "${output}" == *'"level":"debug"'* ]]
 	[[ "${output}" == *"nsexec started"* ]]
 	[[ "${output}" == *"child process in init()"* ]]

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -28,8 +28,7 @@ function teardown() {
 	runc state testbusyboxdelete
 	[ "$status" -ne 0 ]
 
-	run find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d
-	[ "$status" -eq 0 ]
+	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 
@@ -99,8 +98,7 @@ EOF
 	runc state test_busybox
 	[ "$status" -ne 0 ]
 
-	run find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d
-	[ "$status" -eq 0 ]
+	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -49,10 +49,9 @@ function teardown() {
 
 	[ -e events.log ]
 
-	run cat events.log
-	[ "$status" -eq 0 ]
-	[[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
-	[[ "${lines[0]}" == *"data"* ]]
+	output=$(head -1 events.log)
+	[[ "$output" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
+	[[ "$output" == *"data"* ]]
 }
 
 @test "events --interval 1s" {
@@ -78,8 +77,7 @@ function teardown() {
 
 	[ -e events.log ]
 
-	run eval "grep -q 'test_busybox' events.log"
-	[ "$status" -eq 0 ]
+	grep -q 'test_busybox' events.log
 }
 
 @test "events --interval 100ms" {
@@ -108,8 +106,7 @@ function teardown() {
 
 	[ -e events.log ]
 
-	run eval "grep -q 'test_busybox' events.log"
-	[ "$status" -eq 0 ]
+	grep -q 'test_busybox' events.log
 }
 
 @test "events oom" {

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -35,18 +35,15 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	run cat pid.txt
-	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ [0-9]+ ]]
-	[[ ${lines[0]} != $(__runc state test_busybox | jq '.pid') ]]
+	output=$(cat pid.txt)
+	[[ "$output" =~ [0-9]+ ]]
+	[[ "$output" != $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec --pid-file with new CWD" {
 	# create pid_file directory as the CWD
-	run mkdir pid_file
-	[ "$status" -eq 0 ]
-	run cd pid_file
-	[ "$status" -eq 0 ]
+	mkdir pid_file
+	cd pid_file
 
 	# run busybox detached
 	runc run -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
@@ -60,10 +57,9 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	run cat pid.txt
-	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ [0-9]+ ]]
-	[[ ${lines[0]} != $(__runc state test_busybox | jq '.pid') ]]
+	output=$(cat pid.txt)
+	[[ "$output" =~ [0-9]+ ]]
+	[[ "$output" != $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec ls -la" {

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -133,8 +133,9 @@ function teardown() {
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	run bash -c "cat hello > preserve-fds.test; exec 3<preserve-fds.test; $RUNC ${RUNC_USE_SYSTEMD:+--systemd-cgroup} --log /proc/self/fd/2 --root $ROOT exec --preserve-fds=1 test_busybox cat /proc/self/fd/3"
-	[ "$status" -eq 0 ]
-
-	[[ "${output}" == *"hello"* ]]
+	echo hello >preserve-fds.test
+	# fd 3 is used by bats, so we use 4
+	exec 4<preserve-fds.test
+	output=$(__runc exec --preserve-fds=2 test_busybox cat /proc/self/fd/4)
+	[[ "${output}" == "hello" ]]
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -468,27 +468,11 @@ function setup_debian() {
 }
 
 function teardown_running_container() {
-	runc list
-	# $1 should be a container name such as "test_busybox"
-	# here we detect "test_busybox "(with one extra blank) to avoid conflict prefix
-	# e.g. "test_busybox" and "test_busybox_update"
-	if [[ "${output}" == *"$1 "* ]]; then
-		runc kill $1 KILL
-		retry 10 1 eval "__runc state '$1' | grep -q 'stopped'"
-		runc delete $1
-	fi
+	__runc delete -f "$1"
 }
 
 function teardown_running_container_inroot() {
-	ROOT=$2 runc list
-	# $1 should be a container name such as "test_busybox"
-	# here we detect "test_busybox "(with one extra blank) to avoid conflict prefix
-	# e.g. "test_busybox" and "test_busybox_update"
-	if [[ "${output}" == *"$1 "* ]]; then
-		ROOT=$2 runc kill $1 KILL
-		retry 10 1 eval "ROOT='$2' __runc state '$1' | grep -q 'stopped'"
-		ROOT=$2 runc delete $1
-	fi
+	ROOT="$2" __runc delete -f "$1"
 }
 
 function teardown_busybox() {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -423,8 +423,7 @@ function teardown_recvtty() {
 
 function setup_busybox() {
 	setup_recvtty
-	run mkdir "$BUSYBOX_BUNDLE"
-	run mkdir "$BUSYBOX_BUNDLE"/rootfs
+	mkdir -p "$BUSYBOX_BUNDLE"/rootfs
 	if [ -e "/testdata/busybox.tar" ]; then
 		BUSYBOX_IMAGE="/testdata/busybox.tar"
 	fi
@@ -438,8 +437,7 @@ function setup_busybox() {
 
 function setup_hello() {
 	setup_recvtty
-	run mkdir "$HELLO_BUNDLE"
-	run mkdir "$HELLO_BUNDLE"/rootfs
+	mkdir -p "$HELLO_BUNDLE"/rootfs
 	tar --exclude './dev/*' -C "$HELLO_BUNDLE"/rootfs -xf "$HELLO_IMAGE"
 	cd "$HELLO_BUNDLE"
 	runc_spec
@@ -453,7 +451,7 @@ function setup_debian() {
 	fi
 
 	setup_recvtty
-	run mkdir "$DEBIAN_BUNDLE"
+	mkdir -p "$DEBIAN_BUNDLE"
 
 	if [ ! -d "$DEBIAN_ROOTFS/rootfs" ]; then
 		get_and_extract_debian "$DEBIAN_BUNDLE"
@@ -479,19 +477,19 @@ function teardown_busybox() {
 	cd "$INTEGRATION_ROOT"
 	teardown_recvtty
 	teardown_running_container test_busybox
-	run rm -f -r "$BUSYBOX_BUNDLE"
+	rm -f -r "$BUSYBOX_BUNDLE"
 }
 
 function teardown_hello() {
 	cd "$INTEGRATION_ROOT"
 	teardown_recvtty
 	teardown_running_container test_hello
-	run rm -f -r "$HELLO_BUNDLE"
+	rm -f -r "$HELLO_BUNDLE"
 }
 
 function teardown_debian() {
 	cd "$INTEGRATION_ROOT"
 	teardown_recvtty
 	teardown_running_container test_debian
-	run rm -f -r "$DEBIAN_BUNDLE"
+	rm -f -r "$DEBIAN_BUNDLE"
 }

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -48,17 +48,13 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	run cat pid.txt
-	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	[[ "$(cat pid.txt)" == $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc run detached --pid-file with new CWD" {
 	# create pid_file directory as the CWD
-	run mkdir pid_file
-	[ "$status" -eq 0 ]
-	run cd pid_file
-	[ "$status" -eq 0 ]
+	mkdir pid_file
+	cd pid_file
 
 	# run busybox detached
 	runc run --pid-file pid.txt -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
@@ -70,7 +66,5 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	run cat pid.txt
-	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == $(__runc state test_busybox | jq '.pid') ]]
+	[[ "$(cat pid.txt)" == $(__runc state test_busybox | jq '.pid') ]]
 }

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -58,7 +58,5 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	run cat pid.txt
-	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ [0-9]+ ]]
+	[[ "$(cat pid.txt)" =~ [0-9]+ ]]
 }


### PR DESCRIPTION
### 1. rm excessive `run` use

Bats' run should only be used when we want to check both the command
output and its non-zero exit status.

Otherwise, we can rely on implicit exit code check (as the tests are
run with set -e), or use if, etc.

### 2. fix "runc exec --preserve-fds" test case

1. Fix the check, mostly by changing `cat hello` to `echo hello`,
   and checking for `"hello"` (whole string) rather than `*"hello"*` (substring).

   Previously, `cat hello` generated `cat: hello: no such file or directory`
   error message, which `run` added to `$output` and
   so the check for $output containing `hello` worked!

2. Simplify the test by not using the subshell and the `run`.
   The only catch is, fd 3 is used by bats itself, so we have to use
   fd 4 and thus --preserve-fds 2.

### 3. simplify `teardown_running_container`

In its current form, it is complicated, unreliable, and error prone (TOCTOU etc)

Using `runc delete -f` will kill and remove any container, running or not,
and it won't error if a container with a given name does not exist.