### PR TITLE
libct/int: misc cleanups and fixes

### DIFF
--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -73,7 +73,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{
+	config := newTemplateConfig(t, &tParam{
 		rootfs: rootfs,
 		userns: userns,
 	})

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -62,15 +62,11 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 
 	root, err := newTestRoot()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer os.RemoveAll(root)
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	config := newTemplateConfig(t, &tParam{
@@ -78,21 +74,14 @@ func testCheckpoint(t *testing.T, userns bool) {
 		userns: userns,
 	})
 	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	container, err := factory.Create("test", config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	stdinR, stdinW, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	var stdout bytes.Buffer
 
@@ -108,24 +97,16 @@ func testCheckpoint(t *testing.T, userns bool) {
 	err = container.Run(&pconfig)
 	stdinR.Close()
 	defer stdinW.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	pid, err := pconfig.Pid()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	process, err := os.FindProcess(pid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	parentDir, err := ioutil.TempDir("", "criu-parent")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer os.RemoveAll(parentDir)
 
 	preDumpOpts := &libcontainer.CriuOpts{
@@ -141,18 +122,14 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 
 	state, err := container.Status()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	if state != libcontainer.Running {
 		t.Fatal("Unexpected preDump state: ", state)
 	}
 
 	imagesDir, err := ioutil.TempDir("", "criu")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer os.RemoveAll(imagesDir)
 
 	checkpointOpts := &libcontainer.CriuOpts{
@@ -169,9 +146,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 
 	state, err = container.Status()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	if state != libcontainer.Stopped {
 		t.Fatal("Unexpected state checkpoint: ", state)
@@ -179,20 +154,14 @@ func testCheckpoint(t *testing.T, userns bool) {
 
 	stdinW.Close()
 	_, err = process.Wait()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	// reload the container
 	container, err = factory.Load("test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	restoreStdinR, restoreStdinW, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	var restoreStdout bytes.Buffer
 	restoreProcessConfig := &libcontainer.Process{
@@ -211,33 +180,23 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 
 	state, err = container.Status()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	if state != libcontainer.Running {
 		t.Fatal("Unexpected restore state: ", state)
 	}
 
 	pid, err = restoreProcessConfig.Pid()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	_, err = os.FindProcess(pid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	_, err = restoreStdinW.WriteString("Hello!")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	restoreStdinW.Close()
 	s, err := restoreProcessConfig.Wait()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	if !s.Success() {
 		t.Fatal(s.String(), pid)

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -808,15 +808,11 @@ func TestContainerState(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	l, err := os.Readlink("/proc/1/ns/ipc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Namespaces = configs.Namespaces([]configs.Namespace{
@@ -829,15 +825,12 @@ func TestContainerState(t *testing.T) {
 	})
 
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	stdinR, stdinW, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
+
 	p := &libcontainer.Process{
 		Cwd:   "/",
 		Args:  []string{"cat"},
@@ -846,21 +839,15 @@ func TestContainerState(t *testing.T) {
 		Init:  true,
 	}
 	err = container.Run(p)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	stdinR.Close()
 	defer stdinW.Close()
 
 	st, err := container.State()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	l1, err := os.Readlink(st.NamespacePaths[configs.NEWIPC])
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	if l1 != l {
 		t.Fatal("Container using non-host ipc namespace")
 	}
@@ -874,28 +861,20 @@ func TestPassExtraFiles(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	var stdout bytes.Buffer
 	pipeout1, pipein1, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	pipeout2, pipein2, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	process := libcontainer.Process{
 		Cwd:        "/",
 		Args:       []string{"sh", "-c", "cd /proc/$$/fd; echo -n *; echo -n 1 >3; echo -n 2 >4"},
@@ -906,9 +885,7 @@ func TestPassExtraFiles(t *testing.T) {
 		Init:       true,
 	}
 	err = container.Run(&process)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	waitProcess(&process, t)
 
@@ -919,18 +896,14 @@ func TestPassExtraFiles(t *testing.T) {
 	}
 	var buf = []byte{0}
 	_, err = pipeout1.Read(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	out1 := string(buf)
 	if out1 != "1" {
 		t.Fatalf("expected first pipe to receive '1', got '%s'", out1)
 	}
 
 	_, err = pipeout2.Read(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	out2 := string(buf)
 	if out2 != "2" {
 		t.Fatalf("expected second pipe to receive '2', got '%s'", out2)
@@ -943,15 +916,11 @@ func TestMountCmds(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	tmpDir, err := ioutil.TempDir("", "tmpdir")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer os.RemoveAll(tmpDir)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
@@ -971,9 +940,7 @@ func TestMountCmds(t *testing.T) {
 	})
 
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	pconfig := libcontainer.Process{
@@ -983,17 +950,13 @@ func TestMountCmds(t *testing.T) {
 		Init: true,
 	}
 	err = container.Run(&pconfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	// Wait for process
 	waitProcess(&pconfig, t)
 
 	entries, err := ioutil.ReadDir(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	expected := []string{"hello", "hello-backup", "world", "world-backup"}
 	for i, e := range entries {
 		if e.Name() != expected[i] {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -612,9 +612,6 @@ func testPids(t *testing.T, systemd bool) {
 
 	// Running multiple processes.
 	_, ret, err := runContainer(t, config, "", "/bin/sh", "-c", "/bin/true | /bin/true | /bin/true | /bin/true")
-	if err != nil && strings.Contains(err.Error(), "no such directory for pids.max") {
-		t.Skip("PIDs cgroup is unsupported")
-	}
 	ok(t, err)
 
 	if ret != 0 {
@@ -629,9 +626,6 @@ func testPids(t *testing.T, systemd bool) {
 	/bin/true | /bin/true | /bin/true | /bin/true | /bin/true | /bin/true | bin/true | /bin/true |
 	/bin/true | /bin/true | /bin/true | /bin/true | /bin/true | /bin/true | bin/true | /bin/true |
 	/bin/true | /bin/true | /bin/true | /bin/true | /bin/true | /bin/true | bin/true | /bin/true`)
-	if err != nil && strings.Contains(err.Error(), "no such directory for pids.max") {
-		t.Skip("PIDs cgroup is unsupported")
-	}
 	ok(t, err)
 
 	if ret != 0 {
@@ -650,9 +644,6 @@ func testPids(t *testing.T, systemd bool) {
 	/bin/true | /bin/true | /bin/true | /bin/true | /bin/true | /bin/true | bin/true | /bin/true |
 	/bin/true | /bin/true | /bin/true | /bin/true | /bin/true | /bin/true | bin/true | /bin/true |
 	/bin/true | /bin/true | /bin/true | /bin/true | /bin/true | /bin/true | bin/true | /bin/true`)
-	if err != nil && strings.Contains(err.Error(), "no such directory for pids.max") {
-		t.Skip("PIDs cgroup is unsupported")
-	}
 	if err != nil && !strings.Contains(out.String(), "sh: can't fork") {
 		ok(t, err)
 	}

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -25,8 +25,8 @@ func TestExecIn(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	container, err := newContainer(config)
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -91,12 +91,12 @@ func testExecInRlimit(t *testing.T, userns bool) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{
+	config := newTemplateConfig(t, &tParam{
 		rootfs: rootfs,
 		userns: userns,
 	})
 
-	container, err := newContainer(config)
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -150,8 +150,8 @@ func TestExecInAdditionalGroups(t *testing.T) {
 	ok(t, err)
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	container, err := newContainer(config)
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -207,8 +207,8 @@ func TestExecInError(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	container, err := newContainer(config)
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -261,8 +261,8 @@ func TestExecInTTY(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	container, err := newContainer(config)
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -357,8 +357,8 @@ func TestExecInEnvironment(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	container, err := newContainer(config)
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -419,8 +419,8 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
-	container, err := newContainer(config)
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	container, err := newContainer(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,9 +503,9 @@ func TestExecInOomScoreAdj(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.OomScoreAdj = ptrInt(200)
-	container, err := newContainer(config)
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -555,11 +555,11 @@ func TestExecInUserns(t *testing.T) {
 	rootfs, err := newRootfs()
 	ok(t, err)
 	defer remove(rootfs)
-	config := newTemplateConfig(&tParam{
+	config := newTemplateConfig(t, &tParam{
 		rootfs: rootfs,
 		userns: true,
 	})
-	container, err := newContainer(config)
+	container, err := newContainer(t, config)
 	ok(t, err)
 	defer container.Destroy()
 

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -298,9 +298,7 @@ func TestExecInTTY(t *testing.T) {
 		var stdout bytes.Buffer
 
 		parent, child, err := utils.NewSockPair("console")
-		if err != nil {
-			ok(t, err)
-		}
+		ok(t, err)
 		ps.ConsoleSocket = child
 
 		done := make(chan (error))
@@ -415,22 +413,17 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		return
 	}
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
+
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	// Execute a first process in the container
 	stdinR, stdinW, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	process := &libcontainer.Process{
 		Cwd:   "/",
 		Args:  []string{"cat"},
@@ -441,19 +434,13 @@ func TestExecinPassExtraFiles(t *testing.T) {
 	err = container.Run(process)
 	stdinR.Close()
 	defer stdinW.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	var stdout bytes.Buffer
 	pipeout1, pipein1, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	pipeout2, pipein2, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	inprocess := &libcontainer.Process{
 		Cwd:        "/",
 		Args:       []string{"sh", "-c", "cd /proc/$$/fd; echo -n *; echo -n 1 >3; echo -n 2 >4"},
@@ -463,9 +450,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		Stdout:     &stdout,
 	}
 	err = container.Run(inprocess)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	waitProcess(inprocess, t)
 	stdinW.Close()
@@ -478,18 +463,14 @@ func TestExecinPassExtraFiles(t *testing.T) {
 	}
 	var buf = []byte{0}
 	_, err = pipeout1.Read(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	out1 := string(buf)
 	if out1 != "1" {
 		t.Fatalf("expected first pipe to receive '1', got '%s'", out1)
 	}
 
 	_, err = pipeout2.Read(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	out2 := string(buf)
 	if out2 != "2" {
 		t.Fatalf("expected second pipe to receive '2', got '%s'", out2)

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -18,9 +18,7 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	errnoRet := uint(syscall.ESRCH)
@@ -38,9 +36,7 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 	}
 
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	buffers := newStdBuffers()
@@ -55,9 +51,7 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 	}
 
 	err = container.Run(pwd)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	ps, err := pwd.Wait()
 	if err == nil {
 		t.Fatal("Expecting error (negative return code); instead exited cleanly!")
@@ -90,9 +84,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
@@ -107,9 +99,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 	}
 
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	buffers := newStdBuffers()
@@ -124,9 +114,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 	}
 
 	err = container.Run(pwd)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	ps, err := pwd.Wait()
 	if err == nil {
 		t.Fatal("Expecting error (negative return code); instead exited cleanly!")
@@ -159,9 +147,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
@@ -183,9 +169,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 	}
 
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	buffers := newStdBuffers()
@@ -200,9 +184,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 	}
 
 	err = container.Run(dmesg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	if _, err := dmesg.Wait(); err != nil {
 		t.Fatalf("%s: %s", err, buffers.Stderr)
 	}
@@ -221,9 +203,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
@@ -245,9 +225,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 	}
 
 	container, err := newContainer(t, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer container.Destroy()
 
 	buffers := newStdBuffers()
@@ -262,9 +240,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 	}
 
 	err = container.Run(dmesg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 
 	ps, err := dmesg.Wait()
 	if err == nil {
@@ -299,9 +275,7 @@ func TestSeccompPermitWriteMultipleConditions(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
@@ -354,9 +328,7 @@ func TestSeccompDenyWriteMultipleConditions(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
@@ -403,9 +375,7 @@ func TestSeccompMultipleConditionSameArgDeniesStdout(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	// Prevent writing to both stdout and stderr
@@ -451,9 +421,7 @@ func TestSeccompMultipleConditionSameArgDeniesStderr(t *testing.T) {
 	}
 
 	rootfs, err := newRootfs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ok(t, err)
 	defer remove(rootfs)
 
 	// Prevent writing to both stdout and stderr

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -25,7 +25,7 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 
 	errnoRet := uint(syscall.ESRCH)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -37,7 +37,7 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 		},
 	}
 
-	container, err := newContainer(config)
+	container, err := newContainer(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -106,7 +106,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 		},
 	}
 
-	container, err := newContainer(config)
+	container, err := newContainer(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -182,7 +182,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 		},
 	}
 
-	container, err := newContainer(config)
+	container, err := newContainer(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -244,7 +244,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 		},
 	}
 
-	container, err := newContainer(config)
+	container, err := newContainer(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestSeccompPermitWriteMultipleConditions(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -327,7 +327,7 @@ func TestSeccompPermitWriteMultipleConditions(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(config, "", "ls", "/")
+	buffers, exitCode, err := runContainer(t, config, "", "ls", "/")
 	if err != nil {
 		t.Fatalf("%s: %s", buffers, err)
 	}
@@ -359,7 +359,7 @@ func TestSeccompDenyWriteMultipleConditions(t *testing.T) {
 	}
 	defer remove(rootfs)
 
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -382,7 +382,7 @@ func TestSeccompDenyWriteMultipleConditions(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(config, "", "ls", "/does_not_exist")
+	buffers, exitCode, err := runContainer(t, config, "", "ls", "/does_not_exist")
 	if err == nil {
 		t.Fatalf("Expecting error return, instead got 0")
 	}
@@ -409,7 +409,7 @@ func TestSeccompMultipleConditionSameArgDeniesStdout(t *testing.T) {
 	defer remove(rootfs)
 
 	// Prevent writing to both stdout and stderr
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -432,7 +432,7 @@ func TestSeccompMultipleConditionSameArgDeniesStdout(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(config, "", "ls", "/")
+	buffers, exitCode, err := runContainer(t, config, "", "ls", "/")
 	if err != nil {
 		t.Fatalf("%s: %s", buffers, err)
 	}
@@ -457,7 +457,7 @@ func TestSeccompMultipleConditionSameArgDeniesStderr(t *testing.T) {
 	defer remove(rootfs)
 
 	// Prevent writing to both stdout and stderr
-	config := newTemplateConfig(&tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -480,7 +480,7 @@ func TestSeccompMultipleConditionSameArgDeniesStderr(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(config, "", "ls", "/does_not_exist")
+	buffers, exitCode, err := runContainer(t, config, "", "ls", "/does_not_exist")
 	if err == nil {
 		t.Fatalf("Expecting error return, instead got 0")
 	}

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -1,8 +1,9 @@
 package integration
 
 import (
-	"math/rand"
 	"strconv"
+	"testing"
+	"time"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
@@ -29,7 +30,7 @@ type tParam struct {
 //
 // it uses a network strategy of just setting a loopback interface
 // and the default setup for devices
-func newTemplateConfig(p *tParam) *configs.Config {
+func newTemplateConfig(t *testing.T, p *tParam) *configs.Config {
 	var allowedDevices []*devices.Rule
 	for _, device := range specconv.AllowedDevices {
 		allowedDevices = append(allowedDevices, &device.Rule)
@@ -213,9 +214,9 @@ func newTemplateConfig(p *tParam) *configs.Config {
 	}
 
 	if p.systemd {
-		id := strconv.FormatUint(rand.Uint64(), 36)
-		config.Cgroups.Name = "test" + id
-		// do not change Parent (see newContainerWithName)
+		id := strconv.FormatInt(-int64(time.Now().Nanosecond()), 36)
+		config.Cgroups.Name = t.Name() + id
+		// do not change Parent (see newContainer)
 		config.Cgroups.Parent = "system.slice"
 		config.Cgroups.ScopePrefix = "runc-test"
 	} else {

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -2,8 +2,6 @@ package integration
 
 import (
 	"bytes"
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -152,13 +151,8 @@ func copyBusybox(dest string) error {
 	return nil
 }
 
-func newContainer(config *configs.Config) (libcontainer.Container, error) {
-	h := md5.New()
-	h.Write([]byte(time.Now().String()))
-	return newContainerWithName(hex.EncodeToString(h.Sum(nil)), config)
-}
-
-func newContainerWithName(name string, config *configs.Config) (libcontainer.Container, error) {
+func newContainer(t *testing.T, config *configs.Config) (libcontainer.Container, error) {
+	name := t.Name() + strconv.FormatInt(int64(time.Now().Nanosecond()), 35)
 	root, err := newTestRoot()
 	if err != nil {
 		return nil, err
@@ -181,8 +175,8 @@ func newContainerWithName(name string, config *configs.Config) (libcontainer.Con
 //
 // buffers are returned containing the STDOUT and STDERR output for the run
 // along with the exit code and any go error
-func runContainer(config *configs.Config, console string, args ...string) (buffers *stdBuffers, exitCode int, err error) {
-	container, err := newContainer(config)
+func runContainer(t *testing.T, config *configs.Config, console string, args ...string) (buffers *stdBuffers, exitCode int, err error) {
+	container, err := newContainer(t, config)
 	if err != nil {
 		return nil, -1, err
 	}


### PR DESCRIPTION
Please see individual commits for details. Nothing serious, but improved container names and cgroups randomization might help to reduce flakes.