### PR TITLE
libcontainer/configs/validate: make Validate() less DRY

### DIFF
--- a/libcontainer/configs/validate/rootless.go
+++ b/libcontainer/configs/validate/rootless.go
@@ -11,6 +11,9 @@ import (
 // rootlessEUID makes sure that the config can be applied when runc
 // is being executed as a non-root user (euid != 0) in the current user namespace.
 func (v *ConfigValidator) rootlessEUID(config *configs.Config) error {
+	if !config.RootlessEUID {
+		return nil
+	}
 	if err := rootlessEUIDMappings(config); err != nil {
 		return err
 	}

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -25,33 +25,22 @@ func New() Validator {
 type ConfigValidator struct {
 }
 
+type check func(config *configs.Config) error
+
 func (v *ConfigValidator) Validate(config *configs.Config) error {
-	if err := v.rootfs(config); err != nil {
-		return err
+	checks := []check{
+		v.rootfs,
+		v.network,
+		v.hostname,
+		v.security,
+		v.usernamespace,
+		v.cgroupnamespace,
+		v.sysctl,
+		v.intelrdt,
+		v.rootlessEUID,
 	}
-	if err := v.network(config); err != nil {
-		return err
-	}
-	if err := v.hostname(config); err != nil {
-		return err
-	}
-	if err := v.security(config); err != nil {
-		return err
-	}
-	if err := v.usernamespace(config); err != nil {
-		return err
-	}
-	if err := v.cgroupnamespace(config); err != nil {
-		return err
-	}
-	if err := v.sysctl(config); err != nil {
-		return err
-	}
-	if err := v.intelrdt(config); err != nil {
-		return err
-	}
-	if config.RootlessEUID {
-		if err := v.rootlessEUID(config); err != nil {
+	for _, c := range checks {
+		if err := c(config); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Noticed this when looking through the changes in https://github.com/opencontainers/runc/pull/2855

(this one will need to be updated if that one is merged first) 