### PR TITLE
Fix oss-fuzz build

### DIFF
--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -4,10 +4,10 @@
 # if run outside of it.
 # The api, compile_go_fuzzer() is provided by the OSS-fuzz
 # environment and is a high level helper function for a series
-# of compilation and linking steps to build the fuzzers in the 
+# of compilation and linking steps to build the fuzzers in the
 # OSS-fuzz environment.
 # More info about compile_go_fuzzer() can be found here:
 #     https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
-compile_go_fuzzer ./libcontainer/system FuzzUIDMap id_map_fuzzer linux
-compile_go_fuzzer ./libcontainer/user FuzzUser user_fuzzer
-compile_go_fuzzer ./libcontainer/configs FuzzUnmarshalJSON configs_fuzzer
+compile_go_fuzzer github.com/opencontainers/runc/libcontainer/system FuzzUIDMap id_map_fuzzer linux,gofuzz
+compile_go_fuzzer github.com/opencontainers/runc/libcontainer/user FuzzUser user_fuzzer
+compile_go_fuzzer github.com/opencontainers/runc/libcontainer/configs FuzzUnmarshalJSON configs_fuzzer


### PR DESCRIPTION
THis fixes incorrect module path and also add proper tags for
FuzzUIDMap.

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32109#c1

Signed-off-by: Daniel Dao <dqminh89@gmail.com>