### PR TITLE
curl: add --retry 5

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,7 +60,7 @@ jobs:
       - name: install shellcheck
         run: |
           mkdir ~/bin
-          curl -sSfL $BASEURL/$VERSION/shellcheck-$VERSION.linux.x86_64.tar.xz |
+          curl -sSfL --retry 5 $BASEURL/$VERSION/shellcheck-$VERSION.linux.x86_64.tar.xz |
             tar xfJ - -C ~/bin --strip 1 shellcheck-$VERSION/shellcheck
           sha256sum ~/bin/shellcheck | grep -q $SHA256SUM
           # make sure to remove the old version

--- a/tests/integration/get-images.sh
+++ b/tests/integration/get-images.sh
@@ -36,7 +36,7 @@ function get() {
 		exit 1
 	fi
 
-	if ! curl -o "$dest" -fsSL "$url"; then
+	if ! curl -o "$dest" -fsSL --retry 5 "$url"; then
 		echo "Failed to get $url" 1>&2
 		exit 1
 	fi


### PR DESCRIPTION
Sometimes github gives up 5xx errors, for example:

> panic: getImages error exit status 1 (output: curl: (22) The requested URL returned error: 502
> Failed to get https://github.com/docker-library/busybox/raw/dist-i386/stable/glibc/busybox.tar.xz

(from https://github.com/opencontainers/runc/pull/2807#issuecomment-791031846)

This is unfortunate but temporary, and adding --retry should handle
at least some cases, improving CI stability.