### PR TITLE
checkProcMount: add /proc/slabinfo to whitelist

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -493,6 +493,7 @@ func checkProcMount(rootfs, dest, source string) error {
 		"/proc/swaps",
 		"/proc/uptime",
 		"/proc/loadavg",
+		"/proc/slabinfo",
 		"/proc/net/dev",
 	}
 	for _, valid := range validDestinations {


### PR DESCRIPTION
With lxcfs commit, slabinfo should can be mounted:
"proc_fuse: add /proc/slabinfo with slab accounting memcg"
https://github.com/lxc/lxcfs/commit/1cc68c8bfa

Signed-off-by: Feng Sun <loyou85@gmail.com>