### PR TITLE
Drop Go 1.13 support, require go 1.15+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Docker/Moby still builds runc with Go 1.13, so we should still support Go 1.13.
-        go-version: [1.13.x, 1.15.x, 1.16.x]
+        go-version: [1.15.x, 1.16.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
 

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ BUILDTAGS ?= seccomp
 COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION := $(shell cat ./VERSION)
 
-# TODO: rm -mod=vendor once go 1.13 is unsupported
-ifneq ($(GO111MODULE),off)
-	MOD_VENDOR := "-mod=vendor"
-endif
 ifeq ($(shell $(GO) env GOOS),linux)
 	ifeq (,$(filter $(shell $(GO) env GOARCH),mips mipsle mips64 mips64le ppc64))
 		ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
@@ -24,9 +20,9 @@ ifeq ($(shell $(GO) env GOOS),linux)
 		endif
 	endif
 endif
-GO_BUILD := $(GO) build -trimpath $(MOD_VENDOR) $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
+GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
 	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
-GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(MOD_VENDOR) $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
+GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
 	-ldflags "-w -extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 
 .DEFAULT: runc
@@ -73,7 +69,7 @@ unittest: runcimage
 		$(RUNC_IMAGE) make localunittest TESTFLAGS=$(TESTFLAGS)
 
 localunittest: all
-	$(GO) test $(MOD_VENDOR) -timeout 3m -tags "$(BUILDTAGS)" $(TESTFLAGS) -v ./...
+	$(GO) test -timeout 3m -tags "$(BUILDTAGS)" $(TESTFLAGS) -v ./...
 
 integration: runcimage
 	$(CONTAINER_ENGINE) run $(CONTAINER_ENGINE_RUN_FLAGS) \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A third party security audit was performed by Cure53, you can see the full repor
 ## Building
 
 `runc` currently supports the Linux platform with various architecture support.
-It must be built with Go version 1.14 or higher.
+It must be built with Go version 1.15 or higher.
 
 In order to enable seccomp support you will need to install `libseccomp` on your platform.
 > e.g. `libseccomp-devel` for CentOS, or `libseccomp-dev` for Ubuntu

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A third party security audit was performed by Cure53, you can see the full repor
 ## Building
 
 `runc` currently supports the Linux platform with various architecture support.
-It must be built with Go version 1.13 or higher.
+It must be built with Go version 1.14 or higher.
 
 In order to enable seccomp support you will need to install `libseccomp` on your platform.
 > e.g. `libseccomp-devel` for CentOS, or `libseccomp-dev` for Ubuntu

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/runc
 
-go 1.13
+go 1.15
 
 require (
 	github.com/bits-and-blooms/bitset v1.2.0

--- a/libcontainer/cgroups/fs/blkio_test.go
+++ b/libcontainer/cgroups/fs/blkio_test.go
@@ -179,7 +179,6 @@ func TestBlkioSetWeight(t *testing.T) {
 	for _, legacyIOScheduler := range []bool{false, true} {
 		// Populate cgroup
 		helper := NewCgroupTestUtil("blkio", t)
-		defer helper.cleanup()
 		weightFilename := "blkio.bfq.weight"
 		if legacyIOScheduler {
 			weightFilename = "blkio.weight"
@@ -215,7 +214,6 @@ func TestBlkioSetWeightDevice(t *testing.T) {
 	for _, legacyIOScheduler := range []bool{false, true} {
 		// Populate cgroup
 		helper := NewCgroupTestUtil("blkio", t)
-		defer helper.cleanup()
 		weightFilename := "blkio.bfq.weight"
 		weightDeviceFilename := "blkio.bfq.weight_device"
 		if legacyIOScheduler {
@@ -251,7 +249,6 @@ func TestBlkioSetWeightDevice(t *testing.T) {
 // regression #274
 func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 
 	const (
 		weightDeviceBefore = "8:0 400"
@@ -290,7 +287,6 @@ func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 
 func TestBlkioBFQDebugStats(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(blkioBFQDebugStatsTestFiles)
 	blkio := &BlkioGroup{}
 	actualStats := *cgroups.NewStats()
@@ -345,7 +341,6 @@ func TestBlkioBFQDebugStats(t *testing.T) {
 
 func TestBlkioMultipleStatsFiles(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(blkioBFQDebugStatsTestFiles)
 	helper.writeFileContents(blkioCFQStatsTestFiles)
 	blkio := &BlkioGroup{}
@@ -401,7 +396,6 @@ func TestBlkioMultipleStatsFiles(t *testing.T) {
 
 func TestBlkioBFQStats(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(blkioBFQStatsTestFiles)
 	blkio := &BlkioGroup{}
 	actualStats := *cgroups.NewStats()
@@ -468,7 +462,6 @@ func TestBlkioStatsNoFilesBFQDebug(t *testing.T) {
 
 	for _, testCase := range testCases {
 		helper := NewCgroupTestUtil("cpuset", t)
-		defer helper.cleanup()
 
 		tempBlkioTestFiles := map[string]string{}
 		for i, v := range blkioBFQDebugStatsTestFiles {
@@ -488,7 +481,6 @@ func TestBlkioStatsNoFilesBFQDebug(t *testing.T) {
 
 func TestBlkioCFQStats(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(blkioCFQStatsTestFiles)
 
 	blkio := &BlkioGroup{}
@@ -584,7 +576,6 @@ func TestBlkioStatsNoFilesCFQ(t *testing.T) {
 
 	for _, testCase := range testCases {
 		helper := NewCgroupTestUtil("cpuset", t)
-		defer helper.cleanup()
 
 		tempBlkioTestFiles := map[string]string{}
 		for i, v := range blkioCFQStatsTestFiles {
@@ -604,7 +595,6 @@ func TestBlkioStatsNoFilesCFQ(t *testing.T) {
 
 func TestBlkioStatsUnexpectedNumberOfFields(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "8:0 Read 100 100",
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -626,7 +616,6 @@ func TestBlkioStatsUnexpectedNumberOfFields(t *testing.T) {
 
 func TestBlkioStatsUnexpectedFieldType(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "8:0 Read Write",
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -648,7 +637,6 @@ func TestBlkioStatsUnexpectedFieldType(t *testing.T) {
 
 func TestThrottleRecursiveBlkioStats(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive":          "",
 		"blkio.io_serviced_recursive":               "",
@@ -699,7 +687,6 @@ func TestThrottleRecursiveBlkioStats(t *testing.T) {
 
 func TestThrottleBlkioStats(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "",
 		"blkio.io_serviced_recursive":      "",
@@ -750,7 +737,6 @@ func TestThrottleBlkioStats(t *testing.T) {
 
 func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 
 	const (
 		throttleBefore = `8:0 1024`
@@ -780,7 +766,6 @@ func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
 
 func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 
 	const (
 		throttleBefore = `8:0 1024`
@@ -810,7 +795,6 @@ func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
 
 func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 
 	const (
 		throttleBefore = `8:0 1024`
@@ -840,7 +824,6 @@ func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
 
 func TestBlkioSetThrottleWriteIOpsDevice(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
 
 	const (
 		throttleBefore = `8:0 1024`

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestCpuSetShares(t *testing.T) {
 	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
 
 	const (
 		sharesBefore = 1024
@@ -41,7 +40,6 @@ func TestCpuSetShares(t *testing.T) {
 
 func TestCpuSetBandWidth(t *testing.T) {
 	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
 
 	const (
 		quotaBefore     = 8000
@@ -105,7 +103,6 @@ func TestCpuSetBandWidth(t *testing.T) {
 
 func TestCpuStats(t *testing.T) {
 	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
 
 	const (
 		nrPeriods     = 2000
@@ -137,7 +134,6 @@ func TestCpuStats(t *testing.T) {
 
 func TestNoCpuStatFile(t *testing.T) {
 	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
 
 	cpu := &CpuGroup{}
 	actualStats := *cgroups.NewStats()
@@ -149,7 +145,7 @@ func TestNoCpuStatFile(t *testing.T) {
 
 func TestInvalidCpuStat(t *testing.T) {
 	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
+
 	cpuStatContent := `nr_periods 2000
 	nr_throttled 200
 	throttled_time fortytwo`
@@ -167,7 +163,6 @@ func TestInvalidCpuStat(t *testing.T) {
 
 func TestCpuSetRtSchedAtApply(t *testing.T) {
 	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
 
 	const (
 		rtRuntimeBefore = 0

--- a/libcontainer/cgroups/fs/cpuacct_test.go
+++ b/libcontainer/cgroups/fs/cpuacct_test.go
@@ -27,7 +27,6 @@ const (
 
 func TestCpuacctStats(t *testing.T) {
 	helper := NewCgroupTestUtil("cpuacct.", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"cpuacct.usage":        cpuAcctUsageContents,
 		"cpuacct.usage_percpu": cpuAcctUsagePerCPUContents,
@@ -68,7 +67,6 @@ func TestCpuacctStats(t *testing.T) {
 
 func TestCpuacctStatsWithoutUsageAll(t *testing.T) {
 	helper := NewCgroupTestUtil("cpuacct.", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"cpuacct.usage":        cpuAcctUsageContents,
 		"cpuacct.usage_percpu": cpuAcctUsagePerCPUContents,

--- a/libcontainer/cgroups/fs/cpuset_test.go
+++ b/libcontainer/cgroups/fs/cpuset_test.go
@@ -40,7 +40,6 @@ var cpusetTestFiles = map[string]string{
 
 func TestCPUSetSetCpus(t *testing.T) {
 	helper := NewCgroupTestUtil("cpuset", t)
-	defer helper.cleanup()
 
 	const (
 		cpusBefore = "0"
@@ -68,7 +67,6 @@ func TestCPUSetSetCpus(t *testing.T) {
 
 func TestCPUSetSetMems(t *testing.T) {
 	helper := NewCgroupTestUtil("cpuset", t)
-	defer helper.cleanup()
 
 	const (
 		memsBefore = "0"
@@ -96,7 +94,6 @@ func TestCPUSetSetMems(t *testing.T) {
 
 func TestCPUSetStatsCorrect(t *testing.T) {
 	helper := NewCgroupTestUtil("cpuset", t)
-	defer helper.cleanup()
 	helper.writeFileContents(cpusetTestFiles)
 
 	cpuset := &CpusetGroup{}
@@ -211,7 +208,6 @@ func TestCPUSetStatsMissingFiles(t *testing.T) {
 	} {
 		t.Run(testCase.desc, func(t *testing.T) {
 			helper := NewCgroupTestUtil("cpuset", t)
-			defer helper.cleanup()
 
 			tempCpusetTestFiles := map[string]string{}
 			for i, v := range cpusetTestFiles {

--- a/libcontainer/cgroups/fs/devices_test.go
+++ b/libcontainer/cgroups/fs/devices_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestDevicesSetAllow(t *testing.T) {
 	helper := NewCgroupTestUtil("devices", t)
-	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
 		"devices.allow": "",

--- a/libcontainer/cgroups/fs/freezer_test.go
+++ b/libcontainer/cgroups/fs/freezer_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestFreezerSetState(t *testing.T) {
 	helper := NewCgroupTestUtil("freezer", t)
-	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
 		"freezer.state": string(configs.Frozen),
@@ -34,7 +33,6 @@ func TestFreezerSetState(t *testing.T) {
 
 func TestFreezerSetInvalidState(t *testing.T) {
 	helper := NewCgroupTestUtil("freezer", t)
-	defer helper.cleanup()
 
 	const (
 		invalidArg configs.FreezerState = "Invalid"

--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -27,7 +27,6 @@ const (
 
 func TestHugetlbSetHugetlb(t *testing.T) {
 	helper := NewCgroupTestUtil("hugetlb", t)
-	defer helper.cleanup()
 
 	const (
 		hugetlbBefore = 256
@@ -67,7 +66,6 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 
 func TestHugetlbStats(t *testing.T) {
 	helper := NewCgroupTestUtil("hugetlb", t)
-	defer helper.cleanup()
 	for _, pageSize := range HugePageSizes {
 		helper.writeFileContents(map[string]string{
 			fmt.Sprintf(usage, pageSize):    hugetlbUsageContents,
@@ -90,7 +88,6 @@ func TestHugetlbStats(t *testing.T) {
 
 func TestHugetlbStatsNoUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("hugetlb", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		maxUsage: hugetlbMaxUsageContents,
 	})
@@ -105,7 +102,6 @@ func TestHugetlbStatsNoUsageFile(t *testing.T) {
 
 func TestHugetlbStatsNoMaxUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("hugetlb", t)
-	defer helper.cleanup()
 	for _, pageSize := range HugePageSizes {
 		helper.writeFileContents(map[string]string{
 			fmt.Sprintf(usage, pageSize): hugetlbUsageContents,
@@ -122,7 +118,6 @@ func TestHugetlbStatsNoMaxUsageFile(t *testing.T) {
 
 func TestHugetlbStatsBadUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("hugetlb", t)
-	defer helper.cleanup()
 	for _, pageSize := range HugePageSizes {
 		helper.writeFileContents(map[string]string{
 			fmt.Sprintf(usage, pageSize): "bad",
@@ -140,7 +135,6 @@ func TestHugetlbStatsBadUsageFile(t *testing.T) {
 
 func TestHugetlbStatsBadMaxUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("hugetlb", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		usage:    hugetlbUsageContents,
 		maxUsage: "bad",

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -41,7 +41,6 @@ whatever=100 N0=0
 
 func TestMemorySetMemory(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 
 	const (
 		memoryBefore      = 314572800 // 300M
@@ -81,7 +80,6 @@ func TestMemorySetMemory(t *testing.T) {
 
 func TestMemorySetMemoryswap(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 
 	const (
 		memoryswapBefore = 314572800 // 300M
@@ -109,7 +107,6 @@ func TestMemorySetMemoryswap(t *testing.T) {
 
 func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 
 	const (
 		memoryBefore     = 314572800 // 300M
@@ -154,7 +151,6 @@ func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
 
 func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 
 	const (
 		memoryBefore     = 629145600 // 600M
@@ -194,7 +190,6 @@ func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
 
 func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 
 	swappinessBefore := 60 // default is 60
 	swappinessAfter := uint64(0)
@@ -220,7 +215,6 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 
 func TestMemoryStats(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":                     memoryStatContents,
 		"memory.usage_in_bytes":           memoryUsageContents,
@@ -272,7 +266,6 @@ func TestMemoryStats(t *testing.T) {
 
 func TestMemoryStatsNoStatFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -289,7 +282,6 @@ func TestMemoryStatsNoStatFile(t *testing.T) {
 
 func TestMemoryStatsNoUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -306,7 +298,6 @@ func TestMemoryStatsNoUsageFile(t *testing.T) {
 
 func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":           memoryStatContents,
 		"memory.usage_in_bytes": memoryUsageContents,
@@ -323,7 +314,6 @@ func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
 
 func TestMemoryStatsNoLimitInBytesFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
@@ -340,7 +330,6 @@ func TestMemoryStatsNoLimitInBytesFile(t *testing.T) {
 
 func TestMemoryStatsBadStatFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               "rss rss",
 		"memory.usage_in_bytes":     memoryUsageContents,
@@ -358,7 +347,6 @@ func TestMemoryStatsBadStatFile(t *testing.T) {
 
 func TestMemoryStatsBadUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     "bad",
@@ -376,7 +364,6 @@ func TestMemoryStatsBadUsageFile(t *testing.T) {
 
 func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
@@ -394,7 +381,6 @@ func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
 
 func TestMemoryStatsBadLimitInBytesFile(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
@@ -412,7 +398,6 @@ func TestMemoryStatsBadLimitInBytesFile(t *testing.T) {
 
 func TestMemorySetOomControl(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 
 	const (
 		oomKillDisable = 1 // disable oom killer, default is 0
@@ -438,7 +423,6 @@ func TestMemorySetOomControl(t *testing.T) {
 
 func TestNoHierarchicalNumaStat(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.numa_stat": memoryNUMAStatNoHierarchyContents + memoryNUMAStatExtraContents,
 	})
@@ -489,7 +473,6 @@ anon=183 N0=12 badone
 		},
 	}
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 	for _, c := range memoryNUMAStatBadContents {
 		helper.writeFileContents(map[string]string{
 			"memory.numa_stat": c.contents,
@@ -504,7 +487,6 @@ anon=183 N0=12 badone
 
 func TestWithoutNumaStat(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
 
 	actualStats, err := getPageUsageByNUMA(helper.CgroupPath)
 	if err != nil {

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -16,7 +16,6 @@ const (
 
 func TestNetClsSetClassid(t *testing.T) {
 	helper := NewCgroupTestUtil("net_cls", t)
-	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
 		"net_cls.classid": strconv.FormatUint(classidBefore, 10),

--- a/libcontainer/cgroups/fs/net_prio_test.go
+++ b/libcontainer/cgroups/fs/net_prio_test.go
@@ -19,7 +19,6 @@ var prioMap = []*configs.IfPrioMap{
 
 func TestNetPrioSetIfPrio(t *testing.T) {
 	helper := NewCgroupTestUtil("net_prio", t)
-	defer helper.cleanup()
 
 	helper.CgroupData.config.Resources.NetPrioIfpriomap = prioMap
 	netPrio := &NetPrioGroup{}

--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -17,7 +17,6 @@ const (
 
 func TestPidsSetMax(t *testing.T) {
 	helper := NewCgroupTestUtil("pids", t)
-	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
 		"pids.max": "max",
@@ -40,7 +39,6 @@ func TestPidsSetMax(t *testing.T) {
 
 func TestPidsSetUnlimited(t *testing.T) {
 	helper := NewCgroupTestUtil("pids", t)
-	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
 		"pids.max": strconv.Itoa(maxLimited),
@@ -63,7 +61,6 @@ func TestPidsSetUnlimited(t *testing.T) {
 
 func TestPidsStats(t *testing.T) {
 	helper := NewCgroupTestUtil("pids", t)
-	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
 		"pids.current": strconv.Itoa(1337),
@@ -87,7 +84,6 @@ func TestPidsStats(t *testing.T) {
 
 func TestPidsStatsUnlimited(t *testing.T) {
 	helper := NewCgroupTestUtil("pids", t)
-	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
 		"pids.current": strconv.Itoa(4096),

--- a/libcontainer/cgroups/fs/util_test.go
+++ b/libcontainer/cgroups/fs/util_test.go
@@ -8,7 +8,6 @@ Creates a mock of the cgroup filesystem for the duration of the test.
 package fs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,37 +27,23 @@ type cgroupTestUtil struct {
 	// Path to the mock cgroup directory.
 	CgroupPath string
 
-	// Temporary directory to store mock cgroup filesystem.
-	tempDir string
-	t       *testing.T
+	t *testing.T
 }
 
 // Creates a new test util for the specified subsystem
 func NewCgroupTestUtil(subsystem string, t *testing.T) *cgroupTestUtil {
 	d := &cgroupData{
-		config: &configs.Cgroup{},
+		config: &configs.Cgroup{
+			Resources: &configs.Resources{},
+		},
+		root: t.TempDir(),
 	}
-	d.config.Resources = &configs.Resources{}
-	tempDir, err := ioutil.TempDir("", "cgroup_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	d.root = tempDir
 	testCgroupPath := filepath.Join(d.root, subsystem)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Ensure the full mock cgroup path exists.
-	err = os.MkdirAll(testCgroupPath, 0o755)
-	if err != nil {
+	if err := os.MkdirAll(testCgroupPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	return &cgroupTestUtil{CgroupData: d, CgroupPath: testCgroupPath, tempDir: tempDir, t: t}
-}
-
-func (c *cgroupTestUtil) cleanup() {
-	os.RemoveAll(c.tempDir)
+	return &cgroupTestUtil{CgroupData: d, CgroupPath: testCgroupPath, t: t}
 }
 
 // Write the specified contents on the mock of the specified cgroup files.

--- a/libcontainer/cgroups/fs2/io_test.go
+++ b/libcontainer/cgroups/fs2/io_test.go
@@ -2,7 +2,6 @@ package fs2
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -60,11 +59,7 @@ func TestStatIo(t *testing.T) {
 	// We're using a fake cgroupfs.
 	cgroups.TestMode = true
 
-	fakeCgroupDir, err := ioutil.TempDir("", "runc-stat-io-test.*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(fakeCgroupDir)
+	fakeCgroupDir := t.TempDir()
 	statPath := filepath.Join(fakeCgroupDir, "io.stat")
 
 	if err := ioutil.WriteFile(statPath, []byte(exampleIoStatData), 0o644); err != nil {

--- a/libcontainer/cgroups/fscommon/utils.go
+++ b/libcontainer/cgroups/fscommon/utils.go
@@ -3,6 +3,7 @@
 package fscommon
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"path"
@@ -45,10 +46,7 @@ func ParseUint(s string, base, bitSize int) (uint64, error) {
 		// 2. Handle negative values lesser than MinInt64
 		if intErr == nil && intValue < 0 {
 			return 0, nil
-			// Note errors.Is is not working for strconv errors in Go 1.13,
-			// see https://github.com/golang/go/issues/36325.
-			// TODO: remove nolint and switch to errors.Is once we stop supporting Go 1.13.
-		} else if intErr != nil && intErr.(*strconv.NumError).Err == strconv.ErrRange && intValue < 0 { //nolint:errorlint
+		} else if errors.Is(intErr, strconv.ErrRange) && intValue < 0 {
 			return 0, nil
 		}
 

--- a/libcontainer/cgroups/fscommon/utils_test.go
+++ b/libcontainer/cgroups/fscommon/utils_test.go
@@ -25,16 +25,11 @@ func init() {
 
 func TestGetCgroupParamsInt(t *testing.T) {
 	// Setup tempdir.
-	tempDir, err := ioutil.TempDir("", "cgroup_utils_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, cgroupFile)
 
 	// Success.
-	err = ioutil.WriteFile(tempFile, []byte(floatString), 0o755)
-	if err != nil {
+	if err := ioutil.WriteFile(tempFile, []byte(floatString), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	value, err := GetCgroupParamUint(tempDir, cgroupFile)

--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -1,7 +1,6 @@
 package validate_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -264,13 +263,7 @@ func TestValidateSysctlWithBindHostNetNS(t *testing.T) {
 
 	const selfnet = "/proc/self/ns/net"
 
-	dir, err := ioutil.TempDir("", t.Name()+"-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(dir)
-
-	file := filepath.Join(dir, "default")
+	file := filepath.Join(t.TempDir(), "default")
 	fd, err := os.Create(file)
 	if err != nil {
 		t.Fatal(err)

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -4,7 +4,6 @@ package libcontainer
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -339,14 +338,8 @@ func TestGetContainerStateAfterUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootDir, err := ioutil.TempDir("", "TestGetContainerStateAfterUpdate")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
-
 	container := &linuxContainer{
-		root: rootDir,
+		root: t.TempDir(),
 		id:   "myid",
 		config: &configs.Config{
 			Namespaces: []configs.Namespace{

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -4,7 +4,6 @@ package libcontainer
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,20 +17,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func newTestRoot() (string, error) {
-	dir, err := ioutil.TempDir("", "libcontainer")
-	if err != nil {
-		return "", err
-	}
-	return dir, nil
-}
-
 func TestFactoryNew(t *testing.T) {
-	root, rerr := newTestRoot()
-	if rerr != nil {
-		t.Fatal(rerr)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	factory, err := New(root, Cgroupfs)
 	if err != nil {
 		t.Fatal(err)
@@ -53,11 +40,7 @@ func TestFactoryNew(t *testing.T) {
 }
 
 func TestFactoryNewIntelRdt(t *testing.T) {
-	root, rerr := newTestRoot()
-	if rerr != nil {
-		t.Fatal(rerr)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	factory, err := New(root, Cgroupfs, IntelRdtFs)
 	if err != nil {
 		t.Fatal(err)
@@ -79,11 +62,7 @@ func TestFactoryNewIntelRdt(t *testing.T) {
 }
 
 func TestFactoryNewTmpfs(t *testing.T) {
-	root, rerr := newTestRoot()
-	if rerr != nil {
-		t.Fatal(rerr)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	factory, err := New(root, Cgroupfs, TmpfsRoot)
 	if err != nil {
 		t.Fatal(err)
@@ -130,12 +109,7 @@ func TestFactoryNewTmpfs(t *testing.T) {
 }
 
 func TestFactoryLoadNotExists(t *testing.T) {
-	root, rerr := newTestRoot()
-	if rerr != nil {
-		t.Fatal(rerr)
-	}
-	defer os.RemoveAll(root) //nolint: errcheck
-	factory, err := New(root, Cgroupfs)
+	factory, err := New(t.TempDir(), Cgroupfs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,11 +123,7 @@ func TestFactoryLoadNotExists(t *testing.T) {
 }
 
 func TestFactoryLoadContainer(t *testing.T) {
-	root, err := newTestRoot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(root) //nolint: errcheck
+	root := t.TempDir()
 	// setup default container config and state for mocking
 	var (
 		id            = "1"

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -38,13 +38,7 @@ func testExecPS(t *testing.T, userns bool) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{
-		rootfs: rootfs,
-		userns: userns,
-	})
+	config := newTemplateConfig(t, &tParam{userns: userns})
 
 	buffers, exitCode, err := runContainer(t, config, "", "ps", "-o", "pid,user,comm")
 	if err != nil {
@@ -69,14 +63,10 @@ func TestIPCPrivate(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	l, err := os.Readlink("/proc/1/ns/ipc")
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	buffers, exitCode, err := runContainer(t, config, "", "readlink", "/proc/self/ns/ipc")
 	ok(t, err)
 
@@ -94,14 +84,10 @@ func TestIPCHost(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	l, err := os.Readlink("/proc/1/ns/ipc")
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Namespaces.Remove(configs.NEWIPC)
 	buffers, exitCode, err := runContainer(t, config, "", "readlink", "/proc/self/ns/ipc")
 	ok(t, err)
@@ -120,14 +106,10 @@ func TestIPCJoinPath(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	l, err := os.Readlink("/proc/1/ns/ipc")
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Namespaces.Add(configs.NEWIPC, "/proc/1/ns/ipc")
 
 	buffers, exitCode, err := runContainer(t, config, "", "readlink", "/proc/self/ns/ipc")
@@ -147,15 +129,10 @@ func TestIPCBadPath(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Namespaces.Add(configs.NEWIPC, "/proc/1/ns/ipcc")
 
-	_, _, err = runContainer(t, config, "", "true")
-	if err == nil {
+	if _, _, err := runContainer(t, config, "", "true"); err == nil {
 		t.Fatal("container succeeded with bad ipc path")
 	}
 }
@@ -177,14 +154,7 @@ func testRlimit(t *testing.T, userns bool) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{
-		rootfs: rootfs,
-		userns: userns,
-	})
+	config := newTemplateConfig(t, &tParam{userns: userns})
 
 	// ensure limit is lower than what the config requests to test that in a user namespace
 	// the Setrlimit call happens early enough that we still have permissions to raise the limit.
@@ -205,11 +175,7 @@ func TestEnter(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 
 	container, err := newContainer(t, config)
 	ok(t, err)
@@ -292,12 +258,7 @@ func TestProcessEnv(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
-
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -340,11 +301,7 @@ func TestProcessEmptyCaps(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Capabilities = nil
 
 	container, err := newContainer(t, config)
@@ -389,12 +346,7 @@ func TestProcessCaps(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
-
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -454,12 +406,8 @@ func TestAdditionalGroups(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
-
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -521,14 +469,7 @@ func testFreeze(t *testing.T, withSystemd bool, useSet bool) {
 		t.Skip("Test requires systemd.")
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{
-		rootfs:  rootfs,
-		systemd: withSystemd,
-	})
+	config := newTemplateConfig(t, &tParam{systemd: withSystemd})
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -593,18 +534,10 @@ func testCpuShares(t *testing.T, systemd bool) {
 		t.Skip("cgroup v2 does not support CpuShares")
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{
-		rootfs:  rootfs,
-		systemd: systemd,
-	})
+	config := newTemplateConfig(t, &tParam{systemd: systemd})
 	config.Cgroups.Resources.CpuShares = 1
 
-	_, _, err = runContainer(t, config, "", "ps")
-	if err == nil {
+	if _, _, err := runContainer(t, config, "", "ps"); err == nil {
 		t.Fatalf("runContainer should failed with invalid CpuShares")
 	}
 }
@@ -625,14 +558,7 @@ func testPids(t *testing.T, systemd bool) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{
-		rootfs:  rootfs,
-		systemd: systemd,
-	})
+	config := newTemplateConfig(t, &tParam{systemd: systemd})
 	config.Cgroups.Resources.PidsLimit = -1
 
 	// Running multiple processes.
@@ -701,18 +627,12 @@ func testCgroupResourcesUnifiedErrorOnV1(t *testing.T, systemd bool) {
 	if cgroups.IsCgroup2UnifiedMode() {
 		t.Skip("requires cgroup v1")
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
 
-	config := newTemplateConfig(t, &tParam{
-		rootfs:  rootfs,
-		systemd: systemd,
-	})
+	config := newTemplateConfig(t, &tParam{systemd: systemd})
 	config.Cgroups.Resources.Unified = map[string]string{
 		"memory.min": "10240",
 	}
-	_, _, err = runContainer(t, config, "", "true")
+	_, _, err := runContainer(t, config, "", "true")
 	if !strings.Contains(err.Error(), cgroups.ErrV1NoUnified.Error()) {
 		t.Fatalf("expected error to contain %v, got %v", cgroups.ErrV1NoUnified, err)
 	}
@@ -736,14 +656,8 @@ func testCgroupResourcesUnified(t *testing.T, systemd bool) {
 	if !cgroups.IsCgroup2UnifiedMode() {
 		t.Skip("requires cgroup v2")
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
 
-	config := newTemplateConfig(t, &tParam{
-		rootfs:  rootfs,
-		systemd: systemd,
-	})
+	config := newTemplateConfig(t, &tParam{systemd: systemd})
 	config.Cgroups.Resources.Memory = 536870912     // 512M
 	config.Cgroups.Resources.MemorySwap = 536870912 // 512M, i.e. no swap
 	config.Namespaces.Add(configs.NEWCGROUP, "")
@@ -832,14 +746,10 @@ func TestContainerState(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	l, err := os.Readlink("/proc/1/ns/ipc")
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Namespaces = configs.Namespaces([]configs.Namespace{
 		{Type: configs.NEWNS},
 		{Type: configs.NEWUTS},
@@ -885,12 +795,7 @@ func TestPassExtraFiles(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
-
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -940,15 +845,9 @@ func TestMountCmds(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	tmpDir, err := ioutil.TempDir("", "tmpdir")
-	ok(t, err)
-	defer remove(tmpDir)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	tmpDir := t.TempDir()
+	config := newTemplateConfig(t, nil)
+	rootfs := config.Rootfs
 	config.Mounts = append(config.Mounts, &configs.Mount{
 		Source:      tmpDir,
 		Destination: "/tmp",
@@ -995,11 +894,7 @@ func TestSysctl(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Sysctl = map[string]string{
 		"kernel.shmmni": "8192",
 	}
@@ -1033,10 +928,7 @@ func TestMountCgroupRO(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	buffers, exitCode, err := runContainer(t, config, "", "mount")
 	if err != nil {
 		t.Fatalf("%s: %s", buffers, err)
@@ -1075,10 +967,7 @@ func TestMountCgroupRW(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	// clear the RO flag from cgroup mount
 	for _, m := range config.Mounts {
 		if m.Device == "cgroup" {
@@ -1126,11 +1015,7 @@ func TestOomScoreAdj(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.OomScoreAdj = ptrInt(200)
 
 	container, err := newContainer(t, config)
@@ -1164,16 +1049,8 @@ func TestHook(t *testing.T) {
 		return
 	}
 
-	bundle, err := newTestBundle()
-	ok(t, err)
-	defer remove(bundle)
-
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
-	expectedBundle := bundle
+	config := newTemplateConfig(t, nil)
+	expectedBundle := t.TempDir()
 	config.Labels = append(config.Labels, "bundle="+expectedBundle)
 
 	getRootfsFromBundle := func(bundle string) (string, error) {
@@ -1270,7 +1147,7 @@ func TestHook(t *testing.T) {
 	}
 
 	// write config of json format into config.json under bundle
-	f, err := os.OpenFile(filepath.Join(bundle, "config.json"), os.O_CREATE|os.O_RDWR, 0o644)
+	f, err := os.OpenFile(filepath.Join(expectedBundle, "config.json"), os.O_CREATE|os.O_RDWR, 0o644)
 	ok(t, err)
 	ok(t, json.NewEncoder(f).Encode(config))
 
@@ -1303,7 +1180,7 @@ func TestHook(t *testing.T) {
 	}
 
 	for _, hook := range []string{"prestart", "createRuntime", "poststart"} {
-		fi, err := os.Stat(filepath.Join(rootfs, hook))
+		fi, err := os.Stat(filepath.Join(config.Rootfs, hook))
 		if err == nil || !os.IsNotExist(err) {
 			t.Fatalf("expected file '%s to not exists, but it does", fi.Name())
 		}
@@ -1315,10 +1192,7 @@ func TestSTDIOPermissions(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	buffers, exitCode, err := runContainer(t, config, "", "sh", "-c", "echo hi > /dev/stderr")
 	ok(t, err)
 	if exitCode != 0 {
@@ -1348,21 +1222,15 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
-
+	config := newTemplateConfig(t, nil)
 	config.RootPropagation = unix.MS_SLAVE | unix.MS_REC
 
-	// Bind mount a volume
-	dir1host, err := ioutil.TempDir("", "mnt1host")
-	ok(t, err)
-	defer remove(dir1host)
+	// Bind mount a volume.
+	dir1host := t.TempDir()
 
 	// Make this dir a "shared" mount point. This will make sure a
 	// slave relationship can be established in container.
-	err = unix.Mount(dir1host, dir1host, "bind", unix.MS_BIND|unix.MS_REC, "")
+	err := unix.Mount(dir1host, dir1host, "bind", unix.MS_BIND|unix.MS_REC, "")
 	ok(t, err)
 	err = unix.Mount("", dir1host, "", unix.MS_SHARED|unix.MS_REC, "")
 	ok(t, err)
@@ -1395,9 +1263,10 @@ func TestRootfsPropagationSlaveMount(t *testing.T) {
 	defer stdinW.Close() //nolint: errcheck
 	ok(t, err)
 
-	// Create mnt1host/mnt2host and bind mount itself on top of it. This
-	// should be visible in container.
-	dir2host, err := ioutil.TempDir(dir1host, "mnt2host")
+	// Create mnt2host under dir1host and bind mount itself on top of it.
+	// This should be visible in container.
+	dir2host := filepath.Join(dir1host, "mnt2host")
+	err = os.Mkdir(dir2host, 0o700)
 	ok(t, err)
 	defer remove(dir2host)
 
@@ -1465,20 +1334,15 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.RootPropagation = unix.MS_PRIVATE
 
-	// Bind mount a volume
-	dir1host, err := ioutil.TempDir("", "mnt1host")
-	ok(t, err)
-	defer remove(dir1host)
+	// Bind mount a volume.
+	dir1host := t.TempDir()
 
 	// Make this dir a "shared" mount point. This will make sure a
 	// shared relationship can be established in container.
-	err = unix.Mount(dir1host, dir1host, "bind", unix.MS_BIND|unix.MS_REC, "")
+	err := unix.Mount(dir1host, dir1host, "bind", unix.MS_BIND|unix.MS_REC, "")
 	ok(t, err)
 	err = unix.Mount("", dir1host, "", unix.MS_SHARED|unix.MS_REC, "")
 	ok(t, err)
@@ -1511,10 +1375,11 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 	defer stdinW.Close() //nolint: errcheck
 	ok(t, err)
 
-	// Create mnt1host/mnt2cont.  This will become visible inside container
+	// Create mnt2cont under dir1host. This will become visible inside container
 	// at mnt1cont/mnt2cont. Bind mount itself on top of it. This
 	// should be visible on host now.
-	dir2host, err := ioutil.TempDir(dir1host, "mnt2cont")
+	dir2host := filepath.Join(dir1host, "mnt2cont")
+	err = os.Mkdir(dir2host, 0o700)
 	ok(t, err)
 	defer remove(dir2host)
 
@@ -1571,14 +1436,10 @@ func TestPIDHost(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	l, err := os.Readlink("/proc/1/ns/pid")
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Namespaces.Remove(configs.NEWPID)
 	buffers, exitCode, err := runContainer(t, config, "", "readlink", "/proc/self/ns/pid")
 	ok(t, err)
@@ -1597,14 +1458,10 @@ func TestPIDHostInitProcessWait(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	pidns := "/proc/1/ns/pid"
 
 	// Run a container with two long-running processes.
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Namespaces.Add(configs.NEWPID, pidns)
 	container, err := newContainer(t, config)
 	ok(t, err)
@@ -1649,12 +1506,9 @@ func TestInitJoinPID(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	// Execute a long-running container
-	container1, err := newContainer(t, newTemplateConfig(t, &tParam{rootfs: rootfs}))
+	config1 := newTemplateConfig(t, nil)
+	container1, err := newContainer(t, config1)
 	ok(t, err)
 	defer destroyContainer(container1)
 
@@ -1678,7 +1532,7 @@ func TestInitJoinPID(t *testing.T) {
 	pidns1 := state1.NamespacePaths[configs.NEWPID]
 
 	// Run a container inside the existing pidns but with different cgroups
-	config2 := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config2 := newTemplateConfig(t, nil)
 	config2.Namespaces.Add(configs.NEWPID, pidns1)
 	config2.Cgroups.Path = "integration/test2"
 	container2, err := newContainer(t, config2)
@@ -1752,15 +1606,9 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
 
 	// Execute a long-running container
-	config1 := newTemplateConfig(t, &tParam{
-		rootfs: rootfs,
-		userns: true,
-	})
+	config1 := newTemplateConfig(t, &tParam{userns: true})
 	container1, err := newContainer(t, config1)
 	ok(t, err)
 	defer destroyContainer(container1)
@@ -1785,15 +1633,8 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 	netns1 := state1.NamespacePaths[configs.NEWNET]
 	userns1 := state1.NamespacePaths[configs.NEWUSER]
 
-	// Run a container inside the existing pidns but with different cgroups
-	rootfs2, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs2)
-
-	config2 := newTemplateConfig(t, &tParam{
-		rootfs: rootfs2,
-		userns: true,
-	})
+	// Run a container inside the existing pidns but with different cgroups.
+	config2 := newTemplateConfig(t, &tParam{userns: true})
 	config2.Namespaces.Add(configs.NEWNET, netns1)
 	config2.Namespaces.Add(configs.NEWUSER, userns1)
 	config2.Cgroups.Path = "integration/test2"
@@ -1847,12 +1688,7 @@ func TestTmpfsCopyUp(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
-
+	config := newTemplateConfig(t, nil)
 	config.Mounts = append(config.Mounts, &configs.Mount{
 		Source:      "tmpfs",
 		Destination: "/etc",
@@ -1894,14 +1730,10 @@ func TestCGROUPPrivate(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	l, err := os.Readlink("/proc/1/ns/cgroup")
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Namespaces.Add(configs.NEWCGROUP, "")
 	buffers, exitCode, err := runContainer(t, config, "", "readlink", "/proc/self/ns/cgroup")
 	ok(t, err)
@@ -1923,14 +1755,10 @@ func TestCGROUPHost(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	l, err := os.Readlink("/proc/1/ns/cgroup")
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	buffers, exitCode, err := runContainer(t, config, "", "readlink", "/proc/self/ns/cgroup")
 	ok(t, err)
 
@@ -1959,10 +1787,6 @@ func testFdLeaks(t *testing.T, systemd bool) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	pfd, err := os.Open("/proc/self/fd")
 	ok(t, err)
 	defer pfd.Close()
@@ -1971,10 +1795,7 @@ func testFdLeaks(t *testing.T, systemd bool) {
 	_, err = pfd.Seek(0, 0)
 	ok(t, err)
 
-	config := newTemplateConfig(t, &tParam{
-		rootfs:  rootfs,
-		systemd: systemd,
-	})
+	config := newTemplateConfig(t, &tParam{systemd: systemd})
 	buffers, exitCode, err := runContainer(t, config, "", "true")
 	ok(t, err)
 

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -22,10 +22,7 @@ func TestExecIn(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -87,15 +84,7 @@ func testExecInRlimit(t *testing.T, userns bool) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{
-		rootfs: rootfs,
-		userns: userns,
-	})
-
+	config := newTemplateConfig(t, &tParam{userns: userns})
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -146,11 +135,7 @@ func TestExecInAdditionalGroups(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -204,10 +189,7 @@ func TestExecInError(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -258,10 +240,7 @@ func TestExecInTTY(t *testing.T) {
 		return
 	}
 	t.Skip("racy; see https://github.com/opencontainers/runc/issues/2425")
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -352,10 +331,7 @@ func TestExecInEnvironment(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -412,11 +388,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)
@@ -481,10 +453,7 @@ func TestExecInOomScoreAdj(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.OomScoreAdj = ptrInt(200)
 	container, err := newContainer(t, config)
 	ok(t, err)
@@ -533,13 +502,7 @@ func TestExecInUserns(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{
-		rootfs: rootfs,
-		userns: true,
-	})
+	config := newTemplateConfig(t, &tParam{userns: true})
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)

--- a/libcontainer/integration/init_test.go
+++ b/libcontainer/integration/init_test.go
@@ -28,18 +28,9 @@ func init() {
 	}
 }
 
-var testRoots []string
-
 func TestMain(m *testing.M) {
 	logrus.SetOutput(os.Stderr)
 	logrus.SetLevel(logrus.InfoLevel)
-
-	// Clean up roots after running everything.
-	defer func() {
-		for _, root := range testRoots {
-			os.RemoveAll(root)
-		}
-	}()
 
 	ret := m.Run()
 	os.Exit(ret)

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -17,13 +17,9 @@ func TestSeccompDenyGetcwdWithErrno(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
 	errnoRet := uint(syscall.ESRCH)
 
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -83,11 +79,7 @@ func TestSeccompDenyGetcwd(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -146,11 +138,7 @@ func TestSeccompPermitWriteConditional(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -202,11 +190,7 @@ func TestSeccompDenyWriteConditional(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -274,11 +258,7 @@ func TestSeccompPermitWriteMultipleConditions(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -327,11 +307,7 @@ func TestSeccompDenyWriteMultipleConditions(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -374,12 +350,8 @@ func TestSeccompMultipleConditionSameArgDeniesStdout(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	// Prevent writing to both stdout and stderr
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	// Prevent writing to both stdout and stderr.
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{
@@ -420,12 +392,8 @@ func TestSeccompMultipleConditionSameArgDeniesStderr(t *testing.T) {
 		return
 	}
 
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-
-	// Prevent writing to both stdout and stderr
-	config := newTemplateConfig(t, &tParam{rootfs: rootfs})
+	// Prevent writing to both stdout and stderr.
+	config := newTemplateConfig(t, nil)
 	config.Seccomp = &configs.Seccomp{
 		DefaultAction: configs.Allow,
 		Syscalls: []*configs.Syscall{

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -22,22 +22,26 @@ var standardEnvironment = []string{
 const defaultMountFlags = unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV
 
 type tParam struct {
-	rootfs  string
 	userns  bool
 	systemd bool
 }
 
-// newTemplateConfig returns a base template for running a container
+// newTemplateConfig returns a base template for running a container.
 //
-// it uses a network strategy of just setting a loopback interface
-// and the default setup for devices
+// It uses a network strategy of just setting a loopback interface
+// and the default setup for devices.
+//
+// If p is nil, a default container is created.
 func newTemplateConfig(t *testing.T, p *tParam) *configs.Config {
 	var allowedDevices []*devices.Rule
 	for _, device := range specconv.AllowedDevices {
 		allowedDevices = append(allowedDevices, &device.Rule)
 	}
+	if p == nil {
+		p = &tParam{}
+	}
 	config := &configs.Config{
-		Rootfs: p.rootfs,
+		Rootfs: newRootfs(t),
 		Capabilities: &configs.Capabilities{
 			Bounding: []string{
 				"CAP_CHOWN",

--- a/libcontainer/integration/update_test.go
+++ b/libcontainer/integration/update_test.go
@@ -15,13 +15,7 @@ func testUpdateDevices(t *testing.T, systemd bool) {
 	if testing.Short() {
 		return
 	}
-	rootfs, err := newRootfs()
-	ok(t, err)
-	defer remove(rootfs)
-	config := newTemplateConfig(t, &tParam{
-		rootfs:  rootfs,
-		systemd: systemd,
-	})
+	config := newTemplateConfig(t, &tParam{systemd: systemd})
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer destroyContainer(container)

--- a/libcontainer/intelrdt/cmt_test.go
+++ b/libcontainer/intelrdt/cmt_test.go
@@ -1,7 +1,6 @@
 package intelrdt
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -13,18 +12,7 @@ func TestGetCMTNumaNodeStats(t *testing.T) {
 		"llc_occupancy": 9123911,
 	}
 
-	mockedL3_MON, err := mockResctrlL3_MON(mocksNUMANodesToCreate, mocksFilesToCreate)
-
-	defer func() {
-		err := os.RemoveAll(mockedL3_MON)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockedL3_MON := mockResctrlL3_MON(t, mocksNUMANodesToCreate, mocksFilesToCreate)
 
 	t.Run("Gather mbm", func(t *testing.T) {
 		enabledMonFeatures.llcOccupancy = true

--- a/libcontainer/intelrdt/intelrdt_test.go
+++ b/libcontainer/intelrdt/intelrdt_test.go
@@ -15,7 +15,6 @@ func TestIntelRdtSetL3CacheSchema(t *testing.T) {
 	}
 
 	helper := NewIntelRdtTestUtil(t)
-	defer helper.cleanup()
 
 	const (
 		l3CacheSchemaBefore = "L3:0=f;1=f0"
@@ -50,7 +49,6 @@ func TestIntelRdtSetMemBwSchema(t *testing.T) {
 	}
 
 	helper := NewIntelRdtTestUtil(t)
-	defer helper.cleanup()
 
 	const (
 		memBwSchemaBefore = "MB:0=20;1=70"
@@ -85,7 +83,6 @@ func TestIntelRdtSetMemBwScSchema(t *testing.T) {
 	}
 
 	helper := NewIntelRdtTestUtil(t)
-	defer helper.cleanup()
 
 	const (
 		memBwScSchemaBefore = "MB:0=5000;1=7000"

--- a/libcontainer/intelrdt/mbm_test.go
+++ b/libcontainer/intelrdt/mbm_test.go
@@ -3,7 +3,6 @@
 package intelrdt
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -16,18 +15,7 @@ func TestGetMBMNumaNodeStats(t *testing.T) {
 		"mbm_local_bytes": 2361361,
 	}
 
-	mockedL3_MON, err := mockResctrlL3_MON(mocksNUMANodesToCreate, mocksFilesToCreate)
-
-	defer func() {
-		err := os.RemoveAll(mockedL3_MON)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockedL3_MON := mockResctrlL3_MON(t, mocksNUMANodesToCreate, mocksFilesToCreate)
 
 	t.Run("Gather mbm", func(t *testing.T) {
 		enabledMonFeatures.mbmTotalBytes = true

--- a/libcontainer/intelrdt/util_test.go
+++ b/libcontainer/intelrdt/util_test.go
@@ -7,7 +7,6 @@
 package intelrdt
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,9 +21,7 @@ type intelRdtTestUtil struct {
 	// Path to the mock Intel RDT "resource control" filesystem directory
 	IntelRdtPath string
 
-	// Temporary directory to store mock Intel RDT "resource control" filesystem
-	tempDir string
-	t       *testing.T
+	t *testing.T
 }
 
 // Creates a new test util
@@ -33,27 +30,15 @@ func NewIntelRdtTestUtil(t *testing.T) *intelRdtTestUtil {
 		config: &configs.Config{
 			IntelRdt: &configs.IntelRdt{},
 		},
+		root: t.TempDir(),
 	}
-	tempDir, err := ioutil.TempDir("", "intelrdt_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	d.root = tempDir
 	testIntelRdtPath := filepath.Join(d.root, "resctrl")
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// Ensure the full mock Intel RDT "resource control" filesystem path exists
-	err = os.MkdirAll(testIntelRdtPath, 0o755)
-	if err != nil {
+	if err := os.MkdirAll(testIntelRdtPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	return &intelRdtTestUtil{IntelRdtData: d, IntelRdtPath: testIntelRdtPath, tempDir: tempDir, t: t}
-}
-
-func (c *intelRdtTestUtil) cleanup() {
-	os.RemoveAll(c.tempDir)
+	return &intelRdtTestUtil{IntelRdtData: d, IntelRdtPath: testIntelRdtPath, t: t}
 }
 
 // Write the specified contents on the mock of the specified Intel RDT "resource control" files

--- a/libcontainer/notify_linux_test.go
+++ b/libcontainer/notify_linux_test.go
@@ -17,10 +17,7 @@ import (
 type notifyFunc func(path string) (<-chan struct{}, error)
 
 func testMemoryNotification(t *testing.T, evName string, notify notifyFunc, targ string) {
-	memoryPath, err := ioutil.TempDir("", "testmemnotification-"+evName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	memoryPath := t.TempDir()
 	evFile := filepath.Join(memoryPath, evName)
 	eventPath := filepath.Join(memoryPath, "cgroup.event_control")
 	if err := ioutil.WriteFile(evFile, []byte{}, 0o700); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,9 +1,12 @@
 # github.com/bits-and-blooms/bitset v1.2.0
+## explicit
 github.com/bits-and-blooms/bitset
 # github.com/checkpoint-restore/go-criu/v5 v5.0.0
+## explicit
 github.com/checkpoint-restore/go-criu/v5
 github.com/checkpoint-restore/go-criu/v5/rpc
 # github.com/cilium/ebpf v0.6.2
+## explicit
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm
 github.com/cilium/ebpf/internal
@@ -11,27 +14,36 @@ github.com/cilium/ebpf/internal/btf
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/link
 # github.com/containerd/console v1.0.2
+## explicit
 github.com/containerd/console
 # github.com/coreos/go-systemd/v22 v22.3.2
+## explicit
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/dbus
 # github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/cyphar/filepath-securejoin v0.2.3
+## explicit
 github.com/cyphar/filepath-securejoin
 # github.com/docker/go-units v0.4.0
+## explicit
 github.com/docker/go-units
 # github.com/godbus/dbus/v5 v5.0.4
+## explicit
 github.com/godbus/dbus/v5
 # github.com/golang/protobuf v1.5.0
 github.com/golang/protobuf/proto
 # github.com/moby/sys/mountinfo v0.4.1
+## explicit
 github.com/moby/sys/mountinfo
 # github.com/mrunalp/fileutils v0.5.0
+## explicit
 github.com/mrunalp/fileutils
 # github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
+## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opencontainers/selinux v1.8.2
+## explicit
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
@@ -40,28 +52,36 @@ github.com/pkg/errors
 # github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
 # github.com/seccomp/libseccomp-golang v0.9.1
+## explicit
 github.com/seccomp/libseccomp-golang
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.8.1
+## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/test
 # github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+## explicit
 github.com/syndtr/gocapability/capability
 # github.com/urfave/cli v1.22.1
+## explicit
 github.com/urfave/cli
 # github.com/vishvananda/netlink v1.1.0
+## explicit
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl
 # github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 github.com/vishvananda/netns
 # golang.org/x/net v0.0.0-20201224014010-6772e930b67b
+## explicit
 golang.org/x/net/bpf
 # golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
+## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # google.golang.org/protobuf v1.27.1
+## explicit
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire
 google.golang.org/protobuf/internal/descfmt


### PR DESCRIPTION
Docker/Moby v20.10.8 will bump up Go requirement from 1.13 to 1.16: moby/moby#42643

So we can safely drop support for Go 1.13.

Also, Go 1.14 is no longer supported, so let's settle on Go 1.15+
(which allows to use t.Cleanup and t.TempDir, shaving off some test code).

Go release notes:
* 1.14: https://golang.org/doc/go1.14
* 1.15: https://golang.org/doc/go1.15

Fixes: #3098