### PR TITLE
logging: enable file/line info if --debug is set

### DIFF
--- a/libcontainer/logs/logs.go
+++ b/libcontainer/logs/logs.go
@@ -24,6 +24,7 @@ type Config struct {
 	LogFormat   string
 	LogFilePath string
 	LogPipeFd   int
+	LogCaller   bool
 }
 
 func ForwardLogs(logPipe io.ReadCloser) chan error {
@@ -77,6 +78,7 @@ func ConfigureLogging(config Config) error {
 	}
 
 	logrus.SetLevel(config.LogLevel)
+	logrus.SetReportCaller(config.LogCaller)
 
 	// XXX: while 0 is a valid fd (usually stdin), here we assume
 	// that we never deliberately set LogPipeFd to 0.

--- a/main.go
+++ b/main.go
@@ -190,6 +190,7 @@ func createLogConfig(context *cli.Context) logs.Config {
 		LogLevel:    logrus.InfoLevel,
 		LogFilePath: logFilePath,
 		LogFormat:   context.GlobalString("log-format"),
+		LogCaller:   context.GlobalBool("debug"),
 	}
 	if context.GlobalBool("debug") {
 		config.LogLevel = logrus.DebugLevel


### PR DESCRIPTION
This helps a lot to find out where the errors come from.

Before:
> level=warning msg="lstat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/test_hello: no such file or directory"

After:
> level=warning msg="lstat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/test_hello: no such file or directory" func=github.com/opencontainers/runc/libcontainer.destroy file="github.com/opencontainers/runc/libcontainer/state_linux.go:44"

Presumably this comes with an overhead, but I guess no one is using
`--debug` by default anyway.

PS I'd love to cut the 'github.com/opencontainers/runc/` prefix but don't see an easy way to :-\