### PR TITLE
Revert "checkpoint: resolve symlink for external bind mount"

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -780,9 +780,6 @@ const descriptorsFilename = "descriptors.json"
 
 func (c *linuxContainer) addCriuDumpMount(req *criurpc.CriuReq, m *configs.Mount) {
 	mountDest := strings.TrimPrefix(m.Destination, c.config.Rootfs)
-	if dest, err := securejoin.SecureJoin(c.config.Rootfs, mountDest); err == nil {
-		mountDest = dest[len(c.config.Rootfs):]
-	}
 	extMnt := &criurpc.ExtMountMap{
 		Key: proto.String(mountDest),
 		Val: proto.String(mountDest),

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -126,18 +126,7 @@ function simple_cr() {
 	done
 }
 
-@test "checkpoint and restore" {
-	simple_cr
-}
-
-@test "checkpoint and restore (bind mount, destination is symlink)" {
-	mkdir -p rootfs/real/conf
-	ln -s /real/conf rootfs/conf
-	update_config '	  .mounts += [{
-					source: ".",
-					destination: "/conf",
-					options: ["bind"]
-				}]'
+@test "checkpoint and restore " {
 	simple_cr
 }
 


### PR DESCRIPTION
This reverts commit da22625f6986f0ef196eaa1f8bb6adce098f0fb7
(PR #2902). The reason for revert is #3042.

Fixes: #3042 

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>