### PR TITLE
libct/cg/devices: stop using regex

### DIFF
--- a/libcontainer/cgroups/devices/devices_emulator_test.go
+++ b/libcontainer/cgroups/devices/devices_emulator_test.go
@@ -19,8 +19,10 @@
 package devices
 
 import (
+	"bufio"
 	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/devices"
@@ -1111,4 +1113,32 @@ func TestDeviceEmulatorTransitionFromBlacklist(t *testing.T) {
 
 func TestDeviceEmulatorTransitionFromWhitelist(t *testing.T) {
 	testDeviceEmulatorTransition(t, false)
+}
+
+func BenchmarkParseLine(b *testing.B) {
+	list := `c *:* m
+b *:* m
+c 1:3 rwm
+c 1:5 rwm
+c 1:7 rwm
+c 1:8 rwm
+c 1:9 rwm
+c 5:0 rwm
+c 5:2 rwm
+c 136:* rwm
+c 10:200 rwm`
+
+	var r *deviceRule
+	var err error
+	for i := 0; i < b.N; i++ {
+		s := bufio.NewScanner(strings.NewReader(list))
+		for s.Scan() {
+			line := s.Text()
+			r, err = parseLine(line)
+		}
+		if err := s.Err(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.Logf("rule: %v, err: %v", r, err)
 }


### PR DESCRIPTION
Looking into data generated by setting

	GODEBUG="inittrace=1"

I have noticed this line:

	init github.com/opencontainers/runc/libcontainer/cgroups/devices @1.2 ms, 0.020 ms clock, 10512 bytes, 133 allocs

This is the leader for both bytes and allocs among the packages from
this repo, and all of it is caused by a single regex:

	var devicesListRegexp = regexp.MustCompile(`^([abc])\s+(\d+|\*):(\d+|\*)\s+([rwm]+)$`)

It seems that the same parsing can be done without relying on
a regular expression, no decrease in readability or correctness
(including catching all invalid input), and 2x faster (according to
the benchmark added), and also hopefully makes runc start
slightly faster and leaner.

Before:

	BenchmarkParseLine-4   	  176240	      6768 ns/op	    6576 B/op	      64 allocs/op

After:

	BenchmarkParseLine-4   	  322441	      3535 ns/op	    5520 B/op	      53 allocs/op

[v2: single split with SplitFunc; fix a typo in an error message]
[v3: rebase after #3159 merge; re-ran benchmarks (results are similar)]