### PR TITLE
Validate mounts

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -39,6 +39,7 @@ func (v *ConfigValidator) Validate(config *configs.Config) error {
 		v.sysctl,
 		v.intelrdt,
 		v.rootlessEUID,
+		v.mounts,
 	}
 	for _, c := range checks {
 		if err := c(config); err != nil {
@@ -240,6 +241,16 @@ func (v *ConfigValidator) cgroups(config *configs.Config) error {
 		_, err := cgroups.ConvertMemorySwapToCgroupV2Value(r.MemorySwap, r.Memory)
 		if err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *ConfigValidator) mounts(config *configs.Config) error {
+	for _, m := range config.Mounts {
+		if !filepath.IsAbs(m.Destination) {
+			return fmt.Errorf("invalid mount %+v: mount destination not absolute", m)
 		}
 	}
 

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -238,7 +238,11 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	}
 
 	for _, m := range spec.Mounts {
-		config.Mounts = append(config.Mounts, createLibcontainerMount(cwd, m))
+		cm, err := createLibcontainerMount(cwd, m)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mount %+v: %w", m, err)
+		}
+		config.Mounts = append(config.Mounts, cm)
 	}
 
 	defaultDevs, err := createDevices(spec, config)
@@ -327,7 +331,10 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	return config, nil
 }
 
-func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
+func createLibcontainerMount(cwd string, m specs.Mount) (*configs.Mount, error) {
+	if !filepath.IsAbs(m.Destination) {
+		return nil, fmt.Errorf("mount destination %s not absolute", m.Destination)
+	}
 	flags, pgflags, data, ext := parseMountOptions(m.Options)
 	source := m.Source
 	device := m.Type
@@ -348,7 +355,7 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 		Flags:            flags,
 		PropagationFlags: pgflags,
 		Extensions:       ext,
-	}
+	}, nil
 }
 
 // systemd property name check: latin letters only, at least 3 of them


### PR DESCRIPTION
According to OCI spec, mount destination MUST be an absolute path. We never validate it, I think we should.

Add validation to both specconv and configs/validate, and error out on non-abs paths.