### PR TITLE
libct/cg/sd: fix "SkipDevices" handling

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -178,7 +178,7 @@ func allowAllDevices() []systemdDbus.Property {
 // corresponding set of systemd properties to configure the devices correctly.
 func generateDeviceProperties(r *configs.Resources) ([]systemdDbus.Property, error) {
 	if r.SkipDevices {
-		return allowAllDevices(), nil
+		return nil, nil
 	}
 
 	properties := []systemdDbus.Property{

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -339,27 +339,24 @@ func (m *legacyManager) Set(r *configs.Resources) error {
 		return err
 	}
 
+	// Figure out the current freezer state, so we can revert to it after we
+	// temporarily freeze the container.
+	targetFreezerState, err := m.GetFreezerState()
+	if err != nil {
+		return err
+	}
+	if targetFreezerState == configs.Undefined {
+		targetFreezerState = configs.Thawed
+	}
+
 	// We have to freeze the container while systemd sets the cgroup settings.
 	// The reason for this is that systemd's application of DeviceAllow rules
 	// is done disruptively, resulting in spurrious errors to common devices
 	// (unlike our fs driver, they will happily write deny-all rules to running
 	// containers). So we freeze the container to avoid them hitting the cgroup
 	// error. But if the freezer cgroup isn't supported, we just warn about it.
-	targetFreezerState := configs.Undefined
-	if !m.cgroups.SkipDevices {
-		// Figure out the current freezer state, so we can revert to it after we
-		// temporarily freeze the container.
-		targetFreezerState, err = m.GetFreezerState()
-		if err != nil {
-			return err
-		}
-		if targetFreezerState == configs.Undefined {
-			targetFreezerState = configs.Thawed
-		}
-
-		if err := m.Freeze(configs.Frozen); err != nil {
-			logrus.Infof("freeze container before SetUnitProperties failed: %v", err)
-		}
+	if err := m.Freeze(configs.Frozen); err != nil {
+		logrus.Infof("freeze container before SetUnitProperties failed: %v", err)
 	}
 
 	if err := setUnitProperties(m.dbus, getUnitName(m.cgroups), properties...); err != nil {

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -418,27 +418,24 @@ func (m *unifiedManager) Set(r *configs.Resources) error {
 		return err
 	}
 
+	// Figure out the current freezer state, so we can revert to it after we
+	// temporarily freeze the container.
+	targetFreezerState, err := m.GetFreezerState()
+	if err != nil {
+		return err
+	}
+	if targetFreezerState == configs.Undefined {
+		targetFreezerState = configs.Thawed
+	}
+
 	// We have to freeze the container while systemd sets the cgroup settings.
 	// The reason for this is that systemd's application of DeviceAllow rules
 	// is done disruptively, resulting in spurrious errors to common devices
 	// (unlike our fs driver, they will happily write deny-all rules to running
 	// containers). So we freeze the container to avoid them hitting the cgroup
 	// error. But if the freezer cgroup isn't supported, we just warn about it.
-	targetFreezerState := configs.Undefined
-	if !m.cgroups.SkipDevices {
-		// Figure out the current freezer state, so we can revert to it after we
-		// temporarily freeze the container.
-		targetFreezerState, err = m.GetFreezerState()
-		if err != nil {
-			return err
-		}
-		if targetFreezerState == configs.Undefined {
-			targetFreezerState = configs.Thawed
-		}
-
-		if err := m.Freeze(configs.Frozen); err != nil {
-			logrus.Infof("freeze container before SetUnitProperties failed: %v", err)
-		}
+	if err := m.Freeze(configs.Frozen); err != nil {
+		logrus.Infof("freeze container before SetUnitProperties failed: %v", err)
 	}
 
 	if err := setUnitProperties(m.dbus, getUnitName(m.cgroups), properties...); err != nil {


### PR DESCRIPTION
1. Fix handling of `SkipDevices` option -- it should be what it literally means,
   i.e. do not set any device-related options.

2. Revert the part of commit 108ee85 which skipped the freeze
   when the `SkipDevices` is set. Apparently, the freeze is needed on
   update even if no `Device*` properties are being set.

3. Add `runc update` to "runc run [device cgroup deny]" test.

Fixes: 752e7a8
Fixes: 108ee85
Fixes: #3014 