### PR TITLE
script/release.sh: make builds reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
 	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
-	-ldflags "-w -extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
+	-ldflags "-extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 
 .DEFAULT: runc
 

--- a/script/release.sh
+++ b/script/release.sh
@@ -33,6 +33,7 @@ function build_project() {
 	local libseccomp_ver='2.5.1'
 	local tarball="libseccomp-${libseccomp_ver}.tar.gz"
 	local prefix
+	local ldflags="-w -s"
 	prefix="$(mktemp -d)"
 	wget "https://github.com/seccomp/libseccomp/releases/download/v${libseccomp_ver}/${tarball}"{,.asc}
 	tar xf "$tarball"
@@ -46,8 +47,9 @@ function build_project() {
 	# Add -a to go build flags to make sure it links against
 	# the provided libseccomp, not the system one (otherwise
 	# it can reuse cached pkg-config results).
-	make -C "$root" PKG_CONFIG_PATH="${prefix}/lib/pkgconfig" COMMIT_NO= EXTRA_FLAGS="-a" static
+	make -C "$root" PKG_CONFIG_PATH="${prefix}/lib/pkgconfig" COMMIT_NO= EXTRA_FLAGS="-a" EXTRA_LDFLAGS="${ldflags}" static
 	rm -rf "$prefix"
+	strip "$root/$project"
 	mv "$root/$project" "$1"
 }
 

--- a/script/release.sh
+++ b/script/release.sh
@@ -33,7 +33,6 @@ function build_project() {
 	local libseccomp_ver='2.5.1'
 	local tarball="libseccomp-${libseccomp_ver}.tar.gz"
 	local prefix
-	local ldflags="-w -s"
 	prefix="$(mktemp -d)"
 	wget "https://github.com/seccomp/libseccomp/releases/download/v${libseccomp_ver}/${tarball}"{,.asc}
 	tar xf "$tarball"
@@ -44,6 +43,11 @@ function build_project() {
 	)
 	mv "$tarball"{,.asc} "$builddir"
 
+	# For reproducible builds, add these to EXTRA_LDFLAGS:
+	#  -w to disable DWARF generation;
+	#  -s to disable symbol table;
+	#  -buildid= to remove variable build id.
+	local ldflags="-w -s -buildid="
 	# Add -a to go build flags to make sure it links against
 	# the provided libseccomp, not the system one (otherwise
 	# it can reuse cached pkg-config results).


### PR DESCRIPTION
Carries #3054 (thanks to @kailun-qin).

What it takes is add an empty buildid, which, together with previously
added `strip` invocation, results in reproducible build!
    
NB: earlier versions of this patch also added the following:
1. non-random libseccomp install `$prefix`;
2. `objcopy --enable-deterministic-archives $prefix/lib/libseccomp.a`
       to strip ar dates and UIDs/GIDs;
3. `-B=0x00` to `EXTRA_LDFLAGS` to have non-variable NT_GNU_BUILD_ID.
    
Apparently, all this is not needed with `strip` in place.

Fixes: #2947.
Closes: #3054.
