### PR TITLE
libct/errors.go: remove ConfigError in favor of ErrInvalidConfig

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -62,20 +62,17 @@ func (v *ConfigValidator) Validate(config *configs.Config) error {
 // to the container's root filesystem.
 func (v *ConfigValidator) rootfs(config *configs.Config) error {
 	if _, err := os.Stat(config.Rootfs); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("rootfs (%s) does not exist", config.Rootfs)
-		}
-		return err
+		return fmt.Errorf("invalid rootfs: %w", err)
 	}
 	cleaned, err := filepath.Abs(config.Rootfs)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid rootfs: %w", err)
 	}
 	if cleaned, err = filepath.EvalSymlinks(cleaned); err != nil {
-		return err
+		return fmt.Errorf("invalid rootfs: %w", err)
 	}
 	if filepath.Clean(config.Rootfs) != cleaned {
-		return fmt.Errorf("%s is not an absolute path or is a symlink", config.Rootfs)
+		return fmt.Errorf("invalid rootfs: not an absolute path, or a symlink")
 	}
 	return nil
 }
@@ -176,7 +173,7 @@ func (v *ConfigValidator) sysctl(config *configs.Config) error {
 				hostnet, hostnetErr = isHostNetNS(path)
 			})
 			if hostnetErr != nil {
-				return hostnetErr
+				return fmt.Errorf("invalid netns path: %w", hostnetErr)
 			}
 			if hostnet {
 				return fmt.Errorf("sysctl %q not allowed in host network namespace", s)

--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -35,6 +35,7 @@ func TestValidateWithInvalidRootfs(t *testing.T) {
 
 	validator := validate.New()
 	err := validator.Validate(config)
+	t.Logf("error: %v", err)
 	if err == nil {
 		t.Error("Expected error to occur but it was nil")
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -231,7 +231,7 @@ func (c *linuxContainer) Start(process *Process) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 	if c.config.Cgroups.Resources.SkipDevices {
-		return &ConfigError{"can't start container with SkipDevices set"}
+		return fmt.Errorf("%w: can't start container with SkipDevices set", ErrInvalidConfig)
 	}
 	if process.Init {
 		if err := c.createExecFifo(); err != nil {

--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -1,21 +1,18 @@
 package libcontainer
 
-import "errors"
+import (
+	"errors"
 
-var (
-	ErrExist      = errors.New("container with given ID already exists")
-	ErrInvalidID  = errors.New("invalid container ID format")
-	ErrNotExist   = errors.New("container does not exist")
-	ErrPaused     = errors.New("container paused")
-	ErrRunning    = errors.New("container still running")
-	ErrNotRunning = errors.New("container not running")
-	ErrNotPaused  = errors.New("container not paused")
+	"github.com/opencontainers/runc/libcontainer/configs/validate"
 )
 
-type ConfigError struct {
-	details string
-}
-
-func (e *ConfigError) Error() string {
-	return "invalid configuration: " + e.details
-}
+var (
+	ErrExist         = errors.New("container with given ID already exists")
+	ErrInvalidID     = errors.New("invalid container ID format")
+	ErrNotExist      = errors.New("container does not exist")
+	ErrPaused        = errors.New("container paused")
+	ErrRunning       = errors.New("container still running")
+	ErrNotRunning    = errors.New("container not running")
+	ErrNotPaused     = errors.New("container not paused")
+	ErrInvalidConfig = validate.ErrInvalidConfig
+)

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -251,13 +251,13 @@ type LinuxFactory struct {
 
 func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, error) {
 	if l.Root == "" {
-		return nil, &ConfigError{"invalid root"}
+		return nil, fmt.Errorf("%w: invalid root", ErrInvalidConfig)
 	}
 	if err := l.validateID(id); err != nil {
 		return nil, err
 	}
 	if err := l.Validator.Validate(config); err != nil {
-		return nil, &ConfigError{err.Error()}
+		return nil, fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}
 	containerRoot, err := securejoin.SecureJoin(l.Root, id)
 	if err != nil {
@@ -294,7 +294,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 
 func (l *LinuxFactory) Load(id string) (Container, error) {
 	if l.Root == "" {
-		return nil, &ConfigError{"invalid root"}
+		return nil, fmt.Errorf("%w: invalid root", ErrInvalidConfig)
 	}
 	// when load, we need to check id is valid or not.
 	if err := l.validateID(id); err != nil {


### PR DESCRIPTION
Inspired by https://github.com/opencontainers/runc/pull/3033#discussion_r661966694.

Replace `ConfigError` type (introduced in #3033) with an `ErrInvalidConfig`
variable, for better and more uniform errors returned by libcontainer.
    
This is somewhat complicated, as we need to make all errors returned
from config validator to be `ErrInvalidConfig`, while keeping them
unwrappable.

Implemented by introducing a type which holds an underlying error,
and has the `Is` method that answers that the error is
`ErrInvalidConfig`.