### PR TITLE
Fix oss-fuzz coverage build

### DIFF
--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -8,6 +8,15 @@
 # OSS-fuzz environment.
 # More info about compile_go_fuzzer() can be found here:
 #     https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
+
+if [[ $SANITIZER = *coverage* ]]; then
+        compile_go_fuzzer github.com/opencontainers/runc/libcontainer/system FuzzUIDMap id_map_fuzzer linux gofuzz
+        compile_go_fuzzer github.com/opencontainers/runc/libcontainer/user FuzzUser user_fuzzer gofuzz
+        compile_go_fuzzer github.com/opencontainers/runc/libcontainer/configs FuzzUnmarshalJSON configs_fuzzer gofuzz
+
+        exit 0
+fi
+
 compile_go_fuzzer ./libcontainer/system FuzzUIDMap id_map_fuzzer linux
 compile_go_fuzzer ./libcontainer/user FuzzUser user_fuzzer
 compile_go_fuzzer ./libcontainer/configs FuzzUnmarshalJSON configs_fuzzer


### PR DESCRIPTION
Building on @dqminh's great initiative on fixing the oss-fuzz build (https://github.com/opencontainers/runc/pull/2869), this PR submits a working fix for the broken coverage build.

Also unlocks https://github.com/opencontainers/runc/pull/2878#issuecomment-812203536