### PR TITLE
Do not set devices cgroup when updating containers to avoid eBPF programs leak

### DIFF
--- a/update.go
+++ b/update.go
@@ -327,6 +327,9 @@ other options are ignored.
 			config.IntelRdt.MemBwSchema = memBwSchema
 		}
 
+		// Do not set devices cgroup when updating containers to avoid eBPF programs leak
+		config.Cgroups.SkipDevices = true
+
 		return container.Set(config)
 	},
 }


### PR DESCRIPTION
Do not set devices cgroup when updating containers to fix https://github.com/opencontainers/runc/issues/2366 for cgroup v2

We're running k8s 1.20 with containerd + runc + cgroup v2, and encountered the issue of "failed to call BPF_PROG_ATTACH (BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI): argument list too long" when updating containers.

# Steps to reproduce with runc

1. Run a container with id test
2. Try to update the memory 64 times and you'll get error(there are 64 bpf programs attached ):
```
root@VM-16-3-centos ~]# for i in {1..64}; do runc update --memory=10240000 test;done 
WARN[0000] Setting back cgroup configs failed due to error: failed to call BPF_PROG_ATTACH (BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI): argument list too long, your state.json and actual configs might be inconsistent. 
ERRO[0000] failed to call BPF_PROG_ATTACH (BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI): argument list too long

[root@VM-16-3-centos ~]# bpftool cgroup list /sys/fs/cgroup/user.slice/user-0.slice/test | wc -l
65
```

