### PR TITLE
go.mod: github.com/moby/sys/mountinfo v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/docker/go-units v0.4.0
 	github.com/godbus/dbus/v5 v5.0.4
-	github.com/moby/sys/mountinfo v0.4.0
+	github.com/moby/sys/mountinfo v0.4.1
 	github.com/mrunalp/fileutils v0.5.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/moby/sys/mountinfo v0.4.0 h1:1KInV3Huv18akCu58V7lzNlt+jFmqlu1EaErnEHE/VM=
-github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
+github.com/moby/sys/mountinfo v0.4.1 h1:1O+1cHA1aujwEwwVMa2Xm2l+gIpUHyd3+D+d7LZh1kM=
+github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo.go
@@ -29,35 +29,38 @@ type Info struct {
 	// ID is a unique identifier of the mount (may be reused after umount).
 	ID int
 
-	// Parent indicates the ID of the mount parent (or of self for the top of the
-	// mount tree).
+	// Parent is the ID of the parent mount (or of self for the root
+	// of this mount namespace's mount tree).
 	Parent int
 
-	// Major indicates one half of the device ID which identifies the device class.
-	Major int
+	// Major and Minor are the major and the minor components of the Dev
+	// field of unix.Stat_t structure returned by unix.*Stat calls for
+	// files on this filesystem.
+	Major, Minor int
 
-	// Minor indicates one half of the device ID which identifies a specific
-	// instance of device.
-	Minor int
-
-	// Root of the mount within the filesystem.
+	// Root is the pathname of the directory in the filesystem which forms
+	// the root of this mount.
 	Root string
 
-	// Mountpoint indicates the mount point relative to the process's root.
+	// Mountpoint is the pathname of the mount point relative to the
+	// process's root directory.
 	Mountpoint string
 
-	// Options represents mount-specific options.
+	// Options is a comma-separated list of mount options.
 	Options string
 
-	// Optional represents optional fields.
+	// Optional are zero or more fields of the form "tag[:value]",
+	// separated by a space.  Currently, the possible optional fields are
+	// "shared", "master", "propagate_from", and "unbindable". For more
+	// information, see mount_namespaces(7) Linux man page.
 	Optional string
 
-	// FSType indicates the type of filesystem, such as EXT3.
+	// FSType is the filesystem type in the form "type[.subtype]".
 	FSType string
 
-	// Source indicates filesystem specific information or "none".
+	// Source is filesystem-specific information, or "none".
 	Source string
 
-	// VFSOptions represents per super block options.
+	// VFSOptions is a comma-separated list of superblock options.
 	VFSOptions string
 }

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
@@ -14,11 +14,16 @@ import "strings"
 // stop: true if parsing should be stopped after the entry.
 type FilterFunc func(*Info) (skip, stop bool)
 
-// PrefixFilter discards all entries whose mount points
-// do not start with a specific prefix.
+// PrefixFilter discards all entries whose mount points do not start with, or
+// are equal to the path specified in prefix. The prefix path must be absolute,
+// have all symlinks resolved, and cleaned (i.e. no extra slashes or dots).
+//
+// PrefixFilter treats prefix as a path, not a partial prefix, which means that
+// given "/foo", "/foo/bar" and "/foobar" entries, PrefixFilter("/foo") returns
+// "/foo" and "/foo/bar", and discards "/foobar".
 func PrefixFilter(prefix string) FilterFunc {
 	return func(m *Info) (bool, bool) {
-		skip := !strings.HasPrefix(m.Mountpoint, prefix)
+		skip := !strings.HasPrefix(m.Mountpoint+"/", prefix+"/")
 		return skip, false
 	}
 }

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_linux.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_linux.go
@@ -12,7 +12,8 @@ import (
 // GetMountsFromReader retrieves a list of mounts from the
 // reader provided, with an optional filter applied (use nil
 // for no filter). This can be useful in tests or benchmarks
-// that provide a fake mountinfo data.
+// that provide fake mountinfo data, or when a source other
+// than /proc/self/mountinfo needs to be read from.
 //
 // This function is Linux-specific.
 func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
@@ -133,8 +134,6 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 	return out, nil
 }
 
-// Parse /proc/self/mountinfo because comparing Dev and ino does not work from
-// bind mounts
 func parseMountTable(filter FilterFunc) ([]*Info, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/docker/go-units
 github.com/godbus/dbus/v5
 # github.com/golang/protobuf v1.4.3
 github.com/golang/protobuf/proto
-# github.com/moby/sys/mountinfo v0.4.0
+# github.com/moby/sys/mountinfo v0.4.1
 ## explicit
 github.com/moby/sys/mountinfo
 # github.com/mrunalp/fileutils v0.5.0


### PR DESCRIPTION
full diff: https://github.com/moby/sys/compare/v0.4.0...v0.4.1

github.com/moby/sys/mountinfo v0.4.1
-----------------------------------------

- Fix PrefixFilter() being too greedy
- TestMountedBy*: add missing pre-checks
- Documentation improvements
