### PR TITLE
tests: fix shfmt

### DIFF
--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -22,8 +22,8 @@ function teardown() {
 }
 
 @test "runc run [ro tmpfs mount]" {
-	update_config 	' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}] 
-			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]' 
+	update_config ' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}]
+			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
 	runc run test_ro_tmpfs_mount
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Fix format to avoid "make validate" failing. Ref https://github.com/opencontainers/runc/pull/2570.

It's not my intention to make a lot of noise with this lint related fixes but we're trying to make travis pass on a PR we're preparing and we prefer to summit these changes separately. 

cc @alban 