### PR TITLE
checkpoint: resolve symlink for external bind mount (take II)

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -758,6 +758,9 @@ const descriptorsFilename = "descriptors.json"
 
 func (c *linuxContainer) addCriuDumpMount(req *criurpc.CriuReq, m *configs.Mount) {
 	mountDest := strings.TrimPrefix(m.Destination, c.config.Rootfs)
+	if dest, err := securejoin.SecureJoin(c.config.Rootfs, mountDest); err == nil {
+		mountDest = dest[len(c.config.Rootfs):]
+	}
 	extMnt := &criurpc.ExtMountMap{
 		Key: proto.String(mountDest),
 		Val: proto.String(mountDest),
@@ -1134,6 +1137,9 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 
 func (c *linuxContainer) addCriuRestoreMount(req *criurpc.CriuReq, m *configs.Mount) {
 	mountDest := strings.TrimPrefix(m.Destination, c.config.Rootfs)
+	if dest, err := securejoin.SecureJoin(c.config.Rootfs, mountDest); err == nil {
+		mountDest = dest[len(c.config.Rootfs):]
+	}
 	extMnt := &criurpc.ExtMountMap{
 		Key: proto.String(mountDest),
 		Val: proto.String(m.Source),

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -126,7 +126,18 @@ function simple_cr() {
 	done
 }
 
-@test "checkpoint and restore " {
+@test "checkpoint and restore" {
+	simple_cr
+}
+
+@test "checkpoint and restore (bind mount, destination is symlink)" {
+	mkdir -p rootfs/real/conf
+	ln -s /real/conf rootfs/conf
+	update_config '	  .mounts += [{
+					source: ".",
+					destination: "/conf",
+					options: ["bind"]
+				}]'
 	simple_cr
 }
 


### PR DESCRIPTION
[From @kolyshkin: This is a respin of #2902 which was reverted in #3043]

runc resolves symlink before doing bind mount. So
we should save original path while formatting CriuReq for
dump and restore.
    
"checkpoint: resolve symlink for external bind mount" is merged as 
da22625f6986f0ef196eaa1f8bb6adce098f0fb7 (PR #2902) previously. And reverted
in commit 70fdc0573dced3464e9c31d674559f77c1de3973 (PR #3043) duo to behavior changes
caused by commit 0ca91f44f1664da834bc61115a849b56d22f595f (Fixes: CVE-2021-30465)

Signed-off-by: Liu Hua <weldonliu@tencent.com>

## Changelog entry
(by @kolyshkin)
```Bugfixes:
* runc checkpoint/restore: fixed for containers with an external bind mount
  which destination is a symlink. (#3047).
```