### PR TITLE
[WIP] ci/gha: move fake term to a separate script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: unit test
       if: matrix.rootless != 'rootless'
-      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make localunittest'
+      run: script/gha make localunittest
 
     - name: add rootless user
       if: matrix.rootless == 'rootless'
@@ -74,12 +74,12 @@ jobs:
         sudo chown -R rootless.rootless /home/rootless
 
     - name: integration test (fs driver)
-      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make local${{ matrix.rootless }}integration'
+      run: script/gha make local${{ matrix.rootless }}integration
 
     - name: integration test (systemd driver)
       # can't use systemd driver with cgroupv1
       if: matrix.rootless != 'rootless'
-      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'
+      run: script/gha make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration
 
 
   # cgroup v2 unified hierarchy + very recent kernel (openat2)
@@ -101,21 +101,21 @@ jobs:
         run: ssh default 'sh -exc "uname -a && systemctl --version && df -T"'
 
       - name: unit tests
-        run: ssh default 'cd /vagrant && sudo make localunittest'
+        run: ssh default '/vagrant/script/gha make localunittest'
 
       # The integration tests require tty which GH actions lack;
       # wrap those in "script" to emulate tty.
       - name: cgroupv2 with systemd
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localintegration RUNC_USE_SYSTEMD=yes'"
+        run: ssh default '/vagrant/script/gha make localintegration RUNC_USE_SYSTEMD=yes'
 
       - name: cgroupv2 with fs2
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localintegration'"
+        run: ssh default '/vagrant/script/gha make localintegration'
 
       - name: cgroupv2 with systemd (rootless)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localrootlessintegration RUNC_USE_SYSTEMD=yes'"
+        run: ssh default '/vagrant/script/gha make localrootlessintegration RUNC_USE_SYSTEMD=yes'
 
       - name: cgroupv2 with fs2 (rootless)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localrootlessintegration'"
+        run: ssh default '/vagrant/script/gha make localrootlessintegration'
 
 
   # kernel 3.10 (frankenized), systemd 219
@@ -137,15 +137,15 @@ jobs:
         run: ssh default 'rpm -q centos-release kernel systemd'
 
       - name: unit tests
-        run: ssh default 'sudo -i make -C /vagrant localunittest'
+        run: ssh default '/vagrant/script/gha make localunittest'
 
       - name: integration tests (fs cgroup driver)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo -i make -C /vagrant localintegration'"
+        run: ssh default '/vagrant/script/gha make localintegration'
 
       - name: integration tests (systemd cgroup driver)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo -i make -C /vagrant localintegration RUNC_USE_SYSTEMD=1'"
+        run: ssh default '/vagrant/script/gha make localintegration RUNC_USE_SYSTEMD=1'
 
       - name: rootless integration
       # FIXME: rootless is skipped because of EPERM on writing cgroup.procs
         if: false
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo -i make -C /vagrant localrootlessintegration'"
+        run: ssh default '/vagrant/script/gha make localrootlessintegration'

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ shellcheck:
 
 shfmt:
 	shfmt -ln bats -d -w tests/integration/*.bats
-	shfmt -ln bash -d -w man/*.sh script/*.sh tests/*.sh tests/integration/*.bash
+	shfmt -ln bash -d -w man/*.sh script/* tests/*.sh tests/integration/*.bash
 
 ci: validate test release
 

--- a/Vagrantfile.centos7
+++ b/Vagrantfile.centos7
@@ -3,6 +3,8 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.synced_folder '.', '/vagrant', type: "rsync"
   config.vm.provider :virtualbox do |v|
     v.memory = 2048
     v.cpus = 2

--- a/Vagrantfile.centos7
+++ b/Vagrantfile.centos7
@@ -39,6 +39,8 @@ Vagrant.configure("2") do |config|
     cd bats-core
     git checkout $BATS_VERSION
     ./install.sh /usr/local
+    cd ..
+    rm -rf bats-core
 
     # set PATH (NOTE: sudo without -i ignores this PATH)
     cat >> /etc/profile.d/sh.local <<EOF

--- a/Vagrantfile.centos7
+++ b/Vagrantfile.centos7
@@ -42,7 +42,7 @@ Vagrant.configure("2") do |config|
     cd ..
     rm -rf bats-core
 
-    # set PATH (NOTE: sudo without -i ignores this PATH)
+    # set PATH (NOTE: sudo ignores this unless run as 'sudo -i' or 'sudo -E PATH="$PATH"'.)
     cat >> /etc/profile.d/sh.local <<EOF
 PATH=/usr/local/go/bin:/usr/local/bin:$PATH
 export PATH

--- a/Vagrantfile.fedora33
+++ b/Vagrantfile.fedora33
@@ -4,6 +4,8 @@
 Vagrant.configure("2") do |config|
 # Fedora box is used for testing cgroup v2 support
   config.vm.box = "fedora/33-cloud-base"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.synced_folder '.', '/vagrant', type: "rsync"
   config.vm.provider :virtualbox do |v|
     v.memory = 2048
     v.cpus = 2

--- a/script/gha
+++ b/script/gha
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Github Actions test execution helper script. The purpose is to hide
+# the complexity of running the tests under GHA.
+#
+# 1. GHA execution environment lacks a terminal, and some tests require it.
+#    Fake the terminal by using script utility with some minimal setup
+#    (stty and TERM value).
+#
+# 2. Use sudo -n -E PATH="$PATH" to run tests as root with proper PATH set.
+#
+# 3. Change to the proper directory (needed for vagrant runs).
+
+set -e -u -o pipefail
+
+cd "$(readlink -f "$(dirname "$0")"/..)"
+
+test -z "$TERM" || TERM=xterm
+export TERM
+
+CMD="/bin/bash -c \"stty rows 40 cols 80 && exec sudo -n -E PATH=\"$PATH\" -- $*\""
+exec script -e -c "$CMD"

--- a/script/validate-c
+++ b/script/validate-c
@@ -18,7 +18,7 @@ for f in "${files[@]}"; do
 	orig=$(mktemp)
 	formatted=$(mktemp)
 	# we use "git show" here to validate that what's committed is formatted
-	git show "$VALIDATE_HEAD:$f" > ${orig}
+	git show "$VALIDATE_HEAD:$f" >${orig}
 	${INDENT} ${orig} -o ${formatted}
 	if [ "$(diff -u ${orig} ${formatted})" ]; then
 		badFiles+=("$f")


### PR DESCRIPTION
Add test execution helper script for github actions. The purpose is to hide
the complexity of running the tests under GHA.

1. GHA execution environment lacks a terminal, and some tests require it.
  Fake the terminal by using script utility with some minimal setup
   (stty and TERM value).

2. Use `sudo -n -E PATH="$PATH"` to run tests as root with proper PATH set.

3. Change to the proper directory (needed for vagrant runs).
