### PR TITLE
ci: add integration / unit tests to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,82 @@
+name: ci
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.14.x, 1.15.x]
+        rootless: ["rootless", ""]
+
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: install deps
+      run: |
+        # skopeo repo
+        echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+        wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O- | sudo apt-key add -
+        # criu repo
+        sudo add-apt-repository -y ppa:criu/ppa
+        # apt-add-repository runs apt update so we don't have to
+        sudo apt -q install libseccomp-dev criu skopeo
+
+    - name: install go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: build
+      run: sudo -E PATH="$PATH" make all
+
+    - name: install umoci
+      run: |
+        mkdir ~/bin
+        echo "PATH=$HOME/bin:$PATH" >> $GITHUB_ENV
+        curl -o ~/bin/umoci -fsSL https://github.com/opencontainers/umoci/releases/download/v0.4.6/umoci.amd64
+        chmod +x ~/bin/umoci
+
+    - name: install bats
+      uses: mig4/setup-bats@v1
+      with:
+        bats-version: 1.2.1
+
+    - name: get images for libcontainer/integration unit test
+      # no rootless unit tests
+      if: matrix.rootless != 'rootless'
+      run: |
+        sudo mkdir /busybox /debian
+        . tests/integration/multi-arch.bash
+        curl -fsSL `get_busybox` | sudo tar xfJC - /busybox
+
+    - name: unit test
+      if: matrix.rootless != 'rootless'
+      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make localunittest'
+
+    - name: add rootless user
+      if: matrix.rootless == 'rootless'
+      run: |
+        sudo useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
+        # Allow root to execute `ssh rootless@localhost` in tests/rootless.sh
+        ssh-keygen -t ecdsa -N "" -f $HOME/rootless.key
+        sudo mkdir -m 0700 -p /home/rootless/.ssh
+        sudo cp $HOME/rootless.key.pub /home/rootless/.ssh/authorized_keys
+        sudo chown -R rootless.rootless /home/rootless
+
+    - name: integration test (fs driver)
+      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make local${{ matrix.rootless }}integration'
+
+    - name: integration test (systemd driver)
+      # can't use systemd driver with cgroupv1
+      if: matrix.rootless != 'rootless'
+      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'


### PR DESCRIPTION
This is Ubuntu 20.04 so alas cgroup v1 testing only.

The upside is it's pretty fast :fast_forward: we have results of unit + integration tests
for both go 1.14 and 1.15 within 5 minutes. This seems useful now when travis-ci.org
is throttling jobs :disappointed: 

rootless tests take longer time so we run them in parallel
with non-rootless ones. Also, to balance the time, we run
unit tests when rootless is not set. IOW, 'rootless' in job
name means it's only rootless integration tests, and no rootless
means it's unit tests, integration tests with fs driver, and
integration tests with systemd driver.
    
Note, `script` is used to run integration tests to provide a tty
(which by default is not available on gh actions).