### PR TITLE
libct/int/checkpoint_test: fix ParentImage (and bogus failure with criu 3.16)

### DIFF
--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -133,10 +133,12 @@ func testCheckpoint(t *testing.T, userns bool) {
 	ok(t, err)
 	defer remove(imagesDir)
 
+	relParentDir, err := filepath.Rel(imagesDir, parentDir)
+	ok(t, err)
 	checkpointOpts := &libcontainer.CriuOpts{
 		ImagesDirectory: imagesDir,
 		WorkDirectory:   imagesDir,
-		ParentImage:     "../criu-parent",
+		ParentImage:     relParentDir,
 	}
 	dumpLog := filepath.Join(checkpointOpts.WorkDirectory, "dump.log")
 	restoreLog := filepath.Join(checkpointOpts.WorkDirectory, "restore.log")


### PR DESCRIPTION
The ParentImage set by the test should be a path relative to
ImagesDirectory, pointing to a parent images directory (created
by pre-dump).

The parent directory is created by TempDir and so its name is not
constant but has a variable suffix. So, the config was pointing to
a non-existent directory.

This left unnoticed by criu as it assumed the parent image does not
exist, and performed a full dump (meaning the pre-dump was not used).

Since criu PR https://github.com/checkpoint-restore/criu/pull/1403 (which will
be a part of criu 3.16) that is no longer the case -- the invalid parent
path is treated as an error, and so our test fails like this:

```
== RUN   TestCheckpoint
    checkpoint_test.go:145: === /tmp/criu070876105/dump.log ===
    checkpoint_test.go:145: open /tmp/criu070876105/dump.log: no such file or directory
    checkpoint_test.go:146: criu failed: type DUMP errno 56
        log file: /tmp/criu070876105/dump.log
--- FAIL: TestCheckpoint (0.26s)
```

Fix this by using the actual name of the parent image dir.

Fixes: 98f004182b9a23245
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>