### PR TITLE
CI: update Fedora to 33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         - ln -sf Vagrantfile.fedora33 Vagrantfile
         - sudo vagrant up && sudo mkdir -p /root/.ssh && sudo sh -c "vagrant ssh-config >> /root/.ssh/config"
       script:
+        - sudo ssh default 'sh -exc "uname -a && systemctl --version && df -T"'
         - sudo ssh default -t 'cd /vagrant && sudo make localunittest'
         # cgroupv2+systemd: test on vagrant host itself as we need systemd
         - sudo ssh default -t 'cd /vagrant && sudo make localintegration RUNC_USE_SYSTEMD=yes'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ jobs:
       script:
         - make all
         - sudo PATH="$PATH" make localintegration RUNC_USE_SYSTEMD=1
-    - name: "fedora32"
+    - name: "fedora33"
       before_install:
         - sudo ./script/install-vagrant.sh
-        - ln -sf Vagrantfile.fedora32 Vagrantfile
+        - ln -sf Vagrantfile.fedora33 Vagrantfile
         - sudo vagrant up && sudo mkdir -p /root/.ssh && sudo sh -c "vagrant ssh-config >> /root/.ssh/config"
       script:
         - sudo ssh default -t 'cd /vagrant && sudo make localunittest'

--- a/Vagrantfile.fedora33
+++ b/Vagrantfile.fedora33
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 # Fedora box is used for testing cgroup v2 support
-  config.vm.box = "fedora/32-cloud-base"
+  config.vm.box = "fedora/33-cloud-base"
   config.vm.provider :virtualbox do |v|
     v.memory = 2048
     v.cpus = 2


### PR DESCRIPTION
release note: https://docs.fedoraproject.org/en-US/fedora/f33/release-notes/sysadmin/Distribution/

The vagrant image seems to still use ext4 as the rootfs.

```
$ sudo ssh default 'sh -exc "uname -a && systemctl --version && df -T"'
+ uname -a
Linux localhost.localdomain 5.8.15-301.fc33.x86_64 #1 SMP Thu Oct 15 16:58:06 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+ systemctl --version
systemd 246 (v246.6-3.fc33)
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +ZSTD +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=unified
+ df -T
Filesystem     Type     1K-blocks    Used Available Use% Mounted on
devtmpfs       devtmpfs    995536       0    995536   0% /dev
tmpfs          tmpfs      1013572       0   1013572   0% /dev/shm
tmpfs          tmpfs       405432     540    404892   1% /run
/dev/vda1      ext4      41021664 1955980  36952200   6% /
tmpfs          tmpfs      1013572       4   1013568   1% /tmp
tmpfs          tmpfs       202712       0    202712   0% /run/user/1000
```