### PR TITLE
Move cgroup v2 out of experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ This means that `runc` 1.0.0 should implement the 1.0 version of the specificati
 
 You can find official releases of `runc` on the [release](https://github.com/opencontainers/runc/releases) page.
 
-Currently, the following features are not considered to be production-ready:
-
-* [Support for cgroup v2](./docs/cgroup-v2.md)
-
 ## Security
 
 The reporting process and disclosure communications are outlined [here](https://github.com/opencontainers/org/blob/master/SECURITY.md).

--- a/docs/cgroup-v2.md
+++ b/docs/cgroup-v2.md
@@ -1,6 +1,6 @@
 # cgroup v2
 
-runc supports cgroup v2 (unified mode) experimentally since v1.0.0-rc91.
+runc fully supports cgroup v2 (unified mode) since v1.0.0-rc93.
 
 To use cgroup v2, you might need to change the configuration of the host init system.
 Fedora (>= 31) uses cgroup v2 by default and no extra configuration is required.


### PR DESCRIPTION
After a lot of refactoring, our cgroup v1 and v2 drivers now have same level of implementation quality,
so we can move the v2 driver out of experimental.

Close #2663
