### PR TITLE
checkpoint: resolve symlink for external bind mount

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -779,6 +779,9 @@ const descriptorsFilename = "descriptors.json"
 
 func (c *linuxContainer) addCriuDumpMount(req *criurpc.CriuReq, m *configs.Mount) {
 	mountDest := strings.TrimPrefix(m.Destination, c.config.Rootfs)
+	if dest, err := securejoin.SecureJoin(c.config.Rootfs, mountDest); err == nil {
+		mountDest = dest[len(c.config.Rootfs):]
+	}
 	extMnt := &criurpc.ExtMountMap{
 		Key: proto.String(mountDest),
 		Val: proto.String(mountDest),

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -126,7 +126,18 @@ function simple_cr() {
 	done
 }
 
-@test "checkpoint and restore " {
+@test "checkpoint and restore" {
+	simple_cr
+}
+
+@test "checkpoint and restore (bind mount, destination is symlink)" {
+	mkdir -p rootfs/real/conf
+	ln -s /real/conf rootfs/conf
+	update_config '	  .mounts += [{
+					source: ".",
+					destination: "/conf",
+					options: ["bind"]
+				}]'
 	simple_cr
 }
 


### PR DESCRIPTION
runc resolves symlink before doing bind mount. So
we should save original path while formatting CriuReq for
checkpoint.

Signed-off-by: Liu Hua <weldonliu@tencent.com>