### PR TITLE
github: workflows: fix tiny typo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Dockre/Moby still builds runc with Go 1.13, so we should still support Go 1.13.
+        # Docker/Moby still builds runc with Go 1.13, so we should still support Go 1.13.
         go-version: [1.13.x, 1.15.x, 1.16.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]


### PR DESCRIPTION
Tiny spelling fix - it's called "docker", not "dockre".

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>