### PR TITLE
parseCgroupFromReader(): Ignore unified paths with no subsystem

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -181,7 +181,9 @@ func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
 		}
 
 		for _, subs := range strings.Split(parts[1], ",") {
-			cgroups[subs] = parts[2]
+			if subs != "" {
+				cgroups[subs] = parts[2]
+			}
 		}
 	}
 	if err := s.Err(); err != nil {

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -390,6 +390,30 @@ func TestParseCgroupString(t *testing.T) {
 	}
 }
 
+func TestEmptySubsystem(t *testing.T) {
+	const data = `10:devices:/user.slice
+ 	9:net_cls,net_prio:/
+ 	8:blkio:/
+ 	7:freezer:/
+ 	6:perf_event:/
+ 	5:cpuset:/
+ 	4:memory:/
+ 	3:pids:/user.slice/user-1000.slice/user@1000.service
+ 	2:cpu,cpuacct:/
+ 	1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
+ 	0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service`
+	r := strings.NewReader(data)
+	paths, err := parseCgroupFromReader(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for subsystem, path := range paths {
+		if subsystem == "" {
+			t.Fatalf("empty subsystem for %q", path)
+		}
+	}
+}
+
 func TestIgnoreCgroup2Mount(t *testing.T) {
 	subsystems := map[string]bool{
 		"cpuset":       false,


### PR DESCRIPTION
When working on https://github.com/containerd/cgroups/pull/197, I noticed this change, which was not in the libcontainer variant of the same function. I thought I'd open a pull request in case this is relevant in this repository as well.

This ports the changes from containerd's cgroup package:
https://github.com/containerd/cgroups/commit/fe1947308d8f3fc3a7ef8996ba1da7b82de4e053 (https://github.com/containerd/cgroups/pull/21)
