### PR TITLE
libct/int/execin_tty: do help debug a flake

### DIFF
--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -346,7 +346,7 @@ func TestExecInTTY(t *testing.T) {
 		t.Fatalf("unexpected running process, output %q", out)
 	}
 	if strings.Contains(out, "\r") {
-		t.Fatalf("unexpected carriage-return in output")
+		t.Fatalf("unexpected carriage-return in output %q", out)
 	}
 }
 


### PR DESCRIPTION
Do help to debug https://github.com/opencontainers/runc/issues/2425.

Previous commit 1909051b9cf (PR #2701) modified the code in the wrong place.

