### PR TITLE
Show error stack trace if --debug is given

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -55,6 +55,8 @@ func logrusToStderr() bool {
 func fatal(err error) {
 	// make sure the error is written to the logger
 	logrus.Error(err)
+	// If debug is enabled and pkg/errors was used, show its stack trace.
+	logrus.Debugf("%+v", err)
 	if !logrusToStderr() {
 		fmt.Fprintln(os.Stderr, err)
 	}


### PR DESCRIPTION
We use github.com/pkg/errors to produce an error in many places.
One of its benefits is error comes with a stack trace.

Let's print that stack trace if --debug is given.

Example:

	# ../runc --debug run -d ''
	ERRO[0000] container id cannot be empty
	DEBU[0000] container id cannot be empty
	main.init
		github.com/opencontainers/runc/utils_linux.go:28
	runtime.doInit
		runtime/proc.go:5652
	runtime.main
		runtime/proc.go:191
	runtime.goexit
		runtime/asm_amd64.s:1374