### PR TITLE
Ensure the seccomp pipe is being read while exporting bpf

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux_test.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux_test.go
@@ -281,3 +281,21 @@ func TestEnosysStub_MultiArch(t *testing.T) {
 		}
 	}
 }
+
+func TestPatchHugeSeccompFilterDoesNotBlock(t *testing.T) {
+	hugeFilter, err := libseccomp.NewFilter(libseccomp.ActAllow)
+	if err != nil {
+		t.Fatalf("failed to create seccomp filter: %v", err)
+	}
+
+	for i := 1; i < 10000; i++ {
+		if err := hugeFilter.AddRule(libseccomp.ScmpSyscall(i), libseccomp.ActKill); err != nil {
+			t.Fatalf("failed to add rule to filter %d: %v", i, err)
+		}
+	}
+
+	config := fakeConfig(configs.Kill, []string{}, []string{"amd64"})
+	PatchAndLoad(config, hugeFilter)
+
+	// if we exit, we did not block
+}

--- a/libcontainer/seccomp/patchbpf/enosys_linux_test.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux_test.go
@@ -282,7 +282,7 @@ func TestEnosysStub_MultiArch(t *testing.T) {
 	}
 }
 
-func TestPatchHugeSeccompFilterDoesNotBlock(t *testing.T) {
+func TestDisassembleHugeFilterDoesNotHang(t *testing.T) {
 	hugeFilter, err := libseccomp.NewFilter(libseccomp.ActAllow)
 	if err != nil {
 		t.Fatalf("failed to create seccomp filter: %v", err)
@@ -294,8 +294,10 @@ func TestPatchHugeSeccompFilterDoesNotBlock(t *testing.T) {
 		}
 	}
 
-	config := fakeConfig(configs.Kill, []string{}, []string{"amd64"})
-	PatchAndLoad(config, hugeFilter)
+	_, err = disassembleFilter(hugeFilter)
+	if err != nil {
+		t.Fatalf("failed to disassembleFilter: %v", err)
+	}
 
-	// if we exit, we did not block
+	// if we exit, we did not hang
 }


### PR DESCRIPTION
Not reading from the seccomp pipe might get the ExportBRF function stuck
on writing to the seccomp pipe if its buffer is full (i.e. the writer
wrote more than 65K of data). Reading from the read end of the pipe
asynchronously prevents this from happening.

We have seen the issue in real environments when the system is under heavy load. No idea why it does not always happen, but as demonstrated by the unit test, the issue is real.

(Potentially) related issue:
https://github.com/opencontainers/runc/issues/2530#issuecomment-800690556
https://github.com/opencontainers/runc/issues/2865

cc @cloudfoundry/cf-garden

