### PR TITLE
ci/gha: add i386 unit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,3 +137,33 @@ jobs:
       # FIXME: rootless is skipped because of EPERM on writing cgroup.procs
         if: false
         run: ssh default "sudo -i make -C /vagrant localrootlessintegration"
+
+  # We need to continue support for 32-bit ARM.
+  # However, we do not have 32-bit ARM CI, so we use i386 for testing 32bit stuff.
+  # We are not interested in providing official support for i386.
+  cross-i386:
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: install deps
+      run: |
+        sudo dpkg --add-architecture i386
+        # add criu repo
+        sudo add-apt-repository -y ppa:criu/ppa
+        # apt-add-repository runs apt update so we don't have to.
+
+        # Due to a bug in apt, we have to update it first
+        # (see https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268)
+        sudo apt -q install apt
+        sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib criu
+
+    - name: install go
+      uses: actions/setup-go@v2 # use default Go version
+
+    - name: unit test
+      # cgo is disabled by default when cross-compiling
+      run: sudo -E PATH="$PATH" -- make GOARCH=386 CGO_ENABLED=1 localunittest


### PR DESCRIPTION
Run unit tests on i386. This might help to uncover some issues in the code related to 32-bit arches.