### PR TITLE
Fix data races, enable testing with -race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         go-version: [1.14.x, 1.15.x, 1.16.0-rc1]
         rootless: ["rootless", ""]
+        race: ["-race", ""]
 
     steps:
 
@@ -41,7 +42,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: build
-      run: sudo -E PATH="$PATH" make all
+      run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
 
     - name: install bats
       uses: mig4/setup-bats@v1
@@ -50,7 +51,7 @@ jobs:
 
     - name: unit test
       if: matrix.rootless != 'rootless'
-      run: sudo -E PATH="$PATH" -- make localunittest
+      run: sudo -E PATH="$PATH" -- make TESTFLAGS="${{ matrix.race }}" localunittest
 
     - name: add rootless user
       if: matrix.rootless == 'rootless'

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ ifneq ($(GO111MODULE),off)
 endif
 ifeq ($(shell $(GO) env GOOS),linux)
 	ifeq (,$(filter $(shell $(GO) env GOARCH),mips mipsle mips64 mips64le ppc64))
-		GO_BUILDMODE := "-buildmode=pie"
+		ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+			GO_BUILDMODE := "-buildmode=pie"
+		endif
 	endif
 endif
 GO_BUILD := $(GO) build -trimpath $(MOD_VENDOR) $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -387,7 +387,7 @@ func (c Command) Run(s *specs.State) error {
 		return err
 	case <-timerCh:
 		cmd.Process.Kill()
-		cmd.Wait()
+		<-errC
 		return fmt.Errorf("hook ran past specified timeout of %.1fs", c.Timeout.Seconds())
 	}
 }

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -194,10 +194,11 @@ func testCheckpoint(t *testing.T, userns bool) {
 		t.Fatal(err)
 	}
 
+	var restoreStdout bytes.Buffer
 	restoreProcessConfig := &libcontainer.Process{
 		Cwd:    "/",
 		Stdin:  restoreStdinR,
-		Stdout: &stdout,
+		Stdout: &restoreStdout,
 		Init:   true,
 	}
 
@@ -242,7 +243,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 		t.Fatal(s.String(), pid)
 	}
 
-	output := stdout.String()
+	output := restoreStdout.String()
 	if !strings.Contains(output, "Hello!") {
 		t.Fatal("Did not restore the pipe correctly:", output)
 	}


### PR DESCRIPTION
1. As reported by go test -race ./libcontainer/configs:
```
=== RUN   TestCommandHookRunTimeout
==================
WARNING: DATA RACE
Read at 0x00c000202230 by goroutine 23:
  os/exec.(*Cmd).Wait()
      /usr/lib/golang/src/os/exec/exec.go:502 +0x91
  github.com/opencontainers/runc/libcontainer/configs.Command.Run()
      /home/kir/go/src/github.com/opencontainers/runc/libcontainer/configs/config.go:390 +0x58c
  github.com/opencontainers/runc/libcontainer/configs_test.TestCommandHookRunTimeout()
      /home/kir/go/src/github.com/opencontainers/runc/libcontainer/configs/config_test.go:223 +0x3ed
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1123 +0x202

Previous write at 0x00c000202230 by goroutine 27:
  os/exec.(*Cmd).Wait()
      /usr/lib/golang/src/os/exec/exec.go:505 +0xb4
  github.com/opencontainers/runc/libcontainer/configs.Command.Run.func1()
      /home/kir/go/src/github.com/opencontainers/runc/libcontainer/configs/config.go:373 +0x55

Goroutine 23 (running) created at:
  testing.(*T).Run()
      /usr/lib/golang/src/testing/testing.go:1168 +0x5bb
  testing.runTests.func1()
      /usr/lib/golang/src/testing/testing.go:1439 +0xa6
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1123 +0x202
  testing.runTests()
      /usr/lib/golang/src/testing/testing.go:1437 +0x612
  testing.(*M).Run()
      /usr/lib/golang/src/testing/testing.go:1345 +0x3b3
  main.main()
      _testmain.go:69 +0x236

Goroutine 27 (running) created at:
  github.com/opencontainers/runc/libcontainer/configs.Command.Run()
      /home/kir/go/src/github.com/opencontainers/runc/libcontainer/configs/config.go:372 +0x415
  github.com/opencontainers/runc/libcontainer/configs_test.TestCommandHookRunTimeout()
      /home/kir/go/src/github.com/opencontainers/runc/libcontainer/configs/config_test.go:223 +0x3ed
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1123 +0x202
==================
    testing.go:1038: race detected during execution of test
--- FAIL: TestCommandHookRunTimeout (0.10s)
```

Apparently, the issue is we call two Wait()s for the same command
which can race internally.

Fix is easy -- since we already have a waiting goroutine,
wait for it to return instead of calling a second Wait().

2. Fix https://github.com/opencontainers/runc/issues/2795 (thanks to @avagin).

3. Enable go test run with -race set (#2800), as well as integration tests with race-enabled binaries.

Fixes: #2800
Fixes: #2795