### PR TITLE
[1.0] libct/user: fix parsing long /etc/group lines

### DIFF
--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -187,7 +187,7 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 	)
 
 	for s.Scan() {
-		text := s.Bytes()
+		text := bytes.TrimSpace(s.Bytes())
 		if len(text) == 0 {
 			continue
 		}

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -180,15 +180,53 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 	if r == nil {
 		return nil, fmt.Errorf("nil source for group-formatted data")
 	}
+	rd := bufio.NewReader(r)
+	out := []Group{}
 
-	var (
-		s   = bufio.NewScanner(r)
-		out = []Group{}
-	)
+	// Read the file line-by-line.
+	for {
+		var (
+			isPrefix  bool
+			wholeLine []byte
+			err       error
+		)
 
-	for s.Scan() {
-		text := bytes.TrimSpace(s.Bytes())
-		if len(text) == 0 {
+		// Read the next line. We do so in chunks (as much as reader's
+		// buffer is able to keep), check if we read enough columns
+		// already on each step and store final result in wholeLine.
+		for {
+			var line []byte
+			line, isPrefix, err = rd.ReadLine()
+
+			if err != nil {
+				// We should return no error if EOF is reached
+				// without a match.
+				if err == io.EOF { //nolint:errorlint // comparison with io.EOF is legit, https://github.com/polyfloyd/go-errorlint/pull/12
+					err = nil
+				}
+				return out, err
+			}
+
+			// Simple common case: line is short enough to fit in a
+			// single reader's buffer.
+			if !isPrefix && len(wholeLine) == 0 {
+				wholeLine = line
+				break
+			}
+
+			wholeLine = append(wholeLine, line...)
+
+			// Check if we read the whole line already.
+			if !isPrefix {
+				break
+			}
+		}
+
+		// There's no spec for /etc/passwd or /etc/group, but we try to follow
+		// the same rules as the glibc parser, which allows comments and blank
+		// space at the beginning of a line.
+		wholeLine = bytes.TrimSpace(wholeLine)
+		if len(wholeLine) == 0 || wholeLine[0] == '#' {
 			continue
 		}
 
@@ -198,17 +236,12 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 		//  root:x:0:root
 		//  adm:x:4:root,adm,daemon
 		p := Group{}
-		parseLine(text, &p.Name, &p.Pass, &p.Gid, &p.List)
+		parseLine(wholeLine, &p.Name, &p.Pass, &p.Gid, &p.List)
 
 		if filter == nil || filter(p) {
 			out = append(out, p)
 		}
 	}
-	if err := s.Err(); err != nil {
-		return nil, err
-	}
-
-	return out, nil
 }
 
 type ExecUser struct {

--- a/libcontainer/user/user_test.go
+++ b/libcontainer/user/user_test.go
@@ -16,42 +16,42 @@ func TestUserParseLine(t *testing.T) {
 		d    int
 	)
 
-	parseLine("", &a, &b)
+	parseLine([]byte(""), &a, &b)
 	if a != "" || b != "" {
 		t.Fatalf("a and b should be empty ('%v', '%v')", a, b)
 	}
 
-	parseLine("a", &a, &b)
+	parseLine([]byte("a"), &a, &b)
 	if a != "a" || b != "" {
 		t.Fatalf("a should be 'a' and b should be empty ('%v', '%v')", a, b)
 	}
 
-	parseLine("bad boys:corny cows", &a, &b)
+	parseLine([]byte("bad boys:corny cows"), &a, &b)
 	if a != "bad boys" || b != "corny cows" {
 		t.Fatalf("a should be 'bad boys' and b should be 'corny cows' ('%v', '%v')", a, b)
 	}
 
-	parseLine("", &c)
+	parseLine([]byte(""), &c)
 	if len(c) != 0 {
 		t.Fatalf("c should be empty (%#v)", c)
 	}
 
-	parseLine("d,e,f:g:h:i,j,k", &c, &a, &b, &c)
+	parseLine([]byte("d,e,f:g:h:i,j,k"), &c, &a, &b, &c)
 	if a != "g" || b != "h" || len(c) != 3 || c[0] != "i" || c[1] != "j" || c[2] != "k" {
 		t.Fatalf("a should be 'g', b should be 'h', and c should be ['i','j','k'] ('%v', '%v', '%#v')", a, b, c)
 	}
 
-	parseLine("::::::::::", &a, &b, &c)
+	parseLine([]byte("::::::::::"), &a, &b, &c)
 	if a != "" || b != "" || len(c) != 0 {
 		t.Fatalf("a, b, and c should all be empty ('%v', '%v', '%#v')", a, b, c)
 	}
 
-	parseLine("not a number", &d)
+	parseLine([]byte("not a number"), &d)
 	if d != 0 {
 		t.Fatalf("d should be 0 (%v)", d)
 	}
 
-	parseLine("b:12:c", &a, &d, &b)
+	parseLine([]byte("b:12:c"), &a, &d, &b)
 	if a != "b" || b != "c" || d != 12 {
 		t.Fatalf("a should be 'b' and b should be 'c', and d should be 12 ('%v', '%v', %v)", a, b, d)
 	}


### PR DESCRIPTION
_This is a backport of #3062 to 1.0 branch. Clean cherry-pick, no issues. Original description follows._

Lines in /etc/group longer than 64 characters breaks the current
implementation of group parser. This is caused by bufio.Scanner
buffer limit.
    
Fix by re-using the fix for a similar problem in golang os/user,
namely https://go-review.googlesource.com/c/go/+/283601
(fixing a similar bug in golang os/user, https://github.com/golang/go/issues/43636).
    
Add some tests.

Fixes: #3036 
   
Reported-by: @erict-square 
Co-authored-by: @andreybokhanko
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

## Proposed changelog entry
```
Bugfixes:
* Fixed "unable to find groups ... token too long" error with /etc/group containing lines longer than 64K characters (#3036)
```