### PR TITLE
script/check-config.sh: add SELinux and AppArmor

### DIFF
--- a/script/check-config.sh
+++ b/script/check-config.sh
@@ -271,5 +271,7 @@ flags=(
 	IP_VS_PROTO_TCP
 	IP_VS_PROTO_UDP
 	IP_VS_RR
+	SECURITY_SELINUX
+	SECURITY_APPARMOR
 )
 check_flags "${flags[@]}"


### PR DESCRIPTION
SELinux and AppArmor are always enabled since runc v1.0.0-rc93

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>