### PR TITLE
cgroup2: capitalize io stats read and write Op values

### DIFF
--- a/libcontainer/cgroups/fs2/io.go
+++ b/libcontainer/cgroups/fs2/io.go
@@ -118,9 +118,9 @@ func statIo(dirPath string, stats *cgroups.Stats) error {
 			// Accommodate the cgroup v1 naming
 			switch op {
 			case "rbytes":
-				op = "read"
+				op = "Read"
 			case "wbytes":
-				op = "write"
+				op = "Write"
 			}
 
 			value, err := strconv.ParseUint(d[1], 10, 0)


### PR DESCRIPTION
Fixes #2964 