### PR TITLE
recttty: nits

### DIFF
--- a/contrib/cmd/recvtty/recvtty.go
+++ b/contrib/cmd/recvtty/recvtty.go
@@ -165,15 +165,7 @@ func handleNull(path string) error {
 				return
 			}
 
-			// Just do a dumb copy to /dev/null.
-			devnull, err := os.OpenFile("/dev/null", os.O_RDWR, 0)
-			if err != nil {
-				// TODO: Handle this nicely.
-				return
-			}
-
-			io.Copy(devnull, master)
-			devnull.Close()
+			io.Copy(ioutil.Discard, master)
 		}(conn)
 	}
 }


### PR DESCRIPTION
Related to #2627.

#### 1. recvtty: use ioutil.Discard
    
    Saves us a few lines of code.

#### 2. recvtty: fix waiting for both goroutines
    
    It looks like we need to wait for the both copy goroutines to finish,
    not just the one that happens to finish first.

#### 3. recvtty: fix errcheck linter warnings
    
    Fixes the following errcheck linter warnings
    
    > contrib/cmd/recvtty/recvtty.go:115:10: Error return value of `io.Copy` is not checked (errcheck)
    >               io.Copy(os.Stdout, c)
    >                      ^
    > contrib/cmd/recvtty/recvtty.go:120:11: Error return value of `io.Copy` is not checked (errcheck)
    >                       io.Copy(c, os.Stdin)
    >                              ^
    > contrib/cmd/recvtty/recvtty.go:175:11: Error return value of `io.Copy` is not checked (errcheck)
    >                       io.Copy(devnull, master)
    >                              ^