### PR TITLE
libcontainer/integration: fix unit test

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1661,7 +1661,7 @@ func TestPIDHostInitProcessWait(t *testing.T) {
 	pidns := "/proc/1/ns/pid"
 
 	// Run a container with two long-running processes.
-	config := newTemplateConfig(rootfs)
+	config := newTemplateConfig(&tParam{rootfs: rootfs})
 	config.Namespaces.Add(configs.NEWPID, pidns)
 	container, err := newContainerWithName("test", config)
 	ok(t, err)


### PR DESCRIPTION
~~73d93eeb0192 (part of https://github.com/opencontainers/runc/pull/2600) missed one update in 'TestPIDHostInitProcessWait' and now the unit tests are broken.~~

Edit: It was a merge issue between https://github.com/opencontainers/runc/pull/2633 (Introduced 'TestPIDHostInitProcessWait') & https://github.com/opencontainers/runc/pull/2600 (was opened before 'TestPIDHostInitProcessWait' was present). No idea why the CI didn't catch this problem.

I found it while having a weird linter failure not related to my changes in https://github.com/opencontainers/runc/pull/2660. 

ref https://travis-ci.org/github/opencontainers/runc/jobs/738208029#L345

cc @mrunalp  @kolyshkin 
