### PR TITLE
systemd cgroup v1 freeze fixes

### DIFF
--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -129,7 +129,25 @@ func (s *FreezerGroup) GetState(path string) (configs.FreezerState, error) {
 		case "THAWED":
 			return configs.Thawed, nil
 		case "FROZEN":
-			return configs.Frozen, nil
+			// Find out whether the cgroup is frozen directly,
+			// or indirectly via an ancestor.
+			self, err := cgroups.ReadFile(path, "freezer.self_freezing")
+			if err != nil {
+				// If the kernel is too old, then we just treat
+				// it as being frozen.
+				if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ENODEV) {
+					err = nil
+				}
+				return configs.Frozen, err
+			}
+			switch self {
+			case "0\n":
+				return configs.Thawed, nil
+			case "1\n":
+				return configs.Frozen, nil
+			default:
+				return configs.Undefined, fmt.Errorf(`unknown "freezer.self_freezing" state: %q`, self)
+			}
 		case "FREEZING":
 			// Make sure we get a stable freezer state, so retry if the cgroup
 			// is still undergoing freezing. This should be a temporary delay.

--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -1,6 +1,7 @@
 package systemd
 
 import (
+	"bufio"
 	"bytes"
 	"os"
 	"os/exec"
@@ -191,5 +192,145 @@ func TestUnitExistsIgnored(t *testing.T) {
 		if err := pm.Apply(-1); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestFreezePodCgroup(t *testing.T) {
+	if !IsRunningSystemd() {
+		t.Skip("Test requires systemd.")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("Test requires root.")
+	}
+
+	podConfig := &configs.Cgroup{
+		Parent: "system.slice",
+		Name:   "system-runc_test_pod.slice",
+		Resources: &configs.Resources{
+			SkipDevices: true,
+			Freezer:     configs.Frozen,
+		},
+	}
+	// Create a "pod" cgroup (a systemd slice to hold containers),
+	// which is frozen initially.
+	pm := newManager(podConfig)
+	defer pm.Destroy() //nolint:errcheck
+	if err := pm.Apply(-1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pm.Freeze(configs.Frozen); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.Set(podConfig.Resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the pod is frozen.
+	pf, err := pm.GetFreezerState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pf != configs.Frozen {
+		t.Fatalf("expected pod to be frozen, got %v", pf)
+	}
+
+	// Create a "container" within the "pod" cgroup.
+	// This is not a real container, just a process in the cgroup.
+	containerConfig := &configs.Cgroup{
+		Parent:      "system-runc_test_pod.slice",
+		ScopePrefix: "test",
+		Name:        "inner-contianer",
+		Resources:   &configs.Resources{},
+	}
+
+	cmd := exec.Command("bash", "-c", "while read; do echo $REPLY; done")
+	cmd.Env = append(os.Environ(), "LANG=C")
+
+	// Setup stdin.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stdin = stdinR
+
+	// Setup stdout.
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stdout = stdoutW
+	rdr := bufio.NewReader(stdoutR)
+
+	// Setup stderr.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err = cmd.Start()
+	stdinR.Close()
+	stdoutW.Close()
+	defer func() {
+		_ = stdinW.Close()
+		_ = stdoutR.Close()
+	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure to not leave a zombie.
+	defer func() {
+		// These may fail, we don't care.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// Put the process into a cgroup.
+	cm := newManager(containerConfig)
+	defer cm.Destroy() //nolint:errcheck
+
+	if err := cm.Apply(cmd.Process.Pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.Set(containerConfig.Resources); err != nil {
+		t.Fatal(err)
+	}
+	// Check that we put the "container" into the "pod" cgroup.
+	if !strings.HasPrefix(cm.Path("freezer"), pm.Path("freezer")) {
+		t.Fatalf("expected container cgroup path %q to be under pod cgroup path %q",
+			cm.Path("freezer"), pm.Path("freezer"))
+	}
+	// Check the container is not reported as frozen despite the frozen parent.
+	cf, err := cm.GetFreezerState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cf != configs.Thawed {
+		t.Fatalf("expected container to be thawed, got %v", cf)
+	}
+
+	// Unfreeze the pod.
+	if err := pm.Freeze(configs.Thawed); err != nil {
+		t.Fatal(err)
+	}
+
+	cf, err = cm.GetFreezerState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cf != configs.Thawed {
+		t.Fatalf("expected container to be thawed, got %v", cf)
+	}
+
+	// Check the "container" works.
+	marker := "one two\n"
+	_, err = stdinW.WriteString(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply, err := rdr.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading from container: %v", err)
+	}
+	if reply != marker {
+		t.Fatalf("expected %q, got %q", marker, reply)
 	}
 }


### PR DESCRIPTION
_This is a combo of #3065 and #3072, fixing issues resulting in kubernetes revert of runc 1.0.0 vendoring._

1. Fix cgroup v1 `GetFreezerState` to not report cgroup state as frozen if a parent cgroup is frozen.

   After the fix, we only report the cgroup is frozen if it is frozen directly (and not via an ancestor).
   This is how cgroup v2 GetFreezerState works, so now there's no discrepancy between v1 and v2 behavior.

2. Fix cgroup/systemd v1 Set to not leave sub-cgroup frozen in case a parent cgroup is frozen.

   This issue mostly stems from the `GetFreezerState` reporting incorrect state (fixed above).

3. Cleanup cgroup/systemd v1 freeze/thaw code (do not overwrite cgroup resources freezer).

4. Avoid unnecessary freeze/thaw.

5. Tests for all the above issues.

Co-authored-by: @odinuge 
