### PR TITLE
Renew dbus connection

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -2,7 +2,6 @@ package systemd
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"math"
 	"os"
@@ -29,10 +28,6 @@ const (
 )
 
 var (
-	connOnce sync.Once
-	connDbus *systemdDbus.Conn
-	connErr  error
-
 	versionOnce sync.Once
 	version     int
 
@@ -290,19 +285,6 @@ func generateDeviceProperties(rules []*devices.Rule) ([]systemdDbus.Property, er
 
 	properties = append(properties, newProp("DeviceAllow", deviceAllowList))
 	return properties, nil
-}
-
-// getDbusConnection lazy initializes systemd dbus connection
-// and returns it
-func getDbusConnection(rootless bool) (*systemdDbus.Conn, error) {
-	connOnce.Do(func() {
-		if rootless {
-			connDbus, connErr = NewUserSystemdDbus()
-		} else {
-			connDbus, connErr = systemdDbus.NewWithContext(context.TODO())
-		}
-	})
-	return connDbus, connErr
 }
 
 func newProp(name string, units interface{}) systemdDbus.Property {

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -312,6 +312,16 @@ func isUnitExists(err error) bool {
 	return false
 }
 
+// isDbusClosed returns true if the error is that connection closed.
+func isDbusClosed(err error) bool {
+	if err != nil {
+		if dbusError, ok := err.(dbus.Error); ok {
+			return strings.Contains(dbusError.Name, "connection closed by user")
+		}
+	}
+	return false
+}
+
 func startUnit(dbusConnection *systemdDbus.Conn, unitName string, properties []systemdDbus.Property) error {
 	statusChan := make(chan string, 1)
 	if _, err := dbusConnection.StartTransientUnit(unitName, "replace", properties, statusChan); err == nil {

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -54,7 +54,7 @@ func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
 
 func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
 	if d.rootless {
-		return NewUserSystemdDbus()
+		return newUserSystemdDbus()
 	}
 	return systemdDbus.NewWithContext(context.TODO())
 }

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -1,0 +1,59 @@
+// +build linux
+
+package systemd
+
+import (
+	"context"
+	"sync"
+
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+)
+
+type dbusConnManager struct {
+	conn     *systemdDbus.Conn
+	rootless bool
+	sync.RWMutex
+}
+
+// newDbusConnManager initializes systemd dbus connection
+func newDbusConnManager(rootless bool) *dbusConnManager {
+	return &dbusConnManager{
+		rootless: rootless,
+	}
+}
+
+// getConnection lazy initializes systemd dbus connection and returns it
+func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
+	// In the case where d.conn != nil
+	// Use the read lock the first time to ensure
+	// that Conn can be acquired at the same time.
+	d.RLock()
+	if conn := d.conn; conn != nil {
+		d.RUnlock()
+		return conn, nil
+	}
+	d.RUnlock()
+
+	// In the case where d.conn == nil
+	// Use write lock to ensure that only one
+	// will be created
+	d.Lock()
+	defer d.Unlock()
+	if conn := d.conn; conn != nil {
+		return conn, nil
+	}
+
+	conn, err := d.newConnection()
+	if err != nil {
+		return nil, err
+	}
+	d.conn = conn
+	return conn, nil
+}
+
+func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
+	if d.rootless {
+		return NewUserSystemdDbus()
+	}
+	return systemdDbus.NewWithContext(context.TODO())
+}

--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NewUserSystemdDbus creates a connection for systemd user-instance.
-func NewUserSystemdDbus() (*systemdDbus.Conn, error) {
+// newUserSystemdDbus creates a connection for systemd user-instance.
+func newUserSystemdDbus() (*systemdDbus.Conn, error) {
 	addr, err := DetectUserDbusSessionBusAddress()
 	if err != nil {
 		return nil, err

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -20,12 +20,14 @@ type legacyManager struct {
 	mu      sync.Mutex
 	cgroups *configs.Cgroup
 	paths   map[string]string
+	dbus    *dbusConnManager
 }
 
 func NewLegacyManager(cg *configs.Cgroup, paths map[string]string) cgroups.Manager {
 	return &legacyManager{
 		cgroups: cg,
 		paths:   paths,
+		dbus:    newDbusConnManager(false),
 	}
 }
 
@@ -164,7 +166,7 @@ func (m *legacyManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("DefaultDependencies", false))
 
-	dbusConnection, err := getDbusConnection(false)
+	dbusConnection, err := m.dbus.getConnection()
 	if err != nil {
 		return err
 	}
@@ -208,7 +210,7 @@ func (m *legacyManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dbusConnection, err := getDbusConnection(false)
+	dbusConnection, err := m.dbus.getConnection()
 	if err != nil {
 		return err
 	}
@@ -341,7 +343,7 @@ func (m *legacyManager) Set(container *configs.Config) error {
 	if container.Cgroups.Resources.Unified != nil {
 		return cgroups.ErrV1NoUnified
 	}
-	dbusConnection, err := getDbusConnection(false)
+	dbusConnection, err := m.dbus.getConnection()
 	if err != nil {
 		return err
 	}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -173,6 +173,7 @@ func (m *legacyManager) Apply(pid int) error {
 	properties = append(properties, c.SystemdProps...)
 
 	if err := startUnit(dbusConnection, unitName, properties); err != nil {
+		m.dbus.checkAndReconnect(dbusConnection, err)
 		return err
 	}
 
@@ -376,6 +377,7 @@ func (m *legacyManager) Set(container *configs.Config) error {
 	}
 
 	if err := dbusConnection.SetUnitProperties(getUnitName(container.Cgroups), true, properties...); err != nil {
+		m.dbus.checkAndReconnect(dbusConnection, err)
 		_ = m.Freeze(targetFreezerState)
 		return err
 	}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -288,6 +288,7 @@ func (m *unifiedManager) Apply(pid int) error {
 	properties = append(properties, c.SystemdProps...)
 
 	if err := startUnit(dbusConnection, unitName, properties); err != nil {
+		m.dbus.checkAndReconnect(dbusConnection, err)
 		return errors.Wrapf(err, "error while starting unit %q with properties %+v", unitName, properties)
 	}
 
@@ -462,6 +463,7 @@ func (m *unifiedManager) Set(container *configs.Config) error {
 	}
 
 	if err := dbusConnection.SetUnitProperties(getUnitName(m.cgroups), true, properties...); err != nil {
+		m.dbus.checkAndReconnect(dbusConnection, err)
 		_ = m.Freeze(targetFreezerState)
 		return errors.Wrap(err, "error while setting unit properties")
 	}


### PR DESCRIPTION
After the current dbus restarts, legacyManager will always return an error 'dbus: connection closed by user'
This PR fixes when dbus returns this error, try to reconnect to ensure that subsequent calls are normal
xref https://github.com/kubernetes/kubernetes/issues/100328

Please review the changes, if there is no problem, I will to add a test.