### PR TITLE
libcontainer/cgroups/systemd: don't call stopUnit

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -354,23 +354,6 @@ func startUnit(dbusConnection *systemdDbus.Conn, unitName string, properties []s
 	return nil
 }
 
-func stopUnit(dbusConnection *systemdDbus.Conn, unitName string) error {
-	statusChan := make(chan string, 1)
-	if _, err := dbusConnection.StopUnit(unitName, "replace", statusChan); err == nil {
-		select {
-		case s := <-statusChan:
-			close(statusChan)
-			// Please refer to https://godoc.org/github.com/coreos/go-systemd/dbus#Conn.StartUnit
-			if s != "done" {
-				logrus.Warnf("error removing unit `%s`: got `%s`. Continuing...", unitName, s)
-			}
-		case <-time.After(time.Second):
-			logrus.Warnf("Timed out while waiting for StopUnit(%s) completion signal from dbus. Continuing...", unitName)
-		}
-	}
-	return nil
-}
-
 func systemdVersion(conn *systemdDbus.Conn) int {
 	versionOnce.Do(func() {
 		version = -1

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -216,20 +216,11 @@ func (m *legacyManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dbusConnection, err := getDbusConnection(false)
-	if err != nil {
-		return err
-	}
-	unitName := getUnitName(m.cgroups)
-
-	stopErr := stopUnit(dbusConnection, unitName)
-	// Both on success and on error, cleanup all the cgroups we are aware of.
-	// Some of them were created directly by Apply() and are not managed by systemd.
-	if err := cgroups.RemovePaths(m.paths); err != nil {
-		return err
-	}
-
-	return stopErr
+	// NOTE systemd units are auto-removed as long as the processes are
+	// gone, so there is no need to stop the unit explicitly.
+	// Yet, some cgroup directories (created by joinCgroups) are
+	// not known to systemd so they need to be removed here.
+	return cgroups.RemovePaths(m.paths)
 }
 
 func (m *legacyManager) Path(subsys string) string {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -303,14 +303,8 @@ func (m *unifiedManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dbusConnection, err := getDbusConnection(m.rootless)
-	if err != nil {
-		return err
-	}
-	unitName := getUnitName(m.cgroups)
-	if err := stopUnit(dbusConnection, unitName); err != nil {
-		return err
-	}
+	// NOTE systemd units are auto-removed as long as the processes are
+	// gone, so there is no need to stop the unit explicitly.
 
 	// XXX this is probably not needed, systemd should handle it.
 	return cgroups.RemovePath(m.path)

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -5,7 +5,6 @@ package systemd
 import (
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -313,13 +312,8 @@ func (m *unifiedManager) Destroy() error {
 		return err
 	}
 
-	// XXX this is probably not needed, systemd should handle it
-	err = os.Remove(m.path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	return nil
+	// XXX this is probably not needed, systemd should handle it.
+	return cgroups.RemovePath(m.path)
 }
 
 func (m *unifiedManager) Path(_ string) string {


### PR DESCRIPTION

A cgroup driver manages cgroups. A systemd cgroup driver calls startUnit
to create a new systemd unit. Systemd units are auto-removed ("garbage
collected") as long as systemd sees they are finished (the definition of
"finished" depends on the unit type -- sometimes it's "no more processes
left", sometimes it's "init process exited").

A systemd cgroup driver should not call stopUnit, because case there are
processes inside cgroup, will cause systemd to TERM/KILL those, and this
is not what is expected from a cgroup driver, especially since  runc
already takes care about terminating container's processes. This is
currently manifested in https://github.com/opencontainers/runc/issues/2805 (see https://github.com/opencontainers/runc/issues/2805#issuecomment-810718209 for details).

Note we still try to remove cgroup dir(s) from Destroy, and return an
error if they are still there.

To reiterate:
 - stopUnit is not needed because systemd auto-removes finished units;
 - stopUnit can be dangerous as we do not expect that a cgroup driver
   can kill processes.

So, remove stopUnit implementation and all calls to it.

Fixes: #2805 