### PR TITLE
Misc linter nits

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -278,7 +278,7 @@ func RemovePaths(paths map[string]string) (err error) {
 			}
 		}
 		if len(paths) == 0 {
-			//nolint:ineffassign // done to help garbage collecting: opencontainers/runc#2506
+			//nolint:ineffassign,staticcheck // done to help garbage collecting: opencontainers/runc#2506
 			paths = make(map[string]string)
 			return nil
 		}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -763,11 +763,7 @@ func (c *linuxContainer) checkCriuVersion(minVersion int) error {
 const descriptorsFilename = "descriptors.json"
 
 func (c *linuxContainer) addCriuDumpMount(req *criurpc.CriuReq, m *configs.Mount) {
-	mountDest := m.Destination
-	if strings.HasPrefix(mountDest, c.config.Rootfs) {
-		mountDest = mountDest[len(c.config.Rootfs):]
-	}
-
+	mountDest := strings.TrimPrefix(m.Destination, c.config.Rootfs)
 	extMnt := &criurpc.ExtMountMap{
 		Key: proto.String(mountDest),
 		Val: proto.String(mountDest),
@@ -1145,11 +1141,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 }
 
 func (c *linuxContainer) addCriuRestoreMount(req *criurpc.CriuReq, m *configs.Mount) {
-	mountDest := m.Destination
-	if strings.HasPrefix(mountDest, c.config.Rootfs) {
-		mountDest = mountDest[len(c.config.Rootfs):]
-	}
-
+	mountDest := strings.TrimPrefix(m.Destination, c.config.Rootfs)
 	extMnt := &criurpc.ExtMountMap{
 		Key: proto.String(mountDest),
 		Val: proto.String(m.Source),

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -680,8 +680,7 @@ var criuFeatures *criurpc.CriuFeatures
 
 func (c *linuxContainer) checkCriuFeatures(criuOpts *CriuOpts, rpcOpts *criurpc.CriuOpts, criuFeat *criurpc.CriuFeatures) error {
 
-	var t criurpc.CriuReqType
-	t = criurpc.CriuReqType_FEATURE_CHECK
+	t := criurpc.CriuReqType_FEATURE_CHECK
 
 	// make sure the features we are looking for are really not from
 	// some previous check

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1810,10 +1810,6 @@ func (c *linuxContainer) saveState(s *State) (retErr error) {
 	return os.Rename(tmpFile.Name(), stateFilePath)
 }
 
-func (c *linuxContainer) deleteState() error {
-	return os.Remove(filepath.Join(c.root, stateFilename))
-}
-
 func (c *linuxContainer) currentStatus() (Status, error) {
 	if err := c.refreshState(); err != nil {
 		return -1, err

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -366,7 +366,7 @@ func TestProcessEmptyCaps(t *testing.T) {
 	// Wait for process
 	waitProcess(&pconfig, t)
 
-	outputStatus := string(stdout.Bytes())
+	outputStatus := stdout.String()
 
 	lines := strings.Split(outputStatus, "\n")
 
@@ -419,7 +419,7 @@ func TestProcessCaps(t *testing.T) {
 	// Wait for process
 	waitProcess(&pconfig, t)
 
-	outputStatus := string(stdout.Bytes())
+	outputStatus := stdout.String()
 
 	lines := strings.Split(outputStatus, "\n")
 
@@ -483,7 +483,7 @@ func TestAdditionalGroups(t *testing.T) {
 	// Wait for process
 	waitProcess(&pconfig, t)
 
-	outputGroups := string(stdout.Bytes())
+	outputGroups := stdout.String()
 
 	// Check that the groups output has the groups that we specified
 	if !strings.Contains(outputGroups, "audio") {
@@ -1082,7 +1082,7 @@ func TestSysctl(t *testing.T) {
 	// Wait for process
 	waitProcess(&pconfig, t)
 
-	shmmniOutput := string(bytes.TrimSpace(stdout.Bytes()))
+	shmmniOutput := strings.TrimSpace(stdout.String())
 	if shmmniOutput != "8192" {
 		t.Fatalf("kernel.shmmni property expected to be 8192, but is %s", shmmniOutput)
 	}
@@ -1210,7 +1210,7 @@ func TestOomScoreAdj(t *testing.T) {
 
 	// Wait for process
 	waitProcess(&pconfig, t)
-	outputOomScoreAdj := string(bytes.TrimSpace(stdout.Bytes()))
+	outputOomScoreAdj := strings.TrimSpace(stdout.String())
 
 	// Check that the oom_score_adj matches the value that was set as part of config.
 	if outputOomScoreAdj != strconv.Itoa(*config.OomScoreAdj) {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -444,10 +444,7 @@ func TestProcessCaps(t *testing.T) {
 		t.Fatal("Could not parse effective caps", err)
 	}
 
-	var netAdminMask uint64
-	var netAdminBit uint
-	netAdminBit = 12 // from capability.h
-	netAdminMask = 1 << netAdminBit
+	const netAdminMask = 1 << unix.CAP_NET_ADMIN
 	if effectiveCaps&netAdminMask != netAdminMask {
 		t.Fatal("CAP_NET_ADMIN is not set as expected")
 	}

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -188,7 +188,7 @@ func TestExecInAdditionalGroups(t *testing.T) {
 	stdinW.Close()
 	waitProcess(process, t)
 
-	outputGroups := string(stdout.Bytes())
+	outputGroups := stdout.String()
 
 	// Check that the groups output has the groups that we specified
 	if !strings.Contains(outputGroups, "audio") {
@@ -471,7 +471,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 	stdinW.Close()
 	waitProcess(process, t)
 
-	out := string(stdout.Bytes())
+	out := stdout.String()
 	// fd 5 is the directory handle for /proc/$$/fd
 	if out != "0 1 2 3 4 5" {
 		t.Fatalf("expected to have the file descriptors '0 1 2 3 4 5' passed to exec, got '%s'", out)

--- a/libcontainer/intelrdt/monitoring.go
+++ b/libcontainer/intelrdt/monitoring.go
@@ -2,11 +2,12 @@ package intelrdt
 
 import (
 	"bufio"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -21,10 +22,10 @@ type monFeatures struct {
 
 func getMonFeatures(intelRdtRoot string) (monFeatures, error) {
 	file, err := os.Open(filepath.Join(intelRdtRoot, "info", "L3_MON", "mon_features"))
-	defer file.Close()
 	if err != nil {
 		return monFeatures{}, err
 	}
+	defer file.Close()
 	return parseMonFeatures(file)
 }
 


### PR DESCRIPTION
This fixes some sensible linter warnings, and silence a few that do not make much sense. Please see individual commits for details.

With this other PRs (#2694, #2696, #2700), we are down to 3 warnings (plus a lot of `errcheck` ones which are to be addressed separately):

```console
$ golangci-lint run -D errcheck ./...
libcontainer/cgroups/ebpf/ebpf.go:35:12: SA1019: prog.Attach is deprecated: use link.RawAttachProgram instead.  (staticcheck)
	if err := prog.Attach(dirFD, ebpf.AttachCGroupDevice, unix.BPF_F_ALLOW_MULTI); err != nil {
	          ^
libcontainer/cgroups/ebpf/ebpf.go:39:13: SA1019: prog.Detach is deprecated: use link.RawDetachProgram instead.  (staticcheck)
		if err := prog.Detach(dirFD, ebpf.AttachCGroupDevice, unix.BPF_F_ALLOW_MULTI); err != nil {
		          ^
libcontainer/container_linux.go:32:2: SA1019: package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (staticcheck)
	"github.com/golang/protobuf/proto"
	^
```

The protobuf one needs coordinated changes in go-criu (cc @adrianreber).

The ebfp one is related to https://github.com/cilium/ebpf/pull/108/commits/5727d650c09d79ac987b3c2d4e5420e6393cd5c7 and probably https://github.com/cilium/ebpf/pull/110

Related to #2627 