### PR TITLE
shfmt mounts.bats to pass `make validate`

### DIFF
--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -22,8 +22,8 @@ function teardown() {
 }
 
 @test "runc run [ro tmpfs mount]" {
-	update_config 	' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}] 
-			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]' 
+	update_config ' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}] 
+			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
 	runc run test_ro_tmpfs_mount
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
CI on the master has been broken due to this.

https://travis-ci.org/github/opencontainers/runc/builds/739817745

Not sure why we couldn't catch this before merging it.
