### PR TITLE
umount all mount points in runc root dir

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -59,7 +59,7 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 				// if there was an aborted start or something of the sort then the container's directory could exist but
 				// libcontainer does not see it because the state.json file inside that directory was never created.
 				path := filepath.Join(context.GlobalString("root"), id)
-				if e := os.RemoveAll(path); e != nil {
+				if e := libcontainer.DelRootDir(path); e != nil {
 					fmt.Fprintf(os.Stderr, "remove %s: %v\n", path, e)
 				}
 				if force {


### PR DESCRIPTION
Sometimes, `umount` with `MNT_DETACH` flag can't work in a small probability.
So, maybe we should unmount all mount points in runc root dir when we remove this dir.

```
root@f7c63618dde3:/opt/busybox# runc delete test2
remove /run/runc/test2: unlinkat /run/runc/test2/runc.W24K2t: device or resource busy
ERRO[0000] container "test2" does not exist             
```
```
root@f7c63618dde3:/opt/busybox# ls /run/runc/test2 -alh
total 14M
drwx--x--x 2 root root  60 Mar  9 14:24 .
drwx------ 5 root root 100 Mar  9 15:15 ..
-rwxr-xr-x 1 root root 14M Mar  9 15:15 runc.W24K2t
```

Signed-off-by: lifubang <lifubang@acmcoder.com>