### PR TITLE
Make DevicesGroup's "TestingSkipFinalCheck" attribute public

### DIFF
--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -13,7 +13,7 @@ import (
 )
 
 type DevicesGroup struct {
-	testingSkipFinalCheck bool
+	TestingSkipFinalCheck bool
 }
 
 func (s *DevicesGroup) Name() string {
@@ -90,7 +90,7 @@ func (s *DevicesGroup) Set(path string, r *configs.Resources) error {
 	//
 	// This safety-check is skipped for the unit tests because we cannot
 	// currently mock devices.list correctly.
-	if !s.testingSkipFinalCheck {
+	if !s.TestingSkipFinalCheck {
 		currentAfter, err := loadEmulator(path)
 		if err != nil {
 			return err

--- a/libcontainer/cgroups/fs/devices_test.go
+++ b/libcontainer/cgroups/fs/devices_test.go
@@ -29,7 +29,7 @@ func TestDevicesSetAllow(t *testing.T) {
 		},
 	}
 
-	d := &DevicesGroup{testingSkipFinalCheck: true}
+	d := &DevicesGroup{TestingSkipFinalCheck: true}
 	if err := d.Set(path, r); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Users would like to have the possibility to skip checks for their tests the same way they are skipped within the tests in runc.

Not exposing this variable makes it very hard to test components that use this library. To avoid copying-and-pasting the code into outside projects I suggest to expose this variable to the users.

