### PR TITLE
tests/int/dev: only call lsblk once

### DIFF
--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -84,10 +84,10 @@ function teardown() {
 @test "runc run [device cgroup allow rm block device]" {
 	requires root
 
-	# get first block device
-	device="/dev/$(lsblk -nd -o NAME | head -n 1)"
-	major="$(lsblk -nd -o MAJ:MIN | head -n 1 | awk -F":" '{print $1}' | sed "s/\s*//g")"
-	minor="$(lsblk -nd -o MAJ:MIN | head -n 1 | awk -F":" '{print $2}')"
+	# Get the first block device.
+	IFS=$' \t:' read -r device major minor <<<"$(lsblk -nd -o NAME,MAJ:MIN)"
+	# Could have used -o PATH but lsblk from CentOS 7 does not have it.
+	device="/dev/$device"
 
 	update_config ' .linux.resources.devices = [{"allow": false, "access": "rwm"},{"allow": true, "type": "b", "major": '"$major"', "minor": '"$minor"', "access": "rwm"}]
 			| .linux.devices = [{"path": "'"$device"'", "type": "b", "major": '"$major"', "minor": '"$minor"'}]


### PR DESCRIPTION
The "runc run [device cgroup allow rm block device]" test calls lsblk
three times to get device name, minor and major number. This creates a
potential problem when the devices are changed between the calls.

Simplify the code by using bash read together with IFS (as there's no
way to have lsblk output MAJOR:MINOR pair without a semicolon).

Note that head -n 1 is not needed as read already reads a single line.