### PR TITLE
seccomp: skip redundant rules

### DIFF
--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -56,9 +56,7 @@ func ConvertStringToOperator(in string) (configs.Operator, error) {
 }
 
 // ConvertStringToAction converts a string into a Seccomp rule match action.
-// Actions use the names they are assigned in Libseccomp's header, though some
-// (notable, SCMP_ACT_TRACE) are not available in this implementation and will
-// return errors.
+// Actions use the names they are assigned in Libseccomp's header.
 // Attempting to convert a string that is not a valid action results in an
 // error.
 func ConvertStringToAction(in string) (configs.Action, error) {

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -68,7 +68,7 @@ func InitSeccomp(config *configs.Seccomp) error {
 		if call == nil {
 			return errors.New("encountered nil syscall while initializing Seccomp")
 		}
-		if err := matchCall(filter, call); err != nil {
+		if err := matchCall(filter, call, defaultAction); err != nil {
 			return err
 		}
 	}
@@ -143,7 +143,7 @@ func getCondition(arg *configs.Arg) (libseccomp.ScmpCondition, error) {
 }
 
 // Add a rule to match a single syscall
-func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall) error {
+func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall, defAct libseccomp.ScmpAction) error {
 	if call == nil || filter == nil {
 		return errors.New("cannot use nil as syscall to block")
 	}
@@ -152,18 +152,23 @@ func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall) error {
 		return errors.New("empty string is not a valid syscall")
 	}
 
+	// Convert the call's action to the libseccomp equivalent
+	callAct, err := getAction(call.Action, call.ErrnoRet)
+	if err != nil {
+		return fmt.Errorf("action in seccomp profile is invalid: %w", err)
+	}
+	if callAct == defAct {
+		// This rule is redundant, silently skip it
+		// to avoid error from AddRule.
+		return nil
+	}
+
 	// If we can't resolve the syscall, assume it is not supported
 	// by this kernel. Warn about it, don't error out.
 	callNum, err := libseccomp.GetSyscallFromName(call.Name)
 	if err != nil {
 		logrus.Debugf("unknown seccomp syscall %q ignored", call.Name)
 		return nil
-	}
-
-	// Convert the call's action to the libseccomp equivalent
-	callAct, err := getAction(call.Action, call.ErrnoRet)
-	if err != nil {
-		return fmt.Errorf("action in seccomp profile is invalid: %w", err)
 	}
 
 	// Unconditional match - just add the rule

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -6,11 +6,12 @@ import (
 	"errors"
 	"fmt"
 
+	libseccomp "github.com/seccomp/libseccomp-golang"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/seccomp/patchbpf"
-
-	libseccomp "github.com/seccomp/libseccomp-golang"
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -151,10 +152,11 @@ func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall) error {
 		return errors.New("empty string is not a valid syscall")
 	}
 
-	// If we can't resolve the syscall, assume it's not supported on this kernel
-	// Ignore it, don't error out
+	// If we can't resolve the syscall, assume it is not supported
+	// by this kernel. Warn about it, don't error out.
 	callNum, err := libseccomp.GetSyscallFromName(call.Name)
 	if err != nil {
+		logrus.Debugf("unknown seccomp syscall %q ignored", call.Name)
 		return nil
 	}
 

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -76,3 +76,15 @@ function teardown() {
 	runc run test_hello
 	[ "$status" -eq 0 ]
 }
+
+@test "runc run [redundant seccomp rules]" {
+	update_config '	  .linux.seccomp = {
+				"defaultAction": "SCMP_ACT_ALLOW",
+				"syscalls": [{
+					"names": ["bdflush"],
+					"action": "SCMP_ACT_ALLOW",
+				}]
+			    }'
+	runc run test_hello
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This fixes using runc with podman on my system (Fedora 34).

> $ podman --runtime $(pwd)/runc run --rm --memory 4M fedora echo it works
> Error: unable to start container process: error adding seccomp filter rule for syscall bdflush: permission denied: OCI permission denied

The problem is, libseccomp returns EPERM when a redundant rule (i.e. the
rule with the same action as the default one) is added, and podman (on
my machine) sets the following rules in config.json:
```json
    ....
    "seccomp": {
      "defaultAction": "SCMP_ACT_ERRNO",
      "architectures": [
        "SCMP_ARCH_X86_64",
        "SCMP_ARCH_X86",
        "SCMP_ARCH_X32"
      ],
      "syscalls": [
        {
          "names": [
            "bdflush",
            "io_pgetevents",
            ....
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        ....
```
(Note that defaultErrnoRet is not set, but it defaults to 1).

With this commit, it works:

> $ podman --runtime $(pwd)/runc run --memory 4M fedora echo it works
> it works

Similar crun commit:
 * https://github.com/containers/crun/commit/08229f3fb904c5ea19a7d9

Fixes: #1847
See also: https://github.com/containers/podman/issues/11031

## Changelog entry
```
Bugfixes:
* Redundant seccomp rules (i.e. those that has action equal to the default
  one) are now skipped. This fixes the inability to start a container with
  the "adding seccomp filter rule for syscall ..." error.
```