### PR TITLE
libcontainer/intelrdt: rm init() from intelrdt.go

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -148,8 +148,12 @@ func RootlessCgroupfs(l *LinuxFactory) error {
 // containers that use the Intel RDT "resource control" filesystem to
 // create and manage Intel RDT resources (e.g., L3 cache, memory bandwidth).
 func IntelRdtFs(l *LinuxFactory) error {
-	l.NewIntelRdtManager = func(config *configs.Config, id string, path string) intelrdt.Manager {
-		return intelrdt.NewManager(config, id, path)
+	if !intelrdt.IsCATEnabled() && !intelrdt.IsMBAEnabled() {
+		l.NewIntelRdtManager = nil
+	} else {
+		l.NewIntelRdtManager = func(config *configs.Config, id string, path string) intelrdt.Manager {
+			return intelrdt.NewManager(config, id, path)
+		}
 	}
 	return nil
 }
@@ -272,7 +276,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		newgidmapPath: l.NewgidmapPath,
 		cgroupManager: l.NewCgroupsManager(config.Cgroups, nil),
 	}
-	if intelrdt.IsCATEnabled() || intelrdt.IsMBAEnabled() {
+	if l.NewIntelRdtManager != nil {
 		c.intelRdtManager = l.NewIntelRdtManager(config, id, "")
 	}
 	c.state = &stoppedState{c: c}
@@ -314,12 +318,12 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		root:                 containerRoot,
 		created:              state.Created,
 	}
+	if l.NewIntelRdtManager != nil {
+		c.intelRdtManager = l.NewIntelRdtManager(&state.Config, id, state.IntelRdtPath)
+	}
 	c.state = &loadedState{c: c}
 	if err := c.refreshState(); err != nil {
 		return nil, err
-	}
-	if intelrdt.IsCATEnabled() || intelrdt.IsMBAEnabled() {
-		c.intelRdtManager = l.NewIntelRdtManager(&state.Config, id, state.IntelRdtPath)
 	}
 	return c, nil
 }

--- a/libcontainer/intelrdt/cmt.go
+++ b/libcontainer/intelrdt/cmt.go
@@ -6,6 +6,7 @@ var (
 
 // Check if Intel RDT/CMT is enabled.
 func IsCMTEnabled() bool {
+	featuresInit()
 	return cmtEnabled
 }
 

--- a/libcontainer/intelrdt/mbm.go
+++ b/libcontainer/intelrdt/mbm.go
@@ -9,6 +9,7 @@ var (
 
 // Check if Intel RDT/MBM is enabled.
 func IsMBMEnabled() bool {
+	featuresInit()
 	return mbmEnabled
 }
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -13,7 +13,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	"github.com/opencontainers/runc/libcontainer/specconv"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -57,9 +56,6 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	}
 
 	intelRdtManager := libcontainer.IntelRdtFs
-	if !intelrdt.IsCATEnabled() && !intelrdt.IsMBAEnabled() {
-		intelRdtManager = nil
-	}
 
 	// We resolve the paths for {newuidmap,newgidmap} from the context of runc,
 	// to avoid doing a path lookup in the nsexec context. TODO: The binary


### PR DESCRIPTION
Use sync.Once to init Intel RDT when needed for a small speedup to
operations which do not require Intel RDT.

Simplify IntelRdtManager initialization in LinuxFactory.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>