### PR TITLE
runc run: resolve tmpfs mount dest in container scope

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -340,6 +340,13 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string, enableCgroupns b
 	case "tmpfs":
 		copyUp := m.Extensions&configs.EXT_COPYUP == configs.EXT_COPYUP
 		tmpDir := ""
+		// dest might be an absolute symlink, so it needs
+		// to be resolved under rootfs.
+		dest, err := securejoin.SecureJoin(rootfs, m.Destination)
+		if err != nil {
+			return err
+		}
+		m.Destination = dest
 		stat, err := os.Stat(dest)
 		if err != nil {
 			if err := os.MkdirAll(dest, 0755); err != nil {

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -9,14 +9,13 @@ function setup() {
 
 function teardown() {
 	teardown_busybox
-	teardown_running_container test_bind_mount
 }
 
 @test "runc run [bind mount]" {
 	update_config ' .mounts += [{"source": ".", "destination": "/tmp/bind", "options": ["bind"]}]
 			| .process.args |= ["ls", "/tmp/bind/config.json"]'
 
-	runc run test_bind_mount
+	runc run test_busybox
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
 }
@@ -25,7 +24,7 @@ function teardown() {
 	update_config ' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}] 
 			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
-	runc run test_ro_tmpfs_mount
+	runc run test_busybox
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == *'ro,'* ]]
 }

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -37,3 +37,19 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == *'ro,'* ]]
 }
+
+# https://github.com/opencontainers/runc/issues/2683
+@test "runc run [tmpfs mount with absolute symlink]" {
+	# in container, /conf -> /real/conf
+	mkdir -p rootfs/real/conf
+	ln -s /real/conf rootfs/conf
+	update_config '	  .mounts += [{
+					type: "tmpfs",
+					source: "tmpfs",
+					destination: "/conf/stack",
+					options: ["ro", "nodev", "nosuid"]
+				}]
+			| .process.args |= ["true"]'
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+}

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -12,7 +12,11 @@ function teardown() {
 }
 
 @test "runc run [bind mount]" {
-	update_config ' .mounts += [{"source": ".", "destination": "/tmp/bind", "options": ["bind"]}]
+	update_config '	  .mounts += [{
+					source: ".",
+					destination: "/tmp/bind",
+					options: ["bind"]
+				}]
 			| .process.args |= ["ls", "/tmp/bind/config.json"]'
 
 	runc run test_busybox
@@ -21,7 +25,12 @@ function teardown() {
 }
 
 @test "runc run [ro tmpfs mount]" {
-	update_config ' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}] 
+	update_config '	  .mounts += [{
+					source: "tmpfs",
+					destination: "/mnt",
+					type: "tmpfs",
+					options: ["ro", "nodev", "nosuid", "mode=755"]
+				}]
 			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
 	runc run test_busybox


### PR DESCRIPTION
In case a tmpfs mount path contains absolute symlinks, runc errors out
because those symlinks are resolved in the host (rather than container)
filesystem scope.
    
The fix is similar to that for bind mounts -- resolve the destination
in container rootfs scope using securejoin, and use the resolved path.
    
A simple integration test case is added to prevent future regressions.
    
Fixes https://github.com/opencontainers/runc/issues/2683.
