### PR TITLE
ci: make static binary available for every PR

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -156,3 +156,8 @@ jobs:
         sudo apt -qq install libseccomp-dev
     - name: make release
       run: make release
+    - name: upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-${{ github.run_id }}
+        path: release/*

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -153,7 +153,7 @@ jobs:
     - name: install deps
       run: |
         sudo apt -qq update
-        sudo apt -qq install libseccomp-dev
+        sudo apt -qq install gperf
     - name: make release
       run: make release
     - name: upload artifacts

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ cfmt:
 	indent -linux -l120 -il0 -ppi2 -cp1 -T size_t -T jmp_buf $(C_SRC)
 
 shellcheck:
-	shellcheck tests/integration/*.bats tests/integration/*.sh tests/*.sh
+	shellcheck tests/integration/*.bats tests/integration/*.sh tests/*.sh script/release.sh
 	# TODO: add shellcheck for more sh files
 
 shfmt:

--- a/script/release.sh
+++ b/script/release.sh
@@ -19,7 +19,7 @@ set -e
 # Project-specific options and functions. In *theory* you shouldn't need to
 # touch anything else in this script in order to use this elsewhere.
 project="runc"
-root="$(readlink -f "$(dirname "${BASH_SOURCE}")/..")"
+root="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
 
 # This function takes an output path as an argument, where the built
 # (preferably static) binary should be placed.
@@ -80,7 +80,7 @@ while getopts "S:c:r:v:h:" opt; do
 	h)
 		hashcmd="$OPTARG"
 		;;
-	\:)
+	:)
 		echo "Missing argument: -$OPTARG" >&2
 		usage
 		;;
@@ -121,12 +121,13 @@ git archive --format=tar --prefix="$project-$version/" "$commit" | xz >"$release
 )
 
 # Set up the gpgflags.
-[[ "$keyid" ]] && export gpgflags="--default-key $keyid"
-gpg_cansign $gpgflags || bail "Could not find suitable GPG key, skipping signing step."
+gpgflags=()
+[[ "$keyid" ]] && gpgflags=(--default-key "$keyid")
+gpg_cansign "${gpgflags[@]}" || bail "Could not find suitable GPG key, skipping signing step."
 
 # Sign everything.
-gpg $gpgflags --detach-sign --armor "$releasedir/$project.$goarch"
-gpg $gpgflags --detach-sign --armor "$releasedir/$project.tar.xz"
-gpg $gpgflags --clear-sign --armor \
+gpg "${gpgflags[@]}" --detach-sign --armor "$releasedir/$project.$goarch"
+gpg "${gpgflags[@]}" --detach-sign --armor "$releasedir/$project.tar.xz"
+gpg "${gpgflags[@]}" --clear-sign --armor \
 	--output "$releasedir/$project.$hashcmd"{.tmp,} &&
 	mv "$releasedir/$project.$hashcmd"{.tmp,}


### PR DESCRIPTION
This uploads the results of `make release` step (static binary and a source tarball) so that they are available. I am not very sure if it's of any use, but at least one can download and play with a static binary from any PR.

The result is available at Checks -> validate (scroll to the bottom of the page), or from Actions -> Validate -> (any action)

Fixes: https://github.com/opencontainers/runc/issues/2728