### PR TITLE
script/check-config.sh: add CONFIG_SECCOMP_FILTER

### DIFF
--- a/script/check-config.sh
+++ b/script/check-config.sh
@@ -228,6 +228,7 @@ echo 'Optional Features:'
 	check_distro_userns
 
 	check_flags SECCOMP
+	check_flags SECCOMP_FILTER
 	check_flags CGROUP_PIDS
 
 	check_flags MEMCG_SWAP


### PR DESCRIPTION
CONFIG_SECCOMP_FILTER is actually used in runc.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>