### PR TITLE
[1.0] tests/int/no_pivot: fix for new kernels

### DIFF
--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -13,7 +13,9 @@ function teardown() {
 @test "runc run --no-pivot must not expose bare /proc" {
 	requires root
 
-	update_config '.process.args |= ["unshare", "-mrpf", "sh", "-euxc", "mount -t proc none /proc && echo h > /proc/sysrq-trigger"]'
+	update_config '	  .process.args |= ["unshare", "-mrpf", "sh", "-euxc", "mount -t proc none /proc && echo h > /proc/sysrq-trigger"]
+			| .process.capabilities.bounding += ["CAP_SETFCAP"]
+			| .process.capabilities.permitted += ["CAP_SETFCAP"]'
 
 	runc run --no-pivot test_no_pivot
 	[ "$status" -eq 1 ]


### PR DESCRIPTION
_This is a backport of PR #3051 to release-1.0 branch to fix CI. Clean cherry-pick, no issues, original description follows._

The test is failing like this:

	not ok 70 runc run --no-pivot must not expose bare /proc
	# (in test file tests/integration/no_pivot.bats, line 20)
	#   `[[ "$output" == *"mount: permission denied"* ]]' failed
	# runc spec (status=0):
	#
	# runc run --no-pivot test_no_pivot (status=1):
	# unshare: write error: Operation not permitted

Apparently, a recent kernel commit db2e718a47984b9d prevents
root from doing unshare -r unless it has CAP_SETFPCAP.

Add the capability for this specific test.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit 1bbeadae72603c44932d46ade275219dbf718950)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>