### PR TITLE
libcontainer/configs: adjust the file mode

### DIFF
--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -187,7 +187,7 @@ exit 0
 	verifyCommand := fmt.Sprintf(verifyCommandTemplate, stateJson)
 	filename := "/tmp/runc-hooktest.sh"
 	os.Remove(filename)
-	if err := ioutil.WriteFile(filename, []byte(verifyCommand), 0700); err != nil {
+	if err := ioutil.WriteFile(filename, []byte(verifyCommand), 0o700); err != nil {
 		t.Fatalf("Failed to create tmp file: %v", err)
 	}
 	defer os.Remove(filename)


### PR DESCRIPTION
This commit adjusts the file mode to use the latest golang style
Related to #2625

I did not change _700_ of "/tmp/runc-hooktest.sh" because it actually needed the execute permission.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>