### PR TITLE
libcontainer/intelrdt: rename CAT and MBA enabled flags

### DIFF
--- a/events.go
+++ b/events.go
@@ -154,12 +154,12 @@ func convertLibcontainerStats(ls *libcontainer.Stats) *types.Stats {
 	}
 
 	if is := ls.IntelRdtStats; is != nil {
-		if intelrdt.IsCatEnabled() {
+		if intelrdt.IsCATEnabled() {
 			s.IntelRdt.L3CacheInfo = convertL3CacheInfo(is.L3CacheInfo)
 			s.IntelRdt.L3CacheSchemaRoot = is.L3CacheSchemaRoot
 			s.IntelRdt.L3CacheSchema = is.L3CacheSchema
 		}
-		if intelrdt.IsMbaEnabled() {
+		if intelrdt.IsMBAEnabled() {
 			s.IntelRdt.MemBwInfo = convertMemBwInfo(is.MemBwInfo)
 			s.IntelRdt.MemBwSchemaRoot = is.MemBwSchemaRoot
 			s.IntelRdt.MemBwSchema = is.MemBwSchema

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -182,21 +182,21 @@ func (v *ConfigValidator) sysctl(config *configs.Config) error {
 
 func (v *ConfigValidator) intelrdt(config *configs.Config) error {
 	if config.IntelRdt != nil {
-		if !intelrdt.IsCatEnabled() && !intelrdt.IsMbaEnabled() {
+		if !intelrdt.IsCATEnabled() && !intelrdt.IsMBAEnabled() {
 			return errors.New("intelRdt is specified in config, but Intel RDT is not supported or enabled")
 		}
 
-		if !intelrdt.IsCatEnabled() && config.IntelRdt.L3CacheSchema != "" {
+		if !intelrdt.IsCATEnabled() && config.IntelRdt.L3CacheSchema != "" {
 			return errors.New("intelRdt.l3CacheSchema is specified in config, but Intel RDT/CAT is not enabled")
 		}
-		if !intelrdt.IsMbaEnabled() && config.IntelRdt.MemBwSchema != "" {
+		if !intelrdt.IsMBAEnabled() && config.IntelRdt.MemBwSchema != "" {
 			return errors.New("intelRdt.memBwSchema is specified in config, but Intel RDT/MBA is not enabled")
 		}
 
-		if intelrdt.IsCatEnabled() && config.IntelRdt.L3CacheSchema == "" {
+		if intelrdt.IsCATEnabled() && config.IntelRdt.L3CacheSchema == "" {
 			return errors.New("Intel RDT/CAT is enabled and intelRdt is specified in config, but intelRdt.l3CacheSchema is empty")
 		}
-		if intelrdt.IsMbaEnabled() && config.IntelRdt.MemBwSchema == "" {
+		if intelrdt.IsMBAEnabled() && config.IntelRdt.MemBwSchema == "" {
 			return errors.New("Intel RDT/MBA is enabled and intelRdt is specified in config, but intelRdt.memBwSchema is empty")
 		}
 	}

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -202,7 +202,7 @@ func TestGetContainerStats(t *testing.T) {
 	if stats.CgroupStats.MemoryStats.Usage.Usage != 1024 {
 		t.Fatalf("expected memory usage 1024 but received %d", stats.CgroupStats.MemoryStats.Usage.Usage)
 	}
-	if intelrdt.IsCatEnabled() {
+	if intelrdt.IsCATEnabled() {
 		if stats.IntelRdtStats == nil {
 			t.Fatal("intel rdt stats are nil")
 		}
@@ -210,7 +210,7 @@ func TestGetContainerStats(t *testing.T) {
 			t.Fatalf("expected L3CacheSchema L3:0=f;1=f0 but received %s", stats.IntelRdtStats.L3CacheSchema)
 		}
 	}
-	if intelrdt.IsMbaEnabled() {
+	if intelrdt.IsMBAEnabled() {
 		if stats.IntelRdtStats == nil {
 			t.Fatal("intel rdt stats are nil")
 		}
@@ -283,7 +283,7 @@ func TestGetContainerState(t *testing.T) {
 	if memPath := paths["memory"]; memPath != expectedMemoryPath {
 		t.Fatalf("expected memory path %q but received %q", expectedMemoryPath, memPath)
 	}
-	if intelrdt.IsCatEnabled() || intelrdt.IsMbaEnabled() {
+	if intelrdt.IsCATEnabled() || intelrdt.IsMBAEnabled() {
 		intelRdtPath := state.IntelRdtPath
 		if intelRdtPath == "" {
 			t.Fatal("intel rdt path should not be empty")

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -272,7 +272,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		newgidmapPath: l.NewgidmapPath,
 		cgroupManager: l.NewCgroupsManager(config.Cgroups, nil),
 	}
-	if intelrdt.IsCatEnabled() || intelrdt.IsMbaEnabled() {
+	if intelrdt.IsCATEnabled() || intelrdt.IsMBAEnabled() {
 		c.intelRdtManager = l.NewIntelRdtManager(config, id, "")
 	}
 	c.state = &stoppedState{c: c}
@@ -318,7 +318,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	if err := c.refreshState(); err != nil {
 		return nil, err
 	}
-	if intelrdt.IsCatEnabled() || intelrdt.IsMbaEnabled() {
+	if intelrdt.IsCATEnabled() || intelrdt.IsMBAEnabled() {
 		c.intelRdtManager = l.NewIntelRdtManager(&state.Config, id, state.IntelRdtPath)
 	}
 	return c, nil

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -190,11 +190,11 @@ var (
 	intelRdtRootLock sync.Mutex
 
 	// The flag to indicate if Intel RDT/CAT is enabled
-	isCatEnabled bool
+	catEnabled bool
 	// The flag to indicate if Intel RDT/MBA is enabled
-	isMbaEnabled bool
+	mbaEnabled bool
 	// The flag to indicate if Intel RDT/MBA Software Controller is enabled
-	isMbaScEnabled bool
+	mbaScEnabled bool
 )
 
 type intelRdtData struct {
@@ -223,17 +223,17 @@ func init() {
 	// (e.g., rdt=!l3cat,mba) in 4.14 and newer kernel
 	if flagsSet.CAT {
 		if _, err := os.Stat(filepath.Join(intelRdtRoot, "info", "L3")); err == nil {
-			isCatEnabled = true
+			catEnabled = true
 		}
 	}
-	if isMbaScEnabled {
+	if mbaScEnabled {
 		// We confirm MBA Software Controller is enabled in step 2,
 		// MBA should be enabled because MBA Software Controller
 		// depends on MBA
-		isMbaEnabled = true
+		mbaEnabled = true
 	} else if flagsSet.MBA {
 		if _, err := os.Stat(filepath.Join(intelRdtRoot, "info", "MB")); err == nil {
-			isMbaEnabled = true
+			mbaEnabled = true
 		}
 	}
 
@@ -268,7 +268,7 @@ func findIntelRdtMountpointDir(f io.Reader) (string, error) {
 
 	// Check if MBA Software Controller is enabled through mount option "-o mba_MBps"
 	if strings.Contains(","+mi[0].VFSOptions+",", ",mba_MBps,") {
-		isMbaScEnabled = true
+		mbaScEnabled = true
 	}
 
 	return mi[0].Mountpoint, nil
@@ -516,18 +516,18 @@ func WriteIntelRdtTasks(dir string, pid int) error {
 }
 
 // Check if Intel RDT/CAT is enabled
-func IsCatEnabled() bool {
-	return isCatEnabled
+func IsCATEnabled() bool {
+	return catEnabled
 }
 
 // Check if Intel RDT/MBA is enabled
-func IsMbaEnabled() bool {
-	return isMbaEnabled
+func IsMBAEnabled() bool {
+	return mbaEnabled
 }
 
 // Check if Intel RDT/MBA Software Controller is enabled
-func IsMbaScEnabled() bool {
-	return isMbaScEnabled
+func IsMBAScEnabled() bool {
+	return mbaScEnabled
 }
 
 // Get the 'container_id' path in Intel RDT "resource control" filesystem
@@ -613,7 +613,7 @@ func (m *intelRdtManager) GetStats() (*Stats, error) {
 	}
 	schemaStrings := strings.Split(tmpStrings, "\n")
 
-	if IsCatEnabled() {
+	if IsCATEnabled() {
 		// The read-only L3 cache information
 		l3CacheInfo, err := getL3CacheInfo()
 		if err != nil {
@@ -636,7 +636,7 @@ func (m *intelRdtManager) GetStats() (*Stats, error) {
 		}
 	}
 
-	if IsMbaEnabled() {
+	if IsMBAEnabled() {
 		// The read-only memory bandwidth information
 		memBwInfo, err := getMemBwInfo()
 		if err != nil {

--- a/libcontainer/intelrdt/intelrdt_test.go
+++ b/libcontainer/intelrdt/intelrdt_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestIntelRdtSetL3CacheSchema(t *testing.T) {
-	if !IsCatEnabled() {
+	if !IsCATEnabled() {
 		return
 	}
 
@@ -44,7 +44,7 @@ func TestIntelRdtSetL3CacheSchema(t *testing.T) {
 }
 
 func TestIntelRdtSetMemBwSchema(t *testing.T) {
-	if !IsMbaEnabled() {
+	if !IsMBAEnabled() {
 		return
 	}
 
@@ -79,7 +79,7 @@ func TestIntelRdtSetMemBwSchema(t *testing.T) {
 }
 
 func TestIntelRdtSetMemBwScSchema(t *testing.T) {
-	if !IsMbaScEnabled() {
+	if !IsMBAScEnabled() {
 		return
 	}
 
@@ -191,7 +191,7 @@ func TestFindIntelRdtMountpointDir(t *testing.T) {
 		input           io.Reader
 		isNotFoundError bool
 		isError         bool
-		isMbaScEnabled  bool
+		mbaScEnabled    bool
 		mountpoint      string
 	}{
 		{
@@ -200,10 +200,10 @@ func TestFindIntelRdtMountpointDir(t *testing.T) {
 			mountpoint: "/sys/fs/resctrl",
 		},
 		{
-			name:           "Valid mountinfo with MBA Software Controller enabled",
-			input:          strings.NewReader(mountinfoMbaSc),
-			isMbaScEnabled: true,
-			mountpoint:     "/sys/fs/resctrl",
+			name:         "Valid mountinfo with MBA Software Controller enabled",
+			input:        strings.NewReader(mountinfoMbaSc),
+			mbaScEnabled: true,
+			mountpoint:   "/sys/fs/resctrl",
 		},
 		{
 			name:            "Empty mountinfo",
@@ -239,9 +239,9 @@ func TestFindIntelRdtMountpointDir(t *testing.T) {
 				return
 			}
 			// no errors, check the results
-			if tc.isMbaScEnabled != isMbaScEnabled {
-				t.Errorf("expected isMbaScEnabled=%v, got %v",
-					tc.isMbaScEnabled, isMbaScEnabled)
+			if tc.mbaScEnabled != mbaScEnabled {
+				t.Errorf("expected mbaScEnabled=%v, got %v",
+					tc.mbaScEnabled, mbaScEnabled)
 			}
 			if tc.mountpoint != mp {
 				t.Errorf("expected mountpoint=%q, got %q",

--- a/update.go
+++ b/update.go
@@ -299,11 +299,11 @@ other options are ignored.
 		// Update Intel RDT
 		l3CacheSchema := context.String("l3-cache-schema")
 		memBwSchema := context.String("mem-bw-schema")
-		if l3CacheSchema != "" && !intelrdt.IsCatEnabled() {
+		if l3CacheSchema != "" && !intelrdt.IsCATEnabled() {
 			return errors.New("Intel RDT/CAT: l3 cache schema is not enabled")
 		}
 
-		if memBwSchema != "" && !intelrdt.IsMbaEnabled() {
+		if memBwSchema != "" && !intelrdt.IsMBAEnabled() {
 			return errors.New("Intel RDT/MBA: memory bandwidth schema is not enabled")
 		}
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -57,7 +57,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	}
 
 	intelRdtManager := libcontainer.IntelRdtFs
-	if !intelrdt.IsCatEnabled() && !intelrdt.IsMbaEnabled() {
+	if !intelrdt.IsCATEnabled() && !intelrdt.IsMBAEnabled() {
 		intelRdtManager = nil
 	}
 


### PR DESCRIPTION
Rename CAT and MBA enabled flags to be consistent with others.
No functional change.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>