### PR TITLE
cgroup2: map io.stats to v1 blkio.stats correctly

### DIFF
--- a/libcontainer/cgroups/fs2/io.go
+++ b/libcontainer/cgroups/fs2/io.go
@@ -101,11 +101,11 @@ func statIo(dirPath string, stats *cgroups.Stats) error {
 		if len(d) != 2 {
 			continue
 		}
-		major, err := strconv.ParseUint(d[0], 10, 0)
+		major, err := strconv.ParseUint(d[0], 10, 64)
 		if err != nil {
 			return err
 		}
-		minor, err := strconv.ParseUint(d[1], 10, 0)
+		minor, err := strconv.ParseUint(d[1], 10, 64)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func statIo(dirPath string, stats *cgroups.Stats) error {
 				continue
 			}
 
-			value, err := strconv.ParseUint(d[1], 10, 0)
+			value, err := strconv.ParseUint(d[1], 10, 64)
 			if err != nil {
 				return err
 			}

--- a/libcontainer/cgroups/fs2/io_test.go
+++ b/libcontainer/cgroups/fs2/io_test.go
@@ -1,0 +1,87 @@
+package fs2
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
+)
+
+const exampleIoStatData = `254:1 rbytes=6901432320 wbytes=14245535744 rios=263278 wios=248603 dbytes=0 dios=0
+254:0 rbytes=2702336 wbytes=0 rios=97 wios=0 dbytes=0 dios=0
+259:0 rbytes=6911345664 wbytes=14245536256 rios=264538 wios=244914 dbytes=530485248 dios=2`
+
+var exampleIoStatsParsed = cgroups.BlkioStats{
+	IoServiceBytesRecursive: []cgroups.BlkioStatEntry{
+		{Major: 254, Minor: 1, Value: 6901432320, Op: "Read"},
+		{Major: 254, Minor: 1, Value: 14245535744, Op: "Write"},
+		{Major: 254, Minor: 0, Value: 2702336, Op: "Read"},
+		{Major: 254, Minor: 0, Value: 0, Op: "Write"},
+		{Major: 259, Minor: 0, Value: 6911345664, Op: "Read"},
+		{Major: 259, Minor: 0, Value: 14245536256, Op: "Write"},
+	},
+	IoServicedRecursive: []cgroups.BlkioStatEntry{
+		{Major: 254, Minor: 1, Value: 263278, Op: "Read"},
+		{Major: 254, Minor: 1, Value: 248603, Op: "Write"},
+		{Major: 254, Minor: 0, Value: 97, Op: "Read"},
+		{Major: 254, Minor: 0, Value: 0, Op: "Write"},
+		{Major: 259, Minor: 0, Value: 264538, Op: "Read"},
+		{Major: 259, Minor: 0, Value: 244914, Op: "Write"},
+	},
+}
+
+func lessBlkioStatEntry(a, b cgroups.BlkioStatEntry) bool {
+	if a.Major != b.Major {
+		return a.Major < b.Major
+	}
+	if a.Minor != b.Minor {
+		return a.Minor < b.Minor
+	}
+	if a.Op != b.Op {
+		return a.Op < b.Op
+	}
+	return a.Value < b.Value
+}
+
+func sortBlkioStats(stats *cgroups.BlkioStats) {
+	for _, table := range []*[]cgroups.BlkioStatEntry{
+		&stats.IoServicedRecursive,
+		&stats.IoServiceBytesRecursive,
+	} {
+		sort.SliceStable(*table, func(i, j int) bool { return lessBlkioStatEntry((*table)[i], (*table)[j]) })
+	}
+}
+
+func TestStatIo(t *testing.T) {
+	// We're using a fake cgroupfs.
+	fscommon.TestMode = true
+
+	fakeCgroupDir, err := ioutil.TempDir("", "runc-stat-io-test.*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(fakeCgroupDir)
+	statPath := filepath.Join(fakeCgroupDir, "io.stat")
+
+	if err := ioutil.WriteFile(statPath, []byte(exampleIoStatData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotStats cgroups.Stats
+	if err := statIo(fakeCgroupDir, &gotStats); err != nil {
+		t.Error(err)
+	}
+
+	// Sort the output since statIo uses a map internally.
+	sortBlkioStats(&gotStats.BlkioStats)
+	sortBlkioStats(&exampleIoStatsParsed)
+
+	if !reflect.DeepEqual(gotStats.BlkioStats, exampleIoStatsParsed) {
+		t.Errorf("parsed cgroupv2 io.stat doesn't match expected result: \ngot %#v\nexpected %#v\n", gotStats.BlkioStats, exampleIoStatsParsed)
+	}
+}


### PR DESCRIPTION
Kubelet and cAdvisor depend on the metrics having the same values as in
cgroupv1, but we didn't correctly map the number of read and write IOs
to the correct cgroupv1 stats table (blkio.io_serviced).

In addition, don't leak any extra stats in our output -- if users need
that information we can always add a new field for it.

Change-log entry:

```
* cgroupv2: correctly convert "number of IOs" statistics in a cgroupv1-compatible way (#2967, #2964)
* cgroupv2: support larger than 32-bit IO statistics on 32-bit architectures
```

Fixes #2967
Reported-by: Yashpal Choudhary <yashpal.c1995@gmail.com>
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>