### PR TITLE
libct/cg: don't return OOMKillCount error when rootless

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -296,7 +296,7 @@ func (m *manager) Set(container *configs.Config) error {
 			if m.rootless && sys.Name() == "devices" {
 				continue
 			}
-			// When m.Rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
+			// When m.rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
 			// However, errors from other subsystems are not ignored.
 			// see @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
 			if path == "" {

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -428,5 +428,11 @@ func OOMKillCount(path string) (uint64, error) {
 }
 
 func (m *manager) OOMKillCount() (uint64, error) {
-	return OOMKillCount(m.Path("memory"))
+	c, err := OOMKillCount(m.Path("memory"))
+	// Ignore ENOENT when rootless as it couldn't create cgroup.
+	if err != nil && m.rootless && os.IsNotExist(err) {
+		err = nil
+	}
+
+	return c, err
 }

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -263,5 +263,10 @@ func OOMKillCount(path string) (uint64, error) {
 }
 
 func (m *manager) OOMKillCount() (uint64, error) {
-	return OOMKillCount(m.dirPath)
+	c, err := OOMKillCount(m.dirPath)
+	if err != nil && m.rootless && os.IsNotExist(err) {
+		err = nil
+	}
+
+	return c, err
 }

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -188,7 +188,7 @@ func (m *manager) Set(container *configs.Config) error {
 	}
 	// devices (since kernel 4.15, pseudo-controller)
 	//
-	// When m.Rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
+	// When m.rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
 	// However, errors from other subsystems are not ignored.
 	// see @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
 	if err := setDevices(m.dirPath, container.Cgroups); err != nil && !m.rootless {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -498,5 +498,9 @@ func (m *unifiedManager) Exists() bool {
 }
 
 func (m *unifiedManager) OOMKillCount() (uint64, error) {
-	return fs2.OOMKillCount(m.path)
+	fsMgr, err := m.fsManager()
+	if err != nil {
+		return 0, err
+	}
+	return fsMgr.OOMKillCount()
 }


### PR DESCRIPTION
PR #2812 (commit 5d0ffbf9c81f) added OOM kill count checking and better container
start/run/exec error reporting in case we hit OOM.
    
It also introduced warnings like these:
    
> level=warning msg="unable to get oom kill count" error="openat2 /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/test_hello/memory.events: no such file or directory"
    
In case of rootless containers, unless cgroup is delegated or systemd is
used, runc can not create a cgroup and thus it fails to get OOM kill
count. This is expected, and the warning should not be shown in this
case.
