### PR TITLE
libcontainer/factory*: adjust the file mode

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -185,7 +185,7 @@ func CriuPath(criupath string) func(*LinuxFactory) error {
 // configures the factory with the provided option funcs.
 func New(root string, options ...func(*LinuxFactory) error) (Factory, error) {
 	if root != "" {
-		if err := os.MkdirAll(root, 0700); err != nil {
+		if err := os.MkdirAll(root, 0o700); err != nil {
 			return nil, newGenericError(err, SystemError)
 		}
 	}
@@ -259,7 +259,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	} else if !os.IsNotExist(err) {
 		return nil, newGenericError(err, SystemError)
 	}
-	if err := os.MkdirAll(containerRoot, 0711); err != nil {
+	if err := os.MkdirAll(containerRoot, 0o711); err != nil {
 		return nil, newGenericError(err, SystemError)
 	}
 	if err := os.Chown(containerRoot, unix.Geteuid(), unix.Getegid()); err != nil {

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -180,7 +180,7 @@ func TestFactoryLoadContainer(t *testing.T) {
 			},
 		}
 	)
-	if err := os.Mkdir(filepath.Join(root, id), 0700); err != nil {
+	if err := os.Mkdir(filepath.Join(root, id), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := marshal(filepath.Join(root, id, stateFilename), expectedState); err != nil {


### PR DESCRIPTION
This commit adjusts the file mode to use the latest golang style
Related to #2625

BTW, I think we should not only modify the file mode from the old style to the latest style but also check whether the current implementation sets proper file permissions.
So, I will create the PRs each subsystem or codes and I may create the new issue to summarize this activity.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>