### PR TITLE
[WIP] libct/cg/sd/v1: Set: don't leave cgroup frozen

### DIFF
--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -1,6 +1,7 @@
 package systemd
 
 import (
+	"bufio"
 	"bytes"
 	"os"
 	"os/exec"
@@ -191,5 +192,142 @@ func TestUnitExistsIgnored(t *testing.T) {
 		if err := pm.Apply(-1); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestFreezePodCgroup(t *testing.T) {
+	if !IsRunningSystemd() {
+		t.Skip("Test requires systemd.")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("Test requires root.")
+	}
+
+	podConfig := &configs.Cgroup{
+		Parent: "system.slice",
+		Name:   "system-runc_test_pod.slice",
+		Resources: &configs.Resources{
+			SkipDevices: true,
+			Freezer:     configs.Frozen,
+		},
+	}
+	// Create a "pod" cgroup (a systemd slice to hold containers),
+	// which is frozen initially.
+	pm := newManager(podConfig)
+	defer pm.Destroy() //nolint:errcheck
+	if err := pm.Apply(-1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pm.Freeze(configs.Frozen); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.Set(podConfig.Resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the pod is frozen.
+	pf, err := pm.GetFreezerState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pf != configs.Frozen {
+		t.Fatalf("expected pod to be frozen, got %v", pf)
+	}
+	t.Log("pod frozen")
+
+	// Create a "container" within the "pod" cgroup.
+	// This is not a real container, just a process in the cgroup.
+	containerConfig := &configs.Cgroup{
+		Parent:      "system-runc_test_pod.slice",
+		ScopePrefix: "test",
+		Name:        "inner-contianer",
+		Resources:   &configs.Resources{},
+	}
+
+	cmd := exec.Command("bash", "-c", "while read; do echo $REPLY; done")
+	cmd.Env = append(os.Environ(), "LANG=C")
+
+	// Setup stdin.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stdin = stdinR
+
+	// Setup stdout.
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stdout = stdoutW
+	rdr := bufio.NewReader(stdoutR)
+
+	// Setup stderr.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err = cmd.Start()
+	stdinR.Close()
+	stdoutW.Close()
+	defer func() {
+		_ = stdinW.Close()
+		_ = stdoutR.Close()
+	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("container started")
+	// Make sure to not leave a zombie.
+	defer func() {
+		// These may fail, we don't care.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// Put the process into a cgroup.
+	cm := newManager(containerConfig)
+	defer cm.Destroy() //nolint:errcheck
+
+	if err := cm.Apply(cmd.Process.Pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.Set(containerConfig.Resources); err != nil {
+		t.Fatal(err)
+	}
+	t.Log("container pid added")
+	// Check that we put the "container" into the "pod" cgroup.
+	if !strings.HasPrefix(cm.Path("freezer"), pm.Path("freezer")) {
+		t.Fatalf("expected container cgroup path %q to be under pod cgroup path %q",
+			cm.Path("freezer"), pm.Path("freezer"))
+	}
+
+	t.Log("pod is still frozen -- thawing")
+	// Unfreeze the pod.
+	if err := pm.Freeze(configs.Thawed); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("check that container is thawed and working")
+	cf, err := cm.GetFreezerState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cf != configs.Thawed {
+		t.Fatalf("expected container to be thawed, got %v", cf)
+	}
+
+	// Check the "container" works.
+	marker := "one two\n"
+	_, err = stdinW.WriteString(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply, err := rdr.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading from container: %v", err)
+	}
+	if reply != marker {
+		t.Fatalf("expected %q, got %q", marker, reply)
 	}
 }


### PR DESCRIPTION
_This is the alternative to https://github.com/opencontainers/runc/pull/3065 with a different approach and the same test case._

I. In case a parent cgroup is frozen, the current code reads the cgroup
state (into `targetFreezerState`) as `FROZEN`, and sets it explicitly after
setting unit properties. This is obviously wrong, as we should not
explicitly freeze the cgroup because its parent was frozen.
    
The issue happens because:
    
1. The `m.GetFreezerState` method does not distinguish between
     the "self frozen" and "parent frozen" states (i.e. it does not
      consult `freezer.self_freezing`).
    
2. The `m.Freeze` method changes `m.cgroups.Resources.Frozen` field.

II. The current code does freeze/thaw unconditionally, meaning it
        freezes the already frozen cgroup (which is a no-op except it
        still requires some reads and writes to `freezer.state`), and
        thaws the cgroup which is about to be frozen.
    
Solve all this by figuring out whether we need to freeze and thaw,
and introducing and using a method which does not change value of
`m.cgroups.Resources.Frozen`.

Add a test case (initially developed in https://github.com/opencontainers/runc/pull/3065#issuecomment-875217491, and tested to fail without the fix in https://github.com/opencontainers/runc/pull/3066).
    
NOTE the current code assume that the container that is currently frozen
will remain frozen for the duration of `SetUnitProperties`. This might not
be true but there's no way to guarantee it (even in case we freeze the
cgroup ourselves).
