### PR TITLE
libct/cg/sd: fix dbus connection leak (alternative)

### DIFF
--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -10,37 +10,43 @@ import (
 	dbus "github.com/godbus/dbus/v5"
 )
 
+var (
+	dbusC        *systemdDbus.Conn
+	dbusMu       sync.RWMutex
+	dbusInited   bool
+	dbusRootless bool
+)
+
 type dbusConnManager struct {
-	conn     *systemdDbus.Conn
-	rootless bool
-	sync.RWMutex
 }
 
 // newDbusConnManager initializes systemd dbus connection manager.
 func newDbusConnManager(rootless bool) *dbusConnManager {
-	return &dbusConnManager{
-		rootless: rootless,
+	if dbusInited && rootless != dbusRootless {
+		panic("can't have both root and rootless dbus")
 	}
+	dbusRootless = rootless
+	return &dbusConnManager{}
 }
 
 // getConnection lazily initializes and returns systemd dbus connection.
 func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
-	// In the case where d.conn != nil
+	// In the case where dbusC != nil
 	// Use the read lock the first time to ensure
 	// that Conn can be acquired at the same time.
-	d.RLock()
-	if conn := d.conn; conn != nil {
-		d.RUnlock()
+	dbusMu.RLock()
+	if conn := dbusC; conn != nil {
+		dbusMu.RUnlock()
 		return conn, nil
 	}
-	d.RUnlock()
+	dbusMu.RUnlock()
 
-	// In the case where d.conn == nil
+	// In the case where dbusC == nil
 	// Use write lock to ensure that only one
 	// will be created
-	d.Lock()
-	defer d.Unlock()
-	if conn := d.conn; conn != nil {
+	dbusMu.Lock()
+	defer dbusMu.Unlock()
+	if conn := dbusC; conn != nil {
 		return conn, nil
 	}
 
@@ -48,12 +54,12 @@ func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.conn = conn
+	dbusC = conn
 	return conn, nil
 }
 
 func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
-	if d.rootless {
+	if dbusRootless {
 		return newUserSystemdDbus()
 	}
 	return systemdDbus.NewWithContext(context.TODO())
@@ -62,11 +68,11 @@ func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
 // resetConnection resets the connection to its initial state
 // (so it can be reconnected if necessary).
 func (d *dbusConnManager) resetConnection(conn *systemdDbus.Conn) {
-	d.Lock()
-	defer d.Unlock()
-	if d.conn != nil && d.conn == conn {
-		d.conn.Close()
-		d.conn = nil
+	dbusMu.Lock()
+	defer dbusMu.Unlock()
+	if dbusC != nil && dbusC == conn {
+		dbusC.Close()
+		dbusC = nil
 	}
 }
 

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -337,16 +337,8 @@ func (m *unifiedManager) getSliceFull() (string, error) {
 	}
 
 	if m.rootless {
-		dbusConnection, err := m.dbus.getConnection()
-		if err != nil {
-			return "", err
-		}
-		// managerCGQuoted is typically "/user.slice/user-${uid}.slice/user@${uid}.service" including the quote symbols
-		managerCGQuoted, err := dbusConnection.GetManagerProperty("ControlGroup")
-		if err != nil {
-			return "", err
-		}
-		managerCG, err := strconv.Unquote(managerCGQuoted)
+		// managerCG is typically "/user.slice/user-${uid}.slice/user@${uid}.service".
+		managerCG, err := getManagerProperty(m.dbus, "ControlGroup")
 		if err != nil {
 			return "", err
 		}

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1917,6 +1917,14 @@ func TestCGROUPHost(t *testing.T) {
 }
 
 func TestFdLeaks(t *testing.T) {
+	testFdLeaks(t, false)
+}
+
+func TestFdLeaksSystemd(t *testing.T) {
+	testFdLeaks(t, true)
+}
+
+func testFdLeaks(t *testing.T, systemd bool) {
 	if testing.Short() {
 		return
 	}
@@ -1933,7 +1941,10 @@ func TestFdLeaks(t *testing.T) {
 	_, err = pfd.Seek(0, 0)
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, &tParam{
+		rootfs:  rootfs,
+		systemd: systemd,
+	})
 	buffers, exitCode, err := runContainer(t, config, "", "true")
 	ok(t, err)
 


### PR DESCRIPTION
TL;DR: fixes a regression (open fd leak) caused by PR #2923. *This is an alternative to #2936.*

When running libcontainer/integration/TestSystemdFreeze 2000 times,
I got "too many open files" error after a while:

```console
[vagrant@localhost integration]$ sudo -E PATH=$PATH ./integration.test -test.v -test.run Freeze -test.count 2000
<...>
=== RUN   TestFreeze
--- PASS: TestFreeze (0.28s)
=== RUN   TestSystemdFreeze
--- PASS: TestSystemdFreeze (0.42s)
=== RUN   TestFreeze
    utils_test.go:86: exec_test.go:536: unexpected error: container_linux.go:380: starting container process caused: process_linux.go:338: starting init process command caused: fork/exec /proc/self/exe: too many open files
        
--- FAIL: TestFreeze (0.16s)
=== RUN   TestSystemdFreeze
    utils_test.go:86: exec_test.go:536: unexpected error: container_linux.go:380: starting container process caused: process_linux.go:338: starting init process command caused: fork/exec /proc/self/exe: too many open files

<...>

--- FAIL: TestFreeze (0.00s)
=== RUN   TestSystemdFreeze
    utils_test.go:86: exec_test.go:536: unexpected error: container_linux.go:380: starting container process caused: process_linux.go:338: starting init process command caused: open /dev/null: too many open files
        
--- FAIL: TestSystemdFreeze (0.16s)
=== RUN   TestFreeze
    utils_test.go:86: exec_test.go:512: unexpected error: untar error "fork/exec /bin/sh: too many open files": ""
        
--- FAIL: TestFreeze (0.00s)
=== RUN   TestSystemdFreeze
    utils_test.go:86: exec_test.go:536: unexpected error: container_linux.go:364: creating new parent process caused: container_linux.go:496: including execfifo in cmd.Exec setup caused: open /tmp/libcontainer548959440/test/exec.fifo: too many open files
       
 --- FAIL: TestSystemdFreeze (0.17s)
=== RUN   TestFreeze
    utils_test.go:86: exec_test.go:512: unexpected error: untar error "open /dev/null: too many open files": ""
        
<...>
```

Indeed, systemd cgroup manager never closes its dbus connection.
    
This was not a problem before PR #2923 because we only had a single connection
for the whole runtime. Now it is per manager instance, so we leak a
connection (apparently two sockets) per cgroup manager instance.
    
The fix is to go back to using a single global dbus connection.
**UPDATE** this is now done to minimize the diff size.

This also makes it impossible to use both rootful and  rootless dbus connections
at the same time. From what I understand, no runtime ever wants or needs to
do that, so it's not an issue in practice. An assertion is added to make sure this
never happens.

A test case is added in a separate commit. Before the fix, it always fails
like this:
```
        exec_test.go:2030: extra fd 8 -> socket:[659703]
        exec_test.go:2030: extra fd 11 -> socket:[658715]
        exec_test.go:2033: found 2 extra fds after container.Run
    --- FAIL: TestFdLeaksSystemd (0.20s)

```