### PR TITLE
libcontainer: relax validation for absolute paths

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -29,6 +29,7 @@ type check func(config *configs.Config) error
 
 func (v *ConfigValidator) Validate(config *configs.Config) error {
 	checks := []check{
+		v.cgroups,
 		v.rootfs,
 		v.network,
 		v.hostname,
@@ -45,10 +46,6 @@ func (v *ConfigValidator) Validate(config *configs.Config) error {
 			return err
 		}
 	}
-	if err := v.cgroups(config); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	selinux "github.com/opencontainers/selinux/go-selinux"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -39,11 +40,19 @@ func (v *ConfigValidator) Validate(config *configs.Config) error {
 		v.sysctl,
 		v.intelrdt,
 		v.rootlessEUID,
-		v.mounts,
 	}
 	for _, c := range checks {
 		if err := c(config); err != nil {
 			return err
+		}
+	}
+	// Relaxed validation rules for backward compatibility
+	warns := []check{
+		v.mounts, // TODO (runc v1.x.x): make this an error instead of a warning
+	}
+	for _, c := range warns {
+		if err := c(config); err != nil {
+			logrus.WithError(err).Warnf("invalid configuration")
 		}
 	}
 	return nil

--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -323,10 +323,12 @@ func TestValidateMounts(t *testing.T) {
 		isErr bool
 		dest  string
 	}{
-		{isErr: true, dest: "not/an/abs/path"},
-		{isErr: true, dest: "./rel/path"},
-		{isErr: true, dest: "./rel/path"},
-		{isErr: true, dest: "../../path"},
+		// TODO (runc v1.x.x): make these relative paths an error. See https://github.com/opencontainers/runc/pull/3004
+		{isErr: false, dest: "not/an/abs/path"},
+		{isErr: false, dest: "./rel/path"},
+		{isErr: false, dest: "./rel/path"},
+		{isErr: false, dest: "../../path"},
+
 		{isErr: false, dest: "/abs/path"},
 		{isErr: false, dest: "/abs/but/../unclean"},
 	}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -333,7 +333,10 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 
 func createLibcontainerMount(cwd string, m specs.Mount) (*configs.Mount, error) {
 	if !filepath.IsAbs(m.Destination) {
-		return nil, fmt.Errorf("mount destination %s not absolute", m.Destination)
+		// Relax validation for backward compatibility
+		// TODO (runc v1.x.x): change warning to an error
+		// return nil, fmt.Errorf("mount destination %s is not absolute", m.Destination)
+		logrus.Warnf("mount destination %s is not absolute. Support for non-absolute mount destinations will be removed in a future release.", m.Destination)
 	}
 	flags, pgflags, data, ext := parseMountOptions(m.Options)
 	source := m.Source


### PR DESCRIPTION
Commits 1f1e91b1a09b5b22eb414ba7e5ad8c3534526216 and 2192670a2430054c1e539ca7a3bf0ddc43b0bc3d (https://github.com/opencontainers/runc/pull/2917) added validation for mountpoints to be an absolute path, to match the OCI specs.

Unfortunately, the old behavior (accepting the path to be a relative path) has been around for a long time, and although "not according to the spec", various higher level runtimes rely on this behavior.

While higher level runtime have been updated to address this requirement, there will be a transition period before all runtimes are updated to carry these fixes.

This patch relaxes the validation, to generate a WARNING instead of failing, allowing runtimes to update (but allowing them to update runc to the current version, which includes security fixes).

We can remove this exception in a future patch release.


relates to https://github.com/opencontainers/runc/issues/2928, https://github.com/containerd/containerd/issues/5547