### PR TITLE
libct/cg/v1: work around CPU quota period set failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vendor/pkg
 /runc
 /runc-*
 contrib/cmd/recvtty/recvtty
+contrib/cmd/sd-helper/sd-helper
 man/man8
 release
 Vagrantfile

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,15 @@ GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(EXTRA_FLAGS) -tags "$(B
 runc:
 	$(GO_BUILD) -o runc .
 
-all: runc recvtty
+all: runc recvtty sd-helper
 
-recvtty:
-	$(GO_BUILD) -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
+recvtty sd-helper:
+	$(GO_BUILD) -o contrib/cmd/$@/$@ ./contrib/cmd/$@
 
 static:
 	$(GO_BUILD_STATIC) -o runc .
 	$(GO_BUILD_STATIC) -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
+	$(GO_BUILD_STATIC) -o contrib/cmd/sd-helper/sd-helper ./contrib/cmd/sd-helper
 
 release:
 	script/release.sh -r release/$(VERSION) -v $(VERSION)
@@ -110,6 +111,7 @@ install-man: man
 clean:
 	rm -f runc runc-*
 	rm -f contrib/cmd/recvtty/recvtty
+	rm -f contrib/cmd/sd-helper/sd-helper
 	rm -rf release
 	rm -rf man/man8
 
@@ -147,7 +149,7 @@ localcross:
 	CGO_ENABLED=1 GOARCH=arm64 CC=aarch64-linux-gnu-gcc         $(GO_BUILD) -o runc-arm64 .
 	CGO_ENABLED=1 GOARCH=ppc64le CC=powerpc64le-linux-gnu-gcc   $(GO_BUILD) -o runc-ppc64le .
 
-.PHONY: runc all recvtty static release dbuild lint man runcimage \
+.PHONY: runc all recvtty sd-helper static release dbuild lint man runcimage \
 	test localtest unittest localunittest integration localintegration \
 	rootlessintegration localrootlessintegration shell install install-bash \
 	install-man clean cfmt shfmt shellcheck \

--- a/contrib/cmd/sd-helper/helper.go
+++ b/contrib/cmd/sd-helper/helper.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func usage() {
+	fmt.Print(`Open Container Initiative contrib/cmd/sd-helper
+
+sd-helper is a tool that uses runc/libcontainer/cgroups/systemd package
+functionality to communicate to systemd in order to perform various operations.
+Currently this is limited to starting and stopping systemd transient slice
+units.
+
+Usage:
+	sd-helper [-debug] [-parent <pname>] {start|stop} <name>
+
+Example:
+	sd-helper -parent system.slice start system-pod123.slice
+`)
+	os.Exit(1)
+}
+
+var (
+	debug  = flag.Bool("debug", false, "enable debug output")
+	parent = flag.String("parent", "", "parent unit name")
+)
+
+func main() {
+	if !systemd.IsRunningSystemd() {
+		logrus.Fatal("systemd is required")
+	}
+
+	// Set the flags.
+	flag.Parse()
+	if *debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	if flag.NArg() != 2 {
+		usage()
+	}
+
+	cmd := flag.Arg(0)
+	unit := flag.Arg(1)
+
+	err := unitCommand(cmd, unit, *parent)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func newManager(config *configs.Cgroup) cgroups.Manager {
+	if cgroups.IsCgroup2UnifiedMode() {
+		return systemd.NewUnifiedManager(config, "", false)
+	}
+	return systemd.NewLegacyManager(config, nil)
+}
+
+func unitCommand(cmd, name, parent string) error {
+	podConfig := &configs.Cgroup{
+		Name:      name,
+		Parent:    parent,
+		Resources: &configs.Resources{},
+	}
+	pm := newManager(podConfig)
+
+	switch cmd {
+	case "start":
+		return pm.Apply(-1)
+	case "stop":
+		return pm.Destroy()
+	}
+
+	return fmt.Errorf("unknown command: %s", cmd)
+}

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
 )
 
 type CpuGroup struct{}
@@ -71,14 +73,32 @@ func (s *CpuGroup) Set(path string, r *configs.Resources) error {
 			return fmt.Errorf("the minimum allowed cpu-shares is %d", sharesRead)
 		}
 	}
+
+	var period string
 	if r.CpuPeriod != 0 {
-		if err := cgroups.WriteFile(path, "cpu.cfs_period_us", strconv.FormatUint(r.CpuPeriod, 10)); err != nil {
-			return err
+		period = strconv.FormatUint(r.CpuPeriod, 10)
+		if err := cgroups.WriteFile(path, "cpu.cfs_period_us", period); err != nil {
+			// Sometimes when the period to be set is smaller
+			// than the current one, it is rejected by the kernel
+			// (EINVAL) as old_quota/new_period exceeds the parent
+			// cgroup quota limit. If this happens and the quota is
+			// going to be set, ignore the error for now and retry
+			// after setting the quota.
+			if !errors.Is(err, unix.EINVAL) || r.CpuQuota == 0 {
+				return err
+			}
+		} else {
+			period = ""
 		}
 	}
 	if r.CpuQuota != 0 {
 		if err := cgroups.WriteFile(path, "cpu.cfs_quota_us", strconv.FormatInt(r.CpuQuota, 10)); err != nil {
 			return err
+		}
+		if period != "" {
+			if err := cgroups.WriteFile(path, "cpu.cfs_period_us", period); err != nil {
+				return err
+			}
 		}
 	}
 	return s.SetRtSched(path, r)

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -345,6 +345,15 @@ EOF
 	check_cpu_quota -1 1000000 "infinity"
 }
 
+@test "set cpu period with no quota (invalid period)" {
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+
+	update_config '.linux.resources.cpu |= { "period": 100 }'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 1 ]
+}
+
 @test "set cpu quota with no period" {
 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 


### PR DESCRIPTION
_This is based on (and currently includes) #3175._

I. As reported in issue #3084, sometimes setting CPU quota period fails
when a new period is lower and a parent cgroup has CPU quota limit set.

This happens as in cgroup v1 the quota and the period can not be set
together (this is fixed in v2), and since the period is being set first,
`new_limit = old_quota/new_period` may be higher than the parent
cgroup limit.

The fix is to retry setting the period after the quota, to cover all
possible scenarios.

Add a test case to cover a regression caused by an earlier version of
this patch (ignoring a failure of setting invalid period when quota is
not set).

Fixes: #3084
Closes: #2044

II. Add a test case for an issue fixed by the previous commit.
    
Unfortunately, this is somewhat complicated as there's no easy way to
create a transient unit, so a binary, sd-helper, had to be added. On top
of that, an ability to create a parent/pod cgroup is added to
helpers.bash, which might be useful for future integration tests.

#### History
* v2: rearranged, cleanups split to #3175, simplified sd-helper to not depend on urlfave/cli.