### PR TITLE
Use Cirrus CI for Vagrant tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,67 @@
+---
+# We use Cirrus for Vagrant tests, because macOS instances of GHA
+# are too slow and flaky, and Linux instances of GHA do not support KVM.
+
+# NOTE Cirrus execution environments lack a terminal, needed for
+# some integration tests. So we use `ssh -tt` command to fake a terminal.
+
+compute_engine_instance:
+  image_project: cirrus-images
+  image: family/docker-kvm
+  platform: linux
+  nested_virtualization: true
+  # CPU limit: `16 / NTASK`: see https://cirrus-ci.org/faq/#are-there-any-limits
+  cpu: 8
+  # Memory limit: `4GB * NCPU`
+  memory: 32G
+
+vagrant_task:
+  timeout_in: 30m
+  env:
+    DEBIAN_FRONTEND: noninteractive
+    HOME: /root
+    # yamllint disable rule:key-duplicates
+    matrix:
+      DISTRO: fedora34
+      DISTRO: centos7
+  host_info_script: |
+    uname -a
+    echo "-----"
+    cat /etc/os-release
+    echo "-----"
+    cat /proc/cpuinfo
+    echo "-----"
+    df -T
+  install_libvirt_vagrant_script: |
+    apt-get update
+    apt-get install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt
+    systemctl enable --now libvirtd
+  vagrant_cache:
+    fingerprint_script: uname -s ; cat Vagrantfile.$DISTRO
+    folder: /root/.vagrant.d
+  vagrant_up_script: |
+    ln -sf Vagrantfile.$DISTRO Vagrantfile
+    # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
+    vagrant up || vagrant up
+    mkdir -p -m 0700 /root/.ssh
+    vagrant ssh-config >> /root/.ssh/config
+  guest_info_script: |
+    ssh default 'sh -exc "uname -a && systemctl --version && df -T && cat /etc/os-release"'
+  unit_tests_script: |
+    ssh default 'sudo -i make -C /vagrant localunittest'
+  integration_systemd_script: |
+    ssh -tt default "sudo -i make -C /vagrant localintegration RUNC_USE_SYSTEMD=yes"
+  integration_fs_script: |
+    ssh -tt default "sudo -i make -C /vagrant localintegration"
+  integration_systemd_rootless_script: |
+    if [ $DISTRO == centos7 ]; then
+      echo "SKIP: integration_systemd_rootless_script requires cgroup v2"
+    else
+      ssh -tt default "sudo -i make -C /vagrant localrootlessintegration RUNC_USE_SYSTEMD=yes"
+    fi
+  integration_fs_rootless_script: |
+    if [ $DISTRO == centos7 ]; then
+      echo "SKIP: FIXME: integration_fs_rootless_script is skipped because of EPERM on writing cgroup.procs"
+    else
+      ssh -tt default "sudo -i make -C /vagrant localrootlessintegration"
+    fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,5 @@
 # NOTE Github Actions execution environments lack a terminal, needed for
-# some integration tests. Two ways to get a terminal are used below:
-#
-# 1. script utility -- for "local" integration tests;
-# 2. ssh -tt -- for Vagrant VMs (script is buggy on CentOS 7).
+# some integration tests. So we use `script` command to fake a terminal.
 
 name: ci
 on:
@@ -72,88 +69,6 @@ jobs:
       # can't use systemd driver with cgroupv1
       if: matrix.rootless != 'rootless'
       run: sudo -E PATH="$PATH" script -e -c 'make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'
-
-
-  # cgroup v2 unified hierarchy + very recent kernel (openat2)
-  fedora:
-    # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
-    timeout-minutes: 30
-    # only run it if others have passed
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: "Cache ~/.vagrant.d/boxes, using hash of Vagrantfile.fedora34"
-        uses: actions/cache@v2
-        with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-${{ hashFiles('Vagrantfile.fedora34') }}
-
-      - name: prepare vagrant
-        run: |
-          ln -sf Vagrantfile.fedora34 Vagrantfile
-          # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
-          vagrant up || vagrant up
-          vagrant ssh-config >> ~/.ssh/config
-
-      - name: system info
-        run: ssh default 'sh -exc "uname -a && systemctl --version && df -T"'
-
-      - name: unit tests
-        run: ssh default 'cd /vagrant && sudo make localunittest'
-
-      - name: cgroupv2 with systemd
-        run: ssh -tt default "sudo make -C /vagrant localintegration RUNC_USE_SYSTEMD=yes"
-
-      - name: cgroupv2 with fs2
-        run: ssh -tt default "sudo make -C /vagrant localintegration"
-
-      - name: cgroupv2 with systemd (rootless)
-        run: ssh -tt default "sudo make -C /vagrant localrootlessintegration RUNC_USE_SYSTEMD=yes"
-
-      - name: cgroupv2 with fs2 (rootless)
-        run: ssh -tt default "sudo make -C /vagrant localrootlessintegration"
-
-
-  # kernel 3.10 (frankenized), systemd 219
-  centos7:
-    # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
-    timeout-minutes: 15
-    # only run it if others have passed
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: "Cache ~/.vagrant.d/boxes, using hash of Vagrantfile.centos7"
-        uses: actions/cache@v2
-        with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-${{ hashFiles('Vagrantfile.centos7') }}
-
-      - name: prepare vagrant
-        run: |
-          ln -sf Vagrantfile.centos7 Vagrantfile
-          vagrant up
-          vagrant ssh-config >> ~/.ssh/config
-
-      - name: system info
-        run: ssh default 'rpm -q centos-release kernel systemd'
-
-      - name: unit tests
-        run: ssh default 'sudo -i make -C /vagrant localunittest'
-
-      - name: integration tests (fs cgroup driver)
-        run: ssh -tt default "sudo -i make -C /vagrant localintegration"
-
-      - name: integration tests (systemd cgroup driver)
-        run: ssh -tt default "sudo -i make -C /vagrant localintegration RUNC_USE_SYSTEMD=1"
-
-      - name: rootless integration
-      # FIXME: rootless is skipped because of EPERM on writing cgroup.procs
-        if: false
-        run: ssh default "sudo -i make -C /vagrant localrootlessintegration"
 
   # We need to continue support for 32-bit ARM.
   # However, we do not have 32-bit ARM CI, so we use i386 for testing 32bit stuff.


### PR DESCRIPTION
ref: issue #3078 

Cirrus allows using 16 CPUs and 64GB RAM in total.
(We have two Vagrant VMs, so 8 CPUs and 32GB RAM for each)

Cirrus needs to be enabled via https://github.com/marketplace/cirrus-ci
(cc @caniszczyk @cyphar)

Build logs in my fork repo: https://cirrus-ci.com/github/AkihiroSuda/runc

![image](https://user-images.githubusercontent.com/9248427/125601262-8312f56d-ce13-42a2-a1a6-bd7d82e1dc25.png)

TODO (once this is merged, added by @kolyshkin)
* Remove fedora and centos jobs from required in https://github.com/opencontainers/runc/settings/branches for both `master` and `release-*` (btw why do we have two sets of rules if they are supposed to be the same?)
* Add new jobs in there.