### PR TITLE
libct/cgroups/systemd: don't set limits in Apply

### DIFF
--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -86,7 +86,6 @@ func genV1ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]syst
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
-			newProp("TasksAccounting", true),
 			newProp("TasksMax", uint64(r.PidsLimit)))
 	}
 
@@ -158,7 +157,8 @@ func (m *legacyManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("MemoryAccounting", true),
 		newProp("CPUAccounting", true),
-		newProp("BlockIOAccounting", true))
+		newProp("BlockIOAccounting", true),
+		newProp("TasksAccounting", true))
 
 	// Assume DefaultDependencies= will always work (the check for it was previously broken.)
 	properties = append(properties,
@@ -168,11 +168,6 @@ func (m *legacyManager) Apply(pid int) error {
 	if err != nil {
 		return err
 	}
-	resourcesProperties, err := genV1ResourcesProperties(c, dbusConnection)
-	if err != nil {
-		return err
-	}
-	properties = append(properties, resourcesProperties...)
 	properties = append(properties, c.SystemdProps...)
 
 	// We have to set kernel memory here, as we can't change it once

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -205,7 +205,6 @@ func genV2ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]syst
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
-			newProp("TasksAccounting", true),
 			newProp("TasksMax", uint64(r.PidsLimit)))
 	}
 
@@ -283,11 +282,6 @@ func (m *unifiedManager) Apply(pid int) error {
 	if err != nil {
 		return err
 	}
-	resourcesProperties, err := genV2ResourcesProperties(c, dbusConnection)
-	if err != nil {
-		return err
-	}
-	properties = append(properties, resourcesProperties...)
 	properties = append(properties, c.SystemdProps...)
 
 	if err := startUnit(dbusConnection, unitName, properties); err != nil {


### PR DESCRIPTION
All cgroup managers has Apply() and Set() methods:

 - Apply is used to create a cgroup (and, in case of systemd,
   a systemd unit) and/or put a PID into the cgroup (and unit);

 - Set is used to set various cgroup resources and limits.

The fs/fs2 cgroup manager implements the functionality as described above.

The systemd v1/v2 manager deviate -- it sets *most* of cgroup limits
(those that can be projected to systemd unit properties) in Apply(),
and then again *all* cgroup limits in Set (first indirectly via systemd
properties -- same as in Apply, then via cgroupfs).

This commit removes setting the cgroup limits from Apply,
so now the systemd manager behaves the same way as the fs manager.

Fixes: #2813 