### PR TITLE
libcontainer: Don't close already closed fds and bail on close(2) failures

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -1044,7 +1044,6 @@ void nsexec(void)
 			syncfd = sync_grandchild_pipe[0];
 			close(sync_grandchild_pipe[1]);
 			close(sync_child_pipe[0]);
-			close(sync_child_pipe[1]);
 
 			/* For debugging. */
 			prctl(PR_SET_NAME, (unsigned long)"runc:[2:INIT]", 0, 0, 0);


### PR DESCRIPTION
Hi!

We've found these bugs while rebasing https://github.com/opencontainers/runc/pull/2576. The bug is that we are closing an fd that is already closed, and as we ignore close(2) failures we never realized.

It was not a big deal in runc master, it seems, as that close fails and is otherwise ignored. However, when working on PR #2576 we are opening a new fd, sometimes between the two close(2) calls, the fd number is reused (allocates the lower available fd) and the second close(2) was closing this new open fd that reused the number.

I've create two patches: one to remove the bogus close, and another one to check failures on close(2) so this bug does not happen again (as long as we continue to check for close failures :)). I've also verified that if we check for close failures on the close I remove, it indeed always returns an error on master.

You can find a more in detail explanation in the commit messages :)

cc @alban 