### PR TITLE
Makefile: allow overriding go command by environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CONTAINER_ENGINE := docker
-GO := go
+GO ?= go
 
 PREFIX ?= /usr/local
 BINDIR := $(PREFIX)/sbin


### PR DESCRIPTION
This is required for environments/build systems where a specific
go version / command needs to be used.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>