### PR TITLE
README.md: remove abandoned versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@
 
 ## Releases
 
-`runc` depends on and tracks the [runtime-spec](https://github.com/opencontainers/runtime-spec) repository.
-We will try to make sure that `runc` and the OCI specification major versions stay in lockstep.
-This means that `runc` 1.0.0 should implement the 1.0 version of the specification.
-
 You can find official releases of `runc` on the [release](https://github.com/opencontainers/runc/releases) page.
 
 ## Security


### PR DESCRIPTION
"`runc` X.Y.Z should implement the X.Y version of the specification." is no longer correct.

runc v1.1 will be probably released ahead of OCI Runtime Spec v1.1.
