### PR TITLE
make systemd and its dependencies optional via 'no_systemd' build tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         go-version: [1.13.x, 1.15.x, 1.16.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
+        buildtags: ["seccomp", "seccomp,no_systemd", "no_systemd", ""]
 
     steps:
 
@@ -42,8 +43,8 @@ jobs:
         stable: '!contains(${{ matrix.go-version }}, "beta") && !contains(${{ matrix.go-version }}, "rc")'
         go-version: ${{ matrix.go-version }}
 
-    - name: build
-      run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
+    - name: build with tags ${{ matrix.buildtags }}
+      run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" BUILDTAGS="${{ matrix.buildtags }}" all
 
     - name: install bats
       uses: mig4/setup-bats@v1

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ e.g. to disable seccomp:
 make BUILDTAGS=""
 ```
 
-| Build Tag | Feature                            | Enabled by default | Dependency |
-|-----------|------------------------------------|--------------------|------------|
-| seccomp   | Syscall filtering                  | yes                | libseccomp |
+| Build Tag  | Feature                            | Enabled by default | Dependency |
+|------------|------------------------------------|--------------------|------------|
+| seccomp    | Syscall filtering                  | yes                | libseccomp |
+| no_systemd | disable systemd dependencies       | no                 | systemd    |
 
 The following build tags were used earlier, but are now obsoleted:
  - **nokmem** (since runc v1.0.0-rc94 kernel memory settings are ignored)

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -1,3 +1,5 @@
+// +build !no_systemd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_systemd
 
 package systemd
 

--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_systemd
 
 package systemd
 

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_systemd
 
 package systemd
 
@@ -165,7 +165,7 @@ func (m *legacyManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("DefaultDependencies", false))
 
-	properties = append(properties, c.SystemdProps...)
+	properties = append(properties, c.Sd.SystemdProps...)
 
 	if err := startUnit(m.dbus, unitName, properties); err != nil {
 		return err

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_systemd
 
 package systemd
 
@@ -280,7 +280,7 @@ func (m *unifiedManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("DefaultDependencies", false))
 
-	properties = append(properties, c.SystemdProps...)
+	properties = append(properties, c.Sd.SystemdProps...)
 
 	if err := startUnit(m.dbus, unitName, properties); err != nil {
 		return errors.Wrapf(err, "error while starting unit %q with properties %+v", unitName, properties)

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -1,7 +1,6 @@
 package configs
 
 import (
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
@@ -38,7 +37,7 @@ type Cgroup struct {
 	// SystemdProps are any additional properties for systemd,
 	// derived from org.systemd.property.xxx annotations.
 	// Ignored unless systemd is used for managing cgroups.
-	SystemdProps []systemdDbus.Property `json:"-"`
+	Sd CgroupSD
 }
 
 type Resources struct {

--- a/libcontainer/configs/cgroup_nosystemd_linux.go
+++ b/libcontainer/configs/cgroup_nosystemd_linux.go
@@ -1,0 +1,7 @@
+// +build linux,no_systemd
+
+package configs
+
+// Empty since we're not building w/ systemd
+type CgroupSD struct {
+}

--- a/libcontainer/configs/cgroup_systemd_linux.go
+++ b/libcontainer/configs/cgroup_systemd_linux.go
@@ -1,0 +1,15 @@
+// +build linux,!no_systemd
+
+package configs
+
+import (
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+)
+
+// Systemd specific parts of Cgroup properties
+type CgroupSD struct {
+	// SystemdProps are any additional properties for systemd,
+	// derived from org.systemd.property.xxx annotations.
+	// Ignored unless systemd is used for managing cgroups.
+	SystemdProps []systemdDbus.Property `json:"-"`
+}

--- a/libcontainer/factory_systemd.go
+++ b/libcontainer/factory_systemd.go
@@ -1,0 +1,48 @@
+// +build linux,!no_systemd
+
+package libcontainer
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func systemdCgroupV2(l *LinuxFactory, rootless bool) error {
+	l.NewCgroupsManager = func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
+		return systemd.NewUnifiedManager(config, getUnifiedPath(paths), rootless)
+	}
+	return nil
+}
+
+// SystemdCgroups is an options func to configure a LinuxFactory to return
+// containers that use systemd to create and manage cgroups.
+func SystemdCgroups(l *LinuxFactory) error {
+	if !systemd.IsRunningSystemd() {
+		return fmt.Errorf("systemd not running on this host, can't use systemd as cgroups manager")
+	}
+
+	if cgroups.IsCgroup2UnifiedMode() {
+		return systemdCgroupV2(l, false)
+	}
+
+	l.NewCgroupsManager = func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
+		return systemd.NewLegacyManager(config, paths)
+	}
+
+	return nil
+}
+
+// RootlessSystemdCgroups is rootless version of SystemdCgroups.
+func RootlessSystemdCgroups(l *LinuxFactory) error {
+	if !systemd.IsRunningSystemd() {
+		return fmt.Errorf("systemd not running on this host, can't use systemd as cgroups manager")
+	}
+
+	if !cgroups.IsCgroup2UnifiedMode() {
+		return fmt.Errorf("cgroup v2 not enabled on this host, can't use systemd (rootless) as cgroups manager")
+	}
+	return systemdCgroupV2(l, true)
+}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -5,7 +5,6 @@
 package specconv
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
-	dbus "github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
@@ -366,115 +363,31 @@ var isValidName = regexp.MustCompile(`^[a-zA-Z]{3,}$`).MatchString
 
 var isSecSuffix = regexp.MustCompile(`[a-z]Sec$`).MatchString
 
-// Some systemd properties are documented as having "Sec" suffix
-// (e.g. TimeoutStopSec) but are expected to have "USec" suffix
-// here, so let's provide conversion to improve compatibility.
-func convertSecToUSec(value dbus.Variant) (dbus.Variant, error) {
-	var sec uint64
-	const M = 1000000
-	vi := value.Value()
-	switch value.Signature().String() {
-	case "y":
-		sec = uint64(vi.(byte)) * M
-	case "n":
-		sec = uint64(vi.(int16)) * M
-	case "q":
-		sec = uint64(vi.(uint16)) * M
-	case "i":
-		sec = uint64(vi.(int32)) * M
-	case "u":
-		sec = uint64(vi.(uint32)) * M
-	case "x":
-		sec = uint64(vi.(int64)) * M
-	case "t":
-		sec = vi.(uint64) * M
-	case "d":
-		sec = uint64(vi.(float64) * M)
-	default:
-		return value, errors.New("not a number")
-	}
-	return dbus.MakeVariant(sec), nil
-}
+func initPlainCgroups(opts *CreateOpts, spec *specs.Spec, c *configs.Cgroup) error {
+	var myCgroupPath string
 
-func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
-	const keyPrefix = "org.systemd.property."
-	var sp []systemdDbus.Property
-
-	for k, v := range spec.Annotations {
-		name := strings.TrimPrefix(k, keyPrefix)
-		if len(name) == len(k) { // prefix not there
-			continue
-		}
-		if !isValidName(name) {
-			return nil, fmt.Errorf("Annotation %s name incorrect: %s", k, name)
-		}
-		value, err := dbus.ParseVariant(v, dbus.Signature{})
-		if err != nil {
-			return nil, fmt.Errorf("Annotation %s=%s value parse error: %v", k, v, err)
-		}
-		if isSecSuffix(name) {
-			name = strings.TrimSuffix(name, "Sec") + "USec"
-			value, err = convertSecToUSec(value)
-			if err != nil {
-				return nil, fmt.Errorf("Annotation %s=%s value parse error: %v", k, v, err)
-			}
-		}
-		sp = append(sp, systemdDbus.Property{Name: name, Value: value})
+	if spec.Linux != nil && spec.Linux.CgroupsPath != "" {
+		myCgroupPath = libcontainerUtils.CleanPath(spec.Linux.CgroupsPath)
 	}
 
-	return sp, nil
+	if myCgroupPath == "" {
+		c.Name = opts.CgroupName
+	}
+	c.Path = myCgroupPath
+
+	return nil
 }
 
 func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*configs.Cgroup, error) {
-	var (
-		myCgroupPath string
-
-		spec             = opts.Spec
-		useSystemdCgroup = opts.UseSystemdCgroup
-		name             = opts.CgroupName
-	)
+	spec := opts.Spec
 
 	c := &configs.Cgroup{
 		Resources: &configs.Resources{},
 	}
 
-	if useSystemdCgroup {
-		sp, err := initSystemdProps(spec)
-		if err != nil {
-			return nil, err
-		}
-		c.SystemdProps = sp
-	}
-
-	if spec.Linux != nil && spec.Linux.CgroupsPath != "" {
-		if useSystemdCgroup {
-			myCgroupPath = spec.Linux.CgroupsPath
-		} else {
-			myCgroupPath = libcontainerUtils.CleanPath(spec.Linux.CgroupsPath)
-		}
-	}
-
-	if useSystemdCgroup {
-		if myCgroupPath == "" {
-			// Default for c.Parent is set by systemd cgroup drivers.
-			c.ScopePrefix = "runc"
-			c.Name = name
-		} else {
-			// Parse the path from expected "slice:prefix:name"
-			// for e.g. "system.slice:docker:1234"
-			parts := strings.Split(myCgroupPath, ":")
-			if len(parts) != 3 {
-				return nil, fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups, got %q instead", myCgroupPath)
-			}
-			c.Parent = parts[0]
-			c.ScopePrefix = parts[1]
-			c.Name = parts[2]
-		}
-	} else {
-		if myCgroupPath == "" {
-			c.Name = name
-		}
-		c.Path = myCgroupPath
+	err := initSystemdCgroups(opts, spec, c)
+	if err != nil {
+		return nil, err
 	}
 
 	// In rootless containers, any attempt to make cgroup changes is likely to fail.

--- a/libcontainer/specconv/spec_nosystemd.go
+++ b/libcontainer/specconv/spec_nosystemd.go
@@ -1,0 +1,12 @@
+// +build linux,no_systemd
+
+package specconv
+
+import (
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func initSystemdCgroups(opts *CreateOpts, spec *specs.Spec, c *configs.Cgroup) (error) {
+	return initPlainCgroups(opts, spec, c)
+}

--- a/libcontainer/specconv/spec_systemd.go
+++ b/libcontainer/specconv/spec_systemd.go
@@ -1,0 +1,108 @@
+// +build linux,!no_systemd
+
+package specconv
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	dbus "github.com/godbus/dbus/v5"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Some systemd properties are documented as having "Sec" suffix
+// (e.g. TimeoutStopSec) but are expected to have "USec" suffix
+// here, so let's provide conversion to improve compatibility.
+func convertSecToUSec(value dbus.Variant) (dbus.Variant, error) {
+	var sec uint64
+	const M = 1000000
+	vi := value.Value()
+	switch value.Signature().String() {
+	case "y":
+		sec = uint64(vi.(byte)) * M
+	case "n":
+		sec = uint64(vi.(int16)) * M
+	case "q":
+		sec = uint64(vi.(uint16)) * M
+	case "i":
+		sec = uint64(vi.(int32)) * M
+	case "u":
+		sec = uint64(vi.(uint32)) * M
+	case "x":
+		sec = uint64(vi.(int64)) * M
+	case "t":
+		sec = vi.(uint64) * M
+	case "d":
+		sec = uint64(vi.(float64) * M)
+	default:
+		return value, errors.New("not a number")
+	}
+	return dbus.MakeVariant(sec), nil
+}
+
+func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
+	const keyPrefix = "org.systemd.property."
+	var sp []systemdDbus.Property
+
+	for k, v := range spec.Annotations {
+		name := strings.TrimPrefix(k, keyPrefix)
+		if len(name) == len(k) { // prefix not there
+			continue
+		}
+		if !isValidName(name) {
+			return nil, fmt.Errorf("Annotation %s name incorrect: %s", k, name)
+		}
+		value, err := dbus.ParseVariant(v, dbus.Signature{})
+		if err != nil {
+			return nil, fmt.Errorf("Annotation %s=%s value parse error: %v", k, v, err)
+		}
+		if isSecSuffix(name) {
+			name = strings.TrimSuffix(name, "Sec") + "USec"
+			value, err = convertSecToUSec(value)
+			if err != nil {
+				return nil, fmt.Errorf("Annotation %s=%s value parse error: %v", k, v, err)
+			}
+		}
+		sp = append(sp, systemdDbus.Property{Name: name, Value: value})
+	}
+
+	return sp, nil
+}
+
+func initSystemdCgroups(opts *CreateOpts, spec *specs.Spec, c *configs.Cgroup) error {
+	var myCgroupPath string
+
+	if !opts.UseSystemdCgroup {
+		return initPlainCgroups(opts, spec, c)
+	}
+
+	sp, err := initSystemdProps(spec)
+	if err != nil {
+		return err
+	}
+	c.Sd.SystemdProps = sp
+	if spec.Linux != nil && spec.Linux.CgroupsPath != "" {
+		myCgroupPath = spec.Linux.CgroupsPath
+	}
+
+	if myCgroupPath == "" {
+		// Default for c.Parent is set by systemd cgroup drivers.
+		c.ScopePrefix = "runc"
+		c.Name = opts.CgroupName
+	} else {
+		// Parse the path from expected "slice:prefix:name"
+		// for e.g. "system.slice:docker:1234"
+		parts := strings.Split(myCgroupPath, ":")
+		if len(parts) != 3 {
+			return fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups, got %q instead", myCgroupPath)
+		}
+		c.Parent = parts[0]
+		c.ScopePrefix = parts[1]
+		c.Name = parts[2]
+	}
+
+	return nil
+}

--- a/rootless_linux.go
+++ b/rootless_linux.go
@@ -5,9 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/userns"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -31,26 +29,7 @@ func shouldUseRootlessCgroupManager(context *cli.Context) (bool, error) {
 	}
 	// euid = 0, in a userns.
 	//
-	// [systemd driver]
-	// We can call DetectUID() to parse the OwnerUID value from `busctl --user --no-pager status` result.
-	// The value corresponds to sd_bus_creds_get_owner_uid(3).
-	// If the value is 0, we have rootful systemd inside userns, so we do not need the rootless cgroup manager.
-	//
-	// On error, we assume we are root. An error may happen during shelling out to `busctl` CLI,
-	// mostly when $DBUS_SESSION_BUS_ADDRESS is unset.
-	if context.GlobalBool("systemd-cgroup") {
-		ownerUID, err := systemd.DetectUID()
-		if err != nil {
-			logrus.WithError(err).Debug("failed to get the OwnerUID value, assuming the value to be 0")
-			ownerUID = 0
-		}
-		return ownerUID != 0, nil
-	}
-	// [cgroupfs driver]
-	// As we are unaware of cgroups path, we can't determine whether we have the full
-	// access to the cgroups path.
-	// Either way, we can safely decide to use the rootless cgroups manager.
-	return true, nil
+	return shouldUseRootlessCgroupManagerUserns(context)
 }
 
 func shouldHonorXDGRuntimeDir() bool {

--- a/rootless_linux_nosystemd.go
+++ b/rootless_linux_nosystemd.go
@@ -1,0 +1,13 @@
+// +build linux,no_systemd
+
+package main
+
+import "github.com/urfave/cli"
+
+func shouldUseRootlessCgroupManagerUserns(context *cli.Context) (bool, error) {
+	// [cgroupfs driver]
+	// As we are unaware of cgroups path, we can't determine whether we have the full
+	// access to the cgroups path.
+	// Either way, we can safely decide to use the rootless cgroups manager.
+	return true, nil
+}

--- a/rootless_linux_systemd.go
+++ b/rootless_linux_systemd.go
@@ -1,0 +1,32 @@
+// +build linux,!no_systemd
+
+package main
+
+import (
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+func shouldUseRootlessCgroupManagerUserns(context *cli.Context) (bool, error) {
+	// [systemd driver]
+	// We can call DetectUID() to parse the OwnerUID value from `busctl --user --no-pager status` result.
+	// The value corresponds to sd_bus_creds_get_owner_uid(3).
+	// If the value is 0, we have rootful systemd inside userns, so we do not need the rootless cgroup manager.
+	//
+	// On error, we assume we are root. An error may happen during shelling out to `busctl` CLI,
+	// mostly when $DBUS_SESSION_BUS_ADDRESS is unset.
+	if context.GlobalBool("systemd-cgroup") {
+		ownerUID, err := systemd.DetectUID()
+		if err != nil {
+			logrus.WithError(err).Debug("failed to get the OwnerUID value, assuming the value to be 0")
+			ownerUID = 0
+		}
+		return ownerUID != 0, nil
+	}
+	// [cgroupfs driver]
+	// As we are unaware of cgroups path, we can't determine whether we have the full
+	// access to the cgroups path.
+	// Either way, we can safely decide to use the rootless cgroups manager.
+	return true, nil
+}

--- a/utils_linux_nosystemd.go
+++ b/utils_linux_nosystemd.go
@@ -1,0 +1,32 @@
+// +build linux,no_systemd
+
+package main
+
+import (
+	"os"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/urfave/cli"
+)
+
+// retrieve fitting the cgroup backend constructor function
+// this exists in two versions, one w/ systemd support, another w/o that
+func getCgroupBackend(context *cli.Context) (func(*libcontainer.LinuxFactory) error, error) {
+	// We default to cgroupfs, and can only use systemd if the system is a
+	// systemd box.
+	cgroupManager := libcontainer.Cgroupfs
+	rootlessCg, err := shouldUseRootlessCgroupManager(context)
+	if err != nil {
+		return nil, err
+	}
+	if rootlessCg {
+		cgroupManager = libcontainer.RootlessCgroupfs
+	}
+
+	return cgroupManager, nil
+}
+
+func getListenFDs() ([]*os.File) {
+	listenFDs := []*os.File{}
+	return listenFDs
+}

--- a/utils_linux_systemd.go
+++ b/utils_linux_systemd.go
@@ -1,0 +1,50 @@
+// +build linux,!no_systemd
+
+package main
+
+import (
+	"os"
+
+	"github.com/coreos/go-systemd/v22/activation"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+// retrieve fitting the cgroup backend constructor function
+// this exists in two versions, one w/ systemd support, another w/o that
+func getCgroupBackend(context *cli.Context) (func(*libcontainer.LinuxFactory) error, error) {
+	// We default to cgroupfs, and can only use systemd if the system is a
+	// systemd box.
+	cgroupManager := libcontainer.Cgroupfs
+	rootlessCg, err := shouldUseRootlessCgroupManager(context)
+	if err != nil {
+		return nil, err
+	}
+	if rootlessCg {
+		cgroupManager = libcontainer.RootlessCgroupfs
+	}
+	if context.GlobalBool("systemd-cgroup") {
+		if !systemd.IsRunningSystemd() {
+			return nil, errors.New("systemd cgroup flag passed, but systemd support for managing cgroups is not available")
+		}
+		cgroupManager = libcontainer.SystemdCgroups
+		if rootlessCg {
+			cgroupManager = libcontainer.RootlessSystemdCgroups
+		}
+	}
+
+	return cgroupManager, nil
+}
+
+func getListenFDs() []*os.File {
+	// Support on-demand socket activation by passing file descriptors into the container init process.
+	listenFDs := []*os.File{}
+	if os.Getenv("LISTEN_FDS") != "" {
+		listenFDs = activation.Files(false)
+	}
+	return listenFDs
+}


### PR DESCRIPTION
Running under systemd requires lots of special code that contributes
to ca. 10 percent (ca. 1 MB) to the binary size. This is only needed on
targets that might run systemd - there're dozens of distros, let alone
embedded/edge devices or special images (eg. cluster worker nodes) that
do not and never will run systemd, thus do not need that code at all.

It's not just about reducing memory consumption, but also having over
10.000 lines of code less to audit.

In order not to change default behaviour, introducing an inverse build tag,
'no_systemd', for explicitly opting out from systemd special handlings.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>