### PR TITLE
tests/int: cleanups

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -61,15 +61,12 @@ load helpers
 
 # setup is called at the beginning of every test.
 function setup() {
-  # see functions teardown_hello and setup_hello in helpers.bash, used to
-  # create a pristine environment for running your tests
-  teardown_hello
   setup_hello
 }
 
 # teardown is called at the end of every test.
 function teardown() {
-  teardown_hello
+  teardown_bundle
 }
 
 @test "this is a simple test" {

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -3,15 +3,10 @@
 load helpers
 
 function teardown() {
-	teardown_running_container test_cgroups_kmem
-	teardown_running_container test_cgroups_permissions
-	teardown_running_container test_cgroups_group
-	teardown_running_container test_cgroups_unified
-	teardown_busybox
+	teardown_bundle
 }
 
 function setup() {
-	teardown
 	setup_busybox
 }
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -19,10 +19,10 @@ function setup() {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 	requires cgroups_kmem
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path
 
 	# Set some initial known values
-	update_config '.linux.resources.memory |= {"kernel": 16777216, "kernelTCP": 11534336}' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.memory |= {"kernel": 16777216, "kernelTCP": 11534336}'
 
 	# run a detached busybox to work with
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
@@ -46,7 +46,7 @@ function setup() {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 	requires cgroups_kmem
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path
 
 	# run a detached busybox to work with
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_kmem
@@ -75,7 +75,7 @@ function setup() {
 	# systemd controls the permission, so error does not happen
 	requires no_systemd
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[ "$status" -eq 1 ]
@@ -88,7 +88,7 @@ function setup() {
 	# systemd controls the permission, so error does not happen
 	requires no_systemd
 
-	set_resources_limit "$BUSYBOX_BUNDLE"
+	set_resources_limit
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[ "$status" -eq 1 ]
@@ -98,8 +98,8 @@ function setup() {
 @test "runc create (limits + cgrouppath + permission on the cgroup dir) succeeds" {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
-	set_resources_limit "$BUSYBOX_BUNDLE"
+	set_cgroups_path
+	set_resources_limit
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[ "$status" -eq 0 ]
@@ -120,8 +120,8 @@ function setup() {
 @test "runc exec (limits + cgrouppath + permission on the cgroup dir) succeeds" {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
-	set_resources_limit "$BUSYBOX_BUNDLE"
+	set_cgroups_path
+	set_resources_limit
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[ "$status" -eq 0 ]
@@ -134,8 +134,8 @@ function setup() {
 @test "runc exec (cgroup v2 + init process in non-root cgroup) succeeds" {
 	requires root cgroups_v2
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
-	set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
+	set_cgroups_path
+	set_cgroup_mount_writable
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
 	[ "$status" -eq 0 ]
@@ -181,9 +181,9 @@ function setup() {
 @test "runc run (cgroup v1 + unified resources should fail)" {
 	requires root cgroups_v1
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
-	set_resources_limit "$BUSYBOX_BUNDLE"
-	update_config '.linux.resources.unified |= {"memory.min": "131072"}' "$BUSYBOX_BUNDLE"
+	set_cgroups_path
+	set_resources_limit
+	update_config '.linux.resources.unified |= {"memory.min": "131072"}'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	[ "$status" -ne 0 ]
@@ -193,7 +193,7 @@ function setup() {
 @test "runc run (cgroup v2 resources.unified only)" {
 	requires root cgroups_v2
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path
 	update_config ' .linux.resources.unified |= {
 				"memory.min":   "131072",
 				"memory.low":   "524288",
@@ -203,7 +203,7 @@ function setup() {
 				"pids.max": "99",
 				"cpu.max": "10000 100000",
 				"cpu.weight": "42"
-			}' "$BUSYBOX_BUNDLE"
+			}'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	[ "$status" -eq 0 ]
@@ -233,7 +233,7 @@ function setup() {
 @test "runc run (cgroup v2 resources.unified override)" {
 	requires root cgroups_v2
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path
 	# CPU shares of 3333 corresponds to CPU weight of 128.
 	update_config '   .linux.resources.memory |= {"limit": 33554432}
 			| .linux.resources.memorySwap |= {"limit": 33554432}
@@ -248,7 +248,7 @@ function setup() {
 				"pids.max": "42",
 				"cpu.max": "5000 50000",
 				"cpu.weight": "42"
-			}' "$BUSYBOX_BUNDLE"
+			}'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	[ "$status" -eq 0 ]

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -6,13 +6,11 @@ function setup() {
 	# XXX: currently criu require root containers.
 	requires criu root
 
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
-	teardown_running_container test_busybox_restore
+	teardown_bundle
 }
 
 function setup_pipes() {

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc create" {

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -61,11 +61,12 @@ function teardown() {
 }
 
 @test "runc create --pid-file with new CWD" {
+	bundle="$(pwd)"
 	# create pid_file directory as the CWD
 	mkdir pid_file
 	cd pid_file
 
-	runc create --pid-file pid.txt -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc create --pid-file pid.txt -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	testcontainer test_busybox created

--- a/tests/integration/cwd.bats
+++ b/tests/integration/cwd.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 # Test case for https://github.com/opencontainers/runc/pull/2086

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_hello
 	setup_hello
 }
 
 function teardown() {
-	teardown_hello
+	teardown_bundle
 }
 
 @test "global --debug" {

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -20,7 +20,7 @@ function teardown() {
 
 	runc kill testbusyboxdelete KILL
 	[ "$status" -eq 0 ]
-	retry 10 1 eval "__runc state testbusyboxdelete | grep -q 'stopped'"
+	wait_for_container 10 1 testbusyboxdelete stopped
 
 	runc delete testbusyboxdelete
 	[ "$status" -eq 0 ]

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -54,8 +54,8 @@ function teardown() {
 
 @test "runc delete --force in cgroupv1 with subcgroups" {
 	requires cgroups_v1 root cgroupns
-	set_cgroups_path "$BUSYBOX_BUNDLE"
-	set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
+	set_cgroups_path
+	set_cgroup_mount_writable
 	# enable cgroupns
 	update_config '.linux.namespaces += [{"type": "cgroup"}]'
 
@@ -104,8 +104,8 @@ EOF
 
 @test "runc delete --force in cgroupv2 with subcgroups" {
 	requires cgroups_v2 root
-	set_cgroups_path "$BUSYBOX_BUNDLE"
-	set_cgroup_mount_writable "$BUSYBOX_BUNDLE"
+	set_cgroups_path
+	set_cgroup_mount_writable
 
 	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -3,13 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
-	teardown_running_container testbusyboxdelete
+	teardown_bundle
 }
 
 @test "runc delete" {

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -3,13 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
-	teardown_running_container test_dev
+	teardown_bundle
 }
 
 @test "runc run [redundant default /dev/tty]" {

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -47,7 +47,7 @@ function test_events() {
 	# 2. Waits for an event that includes test_busybox then kills the
 	#    test_busybox container which causes the event logger to exit.
 	(
-		retry 10 "$retry_every" eval "grep -q 'test_busybox' events.log"
+		retry 10 "$retry_every" grep -q test_busybox events.log
 		teardown_running_container test_busybox
 	) &
 	wait # for both subshells to finish
@@ -89,10 +89,10 @@ function test_events() {
 	# and waits for an oom event
 	(__runc events test_busybox >events.log) &
 	(
-		retry 10 1 eval "grep -q 'test_busybox' events.log"
+		retry 10 1 grep -q test_busybox events.log
 		# shellcheck disable=SC2016
 		__runc exec -d test_busybox sh -c 'test=$(dd if=/dev/urandom ibs=5120k)'
-		retry 10 1 eval "grep -q 'oom' events.log"
+		retry 10 1 grep -q oom events.log
 		__runc delete -f test_busybox
 	) &
 	wait # wait for the above sub shells to finish

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "events --stats" {
@@ -48,7 +47,7 @@ function test_events() {
 	#    test_busybox container which causes the event logger to exit.
 	(
 		retry 10 "$retry_every" grep -q test_busybox events.log
-		teardown_running_container test_busybox
+		__runc delete -f test_busybox
 	) &
 	wait # for both subshells to finish
 

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -77,7 +77,7 @@ function test_events() {
 	init_cgroup_paths
 
 	# we need the container to hit OOM, so disable swap
-	update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}' "${BUSYBOX_BUNDLE}"
+	update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}'
 
 	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -41,12 +41,13 @@ function teardown() {
 }
 
 @test "runc exec --pid-file with new CWD" {
+	bundle="$(pwd)"
 	# create pid_file directory as the CWD
 	mkdir pid_file
 	cd pid_file
 
 	# run busybox detached
-	runc run -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc run -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	runc exec --pid-file pid.txt test_busybox echo Hello from exec

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc exec" {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -478,10 +478,6 @@ function teardown_running_container() {
 	__runc delete -f "$1"
 }
 
-function teardown_running_container_inroot() {
-	ROOT="$2" __runc delete -f "$1"
-}
-
 function teardown_busybox() {
 	cd "$INTEGRATION_ROOT"
 	teardown_recvtty

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# bats-core v1.2.1 defines BATS_RUN_TMPDIR
+if [ -z "$BATS_RUN_TMPDIR" ]; then
+	echo "bats >= v1.2.1 is required. Aborting." >&2
+	exit 1
+fi
+
 # Root directory of integration tests.
 INTEGRATION_ROOT=$(dirname "$(readlink -f "$BASH_SOURCE")")
 
@@ -15,9 +21,9 @@ RECVTTY="${INTEGRATION_ROOT}/../../contrib/cmd/recvtty/recvtty"
 TESTDATA="${INTEGRATION_ROOT}/testdata"
 
 # Destinations for test containers.
-BUSYBOX_BUNDLE="$BATS_TMPDIR/busyboxtest"
-HELLO_BUNDLE="$BATS_TMPDIR/hello-world"
-DEBIAN_BUNDLE="$BATS_TMPDIR/debiantest"
+BUSYBOX_BUNDLE="$BATS_RUN_TMPDIR/busyboxtest"
+HELLO_BUNDLE="$BATS_RUN_TMPDIR/hello-world"
+DEBIAN_BUNDLE="$BATS_RUN_TMPDIR/debiantest"
 
 # CRIU PATH
 CRIU="$(which criu 2>/dev/null || true)"
@@ -29,10 +35,10 @@ KERNEL_MINOR="${KERNEL_VERSION#$KERNEL_MAJOR.}"
 KERNEL_MINOR="${KERNEL_MINOR%%.*}"
 
 # Root state path.
-ROOT=$(mktemp -d "$BATS_TMPDIR/runc.XXXXXX")
+ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc.XXXXXX")
 
 # Path to console socket.
-CONSOLE_SOCKET="$BATS_TMPDIR/console.sock"
+CONSOLE_SOCKET="$BATS_RUN_TMPDIR/console.sock"
 
 # Check if we're in rootless mode.
 ROOTLESS=$(id -u)
@@ -423,17 +429,17 @@ function testcontainer() {
 
 function setup_recvtty() {
 	# We need to start recvtty in the background, so we double fork in the shell.
-	("$RECVTTY" --pid-file "$BATS_TMPDIR/recvtty.pid" --mode null "$CONSOLE_SOCKET" &) &
+	("$RECVTTY" --pid-file "$BATS_RUN_TMPDIR/recvtty.pid" --mode null "$CONSOLE_SOCKET" &) &
 }
 
 function teardown_recvtty() {
 	# When we kill recvtty, the container will also be killed.
-	if [ -f "$BATS_TMPDIR/recvtty.pid" ]; then
-		kill -9 $(cat "$BATS_TMPDIR/recvtty.pid")
+	if [ -f "$BATS_RUN_TMPDIR/recvtty.pid" ]; then
+		kill -9 $(cat "$BATS_RUN_TMPDIR/recvtty.pid")
 	fi
 
 	# Clean up the files that might be left over.
-	rm -f "$BATS_TMPDIR/recvtty.pid"
+	rm -f "$BATS_RUN_TMPDIR/recvtty.pid"
 	rm -f "$CONSOLE_SOCKET"
 }
 

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -400,25 +400,14 @@ function retry() {
 
 # retry until the given container has state
 function wait_for_container() {
-	local attempts=$1
-	local delay=$2
-	local cid=$3
-	# optionally wait for a specific status
-	local wait_for_status="${4:-}"
-	local i
-
-	for ((i = 0; i < attempts; i++)); do
-		runc state $cid
-		if [[ "$status" -eq 0 ]]; then
-			if [[ "${output}" == *"${wait_for_status}"* ]]; then
-				return 0
-			fi
-		fi
-		sleep $delay
-	done
-
-	echo "runc state failed to return state $statecheck $attempts times. Output: $output"
-	false
+	if [ $# -eq 3 ]; then
+		retry "$1" "$2" __runc state "$3"
+	elif [ $# -eq 4 ]; then
+		retry "$1" "$2" eval "__runc state $3 | grep -qw $4"
+	else
+		echo "Usage: wait_for_container ATTEMPTS DELAY ID [STATUS]" 1>&2
+		return 1
+	fi
 }
 
 function testcontainer() {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -421,29 +421,6 @@ function wait_for_container() {
 	false
 }
 
-# retry until the given container has state
-function wait_for_container_inroot() {
-	local attempts=$1
-	local delay=$2
-	local cid=$3
-	# optionally wait for a specific status
-	local wait_for_status="${4:-}"
-	local i
-
-	for ((i = 0; i < attempts; i++)); do
-		ROOT=$4 runc state $cid
-		if [[ "$status" -eq 0 ]]; then
-			if [[ "${output}" == *"${wait_for_status}"* ]]; then
-				return 0
-			fi
-		fi
-		sleep $delay
-	done
-
-	echo "runc state failed to return state $statecheck $attempts times. Output: $output"
-	false
-}
-
 function testcontainer() {
 	# test state of container
 	runc state $1

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -5,7 +5,6 @@ load helpers
 function setup() {
 	requires root no_systemd
 
-	teardown
 	setup_debian
 	# CR = CreateRuntime, CC = CreataContainer
 	HOOKLIBCR=librunc-hooks-create-runtime.so
@@ -19,7 +18,7 @@ function teardown() {
 		umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &>/dev/null || true
 		rm -f $HOOKLIBCR.1.0.0 $HOOKLIBCC.1.0.0
 	fi
-	teardown_debian
+	teardown_bundle
 }
 
 @test "runc run (hooks library tests)" {

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -2,27 +2,23 @@
 
 load helpers
 
-# CR = CreateRuntime
-# CC = CreataContainer
-HOOKLIBCR=librunc-hooks-create-runtime.so
-HOOKLIBCC=librunc-hooks-create-container.so
-LIBPATH="$DEBIAN_BUNDLE/rootfs/lib/"
-
 function setup() {
-	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &>/dev/null || true
-	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &>/dev/null || true
-
 	requires root no_systemd
 
-	teardown_debian
+	teardown
 	setup_debian
+	# CR = CreateRuntime, CC = CreataContainer
+	HOOKLIBCR=librunc-hooks-create-runtime.so
+	HOOKLIBCC=librunc-hooks-create-container.so
+	LIBPATH="$(pwd)/rootfs/lib/"
 }
 
 function teardown() {
-	umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &>/dev/null || true
-	umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &>/dev/null || true
-
-	rm -f $HOOKLIBCR.1.0.0 $HOOKLIBCC.1.0.0
+	if [ -n "$LIBPATH" ]; then
+		umount "$LIBPATH"/$HOOKLIBCR.1.0.0 &>/dev/null || true
+		umount "$LIBPATH"/$HOOKLIBCC.1.0.0 &>/dev/null || true
+		rm -f $HOOKLIBCR.1.0.0 $HOOKLIBCC.1.0.0
+	fi
 	teardown_debian
 }
 
@@ -31,25 +27,25 @@ function teardown() {
 	gcc -shared -Wl,-soname,librunc-hooks-create-runtime.so.1 -o "$HOOKLIBCR.1.0.0"
 	gcc -shared -Wl,-soname,librunc-hooks-create-container.so.1 -o "$HOOKLIBCC.1.0.0"
 
-	current_pwd="$(pwd)"
+	bundle=$(pwd)
 
 	# To mount $HOOKLIBCR we need to do that in the container namespace
 	create_runtime_hook=$(
 		cat <<-EOF
 			pid=\$(cat - | jq -r '.pid')
 			touch "$LIBPATH/$HOOKLIBCR.1.0.0"
-			nsenter -m \$ns -t \$pid mount --bind "$current_pwd/$HOOKLIBCR.1.0.0" "$LIBPATH/$HOOKLIBCR.1.0.0"
+			nsenter -m \$ns -t \$pid mount --bind "$bundle/$HOOKLIBCR.1.0.0" "$LIBPATH/$HOOKLIBCR.1.0.0"
 		EOF
 	)
 
-	create_container_hook="touch ./lib/$HOOKLIBCC.1.0.0 && mount --bind $current_pwd/$HOOKLIBCC.1.0.0 ./lib/$HOOKLIBCC.1.0.0"
+	create_container_hook="touch ./lib/$HOOKLIBCC.1.0.0 && mount --bind $bundle/$HOOKLIBCC.1.0.0 ./lib/$HOOKLIBCC.1.0.0"
 
 	CONFIG=$(jq --arg create_runtime_hook "$create_runtime_hook" --arg create_container_hook "$create_container_hook" '
 		.hooks |= . + {"createRuntime": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_runtime_hook]}]} |
 		.hooks |= . + {"createContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_container_hook]}]} |
 		.hooks |= . + {"startContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", "ldconfig"]}]} |
 		.root.readonly |= false |
-		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' "$DEBIAN_BUNDLE"/config.json)
+		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' "$bundle"/config.json)
 	echo "${CONFIG}" >config.json
 
 	runc run test_debian

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "kill detached busybox" {

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -21,8 +21,7 @@ function teardown() {
 
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
-
-	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	wait_for_container 10 1 test_busybox stopped
 
 	# we should ensure kill work after the container stopped
 	runc kill -a test_busybox 0

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -3,49 +3,54 @@
 load helpers
 
 function setup() {
+	unset ALT_ROOT
 	teardown
 	setup_busybox
+	ALT_ROOT=$(mktemp -d "$BATS_TMPDIR/runc-2.XXXXXX")
 }
 
 function teardown() {
-	ROOT="$HELLO_BUNDLE" teardown_running_container test_box1
-	ROOT="$HELLO_BUNDLE" teardown_running_container test_box2
-	ROOT="$HELLO_BUNDLE" teardown_running_container test_box3
+	if [ -n "$ALT_ROOT" ]; then
+		ROOT="$ALT_ROOT" teardown_running_container test_box1
+		ROOT="$ALT_ROOT" teardown_running_container test_box2
+		ROOT="$ALT_ROOT" teardown_running_container test_box3
+		rm -rf "$ALT_ROOT"
+	fi
 	teardown_busybox
 }
 
 @test "list" {
 	# run a few busyboxes detached
-	ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
+	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
 	[ "$status" -eq 0 ]
 
-	ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
+	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
 	[ "$status" -eq 0 ]
 
-	ROOT=$HELLO_BUNDLE runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
+	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
 	[ "$status" -eq 0 ]
 
-	ROOT=$HELLO_BUNDLE runc list
+	ROOT=$ALT_ROOT runc list
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
 	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 
-	ROOT=$HELLO_BUNDLE runc list -q
+	ROOT=$ALT_ROOT runc list -q
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == "test_box1" ]]
 	[[ "${lines[1]}" == "test_box2" ]]
 	[[ "${lines[2]}" == "test_box3" ]]
 
-	ROOT=$HELLO_BUNDLE runc list --format table
+	ROOT=$ALT_ROOT runc list --format table
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
 	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
 
-	ROOT=$HELLO_BUNDLE runc list --format json
+	ROOT=$ALT_ROOT runc list --format json
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -6,7 +6,7 @@ function setup() {
 	unset ALT_ROOT
 	teardown
 	setup_busybox
-	ALT_ROOT=$(mktemp -d "$BATS_TMPDIR/runc-2.XXXXXX")
+	ALT_ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc-2.XXXXXX")
 }
 
 function teardown() {

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -3,20 +3,16 @@
 load helpers
 
 function setup() {
-	unset ALT_ROOT
-	teardown
 	setup_busybox
-	ALT_ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc-2.XXXXXX")
+	ALT_ROOT="$ROOT/alt"
+	mkdir -p "$ALT_ROOT/state"
 }
 
 function teardown() {
 	if [ -n "$ALT_ROOT" ]; then
-		ROOT="$ALT_ROOT" teardown_running_container test_box1
-		ROOT="$ALT_ROOT" teardown_running_container test_box2
-		ROOT="$ALT_ROOT" teardown_running_container test_box3
-		rm -rf "$ALT_ROOT"
+		ROOT="$ALT_ROOT" teardown_bundle
 	fi
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "list" {

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -20,6 +20,7 @@ function teardown() {
 }
 
 @test "list" {
+	bundle=$(pwd)
 	# run a few busyboxes detached
 	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
 	[ "$status" -eq 0 ]
@@ -33,9 +34,9 @@ function teardown() {
 	ROOT=$ALT_ROOT runc list
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
-	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
+	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
+	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
 
 	ROOT=$ALT_ROOT runc list -q
 	[ "$status" -eq 0 ]
@@ -46,13 +47,13 @@ function teardown() {
 	ROOT=$ALT_ROOT runc list --format table
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
-	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
-	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$BUSYBOX_BUNDLE*[0-9]* ]]
+	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
+	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
+	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
 
 	ROOT=$ALT_ROOT runc list --format json
 	[ "$status" -eq 0 ]
-	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$BUSYBOX_BUNDLE*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
+	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
+	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
+	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
 }

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -3,17 +3,14 @@
 load helpers
 
 function setup() {
-	teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
-	teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
-	teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
-	teardown_busybox
+	teardown
 	setup_busybox
 }
 
 function teardown() {
-	teardown_running_container_inroot test_box1 "$HELLO_BUNDLE"
-	teardown_running_container_inroot test_box2 "$HELLO_BUNDLE"
-	teardown_running_container_inroot test_box3 "$HELLO_BUNDLE"
+	ROOT="$HELLO_BUNDLE" teardown_running_container test_box1
+	ROOT="$HELLO_BUNDLE" teardown_running_container test_box2
+	ROOT="$HELLO_BUNDLE" teardown_running_container test_box3
 	teardown_busybox
 }
 

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -3,7 +3,6 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 
 	# Create fake rootfs.
@@ -15,7 +14,7 @@ function setup() {
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "mask paths [file]" {

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc run [bind mount]" {

--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc run --no-pivot must not expose bare /proc" {

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -14,7 +14,7 @@ function teardown() {
 @test "runc pause and resume" {
 	if [[ "$ROOTLESS" -ne 0 ]]; then
 		requires rootless_cgroup
-		set_cgroups_path "$BUSYBOX_BUNDLE"
+		set_cgroups_path
 	fi
 	requires cgroups_freezer
 
@@ -42,7 +42,7 @@ function teardown() {
 @test "runc pause and resume with nonexist container" {
 	if [[ "$ROOTLESS" -ne 0 ]]; then
 		requires rootless_cgroup
-		set_cgroups_path "$BUSYBOX_BUNDLE"
+		set_cgroups_path
 	fi
 	requires cgroups_freezer
 

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc pause and resume" {

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -78,8 +78,7 @@ function teardown() {
 
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
-
-	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	wait_for_container 10 1 test_busybox stopped
 
 	runc ps test_busybox
 	[ "$status" -eq 0 ]

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -64,7 +64,7 @@ function teardown() {
 @test "ps after the container stopped" {
 	# ps requires cgroups
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path
 
 	# start busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "ps" {

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -3,13 +3,12 @@
 load helpers
 
 function setup() {
-	teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
-	teardown_busybox
+	teardown
 	setup_busybox
 }
 
 function teardown() {
-	teardown_running_container_inroot test_dotbox "$HELLO_BUNDLE"
+	ROOT="$HELLO_BUNDLE" teardown_running_container test_dotbox
 	teardown_busybox
 }
 

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -6,7 +6,7 @@ function setup() {
 	unset ALT_ROOT
 	teardown
 	setup_busybox
-	ALT_ROOT=$(mktemp -d "$BATS_TMPDIR/runc-2.XXXXXX")
+	ALT_ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc-2.XXXXXX")
 }
 
 function teardown() {

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -3,18 +3,17 @@
 load helpers
 
 function setup() {
-	unset ALT_ROOT
-	teardown
 	setup_busybox
-	ALT_ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc-2.XXXXXX")
+	ALT_ROOT="$ROOT/alt"
+	mkdir -p "$ALT_ROOT/state"
 }
 
 function teardown() {
 	if [ -n "$ALT_ROOT" ]; then
-		ROOT=$ALT_ROOT teardown_running_container test_dotbox
+		ROOT=$ALT_ROOT __runc delete -f test_dotbox
 		rm -rf "$ALT_ROOT"
 	fi
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "global --root" {

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -37,13 +37,13 @@ function teardown() {
 
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
-	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	wait_for_container 10 1 test_busybox stopped
 	runc delete test_busybox
 	[ "$status" -eq 0 ]
 
 	ROOT=$HELLO_BUNDLE runc kill test_dotbox KILL
 	[ "$status" -eq 0 ]
-	retry 10 1 eval "ROOT='$HELLO_BUNDLE' __runc state test_dotbox | grep -q 'stopped'"
+	ROOT=$HELLO_BUNDLE wait_for_container 10 1 test_dotbox stopped
 	ROOT=$HELLO_BUNDLE runc delete test_dotbox
 	[ "$status" -eq 0 ]
 }

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc run [seccomp -ENOSYS handling]" {

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -7,7 +7,7 @@ function setup() {
 }
 
 function teardown() {
-	teardown_hello
+	teardown_bundle
 }
 
 @test "spec generation cwd" {

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -16,7 +16,7 @@ function teardown() {
 }
 
 @test "spec generation --bundle" {
-	runc run --bundle "$HELLO_BUNDLE" test_hello
+	runc run --bundle "$(pwd)" test_hello
 	[ "$status" -eq 0 ]
 }
 

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc start" {

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -52,12 +52,13 @@ function teardown() {
 }
 
 @test "runc run detached --pid-file with new CWD" {
+	bundle="$(pwd)"
 	# create pid_file directory as the CWD
 	mkdir pid_file
 	cd pid_file
 
 	# run busybox detached
-	runc run --pid-file pid.txt -d -b "$BUSYBOX_BUNDLE" --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc run --pid-file pid.txt -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	# check state

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc run detached" {

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_hello
 	setup_hello
 }
 
 function teardown() {
-	teardown_hello
+	teardown_bundle
 }
 
 @test "runc run" {

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "state (kill + delete)" {

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -24,9 +24,7 @@ function teardown() {
 
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
-
-	# wait for busybox to be in the destroyed state
-	retry 10 1 eval "__runc state test_busybox | grep -q 'stopped'"
+	wait_for_container 10 1 test_busybox stopped
 
 	# delete test_busybox
 	runc delete test_busybox

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "runc run [stdin not a tty]" {

--- a/tests/integration/umask.bats
+++ b/tests/integration/umask.bats
@@ -3,12 +3,11 @@
 load helpers
 
 function setup() {
-	teardown_busybox
 	setup_busybox
 }
 
 function teardown() {
-	teardown_busybox
+	teardown_bundle
 }
 
 @test "umask" {

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -4,13 +4,10 @@ load helpers
 
 function teardown() {
 	rm -f "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json
-	teardown_running_container test_update
-	teardown_running_container test_update_rt
-	teardown_busybox
+	teardown_bundle
 }
 
 function setup() {
-	teardown
 	setup_busybox
 
 	set_cgroups_path

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -3,7 +3,7 @@
 load helpers
 
 function teardown() {
-	rm -f "$BATS_TMPDIR"/runc-cgroups-integration-test.json
+	rm -f "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json
 	teardown_running_container test_update
 	teardown_running_container test_update_rt
 	teardown_busybox
@@ -208,7 +208,7 @@ EOF
 	check_systemd_value "TasksMax" 10
 
 	# reset to initial test value via json file
-	cat <<EOF >"$BATS_TMPDIR"/runc-cgroups-integration-test.json
+	cat <<EOF >"$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json
 {
   "memory": {
     "limit": 33554432,
@@ -226,7 +226,7 @@ EOF
 }
 EOF
 
-	runc update -r "$BATS_TMPDIR"/runc-cgroups-integration-test.json test_update
+	runc update -r "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json test_update
 	[ "$status" -eq 0 ]
 	check_cgroup_value "cpuset.cpus" 0
 
@@ -297,7 +297,7 @@ EOF
 	check_cpu_quota -1 100000 "infinity"
 
 	# reset to initial test value via json file
-	cat <<EOF >"$BATS_TMPDIR"/runc-cgroups-integration-test.json
+	cat <<EOF >"$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json
 {
   "cpu": {
     "shares": 100,
@@ -308,7 +308,7 @@ EOF
 EOF
 	[ "$status" -eq 0 ]
 
-	runc update -r "$BATS_TMPDIR"/runc-cgroups-integration-test.json test_update
+	runc update -r "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json test_update
 	[ "$status" -eq 0 ]
 	check_cpu_quota 500000 1000000 "500ms"
 	check_cpu_shares 100
@@ -573,7 +573,7 @@ EOF
 	update_config '.process.args |= ["sh", "-c", "while true; do echo >/dev/null; done"]'
 
 	# Set up a temporary console socket and recvtty so we can get the stdio.
-	TMP_RECVTTY_DIR="$(mktemp -d "$BATS_TMPDIR/runc-tmp-recvtty.XXXXXX")"
+	TMP_RECVTTY_DIR="$(mktemp -d "$BATS_RUN_TMPDIR/runc-tmp-recvtty.XXXXXX")"
 	TMP_RECVTTY_PID="$TMP_RECVTTY_DIR/recvtty.pid"
 	TMP_CONSOLE_SOCKET="$TMP_RECVTTY_DIR/console.sock"
 	CONTAINER_OUTPUT="$TMP_RECVTTY_DIR/output"

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -13,12 +13,12 @@ function setup() {
 	teardown
 	setup_busybox
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
+	set_cgroups_path
 
 	# Set some initial known values
 	update_config ' .linux.resources.memory |= {"limit": 33554432, "reservation": 25165824}
 			| .linux.resources.cpu |= {"shares": 100, "quota": 500000, "period": 1000000, "cpus": "0"}
-			| .linux.resources.pids |= {"limit": 20}' "${BUSYBOX_BUNDLE}"
+			| .linux.resources.pids |= {"limit": 20}'
 }
 
 # Tests whatever limits are (more or less) common between cgroup
@@ -317,7 +317,7 @@ EOF
 @test "set cpu period with no quota" {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-	update_config '.linux.resources.cpu |= { "period": 1000000 }' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= { "period": 1000000 }'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
@@ -328,7 +328,7 @@ EOF
 @test "set cpu quota with no period" {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-	update_config '.linux.resources.cpu |= { "quota": 5000 }' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= { "quota": 5000 }'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
@@ -338,7 +338,7 @@ EOF
 @test "update cpu period with no previous period/quota set" {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-	update_config '.linux.resources.cpu |= {}' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= {}'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
@@ -352,7 +352,7 @@ EOF
 @test "update cpu quota with no previous period/quota set" {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 
-	update_config '.linux.resources.cpu |= {}' "${BUSYBOX_BUNDLE}"
+	update_config '.linux.resources.cpu |= {}'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
@@ -407,7 +407,7 @@ EOF
 	update_config ' .linux.resources.CPU |= {
 				"Cpus": "0",
 				"Mems": "0"
-			}' "${BUSYBOX_BUNDLE}"
+			}'
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
 
@@ -455,7 +455,7 @@ EOF
 	update_config ' .linux.resources.unified |= {
 				"cpuset.cpus": "0",
 				"cpuset.mems": "0"
-			}' "${BUSYBOX_BUNDLE}"
+			}'
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
 


### PR DESCRIPTION
The ultimate idea is to parallelize running the integration tests.

So far just some preliminary cleanups, mostly resulting in simpler setup/cleanup
and laying the ground for parallel tests (every test is run in its own set of dirs and cgroups).