### PR TITLE
ci/gha: run on release-* branches after a push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - v*
     branches:
       - master
+      - release-*
   pull_request:
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
       - v*
     branches:
       - master
+      - release-*
   pull_request:
 
 jobs:


### PR DESCRIPTION
A CI is needed after PR merges for release-* branches, too.