### PR TITLE
libcontainer: fix the file mode of the device

### DIFF
--- a/libcontainer/devices/devices.go
+++ b/libcontainer/devices/devices.go
@@ -54,7 +54,7 @@ func DeviceFromPath(path, permissions string) (*Device, error) {
 			Permissions: Permissions(permissions),
 		},
 		Path:     path,
-		FileMode: os.FileMode(mode),
+		FileMode: os.FileMode(mode &^ unix.S_IFMT),
 		Uid:      stat.Uid,
 		Gid:      stat.Gid,
 	}, nil

--- a/libcontainer/devices/devices_test.go
+++ b/libcontainer/devices/devices_test.go
@@ -82,22 +82,13 @@ func TestHostDevicesAllValid(t *testing.T) {
 		if device.Major == 0 {
 			t.Errorf("device entry %+v has zero major number", device)
 		}
-		// Devices should only have file modes that correspond to their type.
-		var expectedType os.FileMode
 		switch device.Type {
-		case BlockDevice:
-			expectedType = unix.S_IFBLK
-		case CharDevice:
-			expectedType = unix.S_IFCHR
+		case BlockDevice, CharDevice:
 		case FifoDevice:
 			t.Logf("fifo devices shouldn't show up from HostDevices")
 			fallthrough
 		default:
 			t.Errorf("device entry %+v has unexpected type %v", device, device.Type)
-		}
-		gotType := device.FileMode & unix.S_IFMT
-		if expectedType != gotType {
-			t.Errorf("device entry %+v has mismatched types (expected %#x, got %#x)", device, expectedType, gotType)
 		}
 	}
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -698,7 +698,7 @@ next:
 				return nil, err
 			}
 			if d.FileMode != nil {
-				filemode = *d.FileMode
+				filemode = *d.FileMode &^ unix.S_IFMT
 			}
 			device := &devices.Device{
 				Rule: devices.Rule{


### PR DESCRIPTION
The file mode of the device does not contain file type bits

`mode &^ unix.S_IFMT` should be added when setting device.FileMode.

Fix containerd: https://github.com/containerd/containerd/pull/5028
Discussions about FileMode: https://github.com/opencontainers/runtime-spec/pull/1082