### PR TITLE
libct/cg/sd/dbus: fix NewDbusConnManager

### DIFF
--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -21,9 +21,12 @@ type dbusConnManager struct{}
 
 // newDbusConnManager initializes systemd dbus connection manager.
 func newDbusConnManager(rootless bool) *dbusConnManager {
+	dbusMu.Lock()
+	defer dbusMu.Unlock()
 	if dbusInited && rootless != dbusRootless {
 		panic("can't have both root and rootless dbus")
 	}
+	dbusInited = true
 	dbusRootless = rootless
 	return &dbusConnManager{}
 }


### PR DESCRIPTION
Noticed (in https://github.com/cri-o/cri-o/pull/4974/commits/5f97b2fb1f4e7f768156a5c52a25c5b8958466b7#r646855529)
 that the check of trying to use both rootful and rootless
in `NewDbusConnManager` never worked, as we never set `dbusInited` to true. 🤦🏻 

Do that. While at it, protect this with the mutex (against the
case of two goroutines simultaneously calling NewDbusConnManager).
This is a rare call, so taking read-only then read-write mutex does not
make sense.

Fixes: c7f847ed3a00a

(Practically, this is not an issue as I don't expect this (someone using rootless and rootful at the same time) to happen -- but if the check is there it should at least work)