### PR TITLE
*: clean up remaining golangci-lint failures

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           # must be specified without patch version
           version: v1.40
-          # Only show new issues for a pull request.
-          only-new-issues: true
 
   shfmt:
     runs-on: ubuntu-20.04

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           # must be specified without patch version
-          version: v1.36
+          version: v1.40
           # Only show new issues for a pull request.
           only-new-issues: true
 

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -200,14 +200,6 @@ func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }
 
-func memoryAssigned(cgroup *configs.Cgroup) bool {
-	return cgroup.Resources.Memory != 0 ||
-		cgroup.Resources.MemoryReservation != 0 ||
-		cgroup.Resources.MemorySwap > 0 ||
-		cgroup.Resources.OomKillDisable ||
-		(cgroup.Resources.MemorySwappiness != nil && int64(*cgroup.Resources.MemorySwappiness) != -1)
-}
-
 func getMemoryData(path, name string) (cgroups.MemoryData, error) {
 	memoryData := cgroups.MemoryData{}
 

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -37,7 +37,7 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 
 	container, err := newContainer(t, config)
 	ok(t, err)
-	defer container.Destroy()
+	defer container.Destroy() //nolint:errcheck
 
 	buffers := newStdBuffers()
 	pwd := &libcontainer.Process{
@@ -100,7 +100,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 
 	container, err := newContainer(t, config)
 	ok(t, err)
-	defer container.Destroy()
+	defer container.Destroy() //nolint:errcheck
 
 	buffers := newStdBuffers()
 	pwd := &libcontainer.Process{
@@ -170,7 +170,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 
 	container, err := newContainer(t, config)
 	ok(t, err)
-	defer container.Destroy()
+	defer container.Destroy() //nolint:errcheck
 
 	buffers := newStdBuffers()
 	dmesg := &libcontainer.Process{
@@ -226,7 +226,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 
 	container, err := newContainer(t, config)
 	ok(t, err)
-	defer container.Destroy()
+	defer container.Destroy() //nolint:errcheck
 
 	buffers := newStdBuffers()
 	dmesg := &libcontainer.Process{

--- a/libcontainer/seccomp/patchbpf/enosys_linux_test.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux_test.go
@@ -106,14 +106,6 @@ var testArches = []string{
 	"s390x",
 }
 
-func archStringToNative(arch string) (nativeArch, error) {
-	scmpArch, err := libseccomp.GetArchFromString(arch)
-	if err != nil {
-		return 0, fmt.Errorf("unknown architecture %q: %v", arch, err)
-	}
-	return archToNative(scmpArch)
-}
-
 func testEnosysStub(t *testing.T, defaultAction configs.Action, arches []string) {
 	explicitSyscalls := []string{
 		"setns",

--- a/libcontainer/system/proc.go
+++ b/libcontainer/system/proc.go
@@ -96,7 +96,7 @@ func parseStat(data string) (stat Stat_t, err error) {
 	// one (PID) and two (Name) in the paren-split.
 	parts = strings.Split(data[i+2:], " ")
 	var state int
-	fmt.Sscanf(parts[3-3], "%c", &state)
+	fmt.Sscanf(parts[3-3], "%c", &state) //nolint:staticcheck // "3-3" is more readable in this context.
 	stat.State = State(state)
 	fmt.Sscanf(parts[22-3], "%d", &stat.StartTime)
 	return stat, nil


### PR DESCRIPTION
Most of these were false positives or cases where we want to ignore the
lint, but the change to the BPF generation is actually useful.

Follow-up to #2781
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>