### PR TITLE
tests/int: fix "update rt period and runtime" for rootless

### DIFF
--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -537,7 +537,7 @@ EOF
 	root_period=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_period_us")
 	root_runtime=$(cat "${CGROUP_CPU_BASE_PATH}/cpu.rt_runtime_us")
 	# the following IFS magic sets dirs=("runc-cgroups-integration-test" "test-cgroup")
-	IFS='/' read -r -a dirs <<<"$REL_CGROUPS_PATH"
+	IFS='/' read -r -a dirs <<<"${REL_CGROUPS_PATH#/}"
 	for ((i = 0; i < ${#dirs[@]}; i++)); do
 		local target="$CGROUP_CPU_BASE_PATH"
 		for ((j = 0; j <= i; j++)); do

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -114,6 +114,8 @@ function enable_cgroup() {
 		# necessary, and might actually be a bug in our impl of cgroup
 		# handling.
 		[[ "$cg" == "cpuset" ]] && chown rootless:rootless "$CGROUP_MOUNT/$cg$CGROUP_PATH/cpuset."{cpus,mems}
+		# The following is required by "update rt period and runtime".
+		[[ "$cg" == "cpu" ]] && chown rootless:rootless "$CGROUP_MOUNT/$cg$CGROUP_PATH/cpu.rt_"{period,quota}_us
 	done
 	# cgroup v2
 	if [[ -e "$CGROUP_MOUNT/cgroup.controllers" ]]; then


### PR DESCRIPTION
Since commit f09a3e1b8db33768, the value passed on to read starts with
a slash, resulting in the first element of the array to be empty.

As a result, the test tries to write to the top-level cgroup, which
fails when rootless:

>  Writing 1000000 to /sys/fs/cgroup/cpu,cpuacct//cpu.rt_period_us
>  /tmp/bats-run-106184/bats.115768.src: line 548: /sys/fs/cgroup/cpu,cpuacct//cpu.rt_period_us: Permission denied

To fix, remove the leading slash.

An alternative fix would be to do `for ((i = 1;` instead of `i = 0`, but
that seems less readable.

Fixes: f09a3e1b8db33768
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>