### PR TITLE
[WIP] ci/gha: redo the commit subject length checker

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,19 +89,16 @@ jobs:
     # Only check commits on pull requests.
     if: github.event_name == 'pull_request'
     steps:
-      - name: get pr commits
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: check subject line length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        uses: gsactions/commit-message-checker@v1
         with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.{0,72}(\n.*)*$'
-          error: 'Subject too long (max 72)'
-
+          pattern: '^.{50}'
+          flags: 'gm'
+          error: 'Subject too long (max 50)'
+          excludeDescription: 'true' # exclude the description body of a pull request
+          excludeTitle: 'true' # exclude the title of a pull request
+          checkAllCommitMessages: 'true' # check all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
 
   cross:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# runc
-
 [![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/runc)](https://goreportcard.com/report/github.com/opencontainers/runc)
 [![GoDoc](https://godoc.org/github.com/opencontainers/runc?status.svg)](https://godoc.org/github.com/opencontainers/runc)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/588/badge)](https://bestpractices.coreinfrastructure.org/projects/588)


### PR DESCRIPTION
We were using https://github.com/tim-actions/commit-message-checker-with-regex
before, but it seems not very well maintained (v1 tag is older than
v0.3.1, and there's no way to file an issue).

Switch to gs-commit-message-checker which gained the ability to check
all commits in v1.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>