### PR TITLE
libct/cg/fs2: set per-device io weight if available

### DIFF
--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -41,11 +41,15 @@ func (s *BlkioGroup) Set(path string, r *configs.Resources) error {
 		}
 	}
 	for _, wd := range r.BlkioWeightDevice {
-		if err := cgroups.WriteFile(path, s.weightDeviceFilename, wd.WeightString()); err != nil {
-			return err
+		if wd.Weight != 0 {
+			if err := cgroups.WriteFile(path, s.weightDeviceFilename, wd.WeightString()); err != nil {
+				return err
+			}
 		}
-		if err := cgroups.WriteFile(path, "blkio.leaf_weight_device", wd.LeafWeightString()); err != nil {
-			return err
+		if wd.LeafWeight != 0 {
+			if err := cgroups.WriteFile(path, "blkio.leaf_weight_device", wd.LeafWeightString()); err != nil {
+				return err
+			}
 		}
 	}
 	for _, td := range r.BlkioThrottleReadBpsDevice {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -168,10 +168,9 @@ function set_cgroups_path() {
 	update_config '.linux.cgroupsPath |= "'"${OCI_CGROUPS_PATH}"'"' "$bundle"
 }
 
-# Helper to check a value in cgroups.
-function check_cgroup_value() {
+# Get a value from a cgroup file.
+function get_cgroup_value() {
 	local source=$1
-	local expected=$2
 	local cgroup var current
 
 	if [ "x$CGROUP_UNIFIED" = "xyes" ]; then
@@ -181,9 +180,15 @@ function check_cgroup_value() {
 		var=CGROUP_${var^^}_BASE_PATH # variable name (e.g. CGROUP_MEMORY_BASE_PATH)
 		eval cgroup=\$${var}${REL_CGROUPS_PATH}
 	fi
+	cat $cgroup/$source
+}
 
-	current=$(cat $cgroup/$source)
-	echo $cgroup/$source
+# Helper to check a if value in a cgroup file matches the expected one.
+function check_cgroup_value() {
+	local current
+	current="$(get_cgroup_value $1)"
+	local expected=$2
+
 	echo "current" $current "!?" "$expected"
 	[ "$current" = "$expected" ]
 }


### PR DESCRIPTION
1. A **bugfix** to be able to set per-device weights on cgroup v1 with BFQ.
2. Set per-device weights for v2 with BFQ.
3. A test case for the above two.

I accidentally found out that per-device weight is supported
in BFQ scheduler since kernel v5.4 (kernel commit 795fe54c2a8),
so let's set those if supplied.

Next, I added a test case for it and decided to not make is v2-specific,
as the test for cgroup v1 would look very much the same. This test found a bug
in v1 (see https://github.com/opencontainers/runc/pull/3010#issuecomment-860302432), so I fixed it as well.

This closes a small gap in cgroup v2 feature parity with cgroup v1.

## Proposed changelog entry
* cgroup v2: set per-device io weights if BFQ IO scheduler is available.