### PR TITLE
.golangci.yml: add

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           # must be specified without patch version
-          version: v1.31
+          version: v1.36
           # Only show new issues for a pull request.
           only-new-issues: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+# For documentation, see https://golangci-lint.run/usage/configuration/
+
+run:
+  build-tags:
+    - seccomp


### PR DESCRIPTION
This is to enable seccomp build tag (some linters do use tags,
some don't).

Related to https://github.com/opencontainers/runc/issues/2778

~~NOTE i have temporary added a commit to test/report all the issues
(rather than only those brought by a PR) -- this is needed to see how
the newly added commit with a build tag works. I will remove the commit later.~~ Removed