### PR TITLE
Fix/improve runc -v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
 BUILDTAGS ?= seccomp
-COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
-COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"$(COMMIT_NO)-dirty","$(COMMIT_NO)")
+COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION := $(shell cat ./VERSION)
 
 # TODO: rm -mod=vendor once go 1.13 is unsupported

--- a/main.go
+++ b/main.go
@@ -15,9 +15,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-// version will be populated by the Makefile, read from
-// VERSION file of the source code.
-var version = ""
+// version must be set from the contents of VERSION file by go build's
+// -X main.version= option in the Makefile.
+var version = "unknown"
 
 // gitCommit will be the hash that the binary was built from
 // and will be populated by the Makefile
@@ -55,10 +55,8 @@ func main() {
 	app.Name = "runc"
 	app.Usage = usage
 
-	var v []string
-	if version != "" {
-		v = append(v, version)
-	}
+	v := []string{version}
+
 	if gitCommit != "" {
 		v = append(v, "commit: "+gitCommit)
 	}


### PR DESCRIPTION
Two things:

1. `runc -v`: set default for, always show `main.version`
    
    Apparently not everyone compiles runc via the provided Makefile. For
    example, one can just run `go build`, in which case `version` variable
    is left empty, which leads to:
    
            $ ./runc -v
            runc version spec: 1.0.2-dev
            go: go1.16.3
    
    Surely, the main problem here is runc was built in a wrong way, but the
    second problem is such output is very confusing -- it may seem that we
    have runc 1.0.2.
    
    To solve, make sure to _always_ add version (even if empty), plus set a
    default value in case someone compiles runc in a wrong way.
    
            $ ./runc -v
            runc version unknown
            spec: 1.0.2-dev
            go: go1.16.3

    NOTE this does not change anything in case runc is compiled normally
    (via the Makefile).
       
2. `Makefile`: use `git describe` for `COMMIT`
    
    Use `git describe --dirty --long` instead of `git rev-parse`. As a
    result, the commit ID will contain the closest tag, the number of commits
    since the tag, and the (abbreviated) git commit sha (see the example below).
    
    NOTE that this tag is still unique and can be used instead of bare sha
    for all git commands.
    
    Example output of `runc -v | grep commit`.
    
    Before:

            commit: 4d875738716862d08a84c00211b1983c3044f711

    After:

            commit: v1.0.0-rc95-9-g6f55d074
    
    This means that
     - the closest tag is v1.0.0-rc95
     - there were 9 commits after the tag
     - the abbreviated sha is 6f55d074
