### PR TITLE
[1.0] retry unix.EINTR for container init process

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -224,7 +224,7 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	if err := unix.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
+	if err := system.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
 		return newSystemErrorWithCause(err, "exec user process")
 	}
 	return nil

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -35,7 +35,16 @@ func Execv(cmd string, args []string, env []string) error {
 		return err
 	}
 
-	return unix.Exec(name, args, env)
+	return Exec(name, args, env)
+}
+
+func Exec(cmd string, args []string, env []string) error {
+	for {
+		err := unix.Exec(cmd, args, env)
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return err
+		}
+	}
 }
 
 func Prlimit(pid, resource int, limit unix.Rlimit) error {


### PR DESCRIPTION
_Backport of PR #3045 to release-1.0 branch. ~~Draft, needs to be rebased on top of PR #3075 to fix CI.~~_

When running a script from an azure file share interrupted syscall
occurs quite frequently, to remedy this add retries around execve
syscall, when EINTR is returned.

Signed-off-by: Maksim An <maksiman@microsoft.com>
(cherry picked from commit e39ad6505995a9e3c098fa4b91d39d266f4e27ba)

[Minor conflict in libcontainer/standard_init_linux.go due to missing
commit e918d021399e62 -- resolved manually]

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

## Proposed changelog entry
```
Bugfixes:
* Fixed occasional runc exec/run failure ("interrupted system call") on an Azure volume.
```