### PR TITLE
Allow restoring with a different LSM profile

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1375,6 +1375,15 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 		},
 	}
 
+	if criuOpts.LsmProfile != "" {
+		// CRIU older than 3.16 has a bug which breaks the possibility
+		// to set a different LSM profile.
+		if err := c.checkCriuVersion(31600); err != nil {
+			return errors.New("--lsm-profile requires at least CRIU 3.16")
+		}
+		req.Opts.LsmProfile = proto.String(criuOpts.LsmProfile)
+	}
+
 	c.handleCriuConfigurationFile(req.Opts)
 
 	if err := c.handleRestoringNamespaces(req.Opts, &extraFiles); err != nil {

--- a/libcontainer/criu_opts_linux.go
+++ b/libcontainer/criu_opts_linux.go
@@ -29,4 +29,5 @@ type CriuOpts struct {
 	AutoDedup               bool               // auto deduplication for incremental dumps
 	LazyPages               bool               // restore memory pages lazily using userfaultfd
 	StatusFd                int                // fd for feedback when lazy server is ready
+	LsmProfile              string             // LSM profile used to restore the container
 }

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -26,3 +26,19 @@ using the runc checkpoint command.
     --pid-file value             specify the file to write the process id to
     --no-subreaper               disable the use of the subreaper used to reap reparented processes
     --no-pivot                   do not use pivot root to jail process inside rootfs.  This should be used whenever the rootfs is on top of a ramdisk
+    --empty-ns value             create a namespace, but don't restore its properties
+    --auto-dedup                 enable auto deduplication of memory images
+    --lazy-pages                 use userfaultfd to lazily restore memory pages
+    --lsm-profile value          Specify an LSM profile to be used during restore in the form of TYPE:NAME.
+
+## OPTION DETAILS
+
+**--lsm-profile**
+
+Specify an LSM profile to be used during restore in the form of TYPE:NAME.
+
+`TYPE` can either be *apparamor* or *selinux* and is followed by *:* and a
+valid LSM label.
+```
+runc restore --lsm-profile "selinux:system_u:system_r:container_t:s0:c82,c137" <container-id>
+```

--- a/restore.go
+++ b/restore.go
@@ -91,6 +91,11 @@ using the runc checkpoint command.`,
 			Name:  "lazy-pages",
 			Usage: "use userfaultfd to lazily restore memory pages",
 		},
+		cli.StringFlag{
+			Name:  "lsm-profile",
+			Value: "",
+			Usage: "Specify an LSM profile to be used during restore in the form of TYPE:NAME.",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {
@@ -139,5 +144,6 @@ func criuOptions(context *cli.Context) *libcontainer.CriuOpts {
 		AutoDedup:               context.Bool("auto-dedup"),
 		LazyPages:               context.Bool("lazy-pages"),
 		StatusFd:                context.Int("status-fd"),
+		LsmProfile:              context.String("lsm-profile"),
 	}
 }


### PR DESCRIPTION
Restoring an SELinux enabled container with Podman will result in a container with the exactly same SELinux process labels as during checkpointing. CRIU takes care of all the process labels.

Restoring multiple copies of a checkpointed container will result in all containers having the same SELinux process labels, which might be undesired.

When looking at Pods all container in a Pod share the process label of the infrastructure container. To restore a container into and existing Pod it is necessary to tell CRIU to restore the container with the infrastructure container process label.

CRIU supports setting different process labels using `--lsm-profile` for a long time and this just passes the process label information from runc to CRIU.

Unfortunately CRIU has a bug as no one was using the `--lsm-profile` option so this changes requires the upcoming CRIU version 3.16.

See: https://github.com/checkpoint-restore/criu/pull/1486