### PR TITLE
gha: cache docker layers to speed up make runcimage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,6 +113,8 @@ jobs:
       # under Docker will emerge, it will be good to have a separate make
       # runcimage job and share its result (the docker image) with whoever
       # needs it.
+    - uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
     - name: build docker image
       run: make runcimage
     - name: cross


### PR DESCRIPTION
It currently takes close to 2 minutes to build docker image
(which is currently only used for cross compilation).

Let's see if caching docker layers will help.