### PR TITLE
tests/int: some refactoring, fix a flake

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -717,7 +717,6 @@ func (c *linuxContainer) checkCriuFeatures(criuOpts *CriuOpts, rpcOpts *criurpc.
 		return errors.New("CRIU feature check failed")
 	}
 
-	logrus.Debugf("Feature check says: %s", criuFeatures)
 	missingFeatures := false
 
 	// The outer if checks if the fields actually exist
@@ -1518,7 +1517,6 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 		// the initial CRIU run to detect the version. Skip it.
 		logrus.Debugf("Using CRIU %d at: %s", c.criuVersion, c.criuPath)
 	}
-	logrus.Debugf("Using CRIU with following args: %s", args)
 	cmd := exec.Command(c.criuPath, args...)
 	if process != nil {
 		cmd.Stdin = process.Stdin

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -189,8 +189,8 @@ function setup() {
 @test "runc run (blkio weight)" {
 	requires root cgroups_v2
 
-	set_cgroups_path "$BUSYBOX_BUNDLE"
-	update_config '.linux.resources.blockIO |= {"weight": 750}' "${BUSYBOX_BUNDLE}"
+	set_cgroups_path
+	update_config '.linux.resources.blockIO |= {"weight": 750}'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	[ "$status" -eq 0 ]

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -211,11 +211,13 @@ function simple_cr() {
 	lp_pid=$!
 
 	# Restore lazily from checkpoint.
-	# The restored container needs a different name as the checkpointed
+	# The restored container needs a different name (as well as systemd
+	# unit name, in case systemd cgroup driver is used) as the checkpointed
 	# container is not yet destroyed. It is only destroyed at that point
 	# in time when the last page is lazily transferred to the destination.
 	# Killing the CRIU on the checkpoint side will let the container
 	# continue to run if the migration failed at some point.
+	[ -n "$RUNC_USE_SYSTEMD" ] && set_cgroups_path
 	runc_restore_with_pipes ./image-dir test_busybox_restore --lazy-pages
 
 	wait $cpt_pid

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -194,6 +194,7 @@ function simple_cr() {
 
 	# wait for lazy page server to be ready
 	out=$(timeout 2 dd if=/proc/self/fd/${lazy_r} bs=1 count=1 2>/dev/null | od)
+	exec {lazy_r}>&-
 	exec {lazy_w}>&-
 	# shellcheck disable=SC2116,SC2086
 	out=$(echo $out) # rm newlines

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -38,11 +38,23 @@ function setup_pipes() {
 }
 
 function check_pipes() {
+	local output stderr
+
 	echo Ping >&${in_w}
 	exec {in_w}>&-
 	exec {out_w}>&-
+	exec {err_w}>&-
+
+	exec {in_r}>&-
 	output=$(cat <&${out_r})
+	exec {out_r}>&-
+	stderr=$(cat <&${err_r})
+	exec {err_r}>&-
+
 	[[ "${output}" == *"ponG Ping"* ]]
+	if [ -n "$stderr" ]; then
+		fail "runc stderr: $stderr"
+	fi
 }
 
 # Usage: runc_run_with_pipes container-name

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -85,8 +85,8 @@ EOF
 	[[ "$output" =~ [0-9]+ ]]
 
 	for s in ${subsystems}; do
-		name=CGROUP_${s^^}
-		eval path=\$"${name}"/foo
+		name=CGROUP_${s^^}_BASE_PATH
+		eval path=\$"${name}${REL_CGROUPS_PATH}/foo"
 		# shellcheck disable=SC2154
 		[ -d "${path}" ] || fail "test failed to create memory sub-cgroup ($path not found)"
 	done

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -532,10 +532,12 @@ EOF
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 	requires cgroups_v1 cgroups_rt no_systemd
 
-	# By default, "${CGROUP_CPU}/cpu.rt_runtime_us" is set to 0, which inhibits
+	local cgroup_cpu="${CGROUP_CPU_BASE_PATH}/${REL_CGROUPS_PATH}"
+
+	# By default, "${cgroup_cpu}/cpu.rt_runtime_us" is set to 0, which inhibits
 	# setting the container's realtimeRuntime. (#2046)
 	#
-	# When $CGROUP_CPU is "/sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/test-cgroup",
+	# When ${cgroup_cpu} is "/sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/test-cgroup",
 	# we write the values of /sys/fs/cgroup/cpu,cpuacct/cpu.rt_{period,runtime}_us to:
 	# - sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/cpu.rt_{period,runtime}_us
 	# - sys/fs/cgroup/cpu,cpuacct/runc-cgroups-integration-test/test-cgroup/cpu.rt_{period,runtime}_us
@@ -543,12 +545,12 @@ EOF
 	# Typically period=1000000 runtime=950000 .
 	#
 	# TODO: support systemd
-	mkdir -p "$CGROUP_CPU"
+	mkdir -p "$cgroup_cpu"
 	local root_period root_runtime
 	root_period=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us")
 	root_runtime=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_runtime_us")
 	# the following IFS magic sets dirs=("runc-cgroups-integration-test" "test-cgroup")
-	IFS='/' read -r -a dirs <<<"${CGROUP_CPU//${CGROUP_CPU_BASE_PATH}/}"
+	IFS='/' read -r -a dirs <<<"$REL_CGROUPS_PATH"
 	for ((i = 0; i < ${#dirs[@]}; i++)); do
 		local target="$CGROUP_CPU_BASE_PATH"
 		for ((j = 0; j <= i; j++)); do


### PR DESCRIPTION
Fixes https://github.com/opencontainers/runc/issues/2805

See all commits for descriptions. Most important ones are:

## tests/int/cpt: fix lazy-pages flakiness

"checkpoint --lazy-pages and restore" test sometimes fails on restore
in our CI on Fedora 33 when systemd cgroup driver is used:

> (00.076104) Error (compel/src/lib/infect.c:1513): Task 48521 is in unexpected state: f7f
> (00.076122) Error (compel/src/lib/infect.c:1520): Task stopped with 15: Terminated
> ...
> (00.078246) Error (criu/cr-restore.c:2483): Restoring FAILED.

I think what happens is

1. The test runs runc checkpoint in lazy-pages mode in background.
2. The test runs criu lazy-pages in background.
3. The test runs runc restore.

Now, all three are working in together: criu restore restores, criu
lazy-pages listens for page faults on a uffd and fetch missing pages
from runc checkpoint, who serves those pages.

At some point criu lazy-pages decides to fetch the rest of the pages,
and once it's done it exits, and runc checkpoint, as there are no more
pages to serve, exits too.

At the end of runc checkpoint the container is removed (see "defer
destroy(container)" in checkpoint.go. This involves a call to
cgroupManager.Destroy, which, in case systemd manager is used,
calls stopUnit, which makes systemd to not just remove the unit,
but also send SIGTERM to its processes, if there are any.

As the container is being restored into the same systemd unit,
sometimes this results in sending SIGTERM to a process which
criu restores, and thus restoring fails.

:spiral_notepad: for slightly more detailed description of the above, see https://github.com/opencontainers/runc/issues/2805#issuecomment-810718209)

The remedy here is to change the name of systemd unit to which the
container is restored.

##     tests/int: really randomize cgroup/unit names
    
Commit 41670e21f0 added some randomization to cgroup paths
and (if systemd cgroup driver is used) systemd unit names,
but
    
 - the randomization was done only if set_cgroups_path is called,
    which is not done by every test;
    
 - the randomization was per bats instance, not per test.
    
Fix both issues by refactoring init_cgroups_path/set_cgroups_path
(moving variable part to set_cgroups_path), and calling the latter
from runc_spec, so it is now applicable to every container.