### PR TITLE
libct/cg/fs: getPageUsageByNUMA: rewrite/optimize, fix panic, add more tests

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -294,6 +294,9 @@ func getPageUsageByNUMA(cgroupPath string) (cgroups.PageUsageByNUMA, error) {
 
 		for _, column := range columns {
 			pagesByNode := strings.SplitN(column, numaStatKeyValueSeparator, numaStatColumnSliceLength)
+			if len(pagesByNode) != numaStatColumnSliceLength {
+				continue
+			}
 
 			if strings.HasPrefix(pagesByNode[numaStatTypeIndex], numaNodeSymbol) {
 				nodeID, err := strconv.ParseUint(pagesByNode[numaStatTypeIndex][1:], 10, 8)

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -19,7 +19,7 @@ func (s *NameGroup) Name() string {
 func (s *NameGroup) Apply(path string, d *cgroupData) error {
 	if s.Join {
 		// ignore errors if the named cgroup does not exist
-		join(path, d.pid)
+		_ = join(path, d.pid)
 	}
 	return nil
 }


### PR DESCRIPTION
This is a rewrite of getPageUsageByNUMA, fixing a number of issues.

0. Fix a panic for lines that do not contain `=` (first commit, by @Ace-Tang).

1. Be less strict to unknown contents, i.e. skip it. This makes the
       function more future-proof. Before this commit, if a line like
       "a=b" is encountered, the function returns an error, which is
       propagated all the way up to and returned by (CgroupManager).GetStats.
    
2. Be more strict to contents it recognizes, i.e. return an error.
       In case the first field in the line is recognized (e.g. "total=123",
       the rest of the line should be in format "N<id>=<value> ...".
    
3. Optimize. Before this commit, addNUMAStatsByType was called for every
       item in the line, which is excessive and might even be slow in case
       there are many NUMA nodes. It is enough to look up the field once.
       This probably helps to reduce the load on garbage collector, too.
    
4. Remove a bunch of global numaNode* and numaStat* constants. Those
       were used by only one function, and it does not make sense to have
       them defined globally. Some were moved to the function, some were
       eliminated entirely.
    
5. Improve readability and added code comments.
    
Finally, add some test cases for good and bad contents.

NOTE this PR includes #2751.

Closes: #2751
