### PR TITLE
tests/checkpoint: show full log lazy pages cpt

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -185,8 +185,8 @@ function simple_cr() {
 	exec {lazy_w}>&-
 	# shellcheck disable=SC2116,SC2086
 	out=$(echo $out) # rm newlines
-	# show errors if there are any before we fail
-	grep -B5 Error ./work-dir/dump.log || true
+	# show log in case something is wrong before we fail
+	cat ./work-dir/dump.log
 	# expecting \0 which od prints as
 	[ "$out" = "0000000 000000 0000001" ]
 


### PR DESCRIPTION
Sometimes the test fails without any clear diagnostics:

> not ok 16 checkpoint --lazy-pages and restore
> (in test file tests/integration/checkpoint.bats, line 191)
>  `[ "$out" = "0000000 000000 0000001" ]' failed
> ...
> criu failed: type NOTIFY errno 3\nlog file: work-dir/dump.log

We look for and print errors via grep, but in the above case
there are nothing that is denoted error in the log.

So, let's show the damn log in its entirely (note it is only shown
if test fails).

Hope it will help with #2760 