### PR TITLE
Fuzzing: Build fuzzers from other repository

### DIFF
--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -11,3 +11,7 @@
 compile_go_fuzzer ./libcontainer/system FuzzUIDMap id_map_fuzzer linux
 compile_go_fuzzer ./libcontainer/user FuzzUser user_fuzzer
 compile_go_fuzzer ./libcontainer/configs FuzzUnmarshalJSON configs_fuzzer
+
+# Build fuzzers from an independent repository
+git clone --depth 1 https://github.com/AdaLogics/runc-fuzzers $SRC/runc-fuzzers
+$SRC/runc-fuzzers/build.sh


### PR DESCRIPTION
This PR adds two lines to the OSS-fuzz build script that builds the fuzzers from an independent repository.

It builds the fuzzers from the following PRs:

1. https://github.com/opencontainers/runc/pull/2848
2. https://github.com/opencontainers/runc/pull/2858
3. https://github.com/opencontainers/runc/pull/2864
4. https://github.com/opencontainers/runc/pull/2872
5. https://github.com/opencontainers/runc/pull/2878
6. https://github.com/opencontainers/runc/pull/2879

While it would be good to merge the fuzzers from the PR's above, it is not necessary to do that now. What is important is to run the fuzzers and this PR allows that without merging the PR's above now.

Once this PR is merged, the fuzzers will be built and run by OSS-fuzz continuously.