### PR TITLE
libctl/cgroups/fscommon: close fd

### DIFF
--- a/libcontainer/cgroups/fscommon/fscommon.go
+++ b/libcontainer/cgroups/fscommon/fscommon.go
@@ -32,6 +32,7 @@ func ReadFile(dir, file string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer fd.Close()
 	var buf bytes.Buffer
 
 	_, err = buf.ReadFrom(fd)


### PR DESCRIPTION
A file descriptor should be closed after reading.

Signed-off-by: Paweł Szulik <pawel.szulik@intel.com>