### PR TITLE
runc update: skip devices

### DIFF
--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -127,8 +127,8 @@ type Resources struct {
 
 	// SkipDevices allows to skip configuring device permissions.
 	// Used by e.g. kubelet while creating a parent cgroup (kubepods)
-	// common for many containers.
+	// common for many containers, and by runc update.
 	//
 	// NOTE it is impossible to start a container which has this flag set.
-	SkipDevices bool `json:"skip_devices"`
+	SkipDevices bool `json:"-"`
 }

--- a/update.go
+++ b/update.go
@@ -329,6 +329,13 @@ other options are ignored.
 			config.IntelRdt.MemBwSchema = memBwSchema
 		}
 
+		// XXX(kolyshkin@): currently "runc update" is unable to change
+		// device configuration, so add this to skip device update.
+		// This helps in case an extra plugin (nvidia GPU) applies some
+		// configuration on top of what runc does.
+		// Note this field is not saved into container's state.json.
+		config.Cgroups.SkipDevices = true
+
 		return container.Set(config)
 	},
 }


### PR DESCRIPTION
Since `runc update` CLI is not able to modify devices (and it is not clear
how to implement that properly), let's set `SkipDevices=true`,
so that a cgroup controller won't try to update devices cgroup.

This helps use cases when some other device management (NVIDIA GPUs)
applies its configuration on top of what runc does.

Make sure we do not save `SkipDevices` into `state.json`.

This is an alternative to https://github.com/opencontainers/runc/pull/2988.

## Proposed changelog entry
* `runc update` no longer updates cgroup devices configuration.