### PR TITLE
Fix typo 'execing' to 'executing'

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -27,7 +27,7 @@ import (
 
 var errEmptyID = errors.New("container id cannot be empty")
 
-// loadFactory returns the configured factory instance for execing containers.
+// loadFactory returns the configured factory instance for executing containers.
 func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	root := context.GlobalString("root")
 	abs, err := filepath.Abs(root)


### PR DESCRIPTION
Fix `execing` to `executing` in `utils_linux.go`

Signed-off-by: Yamazaki Masashi <masi19bw@gmail.com>