### PR TITLE
ci/unit tests: decrease verbosity

### DIFF
--- a/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
+++ b/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
@@ -26,7 +26,6 @@ func testDeviceFilter(t testing.TB, devices []*devices.Rule, expectedStr string)
 		t.Fatalf("%s: %v (devices: %+v)", t.Name(), err, devices)
 	}
 	s := insts.String()
-	t.Logf("%s: devices: %+v\n%s", t.Name(), devices, s)
 	if expectedStr != "" {
 		hashed := hash(s, "//")
 		expectedHashed := hash(expectedStr, "//")

--- a/libcontainer/cgroups/systemd/cpuset_test.go
+++ b/libcontainer/cgroups/systemd/cpuset_test.go
@@ -40,19 +40,16 @@ func TestRangeToBits(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Logf("case: %q", tc.in)
 		out, err := rangeToBits(tc.in)
 		if err != nil {
-			t.Logf("   got error: %s", err)
 			if !tc.isErr {
-				t.Error("   ^^^ unexpected error")
+				t.Errorf("case %q: unexpected error: %v", tc.in, err)
 			}
 
 			continue
 		}
-		t.Logf("   expected %v, got %v", tc.out, out)
 		if !bytes.Equal(out, tc.out) {
-			t.Error("   ^^^ unexpected result")
+			t.Errorf("case %q: expected %v, got %v", tc.in, tc.out, out)
 		}
 	}
 }

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -501,9 +501,8 @@ func TestGetHugePageSizeImpl(t *testing.T) {
 		warns.Reset()
 		output, err := getHugePageSizeFromFilenames(c.input)
 		if err != nil {
-			t.Logf("(input %v, error %v)", c.input, err)
 			if !c.isErr {
-				t.Error("unexpected error ^^^^")
+				t.Errorf("input %v, expected nil, got error: %v", c.input, err)
 			}
 			// no more checks
 			continue


### PR DESCRIPTION
Remove or comment out some `t.Logf` statements in unit tests. See individual commits for details.