### PR TITLE
libcontainer: fix bad conversion from syscall.Errno to error

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -584,9 +584,12 @@ func sysSeccompSetFilter(flags uint, filter []unix.SockFilter) (err error) {
 			unix.SECCOMP_MODE_FILTER,
 			uintptr(unsafe.Pointer(&fprog)), 0, 0)
 	} else {
-		_, _, err = unix.RawSyscall(unix.SYS_SECCOMP,
+		_, _, errno := unix.RawSyscall(unix.SYS_SECCOMP,
 			uintptr(C.C_SET_MODE_FILTER),
 			uintptr(flags), uintptr(unsafe.Pointer(&fprog)))
+		if errno != 0 {
+			err = errno
+		}
 	}
 	runtime.KeepAlive(filter)
 	runtime.KeepAlive(fprog)


### PR DESCRIPTION
The correct way to do that conversion according to
https://pkg.go.dev/syscall#Errno is:

```
err = nil
if errno != 0 {
	err = errno
}
```

In this case the error check will always report a false positive in
unix.RawSyscall(unix.SYS_SECCOMP, ...), probably nobody has faced this
problem because the code takes the other path in most of the cases.

I found that while rebasing https://github.com/opencontainers/runc/pull/2682. 

cc @cyphar 