### PR TITLE
ci: pin shfmt to v3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
   - sudo apt-get install -y libseccomp-dev
   - GO111MODULE=off go get -u golang.org/x/lint/golint
   - GO111MODULE=off go get -u github.com/vbatts/git-validation
-  - GO111MODULE=off go get github.com/mvdan/sh/cmd/shfmt
+  - (cd ~ && GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt@v3.2.0)
   - env | grep TRAVIS_
 
 script:


### PR DESCRIPTION
We had to use shfmt from git master/HEAD in commit 069fddfa1 as at the
time there was no released/tagged version that supports bats syntax.

Now there is (https://github.com/mvdan/sh/releases/tag/v3.2.0),
so let's pin it to avoid sudden regressions caused by changes in master
branch.