### PR TITLE
libcontainer: signalAllProcesses(): log warning when failing to thaw

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -484,7 +484,9 @@ func signalAllProcesses(m cgroups.Manager, s os.Signal) error {
 	}
 	pids, err := m.GetAllPids()
 	if err != nil {
-		m.Freeze(configs.Thawed)
+		if err := m.Freeze(configs.Thawed); err != nil {
+			logrus.Warn(err)
+		}
 		return err
 	}
 	for _, pid := range pids {


### PR DESCRIPTION
I noticed this was the only place in this function where we didn't handle errors on freezing/thawing. Logging as a warning, consistent with the other cases.
