### PR TITLE
Fix memory stats for cache in fs2

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -88,7 +88,7 @@ func statMemory(dirPath string, stats *cgroups.Stats) error {
 		}
 		stats.MemoryStats.Stats[t] = v
 	}
-	stats.MemoryStats.Cache = stats.MemoryStats.Stats["cache"]
+	stats.MemoryStats.Cache = stats.MemoryStats.Stats["file"]
 
 	memoryUsage, err := getMemoryDataV2(dirPath, "")
 	if err != nil {


### PR DESCRIPTION
In cgroup v2, the "cache" value from cgroup v1 is called "file" in v2.
There are no values called "cache" in v2.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/memcontrol.c?id=31caf8b2a847214be856f843e251fc2ed2cd1075#n1521