### PR TITLE
retry unix.EINTR for container init process

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -227,7 +227,7 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	if err := unix.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
+	if err := system.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
 		return fmt.Errorf("can't exec user process: %w", err)
 	}
 	return nil

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -35,7 +35,16 @@ func Execv(cmd string, args []string, env []string) error {
 		return err
 	}
 
-	return unix.Exec(name, args, env)
+	return Exec(name, args, env)
+}
+
+func Exec(cmd string, args []string, env []string) error {
+	for {
+		err := unix.Exec(cmd, args, env)
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return err
+		}
+	}
 }
 
 func Prlimit(pid, resource int, limit unix.Rlimit) error {


### PR DESCRIPTION
When running a script from an azure file share interrupted syscall
occurs quite frequently, to remedy this add retries around execve
syscall, when EINTR is returned.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1917662