### PR TITLE
Improve error reporting, add errorlint, fix its warnings; drop pkg/errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,4 @@ run:
 linters:
   enable:
     - gofumpt
+    - errorlint

--- a/contrib/cmd/recvtty/recvtty.go
+++ b/contrib/cmd/recvtty/recvtty.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -88,7 +89,7 @@ func handleSingle(path string, noStdin bool) error {
 	// Get the fd of the connection.
 	unixconn, ok := conn.(*net.UnixConn)
 	if !ok {
-		return fmt.Errorf("failed to cast to unixconn")
+		return errors.New("failed to cast to unixconn")
 	}
 
 	socket, err := unixconn.File()
@@ -217,7 +218,7 @@ func main() {
 	app.Action = func(ctx *cli.Context) error {
 		args := ctx.Args()
 		if len(args) != 1 {
-			return fmt.Errorf("need to specify a single socket path")
+			return errors.New("need to specify a single socket path")
 		}
 		path := ctx.Args()[0]
 

--- a/delete.go
+++ b/delete.go
@@ -55,7 +55,8 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 		force := context.Bool("force")
 		container, err := getContainer(context)
 		if err != nil {
-			if lerr, ok := err.(libcontainer.Error); ok && lerr.Code() == libcontainer.ContainerNotExists {
+			var lerr libcontainer.Error
+			if errors.As(err, &lerr) && lerr.Code() == libcontainer.ContainerNotExists {
 				// if there was an aborted start or something of the sort then the container's directory could exist but
 				// libcontainer does not see it because the state.json file inside that directory was never created.
 				path := filepath.Join(context.GlobalString("root"), id)

--- a/exec.go
+++ b/exec.go
@@ -101,7 +101,7 @@ following will output a list of processes running in the container:
 		if err == nil {
 			os.Exit(status)
 		}
-		return fmt.Errorf("exec failed: %v", err)
+		return fmt.Errorf("exec failed: %w", err)
 	},
 	SkipArgReorder: true,
 }
@@ -212,13 +212,13 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 		if len(u) > 1 {
 			gid, err := strconv.Atoi(u[1])
 			if err != nil {
-				return nil, fmt.Errorf("parsing %s as int for gid failed: %v", u[1], err)
+				return nil, fmt.Errorf("parsing %s as int for gid failed: %w", u[1], err)
 			}
 			p.User.GID = uint32(gid)
 		}
 		uid, err := strconv.Atoi(u[0])
 		if err != nil {
-			return nil, fmt.Errorf("parsing %s as int for uid failed: %v", u[0], err)
+			return nil, fmt.Errorf("parsing %s as int for uid failed: %w", u[0], err)
 		}
 		p.User.UID = uint32(uid)
 	}

--- a/exec.go
+++ b/exec.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -115,11 +116,11 @@ func execProcess(context *cli.Context) (int, error) {
 		return -1, err
 	}
 	if status == libcontainer.Stopped {
-		return -1, fmt.Errorf("cannot exec a container that has stopped")
+		return -1, errors.New("cannot exec a container that has stopped")
 	}
 	path := context.String("process")
 	if path == "" && len(context.Args()) == 1 {
-		return -1, fmt.Errorf("process args cannot be empty")
+		return -1, errors.New("process args cannot be empty")
 	}
 	detach := context.Bool("detach")
 	state, err := container.State()

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/mrunalp/fileutils v0.5.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux v1.8.2
-	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635

--- a/libcontainer/apparmor/apparmor_linux.go
+++ b/libcontainer/apparmor/apparmor_linux.go
@@ -52,7 +52,7 @@ func setProcAttr(attr, value string) error {
 // changeOnExec reimplements aa_change_onexec from libapparmor in Go
 func changeOnExec(name string) error {
 	if err := setProcAttr("exec", "exec "+name); err != nil {
-		return fmt.Errorf("apparmor failed to apply profile: %s", err)
+		return fmt.Errorf("apparmor failed to apply profile: %w", err)
 	}
 	return nil
 }

--- a/libcontainer/cgroups/ebpf/devicefilter/devicefilter.go
+++ b/libcontainer/cgroups/ebpf/devicefilter/devicefilter.go
@@ -7,13 +7,14 @@
 package devicefilter
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"strconv"
 
 	"github.com/cilium/ebpf/asm"
 	devicesemulator "github.com/opencontainers/runc/libcontainer/cgroups/devices"
 	"github.com/opencontainers/runc/libcontainer/devices"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -51,14 +52,14 @@ func DeviceFilter(rules []*devices.Rule) (asm.Instructions, string, error) {
 			// only be one (at most) at the very start to instruct cgroupv1 to
 			// go into allow-list mode. However we do double-check this here.
 			if idx != 0 || rule.Allow != emu.IsBlacklist() {
-				return nil, "", errors.Errorf("[internal error] emulated cgroupv2 devices ruleset had bad wildcard at idx %v (%s)", idx, rule.CgroupString())
+				return nil, "", fmt.Errorf("[internal error] emulated cgroupv2 devices ruleset had bad wildcard at idx %v (%s)", idx, rule.CgroupString())
 			}
 			continue
 		}
 		if rule.Allow == p.defaultAllow {
 			// There should be no rules which have an action equal to the
 			// default action, the emulator removes those.
-			return nil, "", errors.Errorf("[internal error] emulated cgroupv2 devices ruleset had no-op rule at idx %v (%s)", idx, rule.CgroupString())
+			return nil, "", fmt.Errorf("[internal error] emulated cgroupv2 devices ruleset had no-op rule at idx %v (%s)", idx, rule.CgroupString())
 		}
 		if err := p.appendRule(rule); err != nil {
 			return nil, "", err
@@ -118,13 +119,13 @@ func (p *program) appendRule(rule *devices.Rule) error {
 		bpfType = int32(unix.BPF_DEVCG_DEV_BLOCK)
 	default:
 		// We do not permit 'a', nor any other types we don't know about.
-		return errors.Errorf("invalid type %q", string(rule.Type))
+		return fmt.Errorf("invalid type %q", string(rule.Type))
 	}
 	if rule.Major > math.MaxUint32 {
-		return errors.Errorf("invalid major %d", rule.Major)
+		return fmt.Errorf("invalid major %d", rule.Major)
 	}
 	if rule.Minor > math.MaxUint32 {
-		return errors.Errorf("invalid minor %d", rule.Major)
+		return fmt.Errorf("invalid minor %d", rule.Major)
 	}
 	hasMajor := rule.Major >= 0 // if not specified in OCI json, major is set to -1
 	hasMinor := rule.Minor >= 0
@@ -138,7 +139,7 @@ func (p *program) appendRule(rule *devices.Rule) error {
 		case 'm':
 			bpfAccess |= unix.BPF_DEVCG_ACC_MKNOD
 		default:
-			return errors.Errorf("unknown device access %v", r)
+			return fmt.Errorf("unknown device access %v", r)
 		}
 	}
 	// If the access is rwm, skip the check.

--- a/libcontainer/cgroups/ebpf/ebpf_linux.go
+++ b/libcontainer/cgroups/ebpf/ebpf_linux.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -10,7 +11,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/link"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )

--- a/libcontainer/cgroups/file.go
+++ b/libcontainer/cgroups/file.go
@@ -2,11 +2,12 @@ package cgroups
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -15,7 +16,7 @@ import (
 // It is supposed to be used for cgroup files only.
 func OpenFile(dir, file string, flags int) (*os.File, error) {
 	if dir == "" {
-		return nil, errors.Errorf("no directory specified for %s", file)
+		return nil, fmt.Errorf("no directory specified for %s", file)
 	}
 	return openFile(dir, file, flags)
 }
@@ -43,7 +44,8 @@ func WriteFile(dir, file, data string) error {
 	}
 	defer fd.Close()
 	if err := retryingWriteFile(fd, data); err != nil {
-		return errors.Wrapf(err, "failed to write %q", data)
+		// Having data in the error message helps in debugging.
+		return fmt.Errorf("failed to write %q: %w", data, err)
 	}
 	return nil
 }

--- a/libcontainer/cgroups/file.go
+++ b/libcontainer/cgroups/file.go
@@ -81,7 +81,7 @@ func prepareOpenat2() error {
 		})
 		if err != nil {
 			prepErr = &os.PathError{Op: "openat2", Path: cgroupfsDir, Err: err}
-			if err != unix.ENOSYS {
+			if err != unix.ENOSYS { //nolint:errorlint // unix errors are bare
 				logrus.Warnf("falling back to securejoin: %s", prepErr)
 			} else {
 				logrus.Debug("openat2 not available, falling back to securejoin")

--- a/libcontainer/cgroups/fs/blkio_test.go
+++ b/libcontainer/cgroups/fs/blkio_test.go
@@ -283,7 +283,6 @@ func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if value != weightDeviceAfter {
 		t.Fatalf("Got the wrong value, set %s failed.", blkio.weightDeviceFilename)
 	}
@@ -772,9 +771,8 @@ func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "blkio.throttle.read_bps_device")
 	if err != nil {
-		t.Fatalf("Failed to parse blkio.throttle.read_bps_device - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != throttleAfter {
 		t.Fatal("Got the wrong value, set blkio.throttle.read_bps_device failed.")
 	}
@@ -803,9 +801,8 @@ func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "blkio.throttle.write_bps_device")
 	if err != nil {
-		t.Fatalf("Failed to parse blkio.throttle.write_bps_device - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != throttleAfter {
 		t.Fatal("Got the wrong value, set blkio.throttle.write_bps_device failed.")
 	}
@@ -834,9 +831,8 @@ func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "blkio.throttle.read_iops_device")
 	if err != nil {
-		t.Fatalf("Failed to parse blkio.throttle.read_iops_device - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != throttleAfter {
 		t.Fatal("Got the wrong value, set blkio.throttle.read_iops_device failed.")
 	}
@@ -865,9 +861,8 @@ func TestBlkioSetThrottleWriteIOpsDevice(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "blkio.throttle.write_iops_device")
 	if err != nil {
-		t.Fatalf("Failed to parse blkio.throttle.write_iops_device - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != throttleAfter {
 		t.Fatal("Got the wrong value, set blkio.throttle.write_iops_device failed.")
 	}

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -85,7 +85,8 @@ func (s *CpuGroup) Set(path string, r *configs.Resources) error {
 }
 
 func (s *CpuGroup) GetStats(path string, stats *cgroups.Stats) error {
-	f, err := cgroups.OpenFile(path, "cpu.stat", os.O_RDONLY)
+	const file = "cpu.stat"
+	f, err := cgroups.OpenFile(path, file, os.O_RDONLY)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -98,7 +99,7 @@ func (s *CpuGroup) GetStats(path string, stats *cgroups.Stats) error {
 	for sc.Scan() {
 		t, v, err := fscommon.ParseKeyValue(sc.Text())
 		if err != nil {
-			return err
+			return &parseError{Path: path, File: file, Err: err}
 		}
 		switch t {
 		case "nr_periods":

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -32,9 +32,8 @@ func TestCpuSetShares(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cpu.shares")
 	if err != nil {
-		t.Fatalf("Failed to parse cpu.shares - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != sharesAfter {
 		t.Fatal("Got the wrong value, set cpu.shares failed.")
 	}
@@ -73,7 +72,7 @@ func TestCpuSetBandWidth(t *testing.T) {
 
 	quota, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cpu.cfs_quota_us")
 	if err != nil {
-		t.Fatalf("Failed to parse cpu.cfs_quota_us - %s", err)
+		t.Fatal(err)
 	}
 	if quota != quotaAfter {
 		t.Fatal("Got the wrong value, set cpu.cfs_quota_us failed.")
@@ -81,21 +80,23 @@ func TestCpuSetBandWidth(t *testing.T) {
 
 	period, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cpu.cfs_period_us")
 	if err != nil {
-		t.Fatalf("Failed to parse cpu.cfs_period_us - %s", err)
+		t.Fatal(err)
 	}
 	if period != periodAfter {
 		t.Fatal("Got the wrong value, set cpu.cfs_period_us failed.")
 	}
+
 	rtRuntime, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cpu.rt_runtime_us")
 	if err != nil {
-		t.Fatalf("Failed to parse cpu.rt_runtime_us - %s", err)
+		t.Fatal(err)
 	}
 	if rtRuntime != rtRuntimeAfter {
 		t.Fatal("Got the wrong value, set cpu.rt_runtime_us failed.")
 	}
+
 	rtPeriod, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cpu.rt_period_us")
 	if err != nil {
-		t.Fatalf("Failed to parse cpu.rt_period_us - %s", err)
+		t.Fatal(err)
 	}
 	if rtPeriod != rtPeriodAfter {
 		t.Fatal("Got the wrong value, set cpu.rt_period_us failed.")
@@ -191,21 +192,23 @@ func TestCpuSetRtSchedAtApply(t *testing.T) {
 
 	rtRuntime, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cpu.rt_runtime_us")
 	if err != nil {
-		t.Fatalf("Failed to parse cpu.rt_runtime_us - %s", err)
+		t.Fatal(err)
 	}
 	if rtRuntime != rtRuntimeAfter {
 		t.Fatal("Got the wrong value, set cpu.rt_runtime_us failed.")
 	}
+
 	rtPeriod, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cpu.rt_period_us")
 	if err != nil {
-		t.Fatalf("Failed to parse cpu.rt_period_us - %s", err)
+		t.Fatal(err)
 	}
 	if rtPeriod != rtPeriodAfter {
 		t.Fatal("Got the wrong value, set cpu.rt_period_us failed.")
 	}
+
 	pid, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "cgroup.procs")
 	if err != nil {
-		t.Fatalf("Failed to parse cgroup.procs - %s", err)
+		t.Fatal(err)
 	}
 	if pid != 1234 {
 		t.Fatal("Got the wrong value, set cgroup.procs failed.")

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -4,9 +4,7 @@ package fs
 
 import (
 	"bufio"
-	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -85,45 +83,43 @@ func getCpuUsageBreakdown(path string) (uint64, uint64, error) {
 	const (
 		userField   = "user"
 		systemField = "system"
+		file        = cgroupCpuacctStat
 	)
 
 	// Expected format:
 	// user <usage in ticks>
 	// system <usage in ticks>
-	data, err := cgroups.ReadFile(path, cgroupCpuacctStat)
+	data, err := cgroups.ReadFile(path, file)
 	if err != nil {
 		return 0, 0, err
 	}
+	// TODO: use strings.SplitN instead.
 	fields := strings.Fields(data)
-	if len(fields) < 4 {
-		return 0, 0, fmt.Errorf("failure - %s is expected to have at least 4 fields", filepath.Join(path, cgroupCpuacctStat))
-	}
-	if fields[0] != userField {
-		return 0, 0, fmt.Errorf("unexpected field %q in %q, expected %q", fields[0], cgroupCpuacctStat, userField)
-	}
-	if fields[2] != systemField {
-		return 0, 0, fmt.Errorf("unexpected field %q in %q, expected %q", fields[2], cgroupCpuacctStat, systemField)
+	if len(fields) < 4 || fields[0] != userField || fields[2] != systemField {
+		return 0, 0, malformedLine(path, file, data)
 	}
 	if userModeUsage, err = strconv.ParseUint(fields[1], 10, 64); err != nil {
-		return 0, 0, err
+		return 0, 0, &parseError{Path: path, File: file, Err: err}
 	}
 	if kernelModeUsage, err = strconv.ParseUint(fields[3], 10, 64); err != nil {
-		return 0, 0, err
+		return 0, 0, &parseError{Path: path, File: file, Err: err}
 	}
 
 	return (userModeUsage * nanosecondsInSecond) / clockTicks, (kernelModeUsage * nanosecondsInSecond) / clockTicks, nil
 }
 
 func getPercpuUsage(path string) ([]uint64, error) {
+	const file = "cpuacct.usage_percpu"
 	percpuUsage := []uint64{}
-	data, err := cgroups.ReadFile(path, "cpuacct.usage_percpu")
+	data, err := cgroups.ReadFile(path, file)
 	if err != nil {
 		return percpuUsage, err
 	}
+	// TODO: use strings.SplitN instead.
 	for _, value := range strings.Fields(data) {
 		value, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
-			return percpuUsage, fmt.Errorf("Unable to convert param value to uint64: %s", err)
+			return percpuUsage, &parseError{Path: path, File: file, Err: err}
 		}
 		percpuUsage = append(percpuUsage, value)
 	}
@@ -133,16 +129,17 @@ func getPercpuUsage(path string) ([]uint64, error) {
 func getPercpuUsageInModes(path string) ([]uint64, []uint64, error) {
 	usageKernelMode := []uint64{}
 	usageUserMode := []uint64{}
+	const file = cgroupCpuacctUsageAll
 
-	file, err := cgroups.OpenFile(path, cgroupCpuacctUsageAll, os.O_RDONLY)
+	fd, err := cgroups.OpenFile(path, file, os.O_RDONLY)
 	if os.IsNotExist(err) {
 		return usageKernelMode, usageUserMode, nil
 	} else if err != nil {
 		return nil, nil, err
 	}
-	defer file.Close()
+	defer fd.Close()
 
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(fd)
 	scanner.Scan() // skipping header line
 
 	for scanner.Scan() {
@@ -153,19 +150,18 @@ func getPercpuUsageInModes(path string) ([]uint64, []uint64, error) {
 
 		usageInKernelMode, err := strconv.ParseUint(lineFields[kernelModeColumn], 10, 64)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to convert CPU usage in kernel mode to uint64: %s", err)
+			return nil, nil, &parseError{Path: path, File: file, Err: err}
 		}
 		usageKernelMode = append(usageKernelMode, usageInKernelMode)
 
 		usageInUserMode, err := strconv.ParseUint(lineFields[userModeColumn], 10, 64)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to convert CPU usage in user mode to uint64: %s", err)
+			return nil, nil, &parseError{Path: path, File: file, Err: err}
 		}
 		usageUserMode = append(usageUserMode, usageInUserMode)
 	}
-
 	if err := scanner.Err(); err != nil {
-		return nil, nil, fmt.Errorf("Problem in reading %s line by line, %s", cgroupCpuacctUsageAll, err)
+		return nil, nil, &parseError{Path: path, File: file, Err: err}
 	}
 
 	return usageKernelMode, usageUserMode, nil

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -197,7 +197,7 @@ func cpusetEnsureParent(current string) error {
 	}
 	// Treat non-existing directory as cgroupfs as it will be created,
 	// and the root cpuset directory obviously exists.
-	if err != nil && err != unix.ENOENT {
+	if err != nil && err != unix.ENOENT { //nolint:errorlint // unix errors are bare
 		return &os.PathError{Op: "statfs", Path: parent, Err: err}
 	}
 

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -3,16 +3,17 @@
 package fs
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 type CpusetGroup struct{}

--- a/libcontainer/cgroups/fs/cpuset_test.go
+++ b/libcontainer/cgroups/fs/cpuset_test.go
@@ -59,9 +59,8 @@ func TestCPUSetSetCpus(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "cpuset.cpus")
 	if err != nil {
-		t.Fatalf("Failed to parse cpuset.cpus - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != cpusAfter {
 		t.Fatal("Got the wrong value, set cpuset.cpus failed.")
 	}
@@ -88,9 +87,8 @@ func TestCPUSetSetMems(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "cpuset.mems")
 	if err != nil {
-		t.Fatalf("Failed to parse cpuset.mems - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != memsAfter {
 		t.Fatal("Got the wrong value, set cpuset.mems failed.")
 	}

--- a/libcontainer/cgroups/fs/devices_test.go
+++ b/libcontainer/cgroups/fs/devices_test.go
@@ -37,7 +37,7 @@ func TestDevicesSetAllow(t *testing.T) {
 	// The default deny rule must be written.
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "devices.deny")
 	if err != nil {
-		t.Fatalf("Failed to parse devices.deny: %s", err)
+		t.Fatal(err)
 	}
 	if value[0] != 'a' {
 		t.Errorf("Got the wrong value (%q), set devices.deny failed.", value)
@@ -45,7 +45,7 @@ func TestDevicesSetAllow(t *testing.T) {
 
 	// Permitted rule must be written.
 	if value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "devices.allow"); err != nil {
-		t.Fatalf("Failed to parse devices.allow: %s", err)
+		t.Fatal(err)
 	} else if value != "c 1:5 rwm" {
 		t.Errorf("Got the wrong value (%q), set devices.allow failed.", value)
 	}

--- a/libcontainer/cgroups/fs/error.go
+++ b/libcontainer/cgroups/fs/error.go
@@ -1,0 +1,15 @@
+package fs
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
+)
+
+type parseError = fscommon.ParseError
+
+// malformedLine is used by all cgroupfs file parsers that expect a line
+// in a particular format but get some garbage instead.
+func malformedLine(path, file, line string) error {
+	return &parseError{Path: path, File: file, Err: fmt.Errorf("malformed line: %s", line)}
+}

--- a/libcontainer/cgroups/fs/freezer_test.go
+++ b/libcontainer/cgroups/fs/freezer_test.go
@@ -25,7 +25,7 @@ func TestFreezerSetState(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "freezer.state")
 	if err != nil {
-		t.Fatalf("Failed to parse freezer.state - %s", err)
+		t.Fatal(err)
 	}
 	if value != string(configs.Thawed) {
 		t.Fatal("Got the wrong value, set freezer.state failed.")

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -3,17 +3,18 @@
 package fs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -171,8 +172,6 @@ func isIgnorableError(rootless bool, err error) bool {
 	if !rootless {
 		return false
 	}
-	// TODO: rm errors.Cause once we switch to %w everywhere
-	err = errors.Cause(err)
 	// Is it an ordinary EPERM?
 	if errors.Is(err, os.ErrPermission) {
 		return true

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -3,7 +3,6 @@
 package fs
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -40,21 +39,21 @@ func (s *HugetlbGroup) GetStats(path string, stats *cgroups.Stats) error {
 		usage := "hugetlb." + pageSize + ".usage_in_bytes"
 		value, err := fscommon.GetCgroupParamUint(path, usage)
 		if err != nil {
-			return fmt.Errorf("failed to parse %s - %v", usage, err)
+			return err
 		}
 		hugetlbStats.Usage = value
 
 		maxUsage := "hugetlb." + pageSize + ".max_usage_in_bytes"
 		value, err = fscommon.GetCgroupParamUint(path, maxUsage)
 		if err != nil {
-			return fmt.Errorf("failed to parse %s - %v", maxUsage, err)
+			return err
 		}
 		hugetlbStats.MaxUsage = value
 
 		failcnt := "hugetlb." + pageSize + ".failcnt"
 		value, err = fscommon.GetCgroupParamUint(path, failcnt)
 		if err != nil {
-			return fmt.Errorf("failed to parse %s - %v", failcnt, err)
+			return err
 		}
 		hugetlbStats.Failcnt = value
 

--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -57,7 +57,7 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 		limit := fmt.Sprintf(limit, pageSize)
 		value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, limit)
 		if err != nil {
-			t.Fatalf("Failed to parse %s - %s", limit, err)
+			t.Fatal(err)
 		}
 		if value != hugetlbAfter {
 			t.Fatalf("Set hugetlb.limit_in_bytes failed. Expected: %v, Got: %v", hugetlbAfter, value)

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -134,15 +134,15 @@ func (s *MemoryGroup) Set(path string, r *configs.Resources) error {
 			return err
 		}
 	} else {
-		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", *r.MemorySwappiness)
+		return fmt.Errorf("invalid memory swappiness value: %d (valid range is 0-100)", *r.MemorySwappiness)
 	}
 
 	return nil
 }
 
 func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
-	// Set stats from memory.stat.
-	statsFile, err := cgroups.OpenFile(path, "memory.stat", os.O_RDONLY)
+	const file = "memory.stat"
+	statsFile, err := cgroups.OpenFile(path, file, os.O_RDONLY)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -155,7 +155,7 @@ func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
 	for sc.Scan() {
 		t, v, err := fscommon.ParseKeyValue(sc.Text())
 		if err != nil {
-			return fmt.Errorf("failed to parse memory.stat (%q) - %v", sc.Text(), err)
+			return &parseError{Path: path, File: file, Err: err}
 		}
 		stats.MemoryStats.Stats[t] = v
 	}
@@ -220,42 +220,42 @@ func getMemoryData(path, name string) (cgroups.MemoryData, error) {
 			// are optional in the kernel.
 			return cgroups.MemoryData{}, nil
 		}
-		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", usage, err)
+		return cgroups.MemoryData{}, err
 	}
 	memoryData.Usage = value
 	value, err = fscommon.GetCgroupParamUint(path, maxUsage)
 	if err != nil {
-		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", maxUsage, err)
+		return cgroups.MemoryData{}, err
 	}
 	memoryData.MaxUsage = value
 	value, err = fscommon.GetCgroupParamUint(path, failcnt)
 	if err != nil {
-		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", failcnt, err)
+		return cgroups.MemoryData{}, err
 	}
 	memoryData.Failcnt = value
 	value, err = fscommon.GetCgroupParamUint(path, limit)
 	if err != nil {
-		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", limit, err)
+		return cgroups.MemoryData{}, err
 	}
 	memoryData.Limit = value
 
 	return memoryData, nil
 }
 
-func getPageUsageByNUMA(cgroupPath string) (cgroups.PageUsageByNUMA, error) {
+func getPageUsageByNUMA(path string) (cgroups.PageUsageByNUMA, error) {
 	const (
 		maxColumns = math.MaxUint8 + 1
-		filename   = "memory.numa_stat"
+		file       = "memory.numa_stat"
 	)
 	stats := cgroups.PageUsageByNUMA{}
 
-	file, err := cgroups.OpenFile(cgroupPath, filename, os.O_RDONLY)
+	fd, err := cgroups.OpenFile(path, file, os.O_RDONLY)
 	if os.IsNotExist(err) {
 		return stats, nil
 	} else if err != nil {
 		return stats, err
 	}
-	defer file.Close()
+	defer fd.Close()
 
 	// File format is documented in linux/Documentation/cgroup-v1/memory.txt
 	// and it looks like this:
@@ -266,7 +266,7 @@ func getPageUsageByNUMA(cgroupPath string) (cgroups.PageUsageByNUMA, error) {
 	// unevictable=<total anon pages> N0=<node 0 pages> N1=<node 1 pages> ...
 	// hierarchical_<counter>=<counter pages> N0=<node 0 pages> N1=<node 1 pages> ...
 
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(fd)
 	for scanner.Scan() {
 		var field *cgroups.PageStats
 
@@ -284,8 +284,7 @@ func getPageUsageByNUMA(cgroupPath string) (cgroups.PageUsageByNUMA, error) {
 				} else {
 					// The first column was already validated,
 					// so be strict to the rest.
-					return stats, fmt.Errorf("malformed line %q in %s",
-						line, filename)
+					return stats, malformedLine(path, file, line)
 				}
 			}
 			key, val := byNode[0], byNode[1]
@@ -296,24 +295,23 @@ func getPageUsageByNUMA(cgroupPath string) (cgroups.PageUsageByNUMA, error) {
 				}
 				field.Total, err = strconv.ParseUint(val, 0, 64)
 				if err != nil {
-					return stats, err
+					return stats, &parseError{Path: path, File: file, Err: err}
 				}
 				field.Nodes = map[uint8]uint64{}
 			} else { // Subsequent columns: key is N<id>, val is usage.
 				if len(key) < 2 || key[0] != 'N' {
 					// This is definitely an error.
-					return stats, fmt.Errorf("malformed line %q in %s",
-						line, filename)
+					return stats, malformedLine(path, file, line)
 				}
 
 				n, err := strconv.ParseUint(key[1:], 10, 8)
 				if err != nil {
-					return cgroups.PageUsageByNUMA{}, err
+					return stats, &parseError{Path: path, File: file, Err: err}
 				}
 
 				usage, err := strconv.ParseUint(val, 10, 64)
 				if err != nil {
-					return cgroups.PageUsageByNUMA{}, err
+					return stats, &parseError{Path: path, File: file, Err: err}
 				}
 
 				field.Nodes[uint8(n)] = usage
@@ -321,9 +319,8 @@ func getPageUsageByNUMA(cgroupPath string) (cgroups.PageUsageByNUMA, error) {
 
 		}
 	}
-	err = scanner.Err()
-	if err != nil {
-		return cgroups.PageUsageByNUMA{}, err
+	if err := scanner.Err(); err != nil {
+		return cgroups.PageUsageByNUMA{}, &parseError{Path: path, File: file, Err: err}
 	}
 
 	return stats, nil

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -11,11 +12,11 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -56,7 +57,7 @@ func setMemory(path string, val int64) error {
 		return err
 	}
 
-	return errors.Errorf("unable to set memory limit to %d (current usage: %d, peak usage: %d)", val, usage, max)
+	return fmt.Errorf("unable to set memory limit to %d (current usage: %d, peak usage: %d)", val, usage, max)
 }
 
 func setSwap(path string, val int64) error {

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -64,7 +64,7 @@ func TestMemorySetMemory(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.limit_in_bytes")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.limit_in_bytes - %s", err)
+		t.Fatal(err)
 	}
 	if value != memoryAfter {
 		t.Fatal("Got the wrong value, set memory.limit_in_bytes failed.")
@@ -72,7 +72,7 @@ func TestMemorySetMemory(t *testing.T) {
 
 	value, err = fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.soft_limit_in_bytes")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.soft_limit_in_bytes - %s", err)
+		t.Fatal(err)
 	}
 	if value != reservationAfter {
 		t.Fatal("Got the wrong value, set memory.soft_limit_in_bytes failed.")
@@ -100,7 +100,7 @@ func TestMemorySetMemoryswap(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.memsw.limit_in_bytes")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.memsw.limit_in_bytes - %s", err)
+		t.Fatal(err)
 	}
 	if value != memoryswapAfter {
 		t.Fatal("Got the wrong value, set memory.memsw.limit_in_bytes failed.")
@@ -137,14 +137,15 @@ func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.limit_in_bytes")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.limit_in_bytes - %s", err)
+		t.Fatal(err)
 	}
 	if value != memoryAfter {
 		t.Fatal("Got the wrong value, set memory.limit_in_bytes failed.")
 	}
+
 	value, err = fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.memsw.limit_in_bytes")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.memsw.limit_in_bytes - %s", err)
+		t.Fatal(err)
 	}
 	if value != memoryswapAfter {
 		t.Fatal("Got the wrong value, set memory.memsw.limit_in_bytes failed.")
@@ -176,14 +177,15 @@ func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.limit_in_bytes")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.limit_in_bytes - %s", err)
+		t.Fatal(err)
 	}
 	if value != memoryAfter {
 		t.Fatalf("Got the wrong value (%d != %d), set memory.limit_in_bytes failed", value, memoryAfter)
 	}
+
 	value, err = fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.memsw.limit_in_bytes")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.memsw.limit_in_bytes - %s", err)
+		t.Fatal(err)
 	}
 	if value != memoryswapAfter {
 		t.Fatalf("Got the wrong value (%d != %d), set memory.memsw.limit_in_bytes failed", value, memoryswapAfter)
@@ -209,7 +211,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.swappiness")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.swappiness - %s", err)
+		t.Fatal(err)
 	}
 	if value != swappinessAfter {
 		t.Fatalf("Got the wrong value (%d), set memory.swappiness = %d failed.", value, swappinessAfter)
@@ -427,9 +429,8 @@ func TestMemorySetOomControl(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "memory.oom_control")
 	if err != nil {
-		t.Fatalf("Failed to parse memory.oom_control - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != oomKillDisable {
 		t.Fatalf("Got the wrong value, set memory.oom_control failed.")
 	}

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -33,7 +33,7 @@ func TestNetClsSetClassid(t *testing.T) {
 	// So. we just judge if we successfully write classid into file
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "net_cls.classid")
 	if err != nil {
-		t.Fatalf("Failed to parse net_cls.classid - %s", err)
+		t.Fatal(err)
 	}
 	if value != classidAfter {
 		t.Fatal("Got the wrong value, set net_cls.classid failed.")

--- a/libcontainer/cgroups/fs/net_prio_test.go
+++ b/libcontainer/cgroups/fs/net_prio_test.go
@@ -29,7 +29,7 @@ func TestNetPrioSetIfPrio(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "net_prio.ifpriomap")
 	if err != nil {
-		t.Fatalf("Failed to parse net_prio.ifpriomap - %s", err)
+		t.Fatal(err)
 	}
 	if !strings.Contains(value, "test 5") {
 		t.Fatal("Got the wrong value, set net_prio.ifpriomap failed.")

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -3,8 +3,7 @@
 package fs
 
 import (
-	"fmt"
-	"path/filepath"
+	"math"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -45,21 +44,18 @@ func (s *PidsGroup) GetStats(path string, stats *cgroups.Stats) error {
 	}
 	current, err := fscommon.GetCgroupParamUint(path, "pids.current")
 	if err != nil {
-		return fmt.Errorf("failed to parse pids.current - %s", err)
+		return err
 	}
 
-	maxString, err := fscommon.GetCgroupParamString(path, "pids.max")
+	max, err := fscommon.GetCgroupParamUint(path, "pids.max")
 	if err != nil {
-		return fmt.Errorf("failed to parse pids.max - %s", err)
+		return err
 	}
-
-	// Default if pids.max == "max" is 0 -- which represents "no limit".
-	var max uint64
-	if maxString != "max" {
-		max, err = fscommon.ParseUint(maxString, 10, 64)
-		if err != nil {
-			return fmt.Errorf("failed to parse pids.max - unable to parse %q as a uint from Cgroup file %q", maxString, filepath.Join(path, "pids.max"))
-		}
+	// If no limit is set, read from pids.max returns "max", which is
+	// converted to MaxUint64 by GetCgroupParamUint. Historically, we
+	// represent "no limit" for pids as 0, thus this conversion.
+	if max == math.MaxUint64 {
+		max = 0
 	}
 
 	stats.PidsStats.Current = current

--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -31,9 +31,8 @@ func TestPidsSetMax(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "pids.max")
 	if err != nil {
-		t.Fatalf("Failed to parse pids.max - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != maxLimited {
 		t.Fatalf("Expected %d, got %d for setting pids.max - limited", maxLimited, value)
 	}
@@ -55,9 +54,8 @@ func TestPidsSetUnlimited(t *testing.T) {
 
 	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "pids.max")
 	if err != nil {
-		t.Fatalf("Failed to parse pids.max - %s", err)
+		t.Fatal(err)
 	}
-
 	if value != "max" {
 		t.Fatalf("Expected %s, got %s for setting pids.max - unlimited", "max", value)
 	}

--- a/libcontainer/cgroups/fs/stats_util_test.go
+++ b/libcontainer/cgroups/fs/stats_util_test.go
@@ -18,7 +18,7 @@ func blkioStatEntryEquals(expected, actual []cgroups.BlkioStatEntry) error {
 	for i, expValue := range expected {
 		actValue := actual[i]
 		if expValue != actValue {
-			return fmt.Errorf("Expected blkio stat entry %v but found %v", expValue, actValue)
+			return fmt.Errorf("expected: %v, actual: %v", expValue, actValue)
 		}
 	}
 	return nil
@@ -27,49 +27,49 @@ func blkioStatEntryEquals(expected, actual []cgroups.BlkioStatEntry) error {
 func expectBlkioStatsEquals(t *testing.T, expected, actual cgroups.BlkioStats) {
 	t.Helper()
 	if err := blkioStatEntryEquals(expected.IoServiceBytesRecursive, actual.IoServiceBytesRecursive); err != nil {
-		t.Errorf("blkio IoServiceBytesRecursive do not match - %s\n", err)
+		t.Errorf("blkio IoServiceBytesRecursive do not match: %s", err)
 	}
 
 	if err := blkioStatEntryEquals(expected.IoServicedRecursive, actual.IoServicedRecursive); err != nil {
-		t.Errorf("blkio IoServicedRecursive do not match - %s\n", err)
+		t.Errorf("blkio IoServicedRecursive do not match: %s", err)
 	}
 
 	if err := blkioStatEntryEquals(expected.IoQueuedRecursive, actual.IoQueuedRecursive); err != nil {
-		t.Errorf("blkio IoQueuedRecursive do not match - %s\n", err)
+		t.Errorf("blkio IoQueuedRecursive do not match: %s", err)
 	}
 
 	if err := blkioStatEntryEquals(expected.SectorsRecursive, actual.SectorsRecursive); err != nil {
-		t.Errorf("blkio SectorsRecursive do not match - %s\n", err)
+		t.Errorf("blkio SectorsRecursive do not match: %s", err)
 	}
 
 	if err := blkioStatEntryEquals(expected.IoServiceTimeRecursive, actual.IoServiceTimeRecursive); err != nil {
-		t.Errorf("blkio IoServiceTimeRecursive do not match - %s\n", err)
+		t.Errorf("blkio IoServiceTimeRecursive do not match: %s", err)
 	}
 
 	if err := blkioStatEntryEquals(expected.IoWaitTimeRecursive, actual.IoWaitTimeRecursive); err != nil {
-		t.Errorf("blkio IoWaitTimeRecursive do not match - %s\n", err)
+		t.Errorf("blkio IoWaitTimeRecursive do not match: %s", err)
 	}
 
 	if err := blkioStatEntryEquals(expected.IoMergedRecursive, actual.IoMergedRecursive); err != nil {
-		t.Errorf("blkio IoMergedRecursive do not match - %v vs %v\n", expected.IoMergedRecursive, actual.IoMergedRecursive)
+		t.Errorf("blkio IoMergedRecursive do not match: expcted: %v, actual: %v", expected.IoMergedRecursive, actual.IoMergedRecursive)
 	}
 
 	if err := blkioStatEntryEquals(expected.IoTimeRecursive, actual.IoTimeRecursive); err != nil {
-		t.Errorf("blkio IoTimeRecursive do not match - %s\n", err)
+		t.Errorf("blkio IoTimeRecursive do not match: %s", err)
 	}
 }
 
 func expectThrottlingDataEquals(t *testing.T, expected, actual cgroups.ThrottlingData) {
 	t.Helper()
 	if expected != actual {
-		t.Errorf("Expected throttling data %v but found %v\n", expected, actual)
+		t.Errorf("Expected throttling data: %v, actual: %v", expected, actual)
 	}
 }
 
 func expectHugetlbStatEquals(t *testing.T, expected, actual cgroups.HugetlbStats) {
 	t.Helper()
 	if expected != actual {
-		t.Errorf("Expected hugetlb stats %v but found %v\n", expected, actual)
+		t.Errorf("Expected hugetlb stats: %v, actual: %v", expected, actual)
 	}
 }
 
@@ -81,16 +81,16 @@ func expectMemoryStatEquals(t *testing.T, expected, actual cgroups.MemoryStats) 
 	expectPageUsageByNUMAEquals(t, expected.PageUsageByNUMA, actual.PageUsageByNUMA)
 
 	if expected.UseHierarchy != actual.UseHierarchy {
-		t.Errorf("Expected memory use hierarchy %v, but found %v\n", expected.UseHierarchy, actual.UseHierarchy)
+		t.Errorf("Expected memory use hierarchy: %v, actual: %v", expected.UseHierarchy, actual.UseHierarchy)
 	}
 
 	for key, expValue := range expected.Stats {
 		actValue, ok := actual.Stats[key]
 		if !ok {
-			t.Errorf("Expected memory stat key %s not found\n", key)
+			t.Errorf("Expected memory stat key %s not found", key)
 		}
 		if expValue != actValue {
-			t.Errorf("Expected memory stat value %d but found %d\n", expValue, actValue)
+			t.Errorf("Expected memory stat value: %d, actual: %d", expValue, actValue)
 		}
 	}
 }
@@ -98,43 +98,43 @@ func expectMemoryStatEquals(t *testing.T, expected, actual cgroups.MemoryStats) 
 func expectMemoryDataEquals(t *testing.T, expected, actual cgroups.MemoryData) {
 	t.Helper()
 	if expected.Usage != actual.Usage {
-		t.Errorf("Expected memory usage %d but found %d\n", expected.Usage, actual.Usage)
+		t.Errorf("Expected memory usage: %d, actual: %d", expected.Usage, actual.Usage)
 	}
 	if expected.MaxUsage != actual.MaxUsage {
-		t.Errorf("Expected memory max usage %d but found %d\n", expected.MaxUsage, actual.MaxUsage)
+		t.Errorf("Expected memory max usage: %d, actual: %d", expected.MaxUsage, actual.MaxUsage)
 	}
 	if expected.Failcnt != actual.Failcnt {
-		t.Errorf("Expected memory failcnt %d but found %d\n", expected.Failcnt, actual.Failcnt)
+		t.Errorf("Expected memory failcnt %d, actual: %d", expected.Failcnt, actual.Failcnt)
 	}
 	if expected.Limit != actual.Limit {
-		t.Errorf("Expected memory limit %d but found %d\n", expected.Limit, actual.Limit)
+		t.Errorf("Expected memory limit: %d, actual: %d", expected.Limit, actual.Limit)
 	}
 }
 
 func expectPageUsageByNUMAEquals(t *testing.T, expected, actual cgroups.PageUsageByNUMA) {
 	t.Helper()
 	if !reflect.DeepEqual(expected.Total, actual.Total) {
-		t.Errorf("Expected total page usage by NUMA %#v but found %#v", expected.Total, actual.Total)
+		t.Errorf("Expected total page usage by NUMA: %#v, actual: %#v", expected.Total, actual.Total)
 	}
 	if !reflect.DeepEqual(expected.File, actual.File) {
-		t.Errorf("Expected file page usage by NUMA %#v but found %#v", expected.File, actual.File)
+		t.Errorf("Expected file page usage by NUMA: %#v, actual: %#v", expected.File, actual.File)
 	}
 	if !reflect.DeepEqual(expected.Anon, actual.Anon) {
-		t.Errorf("Expected anon page usage by NUMA %#v but found %#v", expected.Anon, actual.Anon)
+		t.Errorf("Expected anon page usage by NUMA: %#v, actual: %#v", expected.Anon, actual.Anon)
 	}
 	if !reflect.DeepEqual(expected.Unevictable, actual.Unevictable) {
-		t.Errorf("Expected unevictable page usage by NUMA %#v but found %#v", expected.Unevictable, actual.Unevictable)
+		t.Errorf("Expected unevictable page usage by NUMA: %#v, actual: %#v", expected.Unevictable, actual.Unevictable)
 	}
 	if !reflect.DeepEqual(expected.Hierarchical.Total, actual.Hierarchical.Total) {
-		t.Errorf("Expected hierarchical total page usage by NUMA %#v but found %#v", expected.Hierarchical.Total, actual.Hierarchical.Total)
+		t.Errorf("Expected hierarchical total page usage by NUMA: %#v, actual: %#v", expected.Hierarchical.Total, actual.Hierarchical.Total)
 	}
 	if !reflect.DeepEqual(expected.Hierarchical.File, actual.Hierarchical.File) {
-		t.Errorf("Expected hierarchical file page usage by NUMA %#v but found %#v", expected.Hierarchical.File, actual.Hierarchical.File)
+		t.Errorf("Expected hierarchical file page usage by NUMA: %#v, actual: %#v", expected.Hierarchical.File, actual.Hierarchical.File)
 	}
 	if !reflect.DeepEqual(expected.Hierarchical.Anon, actual.Hierarchical.Anon) {
-		t.Errorf("Expected hierarchical anon page usage by NUMA %#v but found %#v", expected.Hierarchical.Anon, actual.Hierarchical.Anon)
+		t.Errorf("Expected hierarchical anon page usage by NUMA: %#v, actual: %#v", expected.Hierarchical.Anon, actual.Hierarchical.Anon)
 	}
 	if !reflect.DeepEqual(expected.Hierarchical.Unevictable, actual.Hierarchical.Unevictable) {
-		t.Errorf("Expected hierarchical total page usage by NUMA %#v but found %#v", expected.Hierarchical.Unevictable, actual.Hierarchical.Unevictable)
+		t.Errorf("Expected hierarchical total page usage by NUMA: %#v, actual: %#v", expected.Hierarchical.Unevictable, actual.Hierarchical.Unevictable)
 	}
 }

--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -49,7 +49,8 @@ func setCpu(dirPath string, r *configs.Resources) error {
 }
 
 func statCpu(dirPath string, stats *cgroups.Stats) error {
-	f, err := cgroups.OpenFile(dirPath, "cpu.stat", os.O_RDONLY)
+	const file = "cpu.stat"
+	f, err := cgroups.OpenFile(dirPath, file, os.O_RDONLY)
 	if err != nil {
 		return err
 	}
@@ -59,7 +60,7 @@ func statCpu(dirPath string, stats *cgroups.Stats) error {
 	for sc.Scan() {
 		t, v, err := fscommon.ParseKeyValue(sc.Text())
 		if err != nil {
-			return err
+			return &parseError{Path: dirPath, File: file, Err: err}
 		}
 		switch t {
 		case "usage_usec":
@@ -80,6 +81,9 @@ func statCpu(dirPath string, stats *cgroups.Stats) error {
 		case "throttled_usec":
 			stats.CpuStats.ThrottlingData.ThrottledTime = v * 1000
 		}
+	}
+	if err := sc.Err(); err != nil {
+		return &parseError{Path: dirPath, File: file, Err: err}
 	}
 	return nil
 }

--- a/libcontainer/cgroups/fs2/defaultpath.go
+++ b/libcontainer/cgroups/fs2/defaultpath.go
@@ -18,6 +18,8 @@ package fs2
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -25,18 +27,17 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
-	"github.com/pkg/errors"
 )
 
 const UnifiedMountpoint = "/sys/fs/cgroup"
 
 func defaultDirPath(c *configs.Cgroup) (string, error) {
 	if (c.Name != "" || c.Parent != "") && c.Path != "" {
-		return "", errors.Errorf("cgroup: either Path or Name and Parent should be used, got %+v", c)
+		return "", fmt.Errorf("cgroup: either Path or Name and Parent should be used, got %+v", c)
 	}
 	if len(c.Paths) != 0 {
 		// never set by specconv
-		return "", errors.Errorf("cgroup: Paths is unsupported, use Path, got %+v", c)
+		return "", fmt.Errorf("cgroup: Paths is unsupported, use Path, got %+v", c)
 	}
 
 	// XXX: Do not remove this code. Path safety is important! -- cyphar
@@ -89,7 +90,7 @@ func parseCgroupFromReader(r io.Reader) (string, error) {
 			parts = strings.SplitN(text, ":", 3)
 		)
 		if len(parts) < 3 {
-			return "", errors.Errorf("invalid cgroup entry: %q", text)
+			return "", fmt.Errorf("invalid cgroup entry: %q", text)
 		}
 		// text is like "0::/user.slice/user-1001.slice/session-1.scope"
 		if parts[0] == "0" && parts[1] == "" {

--- a/libcontainer/cgroups/fs2/devices.go
+++ b/libcontainer/cgroups/fs2/devices.go
@@ -3,14 +3,15 @@
 package fs2
 
 import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups/ebpf"
 	"github.com/opencontainers/runc/libcontainer/cgroups/ebpf/devicefilter"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/userns"
-
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 func isRWM(perms devices.Permissions) bool {
@@ -64,7 +65,7 @@ func setDevices(dirPath string, r *configs.Resources) error {
 	}
 	dirFD, err := unix.Open(dirPath, unix.O_DIRECTORY|unix.O_RDONLY, 0o600)
 	if err != nil {
-		return errors.Errorf("cannot get dir FD for %s", dirPath)
+		return fmt.Errorf("cannot get dir FD for %s", dirPath)
 	}
 	defer unix.Close(dirFD)
 	if _, err := ebpf.LoadAttachCgroupDeviceFilter(insts, license, dirFD); err != nil {

--- a/libcontainer/cgroups/fs2/freezer.go
+++ b/libcontainer/cgroups/fs2/freezer.go
@@ -4,16 +4,16 @@ package fs2
 
 import (
 	"bufio"
-	stdErrors "errors"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 func setFreezer(dirPath string, state configs.FreezerState) error {
@@ -26,7 +26,7 @@ func setFreezer(dirPath string, state configs.FreezerState) error {
 	case configs.Thawed:
 		stateStr = "0"
 	default:
-		return errors.Errorf("invalid freezer state %q requested", state)
+		return fmt.Errorf("invalid freezer state %q requested", state)
 	}
 
 	fd, err := cgroups.OpenFile(dirPath, "cgroup.freeze", unix.O_RDWR)
@@ -37,7 +37,7 @@ func setFreezer(dirPath string, state configs.FreezerState) error {
 		if state != configs.Frozen {
 			return nil
 		}
-		return errors.Wrap(err, "freezer not supported")
+		return fmt.Errorf("freezer not supported: %w", err)
 	}
 	defer fd.Close()
 
@@ -48,7 +48,7 @@ func setFreezer(dirPath string, state configs.FreezerState) error {
 	if actualState, err := readFreezer(dirPath, fd); err != nil {
 		return err
 	} else if actualState != state {
-		return errors.Errorf(`expected "cgroup.freeze" to be in state %q but was in %q`, state, actualState)
+		return fmt.Errorf(`expected "cgroup.freeze" to be in state %q but was in %q`, state, actualState)
 	}
 	return nil
 }
@@ -58,7 +58,7 @@ func getFreezer(dirPath string) (configs.FreezerState, error) {
 	if err != nil {
 		// If the kernel is too old, then we just treat the freezer as being in
 		// an "undefined" state.
-		if os.IsNotExist(err) || stdErrors.Is(err, unix.ENODEV) {
+		if os.IsNotExist(err) || errors.Is(err, unix.ENODEV) {
 			err = nil
 		}
 		return configs.Undefined, err
@@ -82,7 +82,7 @@ func readFreezer(dirPath string, fd *os.File) (configs.FreezerState, error) {
 	case "1\n":
 		return waitFrozen(dirPath)
 	default:
-		return configs.Undefined, errors.Errorf(`unknown "cgroup.freeze" state: %q`, state)
+		return configs.Undefined, fmt.Errorf(`unknown "cgroup.freeze" state: %q`, state)
 	}
 }
 

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+type parseError = fscommon.ParseError
+
 type manager struct {
 	config *configs.Cgroup
 	// dirPath is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope"

--- a/libcontainer/cgroups/fs2/hugetlb.go
+++ b/libcontainer/cgroups/fs2/hugetlb.go
@@ -3,9 +3,8 @@
 package fs2
 
 import (
+	"fmt"
 	"strconv"
-
-	"github.com/pkg/errors"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
@@ -32,7 +31,7 @@ func setHugeTlb(dirPath string, r *configs.Resources) error {
 func statHugeTlb(dirPath string, stats *cgroups.Stats) error {
 	hugePageSizes, err := cgroups.GetHugePageSize()
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch hugetlb info")
+		return fmt.Errorf("failed to fetch hugetlb info: %w", err)
 	}
 	hugetlbStats := cgroups.HugetlbStats{}
 

--- a/libcontainer/cgroups/fs2/hugetlb.go
+++ b/libcontainer/cgroups/fs2/hugetlb.go
@@ -46,7 +46,7 @@ func statHugeTlb(dirPath string, stats *cgroups.Stats) error {
 		fileName := "hugetlb." + pagesize + ".events"
 		value, err = fscommon.GetValueByKey(dirPath, fileName, "max")
 		if err != nil {
-			return errors.Wrap(err, "failed to read stats")
+			return err
 		}
 		hugetlbStats.Failcnt = value
 

--- a/libcontainer/cgroups/fs2/io.go
+++ b/libcontainer/cgroups/fs2/io.go
@@ -117,13 +117,14 @@ func readCgroup2MapFile(dirPath string, name string) (map[string][]string, error
 		ret[parts[0]] = parts[1:]
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return nil, &parseError{Path: dirPath, File: name, Err: err}
 	}
 	return ret, nil
 }
 
 func statIo(dirPath string, stats *cgroups.Stats) error {
-	values, err := readCgroup2MapFile(dirPath, "io.stat")
+	const file = "io.stat"
+	values, err := readCgroup2MapFile(dirPath, file)
 	if err != nil {
 		return err
 	}
@@ -136,11 +137,11 @@ func statIo(dirPath string, stats *cgroups.Stats) error {
 		}
 		major, err := strconv.ParseUint(d[0], 10, 64)
 		if err != nil {
-			return err
+			return &parseError{Path: dirPath, File: file, Err: err}
 		}
 		minor, err := strconv.ParseUint(d[1], 10, 64)
 		if err != nil {
-			return err
+			return &parseError{Path: dirPath, File: file, Err: err}
 		}
 
 		for _, item := range v {
@@ -177,7 +178,7 @@ func statIo(dirPath string, stats *cgroups.Stats) error {
 
 			value, err := strconv.ParseUint(d[1], 10, 64)
 			if err != nil {
-				return err
+				return &parseError{Path: dirPath, File: file, Err: err}
 			}
 
 			entry := cgroups.BlkioStatEntry{

--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -4,16 +4,17 @@ package fs2
 
 import (
 	"bufio"
+	"errors"
 	"math"
 	"os"
 	"strconv"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 // numToStr converts an int64 value to a string for writing to a

--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -3,8 +3,8 @@
 package fs2
 
 import (
+	"math"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -53,22 +53,18 @@ func statPids(dirPath string, stats *cgroups.Stats) error {
 		if os.IsNotExist(err) {
 			return statPidsFromCgroupProcs(dirPath, stats)
 		}
-		return errors.Wrap(err, "failed to parse pids.current")
+		return err
 	}
 
-	maxString, err := fscommon.GetCgroupParamString(dirPath, "pids.max")
+	max, err := fscommon.GetCgroupParamUint(dirPath, "pids.max")
 	if err != nil {
-		return errors.Wrap(err, "failed to parse pids.max")
+		return err
 	}
-
-	// Default if pids.max == "max" is 0 -- which represents "no limit".
-	var max uint64
-	if maxString != "max" {
-		max, err = fscommon.ParseUint(maxString, 10, 64)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse pids.max - unable to parse %q as a uint from Cgroup file %q",
-				maxString, filepath.Join(dirPath, "pids.max"))
-		}
+	// If no limit is set, read from pids.max returns "max", which is
+	// converted to MaxUint64 by GetCgroupParamUint. Historically, we
+	// represent "no limit" for pids as 0, thus this conversion.
+	if max == math.MaxUint64 {
+		max = 0
 	}
 
 	stats.PidsStats.Current = current

--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -3,15 +3,16 @@
 package fs2
 
 import (
+	"errors"
 	"math"
 	"os"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 func isPidsSet(r *configs.Resources) bool {

--- a/libcontainer/cgroups/fscommon/utils.go
+++ b/libcontainer/cgroups/fscommon/utils.go
@@ -45,7 +45,10 @@ func ParseUint(s string, base, bitSize int) (uint64, error) {
 		// 2. Handle negative values lesser than MinInt64
 		if intErr == nil && intValue < 0 {
 			return 0, nil
-		} else if intErr != nil && intErr.(*strconv.NumError).Err == strconv.ErrRange && intValue < 0 {
+			// Note errors.Is is not working for strconv errors in Go 1.13,
+			// see https://github.com/golang/go/issues/36325.
+			// TODO: remove nolint and switch to errors.Is once we stop supporting Go 1.13.
+		} else if intErr != nil && intErr.(*strconv.NumError).Err == strconv.ErrRange && intValue < 0 { //nolint:errorlint
 			return 0, nil
 		}
 

--- a/libcontainer/cgroups/fscommon/utils.go
+++ b/libcontainer/cgroups/fscommon/utils.go
@@ -3,7 +3,6 @@
 package fscommon
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -13,8 +12,6 @@ import (
 )
 
 var (
-	ErrNotValidFormat = errors.New("line is not a valid key value format")
-
 	// Deprecated: use cgroups.OpenFile instead.
 	OpenFile = cgroups.OpenFile
 	// Deprecated: use cgroups.ReadFile instead.

--- a/libcontainer/cgroups/fscommon/utils.go
+++ b/libcontainer/cgroups/fscommon/utils.go
@@ -53,7 +53,7 @@ func ParseKeyValue(t string) (string, uint64, error) {
 
 	value, err := ParseUint(parts[1], 10, 64)
 	if err != nil {
-		return "", 0, fmt.Errorf("unable to convert to uint64: %v", err)
+		return "", 0, err
 	}
 
 	return parts[0], value, nil

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -3,6 +3,7 @@ package systemd
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -14,11 +15,11 @@ import (
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	dbus "github.com/godbus/dbus/v5"
+	"github.com/sirupsen/logrus"
+
 	cgroupdevices "github.com/opencontainers/runc/libcontainer/cgroups/devices"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -92,7 +93,7 @@ func groupPrefix(ruleType devices.Type) (string, error) {
 	case devices.CharDevice:
 		return "char-", nil
 	default:
-		return "", errors.Errorf("device type %v has no group prefix", ruleType)
+		return "", fmt.Errorf("device type %v has no group prefix", ruleType)
 	}
 }
 
@@ -142,9 +143,9 @@ func findDeviceGroup(ruleType devices.Type, ruleMajor int64) (string, error) {
 		)
 		if n, err := fmt.Sscanf(line, "%d %s", &currMajor, &currName); err != nil || n != 2 {
 			if err == nil {
-				err = errors.Errorf("wrong number of fields")
+				err = errors.New("wrong number of fields")
 			}
-			return "", errors.Wrapf(err, "scan /proc/devices line %q", line)
+			return "", fmt.Errorf("scan /proc/devices line %q: %w", line, err)
 		}
 
 		if currMajor == ruleMajor {
@@ -152,7 +153,7 @@ func findDeviceGroup(ruleType devices.Type, ruleMajor int64) (string, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return "", errors.Wrap(err, "reading /proc/devices")
+		return "", fmt.Errorf("reading /proc/devices: %w", err)
 	}
 	// Couldn't find the device group.
 	return "", nil
@@ -192,7 +193,7 @@ func generateDeviceProperties(r *configs.Resources) ([]systemdDbus.Property, err
 	configEmu := &cgroupdevices.Emulator{}
 	for _, rule := range r.Devices {
 		if err := configEmu.Apply(*rule); err != nil {
-			return nil, errors.Wrap(err, "apply rule for systemd")
+			return nil, fmt.Errorf("unable to apply rule for systemd: %w", err)
 		}
 	}
 	// systemd doesn't support blacklists. So we log a warning, and tell
@@ -213,19 +214,19 @@ func generateDeviceProperties(r *configs.Resources) ([]systemdDbus.Property, err
 	// whitelist which is the default for devices.Emulator.
 	finalRules, err := configEmu.Rules()
 	if err != nil {
-		return nil, errors.Wrap(err, "get simplified rules for systemd")
+		return nil, fmt.Errorf("unable to get simplified rules for systemd: %w", err)
 	}
 	var deviceAllowList []deviceAllowEntry
 	for _, rule := range finalRules {
 		if !rule.Allow {
 			// Should never happen.
-			return nil, errors.Errorf("[internal error] cannot add deny rule to systemd DeviceAllow list: %v", *rule)
+			return nil, fmt.Errorf("[internal error] cannot add deny rule to systemd DeviceAllow list: %v", *rule)
 		}
 		switch rule.Type {
 		case devices.BlockDevice, devices.CharDevice:
 		default:
 			// Should never happen.
-			return nil, errors.Errorf("invalid device type for DeviceAllow: %v", rule.Type)
+			return nil, fmt.Errorf("invalid device type for DeviceAllow: %v", rule.Type)
 		}
 
 		entry := deviceAllowEntry{
@@ -271,7 +272,7 @@ func generateDeviceProperties(r *configs.Resources) ([]systemdDbus.Property, err
 			// "_ n:* _" rules require a device group from /proc/devices.
 			group, err := findDeviceGroup(rule.Type, rule.Major)
 			if err != nil {
-				return nil, errors.Wrapf(err, "find device '%v/%d'", rule.Type, rule.Major)
+				return nil, fmt.Errorf("unable to find device '%v/%d': %w", rule.Type, rule.Major, err)
 			}
 			if group == "" {
 				// Couldn't find a group.
@@ -342,7 +343,7 @@ func startUnit(cm *dbusConnManager, unitName string, properties []systemdDbus.Pr
 			// Please refer to https://pkg.go.dev/github.com/coreos/go-systemd/v22/dbus#Conn.StartUnit
 			if s != "done" {
 				resetFailedUnit(cm, unitName)
-				return errors.Errorf("error creating systemd unit `%s`: got `%s`", unitName, s)
+				return fmt.Errorf("error creating systemd unit `%s`: got `%s`", unitName, s)
 			}
 		case <-timeout.C:
 			resetFailedUnit(cm, unitName)
@@ -432,10 +433,10 @@ func systemdVersionAtoi(verStr string) (int, error) {
 	re := regexp.MustCompile(`v?([0-9]+)`)
 	matches := re.FindStringSubmatch(verStr)
 	if len(matches) < 2 {
-		return 0, errors.Errorf("can't parse version %s: incorrect number of matches %v", verStr, matches)
+		return 0, fmt.Errorf("can't parse version %s: incorrect number of matches %v", verStr, matches)
 	}
 	ver, err := strconv.Atoi(matches[1])
-	return ver, errors.Wrapf(err, "can't parse version %s", verStr)
+	return ver, fmt.Errorf("can't parse version: %w", err)
 }
 
 func addCpuQuota(cm *dbusConnManager, properties *[]systemdDbus.Property, quota int64, period uint64) {

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -436,7 +436,10 @@ func systemdVersionAtoi(verStr string) (int, error) {
 		return 0, fmt.Errorf("can't parse version %s: incorrect number of matches %v", verStr, matches)
 	}
 	ver, err := strconv.Atoi(matches[1])
-	return ver, fmt.Errorf("can't parse version: %w", err)
+	if err != nil {
+		return -1, fmt.Errorf("can't parse version: %w", err)
+	}
+	return ver, nil
 }
 
 func addCpuQuota(cm *dbusConnManager, properties *[]systemdDbus.Property, quota int64, period uint64) {

--- a/libcontainer/cgroups/systemd/cpuset.go
+++ b/libcontainer/cgroups/systemd/cpuset.go
@@ -2,11 +2,11 @@ package systemd
 
 import (
 	"encoding/binary"
+	"errors"
 	"strconv"
 	"strings"
 
 	"github.com/bits-and-blooms/bitset"
-	"github.com/pkg/errors"
 )
 
 // RangeToBits converts a text representation of a CPU mask (as written to

--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -5,6 +5,8 @@ package systemd
 import (
 	"bufio"
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,8 +15,8 @@ import (
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	dbus "github.com/godbus/dbus/v5"
+
 	"github.com/opencontainers/runc/libcontainer/userns"
-	"github.com/pkg/errors"
 )
 
 // newUserSystemdDbus creates a connection for systemd user-instance.
@@ -31,17 +33,17 @@ func newUserSystemdDbus() (*systemdDbus.Conn, error) {
 	return systemdDbus.NewConnection(func() (*dbus.Conn, error) {
 		conn, err := dbus.Dial(addr)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error while dialing %q", addr)
+			return nil, fmt.Errorf("error while dialing %q: %w", addr, err)
 		}
 		methods := []dbus.Auth{dbus.AuthExternal(strconv.Itoa(uid))}
 		err = conn.Auth(methods)
 		if err != nil {
 			conn.Close()
-			return nil, errors.Wrapf(err, "error while authenticating connection, address=%q, UID=%d", addr, uid)
+			return nil, fmt.Errorf("error while authenticating connection (address=%q, UID=%d): %w", addr, uid, err)
 		}
 		if err = conn.Hello(); err != nil {
 			conn.Close()
-			return nil, errors.Wrapf(err, "error while sending Hello message, address=%q, UID=%d", addr, uid)
+			return nil, fmt.Errorf("error while sending Hello message (address=%q, UID=%d): %w", addr, uid, err)
 		}
 		return conn, nil
 	})
@@ -57,7 +59,7 @@ func DetectUID() (int, error) {
 	}
 	b, err := exec.Command("busctl", "--user", "--no-pager", "status").CombinedOutput()
 	if err != nil {
-		return -1, errors.Wrapf(err, "could not execute `busctl --user --no-pager status`: %q", string(b))
+		return -1, fmt.Errorf("could not execute `busctl --user --no-pager status` (output: %q): %w", string(b), err)
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(b))
 	for scanner.Scan() {
@@ -66,7 +68,7 @@ func DetectUID() (int, error) {
 			uidStr := strings.TrimPrefix(s, "OwnerUID=")
 			i, err := strconv.Atoi(uidStr)
 			if err != nil {
-				return -1, errors.Wrapf(err, "could not detect the OwnerUID: %s", s)
+				return -1, fmt.Errorf("could not detect the OwnerUID: %w", err)
 			}
 			return i, nil
 		}
@@ -93,7 +95,7 @@ func DetectUserDbusSessionBusAddress() (string, error) {
 	}
 	b, err := exec.Command("systemctl", "--user", "--no-pager", "show-environment").CombinedOutput()
 	if err != nil {
-		return "", errors.Wrapf(err, "could not execute `systemctl --user --no-pager show-environment`, output=%q", string(b))
+		return "", fmt.Errorf("could not execute `systemctl --user --no-pager show-environment` (output=%q): %w", string(b), err)
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(b))
 	for scanner.Scan() {

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -10,10 +10,11 @@ import (
 	"sync"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/sirupsen/logrus"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/sirupsen/logrus"
 )
 
 type legacyManager struct {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -13,11 +13,11 @@ import (
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/sirupsen/logrus"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type unifiedManager struct {
@@ -283,7 +283,7 @@ func (m *unifiedManager) Apply(pid int) error {
 	properties = append(properties, c.SystemdProps...)
 
 	if err := startUnit(m.dbus, unitName, properties); err != nil {
-		return errors.Wrapf(err, "error while starting unit %q with properties %+v", unitName, properties)
+		return fmt.Errorf("unable to start unit %q (properties %+v): %w", unitName, properties, err)
 	}
 
 	if err := m.initPath(); err != nil {
@@ -440,7 +440,7 @@ func (m *unifiedManager) Set(r *configs.Resources) error {
 
 	if err := setUnitProperties(m.dbus, getUnitName(m.cgroups), properties...); err != nil {
 		_ = m.Freeze(targetFreezerState)
-		return errors.Wrap(err, "error while setting unit properties")
+		return fmt.Errorf("unable to set unit properties: %w", err)
 	}
 
 	// Reset freezer state before we apply the configuration, to avoid clashing

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -376,7 +376,7 @@ func WriteCgroupProc(dir string, pid int) error {
 
 	file, err := OpenFile(dir, CgroupProcesses, os.O_WRONLY)
 	if err != nil {
-		return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
+		return fmt.Errorf("failed to write %v to %v: %w", pid, CgroupProcesses, err)
 	}
 	defer file.Close()
 
@@ -393,7 +393,7 @@ func WriteCgroupProc(dir string, pid int) error {
 			continue
 		}
 
-		return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)
+		return fmt.Errorf("failed to write %v to %v: %w", pid, CgroupProcesses, err)
 	}
 	return err
 }

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -210,7 +210,7 @@ func EnterPid(cgroupPaths map[string]string, pid int) error {
 
 func rmdir(path string) error {
 	err := unix.Rmdir(path)
-	if err == nil || err == unix.ENOENT {
+	if err == nil || err == unix.ENOENT { //nolint:errorlint // unix errors are bare
 		return nil
 	}
 	return &os.PathError{Op: "rmdir", Path: path, Err: err}

--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -4,7 +4,7 @@ package cgroups
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -372,7 +372,7 @@ func TestParseCgroupString(t *testing.T) {
 		},
 		{
 			input:         `malformed input`,
-			expectedError: fmt.Errorf(`invalid cgroup entry: must contain at least two colons: malformed input`),
+			expectedError: errors.New(`invalid cgroup entry: must contain at least two colons: malformed input`),
 		},
 	}
 

--- a/libcontainer/cgroups/v1_utils.go
+++ b/libcontainer/cgroups/v1_utils.go
@@ -154,7 +154,7 @@ func findCgroupMountpointAndRootFromMI(mounts []*mountinfo.Info, cgroupPath, sub
 
 func (m Mount) GetOwnCgroup(cgroups map[string]string) (string, error) {
 	if len(m.Subsystems) == 0 {
-		return "", fmt.Errorf("no subsystem for mount")
+		return "", errors.New("no subsystem for mount")
 	}
 
 	return getControllerPath(m.Subsystems[0], cgroups)

--- a/libcontainer/cgroups/v1_utils.go
+++ b/libcontainer/cgroups/v1_utils.go
@@ -46,11 +46,8 @@ func NewNotFoundError(sub string) error {
 }
 
 func IsNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := err.(*NotFoundError)
-	return ok
+	var nfErr *NotFoundError
+	return errors.As(err, &nfErr)
 }
 
 func tryDefaultPath(cgroupPath, subsystem string) string {

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -375,7 +375,7 @@ func (c Command) Run(s *specs.State) error {
 	go func() {
 		err := cmd.Wait()
 		if err != nil {
-			err = fmt.Errorf("error running hook: %v, stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
+			err = fmt.Errorf("error running hook: %w, stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
 		}
 		errC <- err
 	}()

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -7,10 +7,10 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type Rlimit struct {
@@ -262,7 +262,7 @@ type Capabilities struct {
 func (hooks HookList) RunHooks(state *specs.State) error {
 	for i, h := range hooks {
 		if err := h.Run(state); err != nil {
-			return errors.Wrapf(err, "Running hook #%d:", i)
+			return fmt.Errorf("error running hook #%d: %w", i, err)
 		}
 	}
 

--- a/libcontainer/configs/config_linux.go
+++ b/libcontainer/configs/config_linux.go
@@ -1,17 +1,24 @@
 package configs
 
-import "fmt"
+import "errors"
+
+var (
+	errNoUIDMap   = errors.New("User namespaces enabled, but no uid mappings found.")
+	errNoUserMap  = errors.New("User namespaces enabled, but no user mapping found.")
+	errNoGIDMap   = errors.New("User namespaces enabled, but no gid mappings found.")
+	errNoGroupMap = errors.New("User namespaces enabled, but no group mapping found.")
+)
 
 // HostUID gets the translated uid for the process on host which could be
 // different when user namespaces are enabled.
 func (c Config) HostUID(containerId int) (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.UidMappings == nil {
-			return -1, fmt.Errorf("User namespaces enabled, but no uid mappings found.")
+			return -1, errNoUIDMap
 		}
 		id, found := c.hostIDFromMapping(containerId, c.UidMappings)
 		if !found {
-			return -1, fmt.Errorf("User namespaces enabled, but no user mapping found.")
+			return -1, errNoUserMap
 		}
 		return id, nil
 	}
@@ -30,11 +37,11 @@ func (c Config) HostRootUID() (int, error) {
 func (c Config) HostGID(containerId int) (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.GidMappings == nil {
-			return -1, fmt.Errorf("User namespaces enabled, but no gid mappings found.")
+			return -1, errNoGIDMap
 		}
 		id, found := c.hostIDFromMapping(containerId, c.GidMappings)
 		if !found {
-			return -1, fmt.Errorf("User namespaces enabled, but no group mapping found.")
+			return -1, errNoGroupMap
 		}
 		return id, nil
 	}

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -268,10 +268,10 @@ func isHostNetNS(path string) (bool, error) {
 	var st1, st2 unix.Stat_t
 
 	if err := unix.Stat(currentProcessNetns, &st1); err != nil {
-		return false, fmt.Errorf("unable to stat %q: %s", currentProcessNetns, err)
+		return false, &os.PathError{Op: "stat", Path: currentProcessNetns, Err: err}
 	}
 	if err := unix.Stat(path, &st2); err != nil {
-		return false, fmt.Errorf("unable to stat %q: %s", path, err)
+		return false, &os.PathError{Op: "stat", Path: path, Err: err}
 	}
 
 	return (st1.Dev == st2.Dev) && (st1.Ino == st2.Ino), nil

--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -18,7 +18,7 @@ func mountConsole(slavePath string) error {
 	if f != nil {
 		f.Close()
 	}
-	return unix.Mount(slavePath, "/dev/console", "bind", unix.MS_BIND, "")
+	return mount(slavePath, "/dev/console", "", "bind", unix.MS_BIND, "")
 }
 
 // dupStdio opens the slavePath for the console and dups the fds to the current

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -478,7 +478,7 @@ func (c *linuxContainer) newParentProcess(p *Process) (parentProcess, error) {
 
 	parentLogPipe, childLogPipe, err := os.Pipe()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create the log pipe:  %s", err)
+		return nil, fmt.Errorf("unable to create log pipe: %w", err)
 	}
 	logFilePair := filePair{parentLogPipe, childLogPipe}
 
@@ -771,7 +771,7 @@ func (c *linuxContainer) checkCriuVersion(minVersion int) error {
 	var err error
 	c.criuVersion, err = criu.GetCriuVersion()
 	if err != nil {
-		return fmt.Errorf("CRIU version check failed: %s", err)
+		return fmt.Errorf("CRIU version check failed: %w", err)
 	}
 
 	return compareCriuVersion(c.criuVersion, minVersion)

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -666,7 +666,7 @@ func (c *linuxContainer) Resume() error {
 		return err
 	}
 	if status != Paused {
-		return newGenericError(fmt.Errorf("container not paused"), ContainerNotPaused)
+		return newGenericError(errors.New("container not paused"), ContainerNotPaused)
 	}
 	if err := c.cgroupManager.Freeze(configs.Thawed); err != nil {
 		return err

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1282,8 +1282,8 @@ func (c *linuxContainer) prepareCriuRestoreMounts(mounts []*configs.Mount) error
 			// set up in the order they are configured.
 			if m.Device == "bind" {
 				if err := utils.WithProcfd(c.config.Rootfs, m.Destination, func(procfd string) error {
-					if err := unix.Mount(m.Source, procfd, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
-						return errorsf.Wrapf(err, "unable to bind mount %q to %q (through %q)", m.Source, m.Destination, procfd)
+					if err := mount(m.Source, m.Destination, procfd, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+						return err
 					}
 					return nil
 				}); err != nil {
@@ -1346,7 +1346,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 	if err != nil {
 		return err
 	}
-	err = unix.Mount(c.config.Rootfs, root, "", unix.MS_BIND|unix.MS_REC, "")
+	err = mount(c.config.Rootfs, root, "", "", unix.MS_BIND|unix.MS_REC, "")
 	if err != nil {
 		return err
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -19,21 +19,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/checkpoint-restore/go-criu/v5"
+	criurpc "github.com/checkpoint-restore/go-criu/v5/rpc"
 	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/utils"
-	"github.com/opencontainers/runtime-spec/specs-go"
-
-	"github.com/checkpoint-restore/go-criu/v5"
-	criurpc "github.com/checkpoint-restore/go-criu/v5/rpc"
-	errorsf "github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink/nl"
-	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/proto"
 )
 
 const stdioFdCount = 3
@@ -390,7 +389,7 @@ func (c *linuxContainer) start(process *Process) (retErr error) {
 
 			if err := c.config.Hooks[configs.Poststart].RunHooks(s); err != nil {
 				if err := ignoreTerminateErrors(parent.terminate()); err != nil {
-					logrus.Warn(errorsf.Wrapf(err, "Running Poststart hook"))
+					logrus.Warn(fmt.Errorf("error running poststart hook: %w", err))
 				}
 				return err
 			}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1256,7 +1256,7 @@ func (c *linuxContainer) prepareCriuRestoreMounts(mounts []*configs.Mount) error
 		for _, u := range umounts {
 			_ = utils.WithProcfd(c.config.Rootfs, u, func(procfd string) error {
 				if e := unix.Unmount(procfd, unix.MNT_DETACH); e != nil {
-					if e != unix.EINVAL {
+					if e != unix.EINVAL { //nolint:errorlint // unix errors are bare
 						// Ignore EINVAL as it means 'target is not a mount point.'
 						// It probably has already been unmounted.
 						logrus.Warnf("Error during cleanup unmounting of %s (%s): %v", procfd, u, e)

--- a/libcontainer/devices/device_unix.go
+++ b/libcontainer/devices/device_unix.go
@@ -103,7 +103,7 @@ func GetDevices(path string) ([]*Device, error) {
 		}
 		device, err := DeviceFromPath(filepath.Join(path, f.Name()), "rwm")
 		if err != nil {
-			if err == ErrNotADevice {
+			if errors.Is(err, ErrNotADevice) {
 				continue
 			}
 			if os.IsNotExist(err) {

--- a/libcontainer/devices/device_unix_test.go
+++ b/libcontainer/devices/device_unix_test.go
@@ -26,7 +26,7 @@ func TestDeviceFromPathLstatFailure(t *testing.T) {
 	defer cleanupTest()
 
 	_, err := DeviceFromPath("", "")
-	if err != testError {
+	if !errors.Is(err, testError) {
 		t.Fatalf("Unexpected error %v, expected %v", err, testError)
 	}
 }
@@ -41,7 +41,7 @@ func TestHostDevicesIoutilReadDirFailure(t *testing.T) {
 	defer cleanupTest()
 
 	_, err := HostDevices()
-	if err != testError {
+	if !errors.Is(err, testError) {
 		t.Fatalf("Unexpected error %v, expected %v", err, testError)
 	}
 }
@@ -68,7 +68,7 @@ func TestHostDevicesIoutilReadDirDeepFailure(t *testing.T) {
 	defer cleanupTest()
 
 	_, err := HostDevices()
-	if err != testError {
+	if !errors.Is(err, testError) {
 		t.Fatalf("Unexpected error %v, expected %v", err, testError)
 	}
 }

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -168,7 +168,7 @@ func TmpfsRoot(l *LinuxFactory) error {
 		return err
 	}
 	if !mounted {
-		if err := unix.Mount("tmpfs", l.Root, "tmpfs", 0, ""); err != nil {
+		if err := mount("tmpfs", l.Root, "", "tmpfs", 0, ""); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -4,6 +4,7 @@ package libcontainer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/moby/sys/mountinfo"
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
@@ -21,9 +24,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs/validate"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	"github.com/opencontainers/runc/libcontainer/utils"
-	"github.com/pkg/errors"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -59,13 +59,13 @@ func getUnifiedPath(paths map[string]string) string {
 		if path == "" {
 			path = v
 		} else if v != path {
-			panic(errors.Errorf("expected %q path to be unified path %q, got %q", k, path, v))
+			panic(fmt.Errorf("expected %q path to be unified path %q, got %q", k, path, v))
 		}
 	}
 	// can be empty
 	if path != "" {
 		if filepath.Clean(path) != path || !filepath.IsAbs(path) {
-			panic(errors.Errorf("invalid dir path %q", path))
+			panic(fmt.Errorf("invalid dir path %q", path))
 		}
 	}
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -396,7 +396,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	}()
 	defer func() {
 		if e := recover(); e != nil {
-			err = fmt.Errorf("panic from initialization: %v, %v", e, string(debug.Stack()))
+			err = fmt.Errorf("panic from initialization: %w, %v", e, string(debug.Stack()))
 		}
 	}()
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -346,7 +346,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	envInitPipe := os.Getenv("_LIBCONTAINER_INITPIPE")
 	pipefd, err := strconv.Atoi(envInitPipe)
 	if err != nil {
-		return fmt.Errorf("unable to convert _LIBCONTAINER_INITPIPE=%s to int: %s", envInitPipe, err)
+		return fmt.Errorf("unable to convert _LIBCONTAINER_INITPIPE: %w", err)
 	}
 	pipe := os.NewFile(uintptr(pipefd), "pipe")
 	defer pipe.Close()
@@ -358,7 +358,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	if it == initStandard {
 		envFifoFd := os.Getenv("_LIBCONTAINER_FIFOFD")
 		if fifofd, err = strconv.Atoi(envFifoFd); err != nil {
-			return fmt.Errorf("unable to convert _LIBCONTAINER_FIFOFD=%s to int: %s", envFifoFd, err)
+			return fmt.Errorf("unable to convert _LIBCONTAINER_FIFOFD: %w", err)
 		}
 	}
 
@@ -366,7 +366,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	if envConsole := os.Getenv("_LIBCONTAINER_CONSOLE"); envConsole != "" {
 		console, err := strconv.Atoi(envConsole)
 		if err != nil {
-			return fmt.Errorf("unable to convert _LIBCONTAINER_CONSOLE=%s to int: %s", envConsole, err)
+			return fmt.Errorf("unable to convert _LIBCONTAINER_CONSOLE: %w", err)
 		}
 		consoleSocket = os.NewFile(uintptr(console), "console-socket")
 		defer consoleSocket.Close()
@@ -375,7 +375,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	logPipeFdStr := os.Getenv("_LIBCONTAINER_LOGPIPE")
 	logPipeFd, err := strconv.Atoi(logPipeFdStr)
 	if err != nil {
-		return fmt.Errorf("unable to convert _LIBCONTAINER_LOGPIPE=%s to int: %s", logPipeFdStr, err)
+		return fmt.Errorf("unable to convert _LIBCONTAINER_LOGPIPE: %w", err)
 	}
 
 	// clear the current process's environment to clean any libcontainer

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -3,6 +3,7 @@
 package libcontainer
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -142,8 +143,8 @@ func TestFactoryLoadNotExists(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected nil error loading non-existing container")
 	}
-	lerr, ok := err.(Error)
-	if !ok {
+	var lerr Error
+	if !errors.As(err, &lerr) {
 		t.Fatal("expected libcontainer error type")
 	}
 	if lerr.Code() != ContainerNotExists {

--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -1,6 +1,7 @@
 package libcontainer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"text/template"
@@ -22,7 +23,8 @@ File: {{$frame.File}}@{{$frame.Line}}{{end}}
 `))
 
 func newGenericError(err error, c ErrorCode) Error {
-	if le, ok := err.(Error); ok {
+	var le Error
+	if errors.As(err, &le) {
 		return le
 	}
 	gerr := &genericError{

--- a/libcontainer/generic_error_test.go
+++ b/libcontainer/generic_error_test.go
@@ -1,20 +1,20 @@
 package libcontainer
 
 import (
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"testing"
 )
 
 func TestErrorDetail(t *testing.T) {
-	err := newGenericError(fmt.Errorf("test error"), SystemError)
+	err := newGenericError(errors.New("test error"), SystemError)
 	if derr := err.Detail(ioutil.Discard); derr != nil {
 		t.Fatal(derr)
 	}
 }
 
 func TestErrorWithCode(t *testing.T) {
-	err := newGenericError(fmt.Errorf("test error"), SystemError)
+	err := newGenericError(errors.New("test error"), SystemError)
 	if code := err.Code(); code != SystemError {
 		t.Fatalf("expected err code %q but %q", SystemError, code)
 	}
@@ -35,7 +35,7 @@ func TestErrorWithError(t *testing.T) {
 	}
 
 	for _, v := range cc {
-		err := newSystemErrorWithCause(fmt.Errorf(v.errmsg), v.cause)
+		err := newSystemErrorWithCause(errors.New(v.errmsg), v.cause)
 
 		msg := err.Error()
 		if v.cause == "" && msg != v.errmsg {

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -158,7 +158,7 @@ func finalizeNamespace(config *initConfig) error {
 			// to the directory, but the user running runc does not.
 			// This is useful in cases where the cwd is also a volume that's been chowned to the container user.
 		default:
-			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
+			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %w", config.Cwd, err)
 		}
 	}
 
@@ -186,7 +186,7 @@ func finalizeNamespace(config *initConfig) error {
 	// Change working directory AFTER the user has been set up, if we haven't done it yet.
 	if doChdir {
 		if err := unix.Chdir(config.Cwd); err != nil {
-			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
+			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %w", config.Cwd, err)
 		}
 	}
 	if err := system.ClearKeepCaps(); err != nil {
@@ -457,7 +457,7 @@ func setupRoute(config *configs.Config) error {
 func setupRlimits(limits []configs.Rlimit, pid int) error {
 	for _, rlimit := range limits {
 		if err := system.Prlimit(pid, rlimit.Type, unix.Rlimit{Max: rlimit.Hard, Cur: rlimit.Soft}); err != nil {
-			return fmt.Errorf("error setting rlimit type %v: %v", rlimit.Type, err)
+			return fmt.Errorf("error setting rlimit type %v: %w", rlimit.Type, err)
 		}
 	}
 	return nil

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -399,6 +399,8 @@ func fixStdioPermissions(config *initConfig, u *user.ExecUser) error {
 			// privileged_wrt_inode_uidgid() has failed). In either case, we
 			// are in a configuration where it's better for us to just not
 			// touch the stdio rather than bail at this point.
+
+			// nolint:errorlint // unix errors are bare
 			if err == unix.EINVAL || err == unix.EPERM {
 				continue
 			}

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -35,7 +35,7 @@ func init() {
 	// Call it to make sure images are downloaded, and to get the paths.
 	out, err := exec.Command(getImages).CombinedOutput()
 	if err != nil {
-		panic(fmt.Errorf("getImages error %s (output: %s)", err, out))
+		panic(fmt.Errorf("getImages error %w (output: %s)", err, out))
 	}
 	// Extract the value of BUSYBOX_IMAGE.
 	found := regexp.MustCompile(`(?m)^BUSYBOX_IMAGE=(.*)$`).FindSubmatchIndex(out)
@@ -145,7 +145,7 @@ func remove(dir string) {
 func copyBusybox(dest string) error {
 	out, err := exec.Command("sh", "-c", fmt.Sprintf("tar --exclude './dev/*' -C %q -xf %q", dest, busyboxTar)).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("untar error %q: %q", err, out)
+		return fmt.Errorf("untar error %w: %q", err, out)
 	}
 	return nil
 }

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -414,7 +414,7 @@ func writeFile(dir, file, data string) error {
 		return fmt.Errorf("no such directory for %s", file)
 	}
 	if err := ioutil.WriteFile(filepath.Join(dir, file), []byte(data+"\n"), 0o600); err != nil {
-		return fmt.Errorf("failed to write %v: %v", data, err)
+		return fmt.Errorf("failed to write %v: %w", data, err)
 	}
 	return nil
 }
@@ -521,7 +521,7 @@ func WriteIntelRdtTasks(dir string, pid int) error {
 	// Don't attach any pid if -1 is specified as a pid
 	if pid != -1 {
 		if err := ioutil.WriteFile(filepath.Join(dir, IntelRdtTasks), []byte(strconv.Itoa(pid)), 0o600); err != nil {
-			return fmt.Errorf("failed to write %v: %v", pid, err)
+			return fmt.Errorf("failed to write %v: %w", pid, err)
 		}
 	}
 	return nil

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -5,6 +5,7 @@ package intelrdt
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -771,11 +772,8 @@ func NewNotFoundError(res string) error {
 }
 
 func IsNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := err.(*NotFoundError)
-	return ok
+	var nfErr *NotFoundError
+	return errors.As(err, &nfErr)
 }
 
 type LastCmdError struct {

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -414,7 +414,7 @@ func writeFile(dir, file, data string) error {
 		return fmt.Errorf("no such directory for %s", file)
 	}
 	if err := ioutil.WriteFile(filepath.Join(dir, file), []byte(data+"\n"), 0o600); err != nil {
-		return fmt.Errorf("failed to write %v to %v: %v", data, file, err)
+		return fmt.Errorf("failed to write %v: %v", data, err)
 	}
 	return nil
 }
@@ -521,7 +521,7 @@ func WriteIntelRdtTasks(dir string, pid int) error {
 	// Don't attach any pid if -1 is specified as a pid
 	if pid != -1 {
 		if err := ioutil.WriteFile(filepath.Join(dir, IntelRdtTasks), []byte(strconv.Itoa(pid)), 0o600); err != nil {
-			return fmt.Errorf("failed to write %v to %v: %v", pid, IntelRdtTasks, err)
+			return fmt.Errorf("failed to write %v: %v", pid, err)
 		}
 	}
 	return nil

--- a/libcontainer/keys/keyctl.go
+++ b/libcontainer/keys/keyctl.go
@@ -3,10 +3,10 @@
 package keys
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"golang.org/x/sys/unix"
 )
@@ -16,7 +16,7 @@ type KeySerial uint32
 func JoinSessionKeyring(name string) (KeySerial, error) {
 	sessKeyID, err := unix.KeyctlJoinSessionKeyring(name)
 	if err != nil {
-		return 0, errors.Wrap(err, "create session key")
+		return 0, fmt.Errorf("unable to create session key: %w", err)
 	}
 	return KeySerial(sessKeyID), nil
 }

--- a/libcontainer/logs/logs.go
+++ b/libcontainer/logs/logs.go
@@ -3,12 +3,12 @@ package logs
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -41,12 +41,6 @@ func (e *mountError) Error() string {
 	return out
 }
 
-// Cause returns the underlying cause of the error.
-// This is a convention used by github.com/pkg/errors.
-func (e *mountError) Cause() error {
-	return e.err
-}
-
 // Unwrap returns the underlying error.
 // This is a convention used by Go 1.13+ standard library.
 func (e *mountError) Unwrap() error {

--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -1,0 +1,89 @@
+package libcontainer
+
+import (
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// mountError holds an error from a failed mount or unmount operation.
+type mountError struct {
+	op     string
+	source string
+	target string
+	procfd string
+	flags  uintptr
+	data   string
+	err    error
+}
+
+// Error provides a string error representation.
+func (e *mountError) Error() string {
+	out := e.op + " "
+
+	if e.source != "" {
+		out += e.source + ":" + e.target
+	} else {
+		out += e.target
+	}
+	if e.procfd != "" {
+		out += " (via " + e.procfd + ")"
+	}
+
+	if e.flags != uintptr(0) {
+		out += ", flags: 0x" + strconv.FormatUint(uint64(e.flags), 16)
+	}
+	if e.data != "" {
+		out += ", data: " + e.data
+	}
+
+	out += ": " + e.err.Error()
+	return out
+}
+
+// Cause returns the underlying cause of the error.
+// This is a convention used by github.com/pkg/errors.
+func (e *mountError) Cause() error {
+	return e.err
+}
+
+// Unwrap returns the underlying error.
+// This is a convention used by Go 1.13+ standard library.
+func (e *mountError) Unwrap() error {
+	return e.err
+}
+
+// mount is a simple unix.Mount wrapper. If procfd is not empty, it is used
+// instead of target (and the target is only used to add context to an error).
+func mount(source, target, procfd, fstype string, flags uintptr, data string) error {
+	dst := target
+	if procfd != "" {
+		dst = procfd
+	}
+	if err := unix.Mount(source, dst, fstype, flags, data); err != nil {
+		return &mountError{
+			op:     "mount",
+			source: source,
+			target: target,
+			procfd: procfd,
+			flags:  flags,
+			data:   data,
+			err:    err,
+		}
+	}
+	return nil
+}
+
+// unmount is a simple unix.Unmount wrapper.
+func unmount(target string, flags int) error {
+	err := unix.Unmount(target, flags)
+	if err != nil {
+		return &mountError{
+			op:     "unmount",
+			target: target,
+			flags:  uintptr(flags),
+			err:    err,
+		}
+	}
+	return nil
+}

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -1,13 +1,15 @@
 package libcontainer
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"math"
 	"os"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
+
+var errInvalidProcess = errors.New("invalid process")
 
 type processOperations interface {
 	wait() (*os.ProcessState, error)
@@ -84,7 +86,7 @@ type Process struct {
 // Wait releases any resources associated with the Process
 func (p Process) Wait() (*os.ProcessState, error) {
 	if p.ops == nil {
-		return nil, newGenericError(fmt.Errorf("invalid process"), NoProcessOps)
+		return nil, newGenericError(errInvalidProcess, NoProcessOps)
 	}
 	return p.ops.wait()
 }
@@ -94,7 +96,7 @@ func (p Process) Pid() (int, error) {
 	// math.MinInt32 is returned here, because it's invalid value
 	// for the kill() system call.
 	if p.ops == nil {
-		return math.MinInt32, newGenericError(fmt.Errorf("invalid process"), NoProcessOps)
+		return math.MinInt32, newGenericError(errInvalidProcess, NoProcessOps)
 	}
 	return p.ops.pid(), nil
 }
@@ -102,7 +104,7 @@ func (p Process) Pid() (int, error) {
 // Signal sends a signal to the Process.
 func (p Process) Signal(sig os.Signal) error {
 	if p.ops == nil {
-		return newGenericError(fmt.Errorf("invalid process"), NoProcessOps)
+		return newGenericError(errInvalidProcess, NoProcessOps)
 	}
 	return p.ops.signal(sig)
 }

--- a/libcontainer/restored_process.go
+++ b/libcontainer/restored_process.go
@@ -3,7 +3,7 @@
 package libcontainer
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"os/exec"
 
@@ -31,7 +31,7 @@ type restoredProcess struct {
 }
 
 func (p *restoredProcess) start() error {
-	return newGenericError(fmt.Errorf("restored process cannot be started"), SystemError)
+	return newGenericError(errors.New("restored process cannot be started"), SystemError)
 }
 
 func (p *restoredProcess) pid() int {
@@ -89,7 +89,7 @@ type nonChildProcess struct {
 }
 
 func (p *nonChildProcess) start() error {
-	return newGenericError(fmt.Errorf("restored process cannot be started"), SystemError)
+	return newGenericError(errors.New("restored process cannot be started"), SystemError)
 }
 
 func (p *nonChildProcess) pid() int {
@@ -97,11 +97,11 @@ func (p *nonChildProcess) pid() int {
 }
 
 func (p *nonChildProcess) terminate() error {
-	return newGenericError(fmt.Errorf("restored process cannot be terminated"), SystemError)
+	return newGenericError(errors.New("restored process cannot be terminated"), SystemError)
 }
 
 func (p *nonChildProcess) wait() (*os.ProcessState, error) {
-	return nil, newGenericError(fmt.Errorf("restored process cannot be waited on"), SystemError)
+	return nil, newGenericError(errors.New("restored process cannot be waited on"), SystemError)
 }
 
 func (p *nonChildProcess) startTime() (uint64, error) {

--- a/libcontainer/restored_process.go
+++ b/libcontainer/restored_process.go
@@ -51,7 +51,8 @@ func (p *restoredProcess) wait() (*os.ProcessState, error) {
 	// maybe use --exec-cmd in criu
 	err := p.cmd.Wait()
 	if err != nil {
-		if _, ok := err.(*exec.ExitError); !ok {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
 			return nil, err
 		}
 	}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -208,7 +208,7 @@ func mountCmd(cmd configs.Command) error {
 	command.Env = cmd.Env
 	command.Dir = cmd.Dir
 	if out, err := command.CombinedOutput(); err != nil {
-		return fmt.Errorf("%#v failed: %s: %v", cmd, string(out), err)
+		return fmt.Errorf("%#v failed: %s: %w", cmd, string(out), err)
 	}
 	return nil
 }

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -44,7 +44,7 @@ func (l *linuxSetnsInit) Init() error {
 			// don't bail on ENOSYS.
 			//
 			// TODO(cyphar): And we should have logging here too.
-			if errors.Cause(err) != unix.ENOSYS {
+			if !errors.Is(err, unix.ENOSYS) {
 				return errors.Wrap(err, "join session keyring")
 			}
 		}

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -3,17 +3,19 @@
 package libcontainer
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"runtime"
+
+	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/keys"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runc/libcontainer/system"
-	"github.com/opencontainers/selinux/go-selinux"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 // linuxSetnsInit performs the container's initialization for running a new process
@@ -45,7 +47,7 @@ func (l *linuxSetnsInit) Init() error {
 			//
 			// TODO(cyphar): And we should have logging here too.
 			if !errors.Is(err, unix.ENOSYS) {
-				return errors.Wrap(err, "join session keyring")
+				return fmt.Errorf("unable to join session keyring: %w", err)
 			}
 		}
 	}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -216,7 +216,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	}
 	spec := opts.Spec
 	if spec.Root == nil {
-		return nil, fmt.Errorf("Root must be specified")
+		return nil, errors.New("Root must be specified")
 	}
 	rootfsPath := spec.Root.Path
 	if !filepath.IsAbs(rootfsPath) {
@@ -263,7 +263,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 			return nil, fmt.Errorf("rootfsPropagation=%v is not supported", spec.Linux.RootfsPropagation)
 		}
 		if config.NoPivotRoot && (config.RootPropagation&unix.MS_PRIVATE != 0) {
-			return nil, fmt.Errorf("rootfsPropagation of [r]private is not safe without pivot_root")
+			return nil, errors.New("rootfsPropagation of [r]private is not safe without pivot_root")
 		}
 
 		for _, ns := range spec.Linux.Namespaces {
@@ -858,7 +858,7 @@ func SetupSeccomp(config *specs.LinuxSeccomp) (*configs.Seccomp, error) {
 
 	// We don't currently support seccomp flags.
 	if len(config.Flags) != 0 {
-		return nil, fmt.Errorf("seccomp flags are not yet supported by runc")
+		return nil, errors.New("seccomp flags are not yet supported by runc")
 	}
 
 	newConfig := new(configs.Seccomp)

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -410,13 +410,13 @@ func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
 		}
 		value, err := dbus.ParseVariant(v, dbus.Signature{})
 		if err != nil {
-			return nil, fmt.Errorf("Annotation %s=%s value parse error: %v", k, v, err)
+			return nil, fmt.Errorf("Annotation %s=%s value parse error: %w", k, v, err)
 		}
 		if isSecSuffix(name) {
 			name = strings.TrimSuffix(name, "Sec") + "USec"
 			value, err = convertSecToUSec(value)
 			if err != nil {
-				return nil, fmt.Errorf("Annotation %s=%s value parse error: %v", k, v, err)
+				return nil, fmt.Errorf("Annotation %s=%s value parse error: %w", k, v, err)
 			}
 		}
 		sp = append(sp, systemdDbus.Property{Name: name, Value: value})

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -65,7 +65,7 @@ func (l *linuxStandardInit) Init() error {
 			//
 			// TODO(cyphar): Log this so people know what's going on, once we
 			//               have proper logging in 'runc init'.
-			if errors.Cause(err) != unix.ENOSYS {
+			if !errors.Is(err, unix.ENOSYS) {
 				return errors.Wrap(err, "join session keyring")
 			}
 		} else {

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -3,6 +3,7 @@
 package libcontainer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -117,7 +118,7 @@ func (r *runningState) transition(s containerState) error {
 	switch s.(type) {
 	case *stoppedState:
 		if r.c.runType() == Running {
-			return newGenericError(fmt.Errorf("container still running"), ContainerNotStopped)
+			return newGenericError(errors.New("container still running"), ContainerNotStopped)
 		}
 		r.c.state = s
 		return nil
@@ -132,7 +133,7 @@ func (r *runningState) transition(s containerState) error {
 
 func (r *runningState) destroy() error {
 	if r.c.runType() == Running {
-		return newGenericError(fmt.Errorf("container is not destroyed"), ContainerNotStopped)
+		return newGenericError(errors.New("container is not destroyed"), ContainerNotStopped)
 	}
 	return destroy(r.c)
 }
@@ -190,7 +191,7 @@ func (p *pausedState) destroy() error {
 		}
 		return destroy(p.c)
 	}
-	return newGenericError(fmt.Errorf("container is paused"), ContainerPaused)
+	return newGenericError(errors.New("container is paused"), ContainerPaused)
 }
 
 // restoredState is the same as the running state but also has associated checkpoint

--- a/libcontainer/state_linux_test.go
+++ b/libcontainer/state_linux_test.go
@@ -3,6 +3,7 @@
 package libcontainer
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -24,11 +25,6 @@ func TestStateStatus(t *testing.T) {
 	}
 }
 
-func isStateTransitionError(err error) bool {
-	_, ok := err.(*stateTransitionError)
-	return ok
-}
-
 func testTransitions(t *testing.T, initialState containerState, valid []containerState) {
 	validMap := map[reflect.Type]interface{}{}
 	for _, validState := range valid {
@@ -48,7 +44,8 @@ func testTransitions(t *testing.T, initialState containerState, valid []containe
 			if err == nil {
 				t.Fatal("transition should fail")
 			}
-			if !isStateTransitionError(err) {
+			var stErr *stateTransitionError
+			if !errors.As(err, &stErr) {
 				t.Fatal("expected stateTransitionError")
 			}
 		})

--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -45,7 +45,7 @@ func writeSync(pipe io.Writer, sync syncType) error {
 func readSync(pipe io.Reader, expected syncType) error {
 	var procSync syncT
 	if err := json.NewDecoder(pipe).Decode(&procSync); err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return errors.New("parent closed synchronisation channel")
 		}
 		return fmt.Errorf("failed reading error from parent: %w", err)
@@ -74,7 +74,7 @@ func parseSync(pipe io.Reader, fn func(*syncT) error) error {
 	for {
 		var sync syncT
 		if err := dec.Decode(&sync); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return err
@@ -83,7 +83,7 @@ func parseSync(pipe io.Reader, fn func(*syncT) error) error {
 		// We handle this case outside fn for cleanliness reasons.
 		var ierr *genericError
 		if sync.Type == procError {
-			if err := dec.Decode(&ierr); err != nil && err != io.EOF {
+			if err := dec.Decode(&ierr); err != nil && !errors.Is(err, io.EOF) {
 				return newSystemErrorWithCause(err, "decoding proc error from init")
 			}
 			if ierr != nil {

--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -48,14 +48,14 @@ func readSync(pipe io.Reader, expected syncType) error {
 		if err == io.EOF {
 			return errors.New("parent closed synchronisation channel")
 		}
-		return fmt.Errorf("failed reading error from parent: %v", err)
+		return fmt.Errorf("failed reading error from parent: %w", err)
 	}
 
 	if procSync.Type == procError {
 		var ierr genericError
 
 		if err := json.NewDecoder(pipe).Decode(&ierr); err != nil {
-			return fmt.Errorf("failed reading error from parent: %v", err)
+			return fmt.Errorf("failed reading error from parent: %w", err)
 		}
 
 		return &ierr

--- a/libcontainer/system/xattrs_linux.go
+++ b/libcontainer/system/xattrs_linux.go
@@ -10,6 +10,7 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 	dest := make([]byte, 128)
 	sz, errno := unix.Lgetxattr(path, attr, dest)
 
+	//nolint:errorlint // unix errors are bare
 	switch {
 	case errno == unix.ENODATA:
 		return nil, errno

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -119,7 +119,7 @@ func ParsePasswdFileFilter(path string, filter func(User) bool) ([]User, error) 
 
 func ParsePasswdFilter(r io.Reader, filter func(User) bool) ([]User, error) {
 	if r == nil {
-		return nil, fmt.Errorf("nil source for passwd-formatted data")
+		return nil, errors.New("nil source for passwd-formatted data")
 	}
 
 	var (
@@ -177,7 +177,7 @@ func ParseGroupFileFilter(path string, filter func(Group) bool) ([]Group, error)
 
 func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 	if r == nil {
-		return nil, fmt.Errorf("nil source for group-formatted data")
+		return nil, errors.New("nil source for group-formatted data")
 	}
 
 	var (
@@ -487,7 +487,7 @@ func ParseSubIDFileFilter(path string, filter func(SubID) bool) ([]SubID, error)
 
 func ParseSubIDFilter(r io.Reader, filter func(SubID) bool) ([]SubID, error) {
 	if r == nil {
-		return nil, fmt.Errorf("nil source for subid-formatted data")
+		return nil, errors.New("nil source for subid-formatted data")
 	}
 
 	var (
@@ -540,7 +540,7 @@ func ParseIDMapFileFilter(path string, filter func(IDMap) bool) ([]IDMap, error)
 
 func ParseIDMapFilter(r io.Reader, filter func(IDMap) bool) ([]IDMap, error) {
 	if r == nil {
-		return nil, fmt.Errorf("nil source for idmap-formatted data")
+		return nil, errors.New("nil source for idmap-formatted data")
 	}
 
 	var (

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -305,7 +305,7 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 		if userArg == "" {
 			userArg = strconv.Itoa(user.Uid)
 		}
-		return nil, fmt.Errorf("unable to find user %s: %v", userArg, err)
+		return nil, fmt.Errorf("unable to find user %s: %w", userArg, err)
 	}
 
 	var matchedUserName string
@@ -321,7 +321,7 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 
 		if uidErr != nil {
 			// Not numeric.
-			return nil, fmt.Errorf("unable to find user %s: %v", userArg, ErrNoPasswdEntries)
+			return nil, fmt.Errorf("unable to find user %s: %w", userArg, ErrNoPasswdEntries)
 		}
 		user.Uid = uidArg
 
@@ -356,7 +356,7 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 			return g.Name == groupArg
 		})
 		if err != nil && group != nil {
-			return nil, fmt.Errorf("unable to find groups for spec %v: %v", matchedUserName, err)
+			return nil, fmt.Errorf("unable to find groups for spec %v: %w", matchedUserName, err)
 		}
 
 		// Only start modifying user.Gid if it is in explicit form.
@@ -370,7 +370,7 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 
 				if gidErr != nil {
 					// Not numeric.
-					return nil, fmt.Errorf("unable to find group %s: %v", groupArg, ErrNoGroupEntries)
+					return nil, fmt.Errorf("unable to find group %s: %w", groupArg, ErrNoGroupEntries)
 				}
 				user.Gid = gidArg
 
@@ -411,7 +411,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 			return false
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Unable to find additional groups %v: %v", additionalGroups, err)
+			return nil, fmt.Errorf("Unable to find additional groups %v: %w", additionalGroups, err)
 		}
 	}
 
@@ -434,7 +434,8 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 		if !found {
 			gid, err := strconv.ParseInt(ag, 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("Unable to find group %s", ag)
+				// Not a numeric ID either.
+				return nil, fmt.Errorf("Unable to find group %s: %w", ag, ErrNoGroupEntries)
 			}
 			// Ensure gid is inside gid range.
 			if gid < minID || gid > maxID {

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/cyphar/filepath-securejoin"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"golang.org/x/sys/unix"
 )
 
@@ -120,7 +120,7 @@ func WithProcfd(root, unsafePath string, fn func(procfd string) error) error {
 	unsafePath = stripRoot(root, unsafePath)
 	path, err := securejoin.SecureJoin(root, unsafePath)
 	if err != nil {
-		return fmt.Errorf("resolving path inside rootfs failed: %v", err)
+		return fmt.Errorf("resolving path inside rootfs failed: %w", err)
 	}
 
 	// Open the target path.

--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -14,7 +14,7 @@ import (
 func EnsureProcHandle(fh *os.File) error {
 	var buf unix.Statfs_t
 	if err := unix.Fstatfs(int(fh.Fd()), &buf); err != nil {
-		return fmt.Errorf("ensure %s is on procfs: %v", fh.Name(), err)
+		return fmt.Errorf("ensure %s is on procfs: %w", fh.Name(), err)
 	}
 	if buf.Type != unix.PROC_SUPER_MAGIC {
 		return fmt.Errorf("%s is not on procfs", fh.Name())

--- a/ps.go
+++ b/ps.go
@@ -68,7 +68,7 @@ var psCommand = cli.Command{
 		cmd := exec.Command("ps", psArgs...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("%s: %s", err, output)
+			return fmt.Errorf("%w: %s", err, output)
 		}
 
 		lines := strings.Split(string(output), "\n")
@@ -85,7 +85,7 @@ var psCommand = cli.Command{
 			fields := strings.Fields(line)
 			p, err := strconv.Atoi(fields[pidIndex])
 			if err != nil {
-				return fmt.Errorf("unexpected pid '%s': %s", fields[pidIndex], err)
+				return fmt.Errorf("unable to parse pid: %w", err)
 			}
 
 			for _, pid := range pids {

--- a/signals.go
+++ b/signals.go
@@ -120,7 +120,7 @@ func (h *signalHandler) reap() (exits []exit, err error) {
 	for {
 		pid, err := unix.Wait4(-1, &ws, unix.WNOHANG, &rus)
 		if err != nil {
-			if err == unix.ECHILD {
+			if err == unix.ECHILD { //nolint:errorlint // unix errors are bare
 				return exits, nil
 			}
 			return nil, err

--- a/tty.go
+++ b/tty.go
@@ -136,7 +136,7 @@ func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) (Err error
 
 	// Set raw mode for the controlling terminal.
 	if err := t.hostConsole.SetRaw(); err != nil {
-		return fmt.Errorf("failed to set the terminal from the stdin: %v", err)
+		return fmt.Errorf("failed to set the terminal from the stdin: %w", err)
 	}
 	go handleInterrupt(t.hostConsole)
 

--- a/update.go
+++ b/update.go
@@ -205,7 +205,7 @@ other options are ignored.
 					var err error
 					*pair.dest, err = strconv.ParseUint(val, 10, 64)
 					if err != nil {
-						return fmt.Errorf("invalid value for %s: %s", pair.opt, err)
+						return fmt.Errorf("invalid value for %s: %w", pair.opt, err)
 					}
 				}
 			}
@@ -221,7 +221,7 @@ other options are ignored.
 					var err error
 					*pair.dest, err = strconv.ParseInt(val, 10, 64)
 					if err != nil {
-						return fmt.Errorf("invalid value for %s: %s", pair.opt, err)
+						return fmt.Errorf("invalid value for %s: %w", pair.opt, err)
 					}
 				}
 			}
@@ -241,7 +241,7 @@ other options are ignored.
 					if val != "-1" {
 						v, err = units.RAMInBytes(val)
 						if err != nil {
-							return fmt.Errorf("invalid value for %s: %s", pair.opt, err)
+							return fmt.Errorf("invalid value for %s: %w", pair.opt, err)
 						}
 					} else {
 						v = -1

--- a/utils.go
+++ b/utils.go
@@ -55,8 +55,6 @@ func logrusToStderr() bool {
 func fatal(err error) {
 	// make sure the error is written to the logger
 	logrus.Error(err)
-	// If debug is enabled and pkg/errors was used, show its stack trace.
-	logrus.Debugf("%+v", err)
 	if !logrusToStderr() {
 		fmt.Fprintln(os.Stderr, err)
 	}


### PR DESCRIPTION
This commit does a few things related to error reporting and handling.

1. Fix and improve a bunch of error messages and associated error handling,
using features that appear in Go 1.13 (`fmt.Errorf` with `%w` to wrap errors,
`errors.Is` and `errors.As` for unwrapping) and some other methods
(such as using `os.PathError`, introducing and using `ParseError` etc.)

2. Fix all `errorlint` linter warnings, enable errorlint it in CI.

3. Remove all uses of pkg/errors, switching to native Go error (un)wrapping.

~~TODO (not in this PR, as it's already too big):~~
- modernize and simplify `libcontainer/error` (done in #3033)