### PR TITLE
libct/cg/fs: don't forget to close a file

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -255,6 +255,7 @@ func getPageUsageByNUMA(cgroupPath string) (cgroups.PageUsageByNUMA, error) {
 	} else if err != nil {
 		return stats, err
 	}
+	defer file.Close()
 
 	// File format is documented in linux/Documentation/cgroup-v1/memory.txt
 	// and it looks like this:


### PR DESCRIPTION
Fixes: 7fe0a98e79fc87f54f4d

(`os.File` has a runtime finalizer set which closes it when it's garbage collected, but we don't know when it is going to be called)