### PR TITLE
Add cfs throttle stats to cgroup v2

### DIFF
--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -70,6 +70,15 @@ func statCpu(dirPath string, stats *cgroups.Stats) error {
 
 		case "system_usec":
 			stats.CpuStats.CpuUsage.UsageInKernelmode = v * 1000
+
+		case "nr_periods":
+			stats.CpuStats.ThrottlingData.Periods = v
+
+		case "nr_throttled":
+			stats.CpuStats.ThrottlingData.ThrottledPeriods = v
+
+		case "throttled_usec":
+			stats.CpuStats.ThrottlingData.ThrottledTime = v * 1000
 		}
 	}
 	return nil


### PR DESCRIPTION
This adds cfs throttle stats to cgroup v2.

More info here: https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html

Tried adding a test, but cgroup v2 have no tests, and the test infrastructure is tightly coupled with cgroup v1. Adding test infra to v2 is outside the scope of this PR.