### PR TITLE
tests/int/tty.bats: increase timeout

### DIFF
--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -179,8 +179,8 @@ EOF
 	# check the pid was generated
 	[ -e pid.txt ]
 
-	#wait user process to finish
-	timeout 1 tail --pid="$(head -n 1 pid.txt)" -f /dev/null
+	# wait for the process to finish
+	timeout 5 tail --pid="$(head -n 1 pid.txt)" -f /dev/null
 
 	tty_info=$(
 		cat <<EOF


### PR DESCRIPTION
Just saw the timeout being hit on CI (Fedora 33 vagrant VM on Travis)
here (https://github.com/opencontainers/runc/pull/2599#issuecomment-734999958), so let's increase it.