### PR TITLE
libcontainer/notify_linux*: adjust the file mode

### DIFF
--- a/libcontainer/notify_linux.go
+++ b/libcontainer/notify_linux.go
@@ -5,10 +5,10 @@ package libcontainer
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"golang.org/x/sys/unix"
 )
 
@@ -33,13 +33,14 @@ func registerMemoryEvent(cgDir string, evName string, arg string) (<-chan struct
 
 	eventfd := os.NewFile(uintptr(fd), "eventfd")
 
-	eventControlPath := filepath.Join(cgDir, "cgroup.event_control")
+	const cgEvCtlFile = "cgroup.event_control"
 	data := fmt.Sprintf("%d %d %s", eventfd.Fd(), evFile.Fd(), arg)
-	if err := ioutil.WriteFile(eventControlPath, []byte(data), 0o700); err != nil {
+	if err := cgroups.WriteFile(cgDir, cgEvCtlFile, data); err != nil {
 		eventfd.Close()
 		evFile.Close()
 		return nil, err
 	}
+	eventControlPath := filepath.Join(cgDir, cgEvCtlFile)
 	ch := make(chan struct{})
 	go func() {
 		defer func() {

--- a/libcontainer/notify_linux_test.go
+++ b/libcontainer/notify_linux_test.go
@@ -23,10 +23,10 @@ func testMemoryNotification(t *testing.T, evName string, notify notifyFunc, targ
 	}
 	evFile := filepath.Join(memoryPath, evName)
 	eventPath := filepath.Join(memoryPath, "cgroup.event_control")
-	if err := ioutil.WriteFile(evFile, []byte{}, 0o700); err != nil {
+	if err := ioutil.WriteFile(evFile, []byte{}, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(eventPath, []byte{}, 0o700); err != nil {
+	if err := ioutil.WriteFile(eventPath, []byte{}, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	ch, err := notify(memoryPath)


### PR DESCRIPTION
This commit adjusts the file mode to use the latest golang style
In addition to that, I changed those modes from 0700 to 0600
as same as #2636

Related to #2625

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>