### PR TITLE
proposal: add --keep to runc run

### DIFF
--- a/man/runc-run.8.md
+++ b/man/runc-run.8.md
@@ -42,6 +42,12 @@ container to inherit the calling processes session key.
 : Pass _N_ additional file descriptors to the container (**stdio** +
 **$LISTEN_FDS** + _N_ in total). Default is **0**.
 
+**--keep**
+: Keep container's state directory and cgroup. This can be helpful if a user
+wants to check the state (e.g. of cgroup controllers) after the container has
+exited. If this option is used, a manual **runc delete** is needed afterwards
+to clean an exited container's artefacts.
+
 # SEE ALSO
 
 **runc**(8).

--- a/run.go
+++ b/run.go
@@ -40,6 +40,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Name:  "detach, d",
 			Usage: "detach from the container's process",
 		},
+		cli.BoolFlag{
+			Name:  "keep",
+			Usage: "do not delete the container after it exits",
+		},
 		cli.StringFlag{
 			Name:  "pid-file",
 			Value: "",

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_hello
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+@test "runc run" {
+	runc run test_hello
+	[ "$status" -eq 0 ]
+
+	runc state test_hello
+	[ "$status" -ne 0 ]
+}
+
+@test "runc run --keep" {
+	runc run --keep test_run_keep
+	[ "$status" -eq 0 ]
+
+	testcontainer test_run_keep stopped
+
+	runc state test_run_keep
+	[ "$status" -eq 0 ]
+
+	runc delete test_run_keep
+
+	runc state test_run_keep
+	[ "$status" -ne 0 ]
+}
+
+@test "runc run --keep (check cgroup exists)" {
+	# for systemd driver, the unit's cgroup path will be auto removed if container's all processes exited
+	requires no_systemd
+
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+
+	set_cgroups_path
+
+	runc run --keep test_run_keep
+	[ "$status" -eq 0 ]
+
+	testcontainer test_run_keep stopped
+
+	runc state test_run_keep
+	[ "$status" -eq 0 ]
+
+	# check that cgroup exists
+	check_cgroup_value "pids.max" "max"
+
+	runc delete test_run_keep
+
+	runc state test_run_keep
+	[ "$status" -ne 0 ]
+}

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -439,7 +439,7 @@ func startContainer(context *cli.Context, spec *specs.Spec, action CtAct, criuOp
 
 	r := &runner{
 		enableSubreaper: !context.Bool("no-subreaper"),
-		shouldDestroy:   true,
+		shouldDestroy:   !context.Bool("keep"),
 		container:       container,
 		listenFDs:       listenFDs,
 		notifySocket:    notifySocket,


### PR DESCRIPTION
To close #2817

As described in #2817, for some times, we need to analyze the container's resource usage, so we expect runc does not delete the container after it exits.

Signed-off-by: lifubang <lifubang@acmcoder.com>

## Changelog entry
 (by @kolyshkin)
```
New features:
* runc run: new `--keep` option to skip removal exited containers artefacts.
  This might be useful to check the state (e.g. of cgroup controllers) after
  the container has￼exited. (#2817)
```