### PR TITLE
ci/gha/fedora: retry vagrant up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,8 @@ jobs:
       - name: prepare vagrant
         run: |
           ln -sf Vagrantfile.fedora33 Vagrantfile
-          vagrant up
+          # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
+          vagrant up || vagrant up
           vagrant ssh-config >> ~/.ssh/config
 
       - name: system info


### PR DESCRIPTION
download.fedoraproject.org gives HTTP 404 at times
(I think I have seen it at least 3 times this week),
breaking the CI. Let's give it another chance.