### PR TITLE
Remove "PatchAndLoad" stub as it's not used without seccomp enabled

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_unsupported.go
+++ b/libcontainer/seccomp/patchbpf/enosys_unsupported.go
@@ -1,18 +1,3 @@
 // +build !linux !cgo !seccomp
 
 package patchbpf
-
-import (
-	"errors"
-
-	"github.com/opencontainers/runc/libcontainer/configs"
-
-	libseccomp "github.com/seccomp/libseccomp-golang"
-)
-
-func PatchAndLoad(config *configs.Seccomp, filter *libseccomp.ScmpFilter) error {
-	if config != nil {
-		return errors.New("cannot patch and load seccomp filter without runc seccomp support")
-	}
-	return nil
-}


### PR DESCRIPTION
This function is called by `InitSeccomp`, but only when compiled with seccomp (and cgo) enabled, so should not be needed for other situations.

fixes https://github.com/opencontainers/runc/issues/2778