### PR TITLE
gha: don't check commits on push

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,6 +85,8 @@ jobs:
 
   commit:
     runs-on: ubuntu-20.04
+    # Only check commits on pull requests.
+    if: github.event_name == 'pull_request'
     steps:
       - name: get pr commits
         id: 'get-pr-commits'


### PR DESCRIPTION
This check (for commit subject being short) only make sense for pull
requests, and it fails on pushes to master (i.e. on merges, see e.g.
https://github.com/opencontainers/runc/runs/1711154129?check_suite_focus=true)

Make sure it's only run for pull requests.