### PR TITLE
 libcontainer: read root pids.current from /proc 

### DIFF
--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -3,7 +3,10 @@
 package fs2
 
 import (
+	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -51,9 +54,33 @@ func statPidsWithoutController(dirPath string, stats *cgroups.Stats) error {
 	return nil
 }
 
+func readCurrentFromProcRoot() (uint64, error) {
+	fi, err := ioutil.ReadDir("/proc")
+	if err != nil {
+		return 0, err
+	}
+	var ret uint64
+	for _, i := range fi {
+		if !i.IsDir() {
+			continue
+		}
+		if _, err := strconv.ParseInt(i.Name(), 10, 32); err == nil {
+			ret = ret + 1
+		}
+	}
+	return ret, nil
+}
+
 func statPids(dirPath string, stats *cgroups.Stats) error {
 	current, err := fscommon.GetCgroupParamUint(dirPath, "pids.current")
 	if err != nil {
+		if dirPath == UnifiedMountpoint && os.IsNotExist(err) {
+			if current, err = readCurrentFromProcRoot(); err == nil {
+				stats.PidsStats.Current = current
+				stats.PidsStats.Limit = 0
+			}
+			return nil
+		}
 		return errors.Wrap(err, "failed to parse pids.current")
 	}
 

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -86,6 +86,7 @@ func genV1ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]syst
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
+			newProp("TasksAccounting", true),
 			newProp("TasksMax", uint64(r.PidsLimit)))
 	}
 
@@ -157,8 +158,7 @@ func (m *legacyManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("MemoryAccounting", true),
 		newProp("CPUAccounting", true),
-		newProp("BlockIOAccounting", true),
-		newProp("TasksAccounting", true))
+		newProp("BlockIOAccounting", true))
 
 	// Assume DefaultDependencies= will always work (the check for it was previously broken.)
 	properties = append(properties,
@@ -168,6 +168,11 @@ func (m *legacyManager) Apply(pid int) error {
 	if err != nil {
 		return err
 	}
+	resourcesProperties, err := genV1ResourcesProperties(c, dbusConnection)
+	if err != nil {
+		return err
+	}
+	properties = append(properties, resourcesProperties...)
 	properties = append(properties, c.SystemdProps...)
 
 	// We have to set kernel memory here, as we can't change it once

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -205,6 +205,7 @@ func genV2ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]syst
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
+			newProp("TasksAccounting", true),
 			newProp("TasksMax", uint64(r.PidsLimit)))
 	}
 
@@ -282,6 +283,11 @@ func (m *unifiedManager) Apply(pid int) error {
 	if err != nil {
 		return err
 	}
+	resourcesProperties, err := genV2ResourcesProperties(c, dbusConnection)
+	if err != nil {
+		return err
+	}
+	properties = append(properties, resourcesProperties...)
 	properties = append(properties, c.SystemdProps...)
 
 	if err := startUnit(dbusConnection, unitName, properties); err != nil {


### PR DESCRIPTION
more fixes on top of https://github.com/opencontainers/runc/pull/2873

when running on cgroup v2, if pids.current is not present in the
root (as of Linux 5.11 it is not) then read the number of current
processes from /proc.

Also revert a patch that causes a regression in the Kubelet when
vendored in Kubernetes: https://github.com/kubernetes/kubernetes/pull/100631#issuecomment-810001808

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>