### PR TITLE
cloned_binary: switch from #error to #warning for SYS_memfd_create

### DIFF
--- a/libcontainer/nsenter/cloned_binary.c
+++ b/libcontainer/nsenter/cloned_binary.c
@@ -75,12 +75,12 @@
 #      define SYS_memfd_create 385
 #    elif defined(__aarch64__)
 #      define SYS_memfd_create 279
-#    elif defined(__ppc__) || defined(__ppc64__)
+#    elif defined(__ppc__) || defined(__PPC64__) || defined(__powerpc64__)
 #      define SYS_memfd_create 360
 #    elif defined(__s390__) || defined(__s390x__)
 #      define SYS_memfd_create 350
 #    else
-#      error "unknown architecture -- cannot hard-code SYS_memfd_create"
+#      warning "unknown architecture -- cannot hard-code SYS_memfd_create"
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
We shouldn't refuse to build on architectures just because we don't know
what the syscall number of memfd_create(2) is. In addition, use the
correct defined(...) macros for ppc64 (these are the ones glibc uses).

Fixes: 3aead32ea246 ("nsenter: hard-code memfd_create(2) syscall numbers")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>