### PR TITLE
libct/cgroup/utils: fix GetCgroupMounts(all=true)

### DIFF
--- a/libcontainer/cgroups/v1_utils.go
+++ b/libcontainer/cgroups/v1_utils.go
@@ -173,7 +173,7 @@ func getCgroupMountsHelper(ss map[string]bool, mi io.Reader, all bool) ([]Mount,
 	res := make([]Mount, 0, len(ss))
 	scanner := bufio.NewScanner(mi)
 	numFound := 0
-	for scanner.Scan() && numFound < len(ss) {
+	for scanner.Scan() && (all || numFound < len(ss)) {
 		txt := scanner.Text()
 		sepIdx := strings.Index(txt, " - ")
 		if sepIdx == -1 {


### PR DESCRIPTION
The `all` argument was introduced by commit f5579964014 (PR #1049) specifically
for use by cAdvisor (see https://github.com/google/cadvisor/pull/1476), but there were no test cases added,
so it was later accidentally broken by 5ee0648bfbe037bcf4b (#1817) which started incrementing
`numFound` unconditionally.

Fix this (by not checking `numFound` when `all` is true), and add a
simple test case to avoid future regressions.

PS It appears to be that cadvisor is the only user of `all=true` functionality.
If we could eliminate it, we would remove `all=true` entirely, but it's not clear
how to do that. I sincerely hope one day cgroup v1 is going away entirely,
including all this code.