### PR TITLE
Partially revert #2723

### DIFF
--- a/contrib/cmd/recvtty/recvtty.go
+++ b/contrib/cmd/recvtty/recvtty.go
@@ -106,6 +106,9 @@ func handleSingle(path string, noStdin bool) error {
 	if err != nil {
 		return err
 	}
+	if err := console.ClearONLCR(c.Fd()); err != nil {
+		return err
+	}
 
 	// Copy from our stdio to the master fd.
 	var (

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -186,10 +186,6 @@ func setupConsole(socket *os.File, config *initConfig, mount bool) error {
 	if err != nil {
 		return err
 	}
-	err = console.ClearONLCR(pty.Fd())
-	if err != nil {
-		return err
-	}
 
 	// After we return from here, we don't need the console anymore.
 	defer pty.Close()

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -257,6 +257,7 @@ func TestExecInTTY(t *testing.T) {
 	if testing.Short() {
 		return
 	}
+	t.Skip("racy; see https://github.com/opencontainers/runc/issues/2425")
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -313,6 +313,11 @@ func TestExecInTTY(t *testing.T) {
 				done <- fmt.Errorf("ConsoleFromFile: %w", err)
 				return
 			}
+			err = console.ClearONLCR(c.Fd())
+			if err != nil {
+				done <- fmt.Errorf("ClearONLCR: %w", err)
+				return
+			}
 			// An error from io.Copy is expected once the terminal
 			// is gone, so we deliberately ignore it.
 			_, _ = io.Copy(&stdout, c)

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -285,7 +285,6 @@ func TestExecInTTY(t *testing.T) {
 	}()
 	ok(t, err)
 
-	var stdout bytes.Buffer
 	ps := &libcontainer.Process{
 		Cwd:  "/",
 		Args: []string{"ps"},
@@ -295,6 +294,8 @@ func TestExecInTTY(t *testing.T) {
 	// Repeat to increase chances to catch a race; see
 	// https://github.com/opencontainers/runc/issues/2425.
 	for i := 0; i < 300; i++ {
+		var stdout bytes.Buffer
+
 		parent, child, err := utils.NewSockPair("console")
 		if err != nil {
 			ok(t, err)

--- a/tty.go
+++ b/tty.go
@@ -112,6 +112,10 @@ func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) (Err error
 	if err != nil {
 		return err
 	}
+	err = console.ClearONLCR(cons.Fd())
+	if err != nil {
+		return err
+	}
 	epoller, err := console.NewEpoller()
 	if err != nil {
 		return err


### PR DESCRIPTION
This reverts part of https://github.com/opencontainers/runc/pull/2723, which caused a regression (#2747), and also disables the TestExecInTTY as it is racy per #2425 and I have no idea yet how to fix it.

Fixes: #2747