### PR TITLE
fs2: fallback to setting io.weight if io.bfq.weight

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -439,3 +439,14 @@ func ConvertMemorySwapToCgroupV2Value(memorySwap, memory int64) (int64, error) {
 
 	return memorySwap - memory, nil
 }
+
+// Since the OCI spec is designed for cgroup v1, in some cases
+// there is need to convert from the cgroup v1 configuration to cgroup v2
+// the formula for BlkIOWeight to IOWeight is y = (1 + (x - 10) * 9999 / 990)
+// convert linearly from [10-1000] to [1-10000]
+func ConvertBlkIOToIOWeightValue(blkIoWeight uint16) uint64 {
+	if blkIoWeight == 0 {
+		return 0
+	}
+	return uint64(1 + (uint64(blkIoWeight)-10)*9999/990)
+}

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -642,3 +642,17 @@ func TestConvertMemorySwapToCgroupV2Value(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertBlkIOToIOWeightValue(t *testing.T) {
+	cases := map[uint16]uint64{
+		0:    0,
+		10:   1,
+		1000: 10000,
+	}
+	for i, expected := range cases {
+		got := ConvertBlkIOToIOWeightValue(i)
+		if got != expected {
+			t.Errorf("expected ConvertBlkIOToIOWeightValue(%d) to be %d, got %d", i, expected, got)
+		}
+	}
+}

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -195,8 +195,12 @@ function setup() {
 	[ "$status" -eq 0 ]
 
 	runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.bfq.weight'
-	[ "$status" -eq 0 ]
-	[ "$output" = 'default 750' ]
+	if [[ "$status" -eq 0 ]]; then
+		[ "$output" = 'default 750' ]
+	else
+		runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
+		[ "$output" = 'default 7475' ]
+	fi
 }
 
 @test "runc run (cgroup v2 resources.unified only)" {


### PR DESCRIPTION
if bfq is not loaded, then io.bfq.weight is not available. io.weight
should always be available and is the next best equivalent thing.

Signed-off-by: Daniel Dao <dqminh89@gmail.com>