### PR TITLE
tests/int/no_pivot: fixup for new kernels

### DIFF
--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -13,7 +13,9 @@ function teardown() {
 @test "runc run --no-pivot must not expose bare /proc" {
 	requires root
 
-	update_config '.process.args |= ["unshare", "-mrpf", "sh", "-euxc", "mount -t proc none /proc && echo h > /proc/sysrq-trigger"]'
+	update_config '	  .process.args |= ["unshare", "-mrpf", "sh", "-euxc", "mount -t proc none /proc && echo h > /proc/sysrq-trigger"]
+			| .process.capabilities.bounding += ["CAP_SETFCAP"]
+			| .process.capabilities.permitted += ["CAP_SETFCAP"]'
 
 	runc run --no-pivot test_no_pivot
 	[ "$status" -eq 1 ]


### PR DESCRIPTION
Since today, the test is failing like this on GHA CI (and also happens to fail on my machine with a recent F34 kernel):

	not ok 70 runc run --no-pivot must not expose bare /proc
	# (in test file tests/integration/no_pivot.bats, line 20)
	#   `[[ "$output" == *"mount: permission denied"* ]]' failed
	# runc spec (status=0):
	#
	# runc run --no-pivot test_no_pivot (status=1):
	# unshare: write error: Operation not permitted

Apparently, a recent kernel commit [db2e718a47984b9d](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=db2e718a47984b9d71ed890eb2ea36ecf150de18) prevents
root from doing `unshare -r` unless it has `CAP_SETFCAP`.

Add the capability for this specific test.

Fixes: #3050