### PR TITLE
libcontainer/integration: adjust the file mode

### DIFF
--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -187,7 +187,7 @@ exit 0
 	verifyCommand := fmt.Sprintf(verifyCommandTemplate, stateJson)
 	filename := "/tmp/runc-hooktest.sh"
 	os.Remove(filename)
-	if err := ioutil.WriteFile(filename, []byte(verifyCommand), 0700); err != nil {
+	if err := ioutil.WriteFile(filename, []byte(verifyCommand), 0o700); err != nil {
 		t.Fatalf("Failed to create tmp file: %v", err)
 	}
 	defer os.Remove(filename)

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1326,7 +1326,7 @@ func TestHook(t *testing.T) {
 	}
 
 	// write config of json format into config.json under bundle
-	f, err := os.OpenFile(filepath.Join(bundle, "config.json"), os.O_CREATE|os.O_RDWR, 0644)
+	f, err := os.OpenFile(filepath.Join(bundle, "config.json"), os.O_CREATE|os.O_RDWR, 0o644)
 	ok(t, err)
 	ok(t, json.NewEncoder(f).Encode(config))
 

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -105,7 +105,7 @@ func newTestRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	testRoots = append(testRoots, dir)
@@ -117,7 +117,7 @@ func newTestBundle() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	return dir, nil
@@ -129,7 +129,7 @@ func newRootfs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	if err := copyBusybox(dir); err != nil {


### PR DESCRIPTION
This commit adjusts the file mode to use the latest golang style
Related to #2625

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>