### PR TITLE
GHA: use ssh -tt instead of script tool (and fix CI failure reporting)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,9 @@
+# NOTE Github Actions execution environments lack a terminal, needed for
+# some integration tests. Two ways to get a terminal are used below:
+#
+# 1. script utility -- for "local" integration tests;
+# 2. ssh -tt -- for Vagrant VMs (script is buggy on CentOS 7).
+
 name: ci
 on:
   push:
@@ -61,7 +67,7 @@ jobs:
 
     - name: unit test
       if: matrix.rootless != 'rootless'
-      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make localunittest'
+      run: sudo -E PATH="$PATH" -- make localunittest
 
     - name: add rootless user
       if: matrix.rootless == 'rootless'
@@ -74,12 +80,12 @@ jobs:
         sudo chown -R rootless.rootless /home/rootless
 
     - name: integration test (fs driver)
-      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make local${{ matrix.rootless }}integration'
+      run: sudo -E PATH="$PATH" script -e -c 'make local${{ matrix.rootless }}integration'
 
     - name: integration test (systemd driver)
       # can't use systemd driver with cgroupv1
       if: matrix.rootless != 'rootless'
-      run: sudo -E PATH="$PATH" script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'
+      run: sudo -E PATH="$PATH" script -e -c 'make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'
 
 
   # cgroup v2 unified hierarchy + very recent kernel (openat2)
@@ -103,19 +109,17 @@ jobs:
       - name: unit tests
         run: ssh default 'cd /vagrant && sudo make localunittest'
 
-      # The integration tests require tty which GH actions lack;
-      # wrap those in "script" to emulate tty.
       - name: cgroupv2 with systemd
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localintegration RUNC_USE_SYSTEMD=yes'"
+        run: ssh -tt default "sudo make -C /vagrant localintegration RUNC_USE_SYSTEMD=yes"
 
       - name: cgroupv2 with fs2
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localintegration'"
+        run: ssh -tt default "sudo make -C /vagrant localintegration"
 
       - name: cgroupv2 with systemd (rootless)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localrootlessintegration RUNC_USE_SYSTEMD=yes'"
+        run: ssh -tt default "sudo make -C /vagrant localrootlessintegration RUNC_USE_SYSTEMD=yes"
 
       - name: cgroupv2 with fs2 (rootless)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo make -C /vagrant localrootlessintegration'"
+        run: ssh -tt default "sudo make -C /vagrant localrootlessintegration"
 
 
   # kernel 3.10 (frankenized), systemd 219
@@ -140,12 +144,12 @@ jobs:
         run: ssh default 'sudo -i make -C /vagrant localunittest'
 
       - name: integration tests (fs cgroup driver)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo -i make -C /vagrant localintegration'"
+        run: ssh -tt default "sudo -i make -C /vagrant localintegration"
 
       - name: integration tests (systemd cgroup driver)
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo -i make -C /vagrant localintegration RUNC_USE_SYSTEMD=1'"
+        run: ssh -tt default "sudo -i make -C /vagrant localintegration RUNC_USE_SYSTEMD=1"
 
       - name: rootless integration
       # FIXME: rootless is skipped because of EPERM on writing cgroup.procs
         if: false
-        run: ssh default "script -e -c /bin/bash -c 'stty rows 40 cols 80; TERM=xterm sudo -i make -C /vagrant localrootlessintegration'"
+        run: ssh default "sudo -i make -C /vagrant localrootlessintegration"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
   fedora:
     # nested virtualization is only available on macOS hosts
     runs-on: macos-10.15
-    timeout-minutes: 60
+    timeout-minutes: 30
     # only run it if others have passed
     needs: [test]
     steps:
@@ -126,7 +126,7 @@ jobs:
   centos7:
     # nested virtualization is only available on macOS hosts
     runs-on: macos-10.15
-    timeout-minutes: 60
+    timeout-minutes: 15
     # only run it if others have passed
     needs: [test]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ shellcheck:
 
 shfmt:
 	shfmt -ln bats -d -w tests/integration/*.bats
-	shfmt -ln bash -d -w man/*.sh script/*.sh tests/*.sh tests/integration/*.bash
+	shfmt -ln bash -d -w man/*.sh script/* tests/*.sh tests/integration/*.bash
 
 ci: validate test release
 

--- a/Vagrantfile.centos7
+++ b/Vagrantfile.centos7
@@ -37,6 +37,8 @@ Vagrant.configure("2") do |config|
     cd bats-core
     git checkout $BATS_VERSION
     ./install.sh /usr/local
+    cd ..
+    rm -rf bats-core
 
     # set PATH (NOTE: sudo without -i ignores this PATH)
     cat >> /etc/profile.d/sh.local <<EOF

--- a/script/validate-c
+++ b/script/validate-c
@@ -18,7 +18,7 @@ for f in "${files[@]}"; do
 	orig=$(mktemp)
 	formatted=$(mktemp)
 	# we use "git show" here to validate that what's committed is formatted
-	git show "$VALIDATE_HEAD:$f" > ${orig}
+	git show "$VALIDATE_HEAD:$f" >${orig}
 	${INDENT} ${orig} -o ${formatted}
 	if [ "$(diff -u ${orig} ${formatted})" ]; then
 		badFiles+=("$f")


### PR DESCRIPTION
Github Actions execution environments lack tty, which is needed for
integration tests. We have used script utility before to provide a fake
tty, but it appears to be buggy on CentOS 7.
    
Since we use ssh anyway to access Vagant VM, add -tt to forcefully
allocate a tty.
    
Apparently, neither "TERM=xterm" nor "stty size" is needed for
the tests to work, so remove those, too.

The benefits of this are:
 - simpler code;
 - more robust error reporting (I saw failed tests but zero exit code on CentOS 7, presumably an issue with script).

(this also carries some minor cleanups from #2730)