### PR TITLE
Returns clearer error message for Setenv

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -112,9 +112,19 @@ func populateProcessEnvironment(env []string) error {
 	for _, pair := range env {
 		p := strings.SplitN(pair, "=", 2)
 		if len(p) < 2 {
-			return fmt.Errorf("invalid environment '%v'", pair)
+			return fmt.Errorf("invalid environment variable: %q", pair)
 		}
-		if err := os.Setenv(p[0], p[1]); err != nil {
+		name, val := p[0], p[1]
+		if name == "" {
+			return fmt.Errorf("environment variable name can't be empty: %q", pair)
+		}
+		if strings.IndexByte(name, 0) >= 0 {
+			return fmt.Errorf("environment variable name can't contain null(\\x00): %q", pair)
+		}
+		if strings.IndexByte(val, 0) >= 0 {
+			return fmt.Errorf("environment variable value can't contain null(\\x00): %q", pair)
+		}
+		if err := os.Setenv(name, val); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
> container_linux.go:349: starting container process caused "process_linux.go:449: container init caused \"setenv: invalid argument\"": unknown

xref kubernetes/kubernetes#102732

Pick the judgment logic from `os.Setenv`, and added clear error message 
https://github.com/golang/go/blob/27f83723e98d8e3795a07bdca2b3a8155b0d72b3/src/syscall/env_unix.go#L97-L130