### PR TITLE
libctr/init_linux: reorder chdir

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -129,12 +129,6 @@ func finalizeNamespace(config *initConfig) error {
 		return errors.Wrap(err, "close exec fds")
 	}
 
-	if config.Cwd != "" {
-		if err := unix.Chdir(config.Cwd); err != nil {
-			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
-		}
-	}
-
 	capabilities := &configs.Capabilities{}
 	if config.Capabilities != nil {
 		capabilities = config.Capabilities
@@ -155,6 +149,14 @@ func finalizeNamespace(config *initConfig) error {
 	}
 	if err := setupUser(config); err != nil {
 		return errors.Wrap(err, "setup user")
+	}
+	// Change working directory AFTER the user has been set up.
+	// Otherwise, if the cwd is also a volume that's been chowned to the container user (and not the user running runc),
+	// this command will EPERM.
+	if config.Cwd != "" {
+		if err := unix.Chdir(config.Cwd); err != nil {
+			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
+		}
 	}
 	if err := system.ClearKeepCaps(); err != nil {
 		return errors.Wrap(err, "clear keep caps")

--- a/tests/integration/cwd-priv.bats
+++ b/tests/integration/cwd-priv.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# This test must be particular with how it's run. The user that runs it must have the privileges
+# to chown a directory it creates away from itself, but not have CAP_DAC_OVERRIDE to override
+# the fact it was chowned away. However, it must also be able to clean up.
+# Thus, this test must be skipped if the UID running the test is root, or the user doesn't have sudo privileges.
+function setup() {
+	if [ "$EUID" -eq 0 ]; then
+		skip "This test must be run as a non-root user"
+	fi
+	if ! sudo -n -v; then
+		skip "This test must be run as a user with sudo privileges"
+	fi
+
+	teardown_busybox
+	setup_busybox
+
+	SOURCE=$(mktemp -d "$BATS_TMPDIR/cwd.XXXXXX")
+}
+
+function teardown() {
+	sudo -n rm -rf "$SOURCE"
+	teardown_busybox
+}
+
+# Verify a cwd owned by the container user can be chdir'd to,
+# even if runc doesn't have the privilege to do so.
+@test "runc create sets up user before chdir to cwd" {
+	USER=10000001
+	sudo -n chown $USER:$USER "$SOURCE"
+	ls -ld "$SOURCE" >&3
+	# shellcheck disable=SC2016
+	update_config ' .mounts += [{"source": "'"$SOURCE"'", "destination": "'"$SOURCE"'", "options": ["bind"]}]
+				| .process.user.uid = $USER
+				| .process.user.gid = $USER
+				| .process.cwd = "'"$SOURCE"'"
+				| .process.args |= ["ls", "'"$SOURCE"'"]'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${output}" != *"Permission denied"* ]]
+}


### PR DESCRIPTION
commit https://github.com/opencontainers/runc/commit/5e0e67d76cc99d76c8228d48f38f37034503f315 moved the chdir to be one of the
first steps of finalizing the namespace of the container.

However, this causes issues when the cwd is not accessible by the user running runc, but rather
as the container user.

Thus, setupUser has to happen before we call chdir. setupUser still happens before setting the caps,
so the user should be privileged enough to mitigate the issues fixed in https://github.com/opencontainers/runc/commit/5e0e67d76cc99d76c8228d48f38f37034503f315 (I've tested it on my machine, so I believe it does not regress)

Signed-off-by: Peter Hunt <pehunt@redhat.com>