### PR TITLE
libct: suppress bogus "unable to terminate" warnings

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2067,9 +2067,17 @@ func ignoreTerminateErrors(err error) error {
 	if err == nil {
 		return nil
 	}
+	// terminate() might return an error from ether Kill or Wait.
+	// The (*Cmd).Wait documentation says: "If the command fails to run
+	// or doesn't complete successfully, the error is of type *ExitError".
+	// Filter out such errors (like "exit status 1" or "signal: killed").
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return nil
+	}
+
 	s := err.Error()
-	if strings.Contains(s, "signal: killed") ||
-		strings.Contains(s, "process already finished") ||
+	if strings.Contains(s, "process already finished") ||
 		strings.Contains(s, "Wait was already called") {
 		return nil
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2075,6 +2075,9 @@ func ignoreTerminateErrors(err error) error {
 	if errors.As(err, &exitErr) {
 		return nil
 	}
+	// TODO: use errors.Is(err, os.ErrProcessDone) here and
+	// remove "process already finished" string comparison below
+	// once go 1.16 is minimally supported version.
 
 	s := err.Error()
 	if strings.Contains(s, "process already finished") ||


### PR DESCRIPTION
While working on a test case for #2715, I got the following warning:

> level=warning msg="unable to terminate initProcess" error="exit status 1"

Obviously, the warning is bogus since the initProcess is terminated.

This is happening because terminate() can return errors from either
Kill() or Wait(), and the latter returns an error if the process has
not finished successfully (i.e. exit status is not 0 or it was killed).

Check for a particular error type and filter out those errors.