### PR TITLE
libct/cg/sd: fix SkipDevices for systemd

### DIFF
--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -1,7 +1,15 @@
 package systemd
 
 import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
 func TestSystemdVersion(t *testing.T) {
@@ -29,4 +37,134 @@ func TestSystemdVersion(t *testing.T) {
 			t.Errorf("systemdVersionAtoi(%s); want %d; got %d", sdTest.verStr, sdTest.expectedVer, ver)
 		}
 	}
+}
+
+func newManager(config *configs.Cgroup) cgroups.Manager {
+	if cgroups.IsCgroup2UnifiedMode() {
+		return NewUnifiedManager(config, "", false)
+	}
+	return NewLegacyManager(config, nil)
+}
+
+func testSkipDevices(t *testing.T, skipDevices bool, expected []string) {
+	if !IsRunningSystemd() {
+		t.Skip("Test requires systemd.")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("Test requires root.")
+	}
+
+	podConfig := &configs.Cgroup{
+		Parent: "system.slice",
+		Name:   "system-runc_test_pods.slice",
+		Resources: &configs.Resources{
+			SkipDevices: skipDevices,
+		},
+	}
+	// Create "pods" cgroup (a systemd slice to hold containers).
+	pm := newManager(podConfig)
+	defer pm.Destroy() //nolint:errcheck
+	if err := pm.Apply(-1); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.Set(podConfig.Resources); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &configs.Cgroup{
+		Parent:      "system-runc_test_pods.slice",
+		ScopePrefix: "test",
+		Name:        "SkipDevices",
+		Resources: &configs.Resources{
+			Devices: []*devices.Rule{
+				// Allow access to /dev/full only.
+				{
+					Type:        devices.CharDevice,
+					Major:       1,
+					Minor:       7,
+					Permissions: "rwm",
+					Allow:       true,
+				},
+			},
+		},
+	}
+
+	// Create a "container" within the "pods" cgroup.
+	// This is not a real container, just a process in the cgroup.
+	cmd := exec.Command("bash", "-c", "read; echo > /dev/full; cat /dev/null; true")
+	cmd.Env = append(os.Environ(), "LANG=C")
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stdin = stdinR
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err = cmd.Start()
+	stdinR.Close()
+	defer stdinW.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure to not leave a zombie.
+	defer func() {
+		// These may fail, we don't care.
+		_, _ = stdinW.WriteString("hey\n")
+		_ = cmd.Wait()
+	}()
+
+	// Put the process into a cgroup.
+	m := newManager(config)
+	defer m.Destroy() //nolint:errcheck
+
+	if err := m.Apply(cmd.Process.Pid); err != nil {
+		t.Fatal(err)
+	}
+	// Check that we put the "container" into the "pod" cgroup.
+	if !strings.HasPrefix(m.Path("devices"), pm.Path("devices")) {
+		t.Fatalf("expected container cgroup path %q to be under pod cgroup path %q",
+			m.Path("devices"), pm.Path("devices"))
+	}
+	if err := m.Set(config.Resources); err != nil {
+		// failed to write "c 1:7 rwm": write /sys/fs/cgroup/devices/system.slice/system-runc_test_pods.slice/test-SkipDevices.scope/devices.allow: operation not permitted
+		if skipDevices == false && strings.HasSuffix(err.Error(), "/devices.allow: operation not permitted") {
+			// Cgroup v1 devices controller gives EPERM on trying
+			// to enable devices that are not enabled
+			// (skipDevices=false) in a parent cgroup.
+			// If this happens, test is passing.
+			return
+		}
+		t.Fatal(err)
+	}
+
+	// Check that we can access /dev/full but not /dev/zero.
+	if _, err := stdinW.WriteString("wow\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	for _, exp := range expected {
+		if !strings.Contains(stderr.String(), exp) {
+			t.Errorf("expected %q, got: %s", exp, stderr.String())
+		}
+	}
+}
+
+func TestSkipDevicesTrue(t *testing.T) {
+	testSkipDevices(t, true, []string{
+		"echo: write error: No space left on device",
+		"cat: /dev/null: Operation not permitted",
+	})
+}
+
+func TestSkipDevicesFalse(t *testing.T) {
+	// If SkipDevices is not set for the parent slice, access to both
+	// devices should fail. This is done to assess the test correctness.
+	// For cgroup v1, we check for m.Set returning EPERM.
+	// For cgroup v2, we check for the errors below.
+	testSkipDevices(t, false, []string{
+		"/dev/full: Operation not permitted",
+		"cat: /dev/null: Operation not permitted",
+	})
 }

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -61,7 +61,7 @@ var legacySubsystems = []subsystem{
 func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
 
-	deviceProperties, err := generateDeviceProperties(r.Devices)
+	deviceProperties, err := generateDeviceProperties(r)
 	if err != nil {
 		return nil, err
 	}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -172,7 +172,7 @@ func genV2ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]syst
 	//       aren't the end of the world, but it is a bit concerning. However
 	//       it's unclear if systemd removes all eBPF programs attached when
 	//       doing SetUnitProperties...
-	deviceProperties, err := generateDeviceProperties(r.Devices)
+	deviceProperties, err := generateDeviceProperties(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. **libct/cg/sd: fix SkipDevices for systemd**
    
    Commit 108ee85b8271e (PR #2490) adds `SkipDevices` flag, which is used by kubernetes
    to create cgroups for pods.
    
    Unfortunately the above commit falls short, and systemd `DevicePolicy` and
    `DeviceAllow` properties are still set, which requires kubernetes to set
    "allow everything" rule.
    
    This commit fixes this: if `SkipDevices` flag is set, we return
    `Device*` properties to allow all devices.

2. **libct/cg/sd: add SkipDevices unit test**
    
    The idea is to mimic what kubelet is doing, with minimum amount of code.
    
    First, create a slice with `SkipDevices=true`. It should have access to
    all devices.
    
    Next, create a scope within the above slice, allowing access to `/dev/full`
    only.
    
    Check that within that scope we can only access `/dev/full` and not other
    devices (such as `/dev/null`).
    
    Repeat the test with `SkipDevices=false`, make sure we can **not** access any
    devices (as they are disallowed by a parent cgroup). This is done only
    to assess the test correctness.
    
    NOTE that cgroup v1 and v2 behave differently for `SkipDevices=false`
    case, and thus the check is different. Cgroup v1 returns `EPERM` on
    writing to `devices.allow`, so cgroup manager's `Set()` fails, and we check
    for a particular error from `m.Set()`. Cgroup v2 allows to create a child
    cgroup, but denies access to any device (despite access being enabled)
    -- so we check the error from the shell script running in that cgroup.
    Again, this is only about `SkipDevices=false` case.


Previous discussions on topic: https://github.com/opencontainers/runc/pull/2490#discussion_r448702204, https://github.com/kubernetes/kubernetes/pull/92862#discussion_r451147445

Fixes: 108ee85b8271e