### PR TITLE
libct/intelrdt: fix unit test

### DIFF
--- a/libcontainer/intelrdt/intelrdt_test.go
+++ b/libcontainer/intelrdt/intelrdt_test.go
@@ -217,10 +217,10 @@ func TestFindIntelRdtMountpointDir(t *testing.T) {
 		},
 	}
 
-	t.Parallel()
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			mbaScEnabled = false
 			mp, err := findIntelRdtMountpointDir(tc.input)
 			if tc.isNotFoundError {
 				if !IsNotFound(err) {


### PR DESCRIPTION
1. These tests can't be run in parallel since they do check
   a global variable (`mbaScEnabled`).

2. `findIntelRdtMountpointDir()` relies on `mbaScEnabled` to be initially
   set to the default value (`false`) and this the test fails if run
   more than once:

> go test -count 2
> ...
> intelrdt_test.go:243: expected mbaScEnabled=false, got true
>    --- FAIL: TestFindIntelRdtMountpointDir/Valid_mountinfo_with_MBA_Software_Controller_disabled (0.00s)

Fixes: 2c70d2384 (PR #2606)