### PR TITLE
[WIP] [carry #2087] cgroups/systemd: add cgroup-v2 path to the list when using hybrid mode 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,12 @@ jobs:
         go-version: [1.15.x, 1.16.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
+        include:
+          # Also test against latest criu-dev
+          - go-version: 1.16.x
+            rootless: ""
+            race: ""
+            criu: "criu-dev"
 
     steps:
 
@@ -27,11 +33,23 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install deps
+      if: matrix.criu == ''
       run: |
         # criu repo
         sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to
         sudo apt -q install libseccomp-dev criu
+
+    - name: install deps with criu ${{ matrix.criu }}
+      if: matrix.criu != ''
+      run: |
+        sudo apt -q update
+        sudo apt -q install libseccomp-dev \
+          libcap-dev libnet1-dev libnl-3-dev \
+          libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
+        git clone https://github.com/checkpoint-restore/criu.git ~/criu
+        (cd ~/criu && git checkout ${{ matrix.criu }} && sudo make install-criu)
+        rm -rf ~/criu
 
     - name: install go ${{ matrix.go-version }}
       uses: actions/setup-go@v2

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -38,6 +38,14 @@ var (
 
 var errSubsystemDoesNotExist = errors.New("cgroup: subsystem does not exist")
 
+func init() {
+	// If using cgroups-hybrid mode then add a "" controller indicating
+	// it should join the cgroups v2.
+	if cgroups.IsCgroup2HybridMode() {
+		subsystems = append(subsystems, &NameGroup{GroupName: "", Join: true})
+	}
+}
+
 type subsystem interface {
 	// Name returns the name of the subsystem.
 	Name() string

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -191,6 +191,19 @@ func (m *legacyManager) Apply(pid int) error {
 		}
 		paths[s.Name()] = subsystemPath
 	}
+
+	// If systemd is using cgroups-hybrid mode then add the slice path of
+	// this container to the paths so the following process executed with
+	// "runc exec" joins that cgroup as well.
+	if cgroups.IsCgroup2HybridMode() {
+		// "" means cgroup-hybrid path
+		cgroupsHybridPath, err := getSubsystemPath(m.cgroups, "")
+		if err != nil && cgroups.IsNotFound(err) {
+			return err
+		}
+		paths[""] = cgroupsHybridPath
+	}
+
 	m.paths = paths
 
 	if err := m.joinCgroups(pid); err != nil {

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -23,11 +23,14 @@ import (
 const (
 	CgroupProcesses   = "cgroup.procs"
 	unifiedMountpoint = "/sys/fs/cgroup"
+	hybridMountpoint  = "/sys/fs/cgroup/unified"
 )
 
 var (
 	isUnifiedOnce sync.Once
 	isUnified     bool
+	isHybridOnce  sync.Once
+	isHybrid      bool
 )
 
 // IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
@@ -47,6 +50,24 @@ func IsCgroup2UnifiedMode() bool {
 		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
 	})
 	return isUnified
+}
+
+// IsCgroup2HybridMode returns whether we are running in cgroup v2 hybrid mode.
+func IsCgroup2HybridMode() bool {
+	isHybridOnce.Do(func() {
+		var st unix.Statfs_t
+		err := unix.Statfs(hybridMountpoint, &st)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// ignore the "not found" error
+				isHybrid = false
+				return
+			}
+			panic(fmt.Sprintf("cannot statfs cgroup root: %s", err))
+		}
+		isHybrid = st.Type == unix.CGROUP2_SUPER_MAGIC
+	})
+	return isHybrid
 }
 
 type Mount struct {

--- a/libcontainer/cgroups/v1_utils.go
+++ b/libcontainer/cgroups/v1_utils.go
@@ -113,6 +113,11 @@ func FindCgroupMountpoint(cgroupPath, subsystem string) (string, error) {
 		return "", errUnified
 	}
 
+	// If subsystem is empty, we look for the cgroupv2 hybrid path.
+	if len(subsystem) == 0 {
+		return hybridMountpoint, nil
+	}
+
 	// Avoid parsing mountinfo by trying the default path first, if possible.
 	if path := tryDefaultPath(cgroupPath, subsystem); path != "" {
 		return path, nil
@@ -221,6 +226,11 @@ func GetOwnCgroupPath(subsystem string) (string, error) {
 	cgroup, err := GetOwnCgroup(subsystem)
 	if err != nil {
 		return "", err
+	}
+
+	// If subsystem is empty, we look for the cgroupv2 hybrid path.
+	if len(subsystem) == 0 {
+		return hybridMountpoint, nil
 	}
 
 	return getCgroupPathHelper(subsystem, cgroup)

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -129,9 +129,9 @@ func (p *setnsProcess) start() (retErr error) {
 	if err := p.execSetns(); err != nil {
 		return fmt.Errorf("error executing setns process: %w", err)
 	}
-	if len(p.cgroupPaths) > 0 {
-		if err := cgroups.EnterPid(p.cgroupPaths, p.pid()); err != nil && !p.rootlessCgroups {
-			// On cgroup v2 + nesting + domain controllers, EnterPid may fail with EBUSY.
+	for _, path := range p.cgroupPaths {
+		if err := cgroups.WriteCgroupProc(path, p.pid()); err != nil && !p.rootlessCgroups {
+			// On cgroup v2 + nesting + domain controllers, WriteCgroupProc may fail with EBUSY.
 			// https://github.com/opencontainers/runc/issues/2356#issuecomment-621277643
 			// Try to join the cgroup of InitProcessPid.
 			if cgroups.IsCgroup2UnifiedMode() {

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -282,3 +282,25 @@ function setup() {
 	[ "$status" -eq 0 ]
 	[ "$(wc -l <<<"$output")" -eq 1 ]
 }
+
+@test "runc exec (cgroup v2 hybrid joins correct cgroup)" {
+	requires root cgroups_hybrid
+
+	set_cgroups_path
+	set_cgroup_mount_writable
+
+	runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
+	[ "$status" -eq 0 ]
+
+	pid=$(cat pid.txt)
+	run_cgroup=$(tail -1 </proc/"$pid"/cgroup)
+	[[ "$run_cgroup" == *"runc-cgroups-integration-test"* ]]
+
+	runc exec test_cgroups_group cat /proc/self/cgroup
+	[ "$status" -eq 0 ]
+	exec_cgroup=${lines[-1]}
+	[[ $exec_cgroup == *"runc-cgroups-integration-test"* ]]
+
+	# check that the cgroups v2 path is the same for both processes
+	[[ "$run_cgroup" == "$exec_cgroup" ]]
+}

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -127,6 +127,9 @@ function init_cgroup_paths() {
 			CGROUP_SUBSYSTEMS+=" freezer"
 		fi
 	else
+		if stat -f -c %t /sys/fs/cgroup/unified | grep -qFw 63677270; then
+			CGROUP_HYBRID=yes
+		fi
 		CGROUP_UNIFIED=no
 		CGROUP_SUBSYSTEMS=$(awk '!/^#/ {print $1}' /proc/cgroups)
 		local g base_path
@@ -355,6 +358,12 @@ function requires() {
 			init_cgroup_paths
 			var=${var#cgroups_}
 			if [[ "$CGROUP_SUBSYSTEMS" != *"$var"* ]]; then
+				skip_me=1
+			fi
+			;;
+		cgroups_hybrid)
+			init_cgroup_paths
+			if [ "$CGROUP_HYBRID" != "yes" ]; then
 				skip_me=1
 			fi
 			;;


### PR DESCRIPTION
Carry #2087, which I need for #3059. This also demonstrates a bug in criu v3.15 (fixed in criu-dev).

IOW we need criu-3.16 to merge this.