### PR TITLE
Revert "runc update: skip devices"

### DIFF
--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -127,8 +127,8 @@ type Resources struct {
 
 	// SkipDevices allows to skip configuring device permissions.
 	// Used by e.g. kubelet while creating a parent cgroup (kubepods)
-	// common for many containers, and by runc update.
+	// common for many containers.
 	//
 	// NOTE it is impossible to start a container which has this flag set.
-	SkipDevices bool `json:"-"`
+	SkipDevices bool `json:"skip_devices"`
 }

--- a/update.go
+++ b/update.go
@@ -329,13 +329,6 @@ other options are ignored.
 			config.IntelRdt.MemBwSchema = memBwSchema
 		}
 
-		// XXX(kolyshkin@): currently "runc update" is unable to change
-		// device configuration, so add this to skip device update.
-		// This helps in case an extra plugin (nvidia GPU) applies some
-		// configuration on top of what runc does.
-		// Note this field is not saved into container's state.json.
-		config.Cgroups.SkipDevices = true
-
 		return container.Set(config)
 	},
 }


### PR DESCRIPTION
We can not and should not use SkipDevices flag on a running container.

This reverts PR #2994 (commit bf7492ee5d022cd99a9dbe71c5c4f965041552e9)

Fixes: https://github.com/opencontainers/runc/issues/3014