### PR TITLE
libcontainer: the fstype argument is ignored for bind mount

### DIFF
--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -278,7 +278,7 @@ func TestValidateSysctlWithBindHostNetNS(t *testing.T) {
 	defer os.Remove(file)
 	fd.Close()
 
-	if err := unix.Mount(selfnet, file, "bind", unix.MS_BIND, ""); err != nil {
+	if err := unix.Mount(selfnet, file, "", unix.MS_BIND, ""); err != nil {
 		t.Fatalf("can't bind-mount %s to %s: %s", selfnet, file, err)
 	}
 	defer func() {

--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -18,7 +18,7 @@ func mountConsole(slavePath string) error {
 	if f != nil {
 		f.Close()
 	}
-	return unix.Mount(slavePath, "/dev/console", "bind", unix.MS_BIND, "")
+	return unix.Mount(slavePath, "/dev/console", "", unix.MS_BIND, "")
 }
 
 // dupStdio opens the slavePath for the console and dups the fds to the current

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1418,7 +1418,7 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 
 	// Make this dir a "shared" mount point. This will make sure a
 	// slave relationship can be established in container.
-	err = unix.Mount(dir1host, dir1host, "bind", unix.MS_BIND|unix.MS_REC, "")
+	err = unix.Mount(dir1host, dir1host, "", unix.MS_BIND|unix.MS_REC, "")
 	ok(t, err)
 	err = unix.Mount("", dir1host, "", unix.MS_SHARED|unix.MS_REC, "")
 	ok(t, err)
@@ -1456,7 +1456,7 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 	ok(t, err)
 	defer os.RemoveAll(dir2host)
 
-	err = unix.Mount(dir2host, dir2host, "bind", unix.MS_BIND, "")
+	err = unix.Mount(dir2host, dir2host, "", unix.MS_BIND, "")
 	defer unmountOp(dir2host)
 	ok(t, err)
 
@@ -1533,7 +1533,7 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 
 	// Make this dir a "shared" mount point. This will make sure a
 	// shared relationship can be established in container.
-	err = unix.Mount(dir1host, dir1host, "bind", unix.MS_BIND|unix.MS_REC, "")
+	err = unix.Mount(dir1host, dir1host, "", unix.MS_BIND|unix.MS_REC, "")
 	ok(t, err)
 	err = unix.Mount("", dir1host, "", unix.MS_SHARED|unix.MS_REC, "")
 	ok(t, err)

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -171,7 +171,7 @@ func prepareTmp(topTmpDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := unix.Mount(tmpdir, tmpdir, "bind", unix.MS_BIND, ""); err != nil {
+	if err := unix.Mount(tmpdir, tmpdir, "", unix.MS_BIND, ""); err != nil {
 		return "", err
 	}
 	if err := unix.Mount("", tmpdir, "", uintptr(unix.MS_PRIVATE), ""); err != nil {
@@ -631,7 +631,7 @@ func bindMountDeviceNode(dest string, node *devices.Device) error {
 	if f != nil {
 		f.Close()
 	}
-	return unix.Mount(node.Path, dest, "bind", unix.MS_BIND, "")
+	return unix.Mount(node.Path, dest, "", unix.MS_BIND, "")
 }
 
 // Creates the device node in the rootfs of the container.
@@ -746,7 +746,7 @@ func prepareRoot(config *configs.Config) error {
 		return err
 	}
 
-	return unix.Mount(config.Rootfs, config.Rootfs, "bind", unix.MS_BIND|unix.MS_REC, "")
+	return unix.Mount(config.Rootfs, config.Rootfs, "", unix.MS_BIND|unix.MS_REC, "")
 }
 
 func setReadonly() error {


### PR DESCRIPTION
`"bind"` is confusing as a `fstype` argument.
```go
    unix.Mount(node.Path, dest, "bind", unix.MS_BIND, "")
```

And the `fstype` argument is ignored for bind mount.
```go
 func Mount(source string, target string, fstype string, flags uintptr, data string) (err error) 
```