### PR TITLE
ci: enable unconvert linter, fix its warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,3 +8,4 @@ linters:
   enable:
     - gofumpt
     - errorlint
+    - unconvert

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -224,12 +224,12 @@ func cpusetCopyIfNeeded(current, parent string) error {
 	}
 
 	if isEmptyCpuset(currentCpus) {
-		if err := cgroups.WriteFile(current, "cpuset.cpus", string(parentCpus)); err != nil {
+		if err := cgroups.WriteFile(current, "cpuset.cpus", parentCpus); err != nil {
 			return err
 		}
 	}
 	if isEmptyCpuset(currentMems) {
-		if err := cgroups.WriteFile(current, "cpuset.mems", string(parentMems)); err != nil {
+		if err := cgroups.WriteFile(current, "cpuset.mems", parentMems); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fscommon/utils.go
+++ b/libcontainer/cgroups/fscommon/utils.go
@@ -85,7 +85,7 @@ func GetValueByKey(path, file, key string) (uint64, error) {
 		return 0, err
 	}
 
-	lines := strings.Split(string(content), "\n")
+	lines := strings.Split(content, "\n")
 	for _, line := range lines {
 		arr := strings.Split(line, " ")
 		if len(arr) == 2 && arr[0] == key {

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -446,5 +446,5 @@ func ConvertBlkIOToIOWeightValue(blkIoWeight uint16) uint64 {
 	if blkIoWeight == 0 {
 		return 0
 	}
-	return uint64(1 + (uint64(blkIoWeight)-10)*9999/990)
+	return 1 + (uint64(blkIoWeight)-10)*9999/990
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1029,7 +1029,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 
 	// append optional manage cgroups mode
 	if criuOpts.ManageCgroupsMode != 0 {
-		mode := criurpc.CriuCgMode(criuOpts.ManageCgroupsMode)
+		mode := criuOpts.ManageCgroupsMode
 		rpcOpts.ManageCgroupsMode = &mode
 	}
 
@@ -1406,7 +1406,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 
 	// append optional manage cgroups mode
 	if criuOpts.ManageCgroupsMode != 0 {
-		mode := criurpc.CriuCgMode(criuOpts.ManageCgroupsMode)
+		mode := criuOpts.ManageCgroupsMode
 		req.Opts.ManageCgroupsMode = &mode
 	}
 

--- a/libcontainer/devices/device_unix.go
+++ b/libcontainer/devices/device_unix.go
@@ -40,7 +40,7 @@ func DeviceFromPath(path, permissions string) (*Device, error) {
 	var (
 		devType   Type
 		mode      = stat.Mode
-		devNumber = uint64(stat.Rdev)
+		devNumber = uint64(stat.Rdev) //nolint:unconvert // Rdev is uint32 on e.g. MIPS.
 		major     = unix.Major(devNumber)
 		minor     = unix.Minor(devNumber)
 	)

--- a/libcontainer/notify_linux_v2.go
+++ b/libcontainer/notify_linux_v2.go
@@ -53,7 +53,7 @@ func registerMemoryEventV2(cgDir, evName, cgEvName string) (<-chan struct{}, err
 			offset = 0
 			for offset <= uint32(n-unix.SizeofInotifyEvent) {
 				rawEvent := (*unix.InotifyEvent)(unsafe.Pointer(&buffer[offset]))
-				offset += unix.SizeofInotifyEvent + uint32(rawEvent.Len)
+				offset += unix.SizeofInotifyEvent + rawEvent.Len
 				if rawEvent.Mask&unix.IN_MODIFY != unix.IN_MODIFY {
 					continue
 				}


### PR DESCRIPTION
While reviewing a PR I [found](https://github.com/opencontainers/runc/pull/3065/commits/5c8d36ba95cd581f72c63afd9cac125683f313bd#r665570457) we do not enable unconvert linter.

Enable it, and fix initially reported warnings (surprisingly not too many).