### PR TITLE
update cilium/ebpf to fix haveBpfProgReplace() check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/bits-and-blooms/bitset v1.2.0
 	github.com/checkpoint-restore/go-criu/v5 v5.0.0
-	github.com/cilium/ebpf v0.6.0
+	github.com/cilium/ebpf v0.6.1
 	github.com/containerd/console v1.0.2
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/cyphar/filepath-securejoin v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjL
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0 h1:TW8f/UvntYoVDMN1K2HlT82qH1rb0sOjpGw3m6Ym+i4=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
-github.com/cilium/ebpf v0.6.0 h1:hOQqNhQdMIi0zmjii4jKUnI0i+NB7ApvTXs2MstI5S0=
-github.com/cilium/ebpf v0.6.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.6.1 h1:n6ZUOkSFi6OwcMeTCFaDQx2Onx2rEikQo69315MNbdc=
+github.com/cilium/ebpf v0.6.1/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=

--- a/libcontainer/cgroups/ebpf/ebpf_linux.go
+++ b/libcontainer/cgroups/ebpf/ebpf_linux.go
@@ -81,6 +81,8 @@ var (
 
 // Loosely based on the BPF_F_REPLACE support check in
 //   <https://github.com/cilium/ebpf/blob/v0.6.0/link/syscalls.go>.
+//
+// TODO: move this logic to cilium/ebpf
 func haveBpfProgReplace() bool {
 	haveBpfProgReplaceOnce.Do(func() {
 		prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{

--- a/vendor/github.com/cilium/ebpf/CONTRIBUTING.md
+++ b/vendor/github.com/cilium/ebpf/CONTRIBUTING.md
@@ -18,6 +18,23 @@ reason about the proposed changes.
 ## Running the tests
 
 Many of the tests require privileges to set resource limits and load eBPF code.
-The easiest way to obtain these is to run the tests with `sudo`:
+The easiest way to obtain these is to run the tests with `sudo`.
 
-    sudo go test ./...
+To test the current package with your local kernel you can simply run:
+```
+go test -exec sudo  ./...
+```
+
+To test the current package with a different kernel version you can use the [run-tests.sh](run-tests.sh) script.
+It requires [virtme](https://github.com/amluto/virtme) and qemu to be installed.
+
+Examples:
+
+```bash
+# Run all tests on a 5.4 kernel
+./run-tests.sh 5.4
+
+# Run a subset of tests:
+./run-tests.sh 5.4 go test ./link
+```
+

--- a/vendor/github.com/cilium/ebpf/link/kprobe.go
+++ b/vendor/github.com/cilium/ebpf/link/kprobe.go
@@ -131,7 +131,10 @@ func kprobe(symbol string, prog *ebpf.Program, ret bool) (*perfEvent, error) {
 	}
 
 	// Use kprobe PMU if the kernel has it available.
-	tp, err := pmuKprobe(symbol, ret)
+	tp, err := pmuKprobe(platformPrefix(symbol), ret)
+	if errors.Is(err, os.ErrNotExist) {
+		tp, err = pmuKprobe(symbol, ret)
+	}
 	if err == nil {
 		return tp, nil
 	}
@@ -140,7 +143,10 @@ func kprobe(symbol string, prog *ebpf.Program, ret bool) (*perfEvent, error) {
 	}
 
 	// Use tracefs if kprobe PMU is missing.
-	tp, err = tracefsKprobe(symbol, ret)
+	tp, err = tracefsKprobe(platformPrefix(symbol), ret)
+	if errors.Is(err, os.ErrNotExist) {
+		tp, err = tracefsKprobe(symbol, ret)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("creating trace event '%s' in tracefs: %w", symbol, err)
 	}

--- a/vendor/github.com/cilium/ebpf/link/platform.go
+++ b/vendor/github.com/cilium/ebpf/link/platform.go
@@ -1,0 +1,25 @@
+package link
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func platformPrefix(symbol string) string {
+
+	prefix := runtime.GOARCH
+
+	// per https://github.com/golang/go/blob/master/src/go/build/syslist.go
+	switch prefix {
+	case "386":
+		prefix = "ia32"
+	case "amd64", "amd64p32":
+		prefix = "x64"
+	case "arm64", "arm64be":
+		prefix = "arm64"
+	default:
+		return symbol
+	}
+
+	return fmt.Sprintf("__%s_%s", prefix, symbol)
+}

--- a/vendor/github.com/cilium/ebpf/link/program.go
+++ b/vendor/github.com/cilium/ebpf/link/program.go
@@ -43,7 +43,7 @@ func RawAttachProgram(opts RawAttachProgramOptions) error {
 	}
 
 	if err := internal.BPFProgAttach(&attr); err != nil {
-		return fmt.Errorf("can't attach program: %s", err)
+		return fmt.Errorf("can't attach program: %w", err)
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func RawDetachProgram(opts RawDetachProgramOptions) error {
 		AttachType:  uint32(opts.Attach),
 	}
 	if err := internal.BPFProgDetach(&attr); err != nil {
-		return fmt.Errorf("can't detach program: %s", err)
+		return fmt.Errorf("can't detach program: %w", err)
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,7 +3,7 @@ github.com/bits-and-blooms/bitset
 # github.com/checkpoint-restore/go-criu/v5 v5.0.0
 github.com/checkpoint-restore/go-criu/v5
 github.com/checkpoint-restore/go-criu/v5/rpc
-# github.com/cilium/ebpf v0.6.0
+# github.com/cilium/ebpf v0.6.1
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm
 github.com/cilium/ebpf/internal


### PR DESCRIPTION
The `errors.Is(err, unix.EINVAL)` check in `haveBpfProgReplace()` was broken because the `cilium/ebpf` library did not "wrap" errors: https://github.com/cilium/ebpf/blob/v0.6.0/link/program.go#L72

So the eBPF support of runc was broken for kernel prior to 5.6.

The fix for the above is https://github.com/cilium/ebpf/pull/320. This PR bumps cilium/ebpf to include the fix.

Fixes: #3008

- - -

Tested in Moby CI https://github.com/moby/moby/pull/42450