### PR TITLE
[rc94 regression] libct/cg/sd: fix dbus error handling

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -313,7 +313,7 @@ func getUnitName(c *configs.Cgroup) string {
 // isDbusError returns true if the error is a specific dbus error.
 func isDbusError(err error, name string) bool {
 	if err != nil {
-		var derr *dbus.Error
+		var derr dbus.Error
 		if errors.As(err, &derr) {
 			return strings.Contains(derr.Name, name)
 		}


### PR DESCRIPTION
This fixes `isDbusError` function, introduced by commit bacfc2c. Due to a
type error it was not working at all.

This also fixes the whole "retry on dbus disconnect" logic, introduced
in PR #2923. Most probably it was not working at all before this fix.

This also fixes a regression in `startUnit` (and `cgroupManager.Apply()`),
which should never return "unit already exists" error but it did (#2996).

A test case is added to check that the last issue is fixed.

Fixes: bacfc2c
Fixes: https://github.com/opencontainers/runc/issues/2996
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1941456
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1965545

## Proposed changelog entry
* cgroups/systemd: fixed "retry on dbus disconnect" logic introduced in rc94
* cgroups/systemd: fixed returning "unit already exists" error from a systemd cgroup manager (regression in rc94)
