### PR TITLE
tiny fix iterative checkpoint test case

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -121,14 +121,15 @@ using the runc checkpoint command.`,
 }
 
 func criuOptions(context *cli.Context) *libcontainer.CriuOpts {
-	imagePath := getCheckpointImagePath(context)
-	if err := os.MkdirAll(imagePath, 0755); err != nil {
+	imagePath, parentPath, err := prepareImagePaths(context)
+	if err != nil {
 		fatal(err)
 	}
+
 	return &libcontainer.CriuOpts{
 		ImagesDirectory:         imagePath,
 		WorkDirectory:           context.String("work-path"),
-		ParentImage:             context.String("parent-path"),
+		ParentImage:             parentPath,
 		LeaveRunning:            context.Bool("leave-running"),
 		TcpEstablished:          context.Bool("tcp-established"),
 		ExternalUnixConnections: context.Bool("ext-unix-sk"),

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -159,9 +159,12 @@ function simple_cr() {
 	# checkpoint the running container
 	mkdir image-dir
 	mkdir work-dir
-	runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
+	runc --criu "$CRIU" checkpoint --parent-path ../parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
 	grep -B 5 Error ./work-dir/dump.log || true
 	[ "$status" -eq 0 ]
+
+	# check parent path is valid
+	[ -e ./image-dir/parent ]
 
 	# after checkpoint busybox is no longer running
 	testcontainer test_busybox checkpointed

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -144,6 +144,23 @@ function simple_cr() {
 	simple_cr
 }
 
+@test "checkpoint --pre-dump (bad --parent-path)" {
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	testcontainer test_busybox running
+
+	# runc should fail with absolute parent image path.
+	runc --criu "$CRIU" checkpoint --parent-path "$(pwd)"/parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
+	[[ "${output}" == *"--parent-path"* ]]
+	[ "$status" -ne 0 ]
+
+	# runc should fail with invalid parent image path.
+	runc --criu "$CRIU" checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
+	[[ "${output}" == *"--parent-path"* ]]
+	[ "$status" -ne 0 ]
+}
+
 @test "checkpoint --pre-dump and restore" {
 	setup_pipes
 	runc_run_with_pipes test_busybox


### PR DESCRIPTION
Criu creates symlink named "parent" under image-path while doing
interactive checkpoint, without checking wether symlink points to
right place. This patch corrects related test case.

Signed-off-by: Liu Hua <weldonliu@tencent.com>