### PR TITLE
tests/int/multi-arch.bash: fix busybox URL

### DIFF
--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -2,10 +2,10 @@
 get_busybox() {
 	case $(go env GOARCH) in
 	arm64)
-		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/glibc/busybox.tar.xz'
+		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/stable/glibc/busybox.tar.xz'
 		;;
 	*)
-		echo 'https://github.com/docker-library/busybox/raw/dist-amd64/glibc/busybox.tar.xz'
+		echo 'https://github.com/docker-library/busybox/raw/dist-amd64/stable/glibc/busybox.tar.xz'
 		;;
 	esac
 }


### PR DESCRIPTION
Due to https://github.com/docker-library/busybox/pull/94 the URLs
to get busybox has *just* changed, so the current URLs give HTTP 404.

Fix the URLs accordingly to bring CI back to :heavy_check_mark: 

NOTE there can be many improvements made to this script, but
the whole point of this PR is to fix CI, and we can work on the rest
of it separately.