### PR TITLE
vendor: github.com/cilium/ebpf v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/checkpoint-restore/go-criu/v4 v4.1.0
-	github.com/cilium/ebpf v0.1.0
+	github.com/cilium/ebpf v0.2.0
 	github.com/containerd/console v1.0.1
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/cyphar/filepath-securejoin v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0 h1:WW2B2uxx9KWF6bGlHqhm8Okiafwwx7Y2kcpn8lCpjgo=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
-github.com/cilium/ebpf v0.1.0 h1:x/yQklFd+2dSQXS077Yn5nHkQ1+xXPP21HpjXyPEKF0=
-github.com/cilium/ebpf v0.1.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
+github.com/cilium/ebpf v0.2.0 h1:Fv93L3KKckEcEHR3oApXVzyBTDA8WAm6VXhPE00N3f8=
+github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/coreos/go-systemd/v22 v22.1.0 h1:kq/SbG2BCKLkDKkjQf5OWwKWUKj1lgs3lFI4PxnR5lg=

--- a/vendor/github.com/cilium/ebpf/abi.go
+++ b/vendor/github.com/cilium/ebpf/abi.go
@@ -88,12 +88,6 @@ type ProgramABI struct {
 	Type ProgramType
 }
 
-func newProgramABIFromSpec(spec *ProgramSpec) *ProgramABI {
-	return &ProgramABI{
-		spec.Type,
-	}
-}
-
 func newProgramABIFromFd(fd *internal.FD) (string, *ProgramABI, error) {
 	info, err := bpfGetProgInfoByFD(fd)
 	if err != nil {

--- a/vendor/github.com/cilium/ebpf/elf_reader.go
+++ b/vendor/github.com/cilium/ebpf/elf_reader.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"bufio"
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
@@ -236,7 +237,7 @@ func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, 
 
 func (ec *elfCode) loadInstructions(section *elf.Section, symbols, relocations map[uint64]elf.Symbol) (asm.Instructions, uint64, error) {
 	var (
-		r      = section.Open()
+		r      = bufio.NewReader(section.Open())
 		insns  asm.Instructions
 		offset uint64
 	)
@@ -389,7 +390,7 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 		}
 
 		var (
-			r    = sec.Open()
+			r    = bufio.NewReader(sec.Open())
 			size = sec.Size / uint64(len(syms))
 		)
 		for i, offset := 0, uint64(0); i < len(syms); i, offset = i+1, offset+size {
@@ -638,6 +639,7 @@ func getProgType(sectionName string) (ProgramType, AttachType, string) {
 		"flow_dissector":        {FlowDissector, AttachFlowDissector},
 		"iter/":                 {Tracing, AttachTraceIter},
 		"sk_lookup/":            {SkLookup, AttachSkLookup},
+		"lsm/":                  {LSM, AttachLSMMac},
 
 		"cgroup_skb/ingress": {CGroupSKB, AttachCGroupInetIngress},
 		"cgroup_skb/egress":  {CGroupSKB, AttachCGroupInetEgress},
@@ -686,7 +688,7 @@ func (ec *elfCode) loadRelocations(sections map[elf.SectionIndex]*elf.Section) (
 			return nil, nil, fmt.Errorf("section %s: relocations are less than 16 bytes", sec.Name)
 		}
 
-		r := sec.Open()
+		r := bufio.NewReader(sec.Open())
 		for off := uint64(0); off < sec.Size; off += sec.Entsize {
 			ent := io.LimitReader(r, int64(sec.Entsize))
 

--- a/vendor/github.com/cilium/ebpf/internal/btf/ext_info.go
+++ b/vendor/github.com/cilium/ebpf/internal/btf/ext_info.go
@@ -1,6 +1,7 @@
 package btf
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"errors"
@@ -58,7 +59,8 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 		return nil, nil, fmt.Errorf("can't seek to function info section: %v", err)
 	}
 
-	funcInfo, err = parseExtInfo(io.LimitReader(r, int64(header.FuncInfoLen)), bo, strings)
+	buf := bufio.NewReader(io.LimitReader(r, int64(header.FuncInfoLen)))
+	funcInfo, err = parseExtInfo(buf, bo, strings)
 	if err != nil {
 		return nil, nil, fmt.Errorf("function info: %w", err)
 	}
@@ -67,7 +69,8 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 		return nil, nil, fmt.Errorf("can't seek to line info section: %v", err)
 	}
 
-	lineInfo, err = parseExtInfo(io.LimitReader(r, int64(header.LineInfoLen)), bo, strings)
+	buf = bufio.NewReader(io.LimitReader(r, int64(header.LineInfoLen)))
+	lineInfo, err = parseExtInfo(buf, bo, strings)
 	if err != nil {
 		return nil, nil, fmt.Errorf("line info: %w", err)
 	}
@@ -127,6 +130,8 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 }
 
 func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[string]extInfo, error) {
+	const maxRecordSize = 256
+
 	var recordSize uint32
 	if err := binary.Read(r, bo, &recordSize); err != nil {
 		return nil, fmt.Errorf("can't read record size: %v", err)
@@ -135,6 +140,9 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 	if recordSize < 4 {
 		// Need at least insnOff
 		return nil, errors.New("record size too short")
+	}
+	if recordSize > maxRecordSize {
+		return nil, fmt.Errorf("record size %v exceeds %v", recordSize, maxRecordSize)
 	}
 
 	result := make(map[string]extInfo)

--- a/vendor/github.com/cilium/ebpf/internal/btf/fuzz.go
+++ b/vendor/github.com/cilium/ebpf/internal/btf/fuzz.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+// Use with https://github.com/dvyukov/go-fuzz
+
+package btf
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cilium/ebpf/internal"
+)
+
+func FuzzSpec(data []byte) int {
+	if len(data) < binary.Size(btfHeader{}) {
+		return -1
+	}
+
+	spec, err := loadNakedSpec(bytes.NewReader(data), internal.NativeEndian, nil, nil)
+	if err != nil {
+		if spec != nil {
+			panic("spec is not nil")
+		}
+		return 0
+	}
+	if spec == nil {
+		panic("spec is nil")
+	}
+	return 1
+}
+
+func FuzzExtInfo(data []byte) int {
+	if len(data) < binary.Size(btfExtHeader{}) {
+		return -1
+	}
+
+	table := stringTable("\x00foo\x00barfoo\x00")
+	info, err := parseExtInfo(bytes.NewReader(data), internal.NativeEndian, table)
+	if err != nil {
+		if info != nil {
+			panic("info is not nil")
+		}
+		return 0
+	}
+	if info == nil {
+		panic("info is nil")
+	}
+	return 1
+}

--- a/vendor/github.com/cilium/ebpf/internal/feature.go
+++ b/vendor/github.com/cilium/ebpf/internal/feature.go
@@ -20,6 +20,9 @@ type UnsupportedFeatureError struct {
 }
 
 func (ufe *UnsupportedFeatureError) Error() string {
+	if ufe.MinimumVersion.Unspecified() {
+		return fmt.Sprintf("%s not supported", ufe.Name)
+	}
 	return fmt.Sprintf("%s not supported (requires >= %s)", ufe.Name, ufe.MinimumVersion)
 }
 
@@ -119,4 +122,9 @@ func (v Version) Less(other Version) bool {
 		return a < other[i]
 	}
 	return false
+}
+
+// Unspecified returns true if the version is all zero.
+func (v Version) Unspecified() bool {
+	return v[0] == 0 && v[1] == 0 && v[2] == 0
 }

--- a/vendor/github.com/cilium/ebpf/internal/syscall.go
+++ b/vendor/github.com/cilium/ebpf/internal/syscall.go
@@ -137,3 +137,30 @@ func BPFObjGet(fileName string) (*FD, error) {
 	}
 	return NewFD(uint32(ptr)), nil
 }
+
+type bpfObjGetInfoByFDAttr struct {
+	fd      uint32
+	infoLen uint32
+	info    Pointer
+}
+
+// BPFObjGetInfoByFD wraps BPF_OBJ_GET_INFO_BY_FD.
+//
+// Available from 4.13.
+func BPFObjGetInfoByFD(fd *FD, info unsafe.Pointer, size uintptr) error {
+	value, err := fd.Value()
+	if err != nil {
+		return err
+	}
+
+	attr := bpfObjGetInfoByFDAttr{
+		fd:      value,
+		infoLen: uint32(size),
+		info:    NewPointer(info),
+	}
+	_, err = BPF(BPF_OBJ_GET_INFO_BY_FD, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
+	if err != nil {
+		return fmt.Errorf("fd %v: %w", fd, err)
+	}
+	return nil
+}

--- a/vendor/github.com/cilium/ebpf/map.go
+++ b/vendor/github.com/cilium/ebpf/map.go
@@ -664,7 +664,7 @@ func (m *Map) Clone() (*Map, error) {
 
 // Pin persists the map past the lifetime of the process that created it.
 //
-// This requires bpffs to be mounted above fileName. See http://cilium.readthedocs.io/en/doc-1.0/kubernetes/install/#mounting-the-bpf-fs-optional
+// This requires bpffs to be mounted above fileName. See https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs
 func (m *Map) Pin(fileName string) error {
 	return internal.BPFObjPin(fileName, m.fd)
 }

--- a/vendor/github.com/cilium/ebpf/readme.md
+++ b/vendor/github.com/cilium/ebpf/readme.md
@@ -23,6 +23,7 @@ right now**. Expect to update your code if you want to follow along.
 
 ## Useful resources
 
-* [Cilium eBPF documentation](https://cilium.readthedocs.io/en/latest/bpf/#bpf-guide) (recommended)
+* [eBPF.io](https://ebpf.io) (recommended)
+* [Cilium eBPF documentation](https://docs.cilium.io/en/latest/bpf/#bpf-guide) (recommended)
 * [Linux documentation on BPF](http://elixir.free-electrons.com/linux/latest/source/Documentation/networking/filter.txt)
 * [eBPF features by Linux version](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md)

--- a/vendor/github.com/cilium/ebpf/run-tests.sh
+++ b/vendor/github.com/cilium/ebpf/run-tests.sh
@@ -12,7 +12,8 @@ if [[ "${1:-}" = "--in-vm" ]]; then
   export CGO_ENABLED=0
   export GOFLAGS=-mod=readonly
   export GOPATH=/run/go-path
-  export GOPROXY=file:///run/go-root/pkg/mod/cache/download
+  export GOPROXY=file:///run/go-path/pkg/mod/cache/download
+  export GOSUMDB=off
   export GOCACHE=/run/go-cache
 
   elfs=""
@@ -22,8 +23,8 @@ if [[ "${1:-}" = "--in-vm" ]]; then
 
   echo Running tests...
   # TestLibBPFCompat runs separately to pass the "-elfs" flag only for it: https://github.com/cilium/ebpf/pull/119
-  go test -v -run TestLibBPFCompat -elfs "$elfs"
-  go test -v ./...
+  go test -v -count 1 -run TestLibBPFCompat -elfs "$elfs"
+  go test -v -count 1 ./...
   touch "$1/success"
   exit 0
 fi

--- a/vendor/github.com/cilium/ebpf/syscalls.go
+++ b/vendor/github.com/cilium/ebpf/syscalls.go
@@ -129,12 +129,6 @@ type bpfProgTestRunAttr struct {
 	duration    uint32
 }
 
-type bpfObjGetInfoByFDAttr struct {
-	fd      uint32
-	infoLen uint32
-	info    internal.Pointer // May be either bpfMapInfo or bpfProgInfo
-}
-
 type bpfGetFDByIDAttr struct {
 	id   uint32
 	next uint32
@@ -353,28 +347,9 @@ func bpfMapFreeze(m *internal.FD) error {
 	return err
 }
 
-func bpfGetObjectInfoByFD(fd *internal.FD, info unsafe.Pointer, size uintptr) error {
-	value, err := fd.Value()
-	if err != nil {
-		return err
-	}
-
-	// available from 4.13
-	attr := bpfObjGetInfoByFDAttr{
-		fd:      value,
-		infoLen: uint32(size),
-		info:    internal.NewPointer(info),
-	}
-	_, err = internal.BPF(internal.BPF_OBJ_GET_INFO_BY_FD, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
-	if err != nil {
-		return fmt.Errorf("fd %v: %w", fd, err)
-	}
-	return nil
-}
-
 func bpfGetProgInfoByFD(fd *internal.FD) (*bpfProgInfo, error) {
 	var info bpfProgInfo
-	if err := bpfGetObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info)); err != nil {
+	if err := internal.BPFObjGetInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info)); err != nil {
 		return nil, fmt.Errorf("can't get program info: %w", err)
 	}
 	return &info, nil
@@ -382,7 +357,7 @@ func bpfGetProgInfoByFD(fd *internal.FD) (*bpfProgInfo, error) {
 
 func bpfGetMapInfoByFD(fd *internal.FD) (*bpfMapInfo, error) {
 	var info bpfMapInfo
-	err := bpfGetObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info))
+	err := internal.BPFObjGetInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info))
 	if err != nil {
 		return nil, fmt.Errorf("can't get map info: %w", err)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,7 +2,7 @@
 ## explicit
 github.com/checkpoint-restore/go-criu/v4
 github.com/checkpoint-restore/go-criu/v4/rpc
-# github.com/cilium/ebpf v0.1.0
+# github.com/cilium/ebpf v0.2.0
 ## explicit
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm


### PR DESCRIPTION
full diff: https://github.com/cilium/ebpf/compare/v0.1.0...v0.2.0

- btf: add go-fuzz targets
- btf: avoid Type copy in FuncProto.walk
- btf: check err in loadSpecFromVmlinux
- btf: handle type name flavours
- CI: test on 5.9 kernel
- cmd/bpf2go: output ELF .o next to the .go file
- link: add AttachSkLookup
- Remove two unused functions
- Support LSM attach
- use buffered I/O to cut down on read syscalls
- Various doc link fixes
