### PR TITLE
Fix int overflow in test on 32 bit system

### DIFF
--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -466,7 +466,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 		// we asked for a group but didn't find it. let's check to see
 		// if we wanted a numeric group
 		if !found {
-			gid, err := strconv.Atoi(ag)
+			gid, err := strconv.ParseInt(ag, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("Unable to find group %s", ag)
 			}
@@ -474,7 +474,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 			if gid < minId || gid > maxId {
 				return nil, ErrRange
 			}
-			gidMap[gid] = struct{}{}
+			gidMap[int(gid)] = struct{}{}
 		}
 	}
 	gids := []int{}

--- a/libcontainer/user/user_test.go
+++ b/libcontainer/user/user_test.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 func TestUserParseLine(t *testing.T) {
@@ -440,15 +438,12 @@ this is just some garbage data
 			expected: nil,
 			hasError: true,
 		},
-	}
-
-	if utils.GetIntSize() > 4 {
-		tests = append(tests, foo{
+		{
 			// groups with too large id
-			groups:   []string{strconv.Itoa(1 << 31)},
+			groups:   []string{strconv.FormatInt(1<<31, 10)},
 			expected: nil,
 			hasError: true,
-		})
+		},
 	}
 
 	for _, test := range tests {

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -105,8 +104,4 @@ func Annotations(labels []string) (bundle string, userAnnotations map[string]str
 		}
 	}
 	return
-}
-
-func GetIntSize() int {
-	return int(unsafe.Sizeof(1))
 }


### PR DESCRIPTION
For #941
Replaces #1821
Rewrite #1080
Closes #1821 

On master it still fails to compile the test on 32bit arch.
```
$ GOARCH=386 go test -v ./libcontainer/user/
# github.com/opencontainers/runc/libcontainer/user [github.com/opencontainers/runc/libcontainer/user.test]
libcontainer/user/user_test.go:448:38: constant 2147483648 overflows int
FAIL    github.com/opencontainers/runc/libcontainer/user [build failed]
FAIL
```