### PR TITLE
runc init: remove some code

### DIFF
--- a/init.go
+++ b/init.go
@@ -10,11 +10,12 @@ import (
 	"github.com/opencontainers/runc/libcontainer/logs"
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 func init() {
 	if len(os.Args) > 1 && os.Args[1] == "init" {
+		// This is the golang entry point for runc init, executed
+		// before main() but after libcontainer/nsenter's nsexec().
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
 
@@ -38,13 +39,7 @@ func init() {
 			panic(fmt.Sprintf("libcontainer: failed to configure logging: %v", err))
 		}
 		logrus.Debug("child process in init()")
-	}
-}
 
-var initCommand = cli.Command{
-	Name:  "init",
-	Usage: `initialize the namespaces and launch the process (do not call it outside of runc)`,
-	Action: func(context *cli.Context) error {
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
 			// as the error is sent back to the parent there is no need to log
@@ -52,5 +47,5 @@ var initCommand = cli.Command{
 			os.Exit(1)
 		}
 		panic("libcontainer: container init failed to exec")
-	},
+	}
 }

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -41,12 +41,6 @@ enum sync_t {
 	SYNC_CHILD_FINISH = 0x45,	/* The child or grandchild has finished. */
 };
 
-/*
- * Synchronisation value for cgroup namespace setup.
- * The same constant is defined in process_linux.go as "createCgroupns".
- */
-#define CREATECGROUPNS 0x80
-
 #define STAGE_SETUP  -1
 /* longjmp() arguments. */
 #define STAGE_PARENT  0
@@ -1075,24 +1069,9 @@ void nsexec(void)
 					bail("setgroups failed");
 			}
 
-			/*
-			 * Wait until our topmost parent has finished cgroup setup in
-			 * p.manager.Apply().
-			 *
-			 * TODO(cyphar): Check if this code is actually needed because we
-			 *               should be in the cgroup even from stage-0, so
-			 *               waiting until now might not make sense.
-			 */
 			if (config.cloneflags & CLONE_NEWCGROUP) {
-				uint8_t value;
-				if (read(pipenum, &value, sizeof(value)) != sizeof(value))
-					bail("read synchronisation value failed");
-				if (value == CREATECGROUPNS) {
-					write_log(DEBUG, "unshare cgroup namespace");
-					if (unshare(CLONE_NEWCGROUP) < 0)
-						bail("failed to unshare cgroup namespace");
-				} else
-					bail("received unknown synchronisation value");
+				if (unshare(CLONE_NEWCGROUP) < 0)
+					bail("failed to unshare cgroup namespace");
 			}
 
 			write_log(DEBUG, "signal completion to stage-0");

--- a/main.go
+++ b/main.go
@@ -119,7 +119,6 @@ func main() {
 		deleteCommand,
 		eventsCommand,
 		execCommand,
-		initCommand,
 		killCommand,
 		listCommand,
 		pauseCommand,
@@ -149,10 +148,7 @@ func main() {
 		if err := reviseRootDir(context); err != nil {
 			return err
 		}
-		// let init configure logging on its own
-		if args := context.Args(); args != nil && args.First() == "init" {
-			return nil
-		}
+
 		return logs.ConfigureLogging(createLogConfig(context))
 	}
 


### PR DESCRIPTION
Remove some code from runc init which is not needed. Please review commit-by-commit.

1. Remove option parsing from runc init.
2. Remove cgroupns sync mechanism (as pointed out in #2446 and in TODO).
