### PR TITLE
libct/cg/fs2.GetStats() improvements

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -260,7 +260,9 @@ func getMemoryData(path, name string) (cgroups.MemoryData, error) {
 
 	value, err := fscommon.GetCgroupParamUint(path, usage)
 	if err != nil {
-		if moduleName != "memory" && os.IsNotExist(err) {
+		if name != "" && os.IsNotExist(err) {
+			// Ignore ENOENT as swap and kmem controllers
+			// are optional in the kernel.
 			return cgroups.MemoryData{}, nil
 		}
 		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", usage, err)
@@ -268,25 +270,16 @@ func getMemoryData(path, name string) (cgroups.MemoryData, error) {
 	memoryData.Usage = value
 	value, err = fscommon.GetCgroupParamUint(path, maxUsage)
 	if err != nil {
-		if moduleName != "memory" && os.IsNotExist(err) {
-			return cgroups.MemoryData{}, nil
-		}
 		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", maxUsage, err)
 	}
 	memoryData.MaxUsage = value
 	value, err = fscommon.GetCgroupParamUint(path, failcnt)
 	if err != nil {
-		if moduleName != "memory" && os.IsNotExist(err) {
-			return cgroups.MemoryData{}, nil
-		}
 		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", failcnt, err)
 	}
 	memoryData.Failcnt = value
 	value, err = fscommon.GetCgroupParamUint(path, limit)
 	if err != nil {
-		if moduleName != "memory" && os.IsNotExist(err) {
-			return cgroups.MemoryData{}, nil
-		}
 		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", limit, err)
 	}
 	memoryData.Limit = value

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -130,10 +130,9 @@ func (m *manager) GetStats() (*cgroups.Stats, error) {
 		}
 	}
 	// cpu (since kernel 4.15)
-	if _, ok := m.controllers["cpu"]; ok {
-		if err := statCpu(m.dirPath, st); err != nil {
-			errs = append(errs, err)
-		}
+	// Note cpu.stat is available even if the controller is not enabled.
+	if err := statCpu(m.dirPath, st); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, err)
 	}
 	// hugetlb (since kernel 5.6)
 	if _, ok := m.controllers["hugetlb"]; ok {

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -108,14 +108,8 @@ func (m *manager) GetStats() (*cgroups.Stats, error) {
 	}
 
 	// pids (since kernel 4.5)
-	if _, ok := m.controllers["pids"]; ok {
-		if err := statPids(m.dirPath, st); err != nil {
-			errs = append(errs, err)
-		}
-	} else {
-		if err := statPidsWithoutController(m.dirPath, st); err != nil {
-			errs = append(errs, err)
-		}
+	if err := statPids(m.dirPath, st); err != nil {
+		errs = append(errs, err)
 	}
 	// memory (since kernel 4.5)
 	if _, ok := m.controllers["memory"]; ok {

--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -127,7 +127,10 @@ func getMemoryDataV2(path, name string) (cgroups.MemoryData, error) {
 
 	value, err := fscommon.GetCgroupParamUint(path, usage)
 	if err != nil {
-		if moduleName != "memory" && os.IsNotExist(err) {
+		if name != "" && os.IsNotExist(err) {
+			// Ignore EEXIST as there's no swap accounting
+			// if kernel CONFIG_MEMCG_SWAP is not set or
+			// swapaccount=0 kernel boot parameter is given.
 			return cgroups.MemoryData{}, nil
 		}
 		return cgroups.MemoryData{}, errors.Wrapf(err, "failed to parse %s", usage)
@@ -136,9 +139,6 @@ func getMemoryDataV2(path, name string) (cgroups.MemoryData, error) {
 
 	value, err = fscommon.GetCgroupParamUint(path, limit)
 	if err != nil {
-		if moduleName != "memory" && os.IsNotExist(err) {
-			return cgroups.MemoryData{}, nil
-		}
 		return cgroups.MemoryData{}, errors.Wrapf(err, "failed to parse %s", limit)
 	}
 	memoryData.Limit = value

--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -40,13 +40,8 @@ func statPidsWithoutController(dirPath string, stats *cgroups.Stats) error {
 	if err != nil {
 		return err
 	}
-	pids := make(map[string]string)
-	for _, i := range strings.Split(contents, "\n") {
-		if i != "" {
-			pids[i] = i
-		}
-	}
-	stats.PidsStats.Current = uint64(len(pids))
+	pids := strings.Count(contents, "\n")
+	stats.PidsStats.Current = uint64(pids)
 	stats.PidsStats.Limit = 0
 	return nil
 }


### PR DESCRIPTION
Various `GetStats()` improvements, mostly to address cgroup v2 compatibility issues.
NOTE that this functionality is not used by runc itself.

## 1. libct/cg/fs2/memory: fix swap reporting
    
cgroup v1 reports combined mem+swap in stats.MemoryStats.SwapUsage.
In cgroup v2, swap is separate.
    
For the sake of compatibility, make v2 report mem+swap as well.
This also includes Limit.

## 2. libct/cg/fs[2]/getMemoryData[V2]: optimize
    
Existing code ignores `ENOENT` in case we're reading data from
controls that might not be enabled. While this is correct, the code
can be improved:
    
1. Check `name != ""` instead of `moduleName != "memory"`, as these checks
       are equivalent but the new one is faster.
    
2. It does not make sense to ignore subsequent errors -- if the control
       is not available, we won't hit this code path.
    
3. Add a comment explaining why we ignore the error.

## 3. libct/cg/fs2/memory.Stat: add usage for root cgroup

There is no memory.{current,max} for the root node in cgroup v2, and
thus stats for "/sys/fs/cgroup" return an error.

The same thing works with cgroup v1 (as there are
memory.{usage,limit}_in_bytes files in the root node).

Emulate stats for /sys/fs/cgroup by getting numbers from
/proc/self/meminfo.

[Initially, I wanted to avoid parsing yet another /proc file and
instead mock some numbers using data from memory.stat but was
unable to come up with formulae that make sense.]

## 4. libct/cg/fs2.Stat: always call statCpu

Giuseppe found out that cpu.stat for a cgroup is available even if
the cpu controller is not enabled for it. So, let's call statCpu
regradress, and ignore ENOENT.

## 5. libct/cg/fs2/getPidsWithoutController: optimize
    
It is inefficient to create an associative map for the whole purpose of
counting the number of elements in it, especially if the elements are
all unique. It uses more CPU than necessary and creates some work for
the garbage collector.
    
The file we read contains PIDs and newlines, and the easiest/fastest way
to get the number of PIDs is just to count the newlines.

## 6. libct/cg/fs2.statPids: fall back directly
    
When getting pids stats, instead of checking whether the pids controller
is available, let's use a fall back function in case pids.current does
not exist. This simplifies the logic in fs2.GetStats.

## 7. libct/cg/fs2.Stat: don't look for available controllers

Some controllers might still have stats available even if they are
disabled (this is definitely so for cpu.stat -- see earlier commit).

Some stat methods might implement sensible fallbacks (see previous
commit for statPids.

In the view of all that, it makes sense to not check if a particular
controller is available, but rather ignore ENOENT from it.