### PR TITLE
libcontainer/user: move userFromOS,groupFromOS to Windows files

### DIFF
--- a/libcontainer/user/lookup_windows.go
+++ b/libcontainer/user/lookup_windows.go
@@ -38,3 +38,42 @@ func lookupGid(gid int) (Group, error) {
 	}
 	return groupFromOS(g)
 }
+
+// userFromOS converts an os/user.(*User) to local User
+//
+// (This does not include Pass, Shell or Gecos)
+func userFromOS(u *user.User) (User, error) {
+	newUser := User{
+		Name: u.Username,
+		Home: u.HomeDir,
+	}
+	id, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return newUser, err
+	}
+	newUser.Uid = id
+
+	id, err = strconv.Atoi(u.Gid)
+	if err != nil {
+		return newUser, err
+	}
+	newUser.Gid = id
+	return newUser, nil
+}
+
+// groupFromOS converts an os/user.(*Group) to local Group
+//
+// (This does not include Pass or List)
+func groupFromOS(g *user.Group) (Group, error) {
+	newGroup := Group{
+		Name: g.Name,
+	}
+
+	id, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return newGroup, err
+	}
+	newGroup.Gid = id
+
+	return newGroup, nil
+}

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"strconv"
 	"strings"
 )
@@ -29,50 +28,11 @@ type User struct {
 	Shell string
 }
 
-// userFromOS converts an os/user.(*User) to local User
-//
-// (This does not include Pass, Shell or Gecos)
-func userFromOS(u *user.User) (User, error) {
-	newUser := User{
-		Name: u.Username,
-		Home: u.HomeDir,
-	}
-	id, err := strconv.Atoi(u.Uid)
-	if err != nil {
-		return newUser, err
-	}
-	newUser.Uid = id
-
-	id, err = strconv.Atoi(u.Gid)
-	if err != nil {
-		return newUser, err
-	}
-	newUser.Gid = id
-	return newUser, nil
-}
-
 type Group struct {
 	Name string
 	Pass string
 	Gid  int
 	List []string
-}
-
-// groupFromOS converts an os/user.(*Group) to local Group
-//
-// (This does not include Pass or List)
-func groupFromOS(g *user.Group) (Group, error) {
-	newGroup := Group{
-		Name: g.Name,
-	}
-
-	id, err := strconv.Atoi(g.Gid)
-	if err != nil {
-		return newGroup, err
-	}
-	newGroup.Gid = id
-
-	return newGroup, nil
 }
 
 // SubID represents an entry in /etc/sub{u,g}id


### PR DESCRIPTION
depends on https://github.com/opencontainers/runc/pull/2775
relates to https://github.com/opencontainers/runc/issues/2627

These are only used on Windows, causing the deadcode linter to complain:

    Error: `userFromOS` is unused (deadcode)
    Error: `groupFromOS` is unused (deadcode)
