### PR TITLE
libct/cg: demote "systemd is too old" to debug

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -410,7 +410,7 @@ func addCpuQuota(conn *systemdDbus.Conn, properties *[]systemdDbus.Property, quo
 			*properties = append(*properties,
 				newProp("CPUQuotaPeriodUSec", period))
 		} else {
-			logrus.Warnf("systemd v%d is too old to support CPUQuotaPeriodSec "+
+			logrus.Debugf("systemd v%d is too old to support CPUQuotaPeriodSec "+
 				" (setting will still be applied to cgroupfs)", sdVer)
 		}
 	}
@@ -444,7 +444,7 @@ func addCpuset(conn *systemdDbus.Conn, props *[]systemdDbus.Property, cpus, mems
 	// systemd only supports AllowedCPUs/AllowedMemoryNodes since v244
 	sdVer := systemdVersion(conn)
 	if sdVer < 244 {
-		logrus.Warnf("systemd v%d is too old to support AllowedCPUs/AllowedMemoryNodes"+
+		logrus.Debugf("systemd v%d is too old to support AllowedCPUs/AllowedMemoryNodes"+
 			" (settings will still be applied to cgroupfs)", sdVer)
 		return nil
 	}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -108,7 +108,7 @@ func unifiedResToSystemdProps(conn *systemdDbus.Conn, res map[string]string) (pr
 				props = append(props,
 					newProp(m[k], bits))
 			} else {
-				logrus.Warnf("systemd v%d is too old to support %s"+
+				logrus.Debugf("systemd v%d is too old to support %s"+
 					" (setting will still be applied to cgroupfs)",
 					sdVer, m[k])
 			}


### PR DESCRIPTION
A recent commit a35cad3b225f8d (PR #2727) added warnings about systemd being
too old. While those warnings are valid, they break some existing tests (e.g. https://github.com/cri-o/cri-o/issues/4509),
and also don't add much value to a user (IOW no one is going to upgrade
systemd because runc says it's old).

Demote those to warnings.