### PR TITLE
libcontainer: configs: initial support for timens

### DIFF
--- a/libcontainer/configs/namespaces_linux.go
+++ b/libcontainer/configs/namespaces_linux.go
@@ -14,6 +14,7 @@ const (
 	NEWIPC    NamespaceType = "NEWIPC"
 	NEWUSER   NamespaceType = "NEWUSER"
 	NEWCGROUP NamespaceType = "NEWCGROUP"
+	NEWTIME   NamespaceType = "NEWTIME"
 )
 
 var (
@@ -38,6 +39,8 @@ func NsName(ns NamespaceType) string {
 		return "uts"
 	case NEWCGROUP:
 		return "cgroup"
+	case NEWTIME:
+		return "time"
 	}
 	return ""
 }
@@ -72,6 +75,7 @@ func NamespaceTypes() []NamespaceType {
 		NEWPID,
 		NEWNS,
 		NEWCGROUP,
+		NEWTIME,
 	}
 }
 

--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -16,6 +16,7 @@ var namespaceInfo = map[NamespaceType]int{
 	NEWUTS:    unix.CLONE_NEWUTS,
 	NEWPID:    unix.CLONE_NEWPID,
 	NEWCGROUP: unix.CLONE_NEWCGROUP,
+	NEWTIME:   unix.CLONE_NEWTIME,
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct


### PR DESCRIPTION
Allow explicit unsharing of time namespace.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>