### PR TITLE
[DNM] runc init log refactor

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -134,11 +134,6 @@ func execProcess(context *cli.Context) (int, error) {
 		return -1, err
 	}
 
-	logLevel := "info"
-	if context.GlobalBool("debug") {
-		logLevel = "debug"
-	}
-
 	r := &runner{
 		enableSubreaper: false,
 		shouldDestroy:   false,
@@ -149,7 +144,6 @@ func execProcess(context *cli.Context) (int, error) {
 		action:          CT_ACT_RUN,
 		init:            false,
 		preserveFDs:     context.Int("preserve-fds"),
-		logLevel:        logLevel,
 	}
 	return r.run(p)
 }

--- a/init.go
+++ b/init.go
@@ -19,12 +19,11 @@ func init() {
 		runtime.LockOSThread()
 
 		// Configure logrus to talk to the parent.
-		level := os.Getenv("_LIBCONTAINER_LOGLEVEL")
-		logLevel, err := logrus.ParseLevel(level)
+		level, err := strconv.Atoi(os.Getenv("_LIBCONTAINER_LOGLEVEL"))
 		if err != nil {
-			panic(fmt.Sprintf("libcontainer: failed to parse log level: %q: %v", level, err))
+			panic(fmt.Sprintf("libcontainer: failed to parse _LIBCONTAINER_LOGLEVEL: %s", err))
 		}
-		logrus.SetLevel(logLevel)
+		logrus.SetLevel(logrus.Level(level))
 
 		logPipeFdStr := os.Getenv("_LIBCONTAINER_LOGPIPE")
 		logPipeFd, err := strconv.Atoi(logPipeFdStr)

--- a/libcontainer/logs/logs.go
+++ b/libcontainer/logs/logs.go
@@ -34,18 +34,13 @@ func processEntry(text []byte) {
 	}
 
 	var jl struct {
-		Level string `json:"level"`
-		Msg   string `json:"msg"`
+		Level logrus.Level `json:"level"`
+		Msg   string       `json:"msg"`
 	}
 	if err := json.Unmarshal(text, &jl); err != nil {
 		logrus.Errorf("failed to decode %q to json: %v", text, err)
 		return
 	}
 
-	lvl, err := logrus.ParseLevel(jl.Level)
-	if err != nil {
-		logrus.Errorf("failed to parse log level %q: %v", jl.Level, err)
-		return
-	}
-	logrus.StandardLogger().Logf(lvl, jl.Msg)
+	logrus.StandardLogger().Logf(jl.Level, jl.Msg)
 }

--- a/libcontainer/logs/logs_linux_test.go
+++ b/libcontainer/logs/logs_linux_test.go
@@ -11,44 +11,51 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const msgErr = `"level":"error"`
+
 func TestLoggingToFile(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"kitten"}`)
+	msg := `"level":"info","msg":"kitten"`
+	logToLogWriter(t, l, msg)
 	finish(t, l)
-	check(t, l, "kitten")
+	check(t, l, msg, msgErr)
 }
 
 func TestLogForwardingDoesNotStopOnJsonDecodeErr(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, "invalid-json-with-kitten")
-	checkWait(t, l, "failed to decode")
+	logToLogWriter(t, l, `"invalid-json-with-kitten"`)
+	checkWait(t, l, msgErr, "")
 
 	truncateLogFile(t, l.file)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"puppy"}`)
+	msg := `"level":"info","msg":"puppy"`
+	logToLogWriter(t, l, msg)
 	finish(t, l)
-	check(t, l, "puppy")
+	check(t, l, msg, msgErr)
 }
 
 func TestLogForwardingDoesNotStopOnLogLevelParsingErr(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, `{"level": "alert","msg":"puppy"}`)
-	checkWait(t, l, "failed to parse log level")
+	msg := `"level":"alert","msg":"puppy"`
+	logToLogWriter(t, l, msg)
+	checkWait(t, l, msgErr, msg)
 
 	truncateLogFile(t, l.file)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"puppy"}`)
+	msg = `"level":"info","msg":"puppy"`
+	logToLogWriter(t, l, msg)
 	finish(t, l)
-	check(t, l, "puppy")
+	check(t, l, msg, msgErr)
 }
 
 func TestLogForwardingStopsAfterClosingTheWriter(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"sync"}`)
+	msg := `"level":"info","msg":"sync"`
+	logToLogWriter(t, l, msg)
 
 	// Do not use finish() here as we check done pipe ourselves.
 	l.w.Close()
@@ -58,12 +65,12 @@ func TestLogForwardingStopsAfterClosingTheWriter(t *testing.T) {
 		t.Fatal("log forwarding did not stop after closing the pipe")
 	}
 
-	check(t, l, "sync")
+	check(t, l, msg, msgErr)
 }
 
 func logToLogWriter(t *testing.T, l *log, message string) {
 	t.Helper()
-	_, err := l.w.Write([]byte(message + "\n"))
+	_, err := l.w.Write([]byte("{" + message + "}\n"))
 	if err != nil {
 		t.Fatalf("failed to write %q to log writer: %v", message, err)
 	}
@@ -119,21 +126,24 @@ func truncateLogFile(t *testing.T, file *os.File) {
 	}
 }
 
-// check checks that file contains txt
-func check(t *testing.T, l *log, txt string) {
+// check checks that the file contains txt and does not contain notxt.
+func check(t *testing.T, l *log, txt, notxt string) {
 	t.Helper()
 	contents, err := ioutil.ReadFile(l.file.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(contents, []byte(txt)) {
-		t.Fatalf("%q does not contain %q", string(contents), txt)
+	if txt != "" && !bytes.Contains(contents, []byte(txt)) {
+		t.Fatalf("%s does not contain %s", string(contents), txt)
+	}
+	if notxt != "" && bytes.Contains(contents, []byte(notxt)) {
+		t.Fatalf("%s does contain %s", string(contents), notxt)
 	}
 }
 
-// checkWait checks that file contains txt. If the file is empty,
+// checkWait is like check, but if the file is empty,
 // it waits until it's not.
-func checkWait(t *testing.T, l *log, txt string) {
+func checkWait(t *testing.T, l *log, txt string, notxt string) {
 	t.Helper()
 	const (
 		delay = 100 * time.Millisecond
@@ -153,5 +163,5 @@ func checkWait(t *testing.T, l *log, txt string) {
 		time.Sleep(delay)
 	}
 
-	check(t, l, txt)
+	check(t, l, txt, notxt)
 }

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -28,10 +28,7 @@ type logentry struct {
 
 func TestNsenterValidPaths(t *testing.T) {
 	args := []string{"nsenter-exec"}
-	parent, child, err := newPipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe %v", err)
-	}
+	parent, child := newPipe(t)
 
 	namespaces := []string{
 		// join pid ns of the current process
@@ -49,6 +46,7 @@ func TestNsenterValidPaths(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal("nsenter failed to start:", err)
 	}
+	child.Close()
 
 	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
@@ -89,10 +87,7 @@ func TestNsenterValidPaths(t *testing.T) {
 
 func TestNsenterInvalidPaths(t *testing.T) {
 	args := []string{"nsenter-exec"}
-	parent, child, err := newPipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe %v", err)
-	}
+	parent, child := newPipe(t)
 
 	namespaces := []string{
 		// join pid ns of the current process
@@ -108,6 +103,8 @@ func TestNsenterInvalidPaths(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal("nsenter failed to start:", err)
 	}
+	child.Close()
+
 	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
 	r.AddData(&libcontainer.Int32msg{
@@ -130,10 +127,7 @@ func TestNsenterInvalidPaths(t *testing.T) {
 
 func TestNsenterIncorrectPathType(t *testing.T) {
 	args := []string{"nsenter-exec"}
-	parent, child, err := newPipe()
-	if err != nil {
-		t.Fatal("failed to create pipe:", err)
-	}
+	parent, child := newPipe(t)
 
 	namespaces := []string{
 		// join pid ns of the current process
@@ -149,6 +143,8 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal("nsenter failed to start:", err)
 	}
+	child.Close()
+
 	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
 	r.AddData(&libcontainer.Int32msg{
@@ -171,18 +167,8 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 
 func TestNsenterChildLogging(t *testing.T) {
 	args := []string{"nsenter-exec"}
-	parent, child, err := newPipe()
-	if err != nil {
-		t.Fatalf("failed to create exec pipe %v", err)
-	}
-	logread, logwrite, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create log pipe %v", err)
-	}
-	defer func() {
-		_ = logwrite.Close()
-		_ = logread.Close()
-	}()
+	parent, child := newPipe(t)
+	logread, logwrite := newPipe(t)
 
 	namespaces := []string{
 		// join pid ns of the current process
@@ -200,6 +186,9 @@ func TestNsenterChildLogging(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal("nsenter failed to start:", err)
 	}
+	child.Close()
+	logwrite.Close()
+
 	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
 	r.AddData(&libcontainer.Int32msg{
@@ -219,7 +208,7 @@ func TestNsenterChildLogging(t *testing.T) {
 	logsDecoder := json.NewDecoder(logread)
 	var logentry *logentry
 
-	err = logsDecoder.Decode(&logentry)
+	err := logsDecoder.Decode(&logentry)
 	if err != nil {
 		t.Fatalf("child log: %v", err)
 	}
@@ -238,12 +227,19 @@ func init() {
 	}
 }
 
-func newPipe() (parent *os.File, child *os.File, err error) {
+func newPipe(t *testing.T) (parent *os.File, child *os.File) {
+	t.Helper()
 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
-		return nil, nil, err
+		t.Fatal("socketpair failed:", err)
 	}
-	return os.NewFile(uintptr(fds[1]), "parent"), os.NewFile(uintptr(fds[0]), "child"), nil
+	parent = os.NewFile(uintptr(fds[1]), "parent")
+	child = os.NewFile(uintptr(fds[0]), "child")
+	t.Cleanup(func() {
+		parent.Close()
+		child.Close()
+	})
+	return
 }
 
 // initWaiter reads back the initial \0 from runc init

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -66,7 +66,6 @@ func TestNsenterInvalidPaths(t *testing.T) {
 	parent, child := newPipe(t)
 
 	namespaces := []string{
-		// join pid ns of the current process
 		fmt.Sprintf("pid:/proc/%d/ns/pid", -1),
 	}
 	cmd := &exec.Cmd{
@@ -106,7 +105,6 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 	parent, child := newPipe(t)
 
 	namespaces := []string{
-		// join pid ns of the current process
 		fmt.Sprintf("net:/proc/%d/ns/pid", os.Getpid()),
 	}
 	cmd := &exec.Cmd{

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -47,7 +47,7 @@ func TestNsenterValidPaths(t *testing.T) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("nsenter failed to start %v", err)
+		t.Fatal("nsenter failed to start:", err)
 	}
 
 	// write cloneFlags
@@ -70,7 +70,7 @@ func TestNsenterValidPaths(t *testing.T) {
 	var pid *pid
 
 	if err := cmd.Wait(); err != nil {
-		t.Fatalf("nsenter exits with a non-zero exit status")
+		t.Fatal("nsenter error:", err)
 	}
 	if err := decoder.Decode(&pid); err != nil {
 		dir, _ := ioutil.ReadDir(fmt.Sprintf("/proc/%d/ns", os.Getpid()))
@@ -106,7 +106,7 @@ func TestNsenterInvalidPaths(t *testing.T) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
+		t.Fatal("nsenter failed to start:", err)
 	}
 	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
@@ -124,7 +124,7 @@ func TestNsenterInvalidPaths(t *testing.T) {
 
 	initWaiter(t, parent)
 	if err := cmd.Wait(); err == nil {
-		t.Fatalf("nsenter exits with a zero exit status")
+		t.Fatal("nsenter error:", err)
 	}
 }
 
@@ -132,7 +132,7 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 	args := []string{"nsenter-exec"}
 	parent, child, err := newPipe()
 	if err != nil {
-		t.Fatalf("failed to create pipe %v", err)
+		t.Fatal("failed to create pipe:", err)
 	}
 
 	namespaces := []string{
@@ -147,7 +147,7 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
+		t.Fatal("nsenter failed to start:", err)
 	}
 	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
@@ -165,7 +165,7 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 
 	initWaiter(t, parent)
 	if err := cmd.Wait(); err == nil {
-		t.Fatalf("nsenter exits with a zero exit status")
+		t.Fatal("nsenter error:", err)
 	}
 }
 
@@ -198,7 +198,7 @@ func TestNsenterChildLogging(t *testing.T) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("nsenter failed to start %v", err)
+		t.Fatal("nsenter failed to start:", err)
 	}
 	// write cloneFlags
 	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
@@ -228,7 +228,7 @@ func TestNsenterChildLogging(t *testing.T) {
 	}
 
 	if err := cmd.Wait(); err != nil {
-		t.Fatalf("nsenter exits with a non-zero exit status")
+		t.Fatal("nsenter error:", err)
 	}
 }
 
@@ -259,5 +259,5 @@ func initWaiter(t *testing.T, r io.Reader) {
 			return
 		}
 	}
-	t.Fatalf("waiting for init preliminary setup: %v", err)
+	t.Fatal("waiting for init preliminary setup:", err)
 }

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -175,10 +175,14 @@ out:
 /* XXX: This is ugly. */
 static int syncfd = -1;
 
-#define bail(fmt, ...)                                       \
-	do {                                                       \
-		write_log(FATAL, fmt ": %m", ##__VA_ARGS__); \
-		exit(1);                                                 \
+#define bail(fmt, ...)                                               \
+	do {                                                         \
+		if (logfd < 0)                                       \
+			fprintf(stderr, "FATAL: " fmt ": %m\n",      \
+				##__VA_ARGS__);                      \
+		else                                                 \
+			write_log(FATAL, fmt ": %m", ##__VA_ARGS__); \
+		exit(1);                                             \
 	} while(0)
 
 static int write_file(char *data, size_t data_len, char *pathfmt, ...)
@@ -400,9 +404,7 @@ static void setup_logpipe(void)
 
 	logfd = strtol(logpipe, &endptr, 10);
 	if (logpipe == endptr || *endptr != '\0') {
-		fprintf(stderr, "unable to parse _LIBCONTAINER_LOGPIPE, value: %s\n", logpipe);
-		/* It is too early to use bail */
-		exit(1);
+		bail("unable to parse _LIBCONTAINER_LOGPIPE, value: %s", logpipe);
 	}
 }
 

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -373,39 +373,48 @@ static int clone_parent(jmp_buf *env, int jmpval)
 }
 
 /*
- * Gets the init pipe fd from the environment, which is used to read the
- * bootstrap data and tell the parent what the new pid is after we finish
- * setting up the environment.
+ * Returns an environment variable value as a non-negative integer, or -ENOENT
+ * if the variable was not found or has an empty value.
+ *
+ * If the value can not be converted to an integer, or the result is out of
+ * range, the function bails out.
  */
-static int initpipe(void)
+static int getenv_int(const char *name)
 {
-	int pipenum;
-	char *initpipe, *endptr;
+	char *val, *endptr;
+	int ret;
 
-	initpipe = getenv("_LIBCONTAINER_INITPIPE");
-	if (initpipe == NULL || *initpipe == '\0')
-		return -1;
+	val = getenv(name);
+	/* Treat empty value as unset variable. */
+	if (val == NULL || *val == '\0')
+		return -ENOENT;
 
-	pipenum = strtol(initpipe, &endptr, 10);
-	if (*endptr != '\0')
-		bail("unable to parse _LIBCONTAINER_INITPIPE");
+	ret = strtol(val, &endptr, 10);
+	if (val == endptr || *endptr != '\0')
+		bail("unable to parse %s=%s", name, val);
+	/*
+	 * Sanity check: this must be a non-negative number.
+	 */
+	if (ret < 0)
+		bail("bad value for %s=%s (%d)", name, val, ret);
 
-	return pipenum;
+	return ret;
 }
 
+/*
+ * Sets up logging by getting log fd from the environment,
+ * if available.
+ */
 static void setup_logpipe(void)
 {
-	char *logpipe, *endptr;
+	int i;
 
-	logpipe = getenv("_LIBCONTAINER_LOGPIPE");
-	if (logpipe == NULL || *logpipe == '\0') {
+	i = getenv_int("_LIBCONTAINER_LOGPIPE");
+	if (i < 0) {
+		/* We are not runc init, or log pipe was not provided. */
 		return;
 	}
-
-	logfd = strtol(logpipe, &endptr, 10);
-	if (logpipe == endptr || *endptr != '\0') {
-		bail("unable to parse _LIBCONTAINER_LOGPIPE, value: %s", logpipe);
-	}
+	logfd = i;
 }
 
 /* Returns the clone(2) flag for a namespace, given the name of a namespace. */
@@ -616,12 +625,15 @@ void nsexec(void)
 	setup_logpipe();
 
 	/*
-	 * If we don't have an init pipe, just return to the go routine.
-	 * We'll only get an init pipe for start or exec.
+	 * Get the init pipe fd from the environment. The init pipe is used to
+	 * read the bootstrap data and tell the parent what the new pids are
+	 * after the setup is done.
 	 */
-	pipenum = initpipe();
-	if (pipenum == -1)
+	pipenum = getenv_int("_LIBCONTAINER_INITPIPE");
+	if (pipenum < 0) {
+		/* We are not a runc init. Just return to go runtime. */
 		return;
+	}
 
 	/*
 	 * We need to re-exec if we are not in a cloned binary. This is necessary

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -89,14 +89,21 @@ struct nlconfig_t {
 	size_t gidmappath_len;
 };
 
-#define PANIC   "panic"
-#define FATAL   "fatal"
-#define ERROR   "error"
-#define WARNING "warning"
-#define INFO    "info"
-#define DEBUG   "debug"
+/*
+ * Log levels are the same as in logrus.
+ */
+#define PANIC   0
+#define FATAL   1
+#define ERROR   2
+#define WARNING 3
+#define INFO    4
+#define DEBUG   5
+#define TRACE   6
+
+static const char *level_str[] = { "panic", "fatal", "error", "warning", "info", "debug", "trace" };
 
 static int logfd = -1;
+static int loglevel = INFO;
 
 /*
  * List of netlink message types sent to us as part of bootstrapping the init.
@@ -134,13 +141,13 @@ int setns(int fd, int nstype)
 }
 #endif
 
-static void write_log(const char *level, const char *format, ...)
+static void write_log(int level, const char *format, ...)
 {
 	char *message = NULL, *stage = NULL, *json = NULL;
 	va_list args;
 	int ret;
 
-	if (logfd < 0 || level == NULL)
+	if (logfd < 0 || level > loglevel)
 		goto out;
 
 	va_start(args, format);
@@ -158,7 +165,8 @@ static void write_log(const char *level, const char *format, ...)
 	if (ret < 0)
 		goto out;
 
-	ret = asprintf(&json, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n", level, stage, getpid(), message);
+	ret = asprintf(&json, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n",
+		       level_str[level], stage, getpid(), message);
 	if (ret < 0) {
 		json = NULL;
 		goto out;
@@ -393,16 +401,18 @@ static int getenv_int(const char *name)
 	if (val == endptr || *endptr != '\0')
 		bail("unable to parse %s=%s", name, val);
 	/*
-	 * Sanity check: this must be a non-negative number.
-	 */
-	if (ret < 0)
+	 * Sanity check: this must be a small non-negative number.
+	 * Practically, we pass two fds (3 and 4) and a log level,
+	 * for which the maximum is 6 (TRACE).
+	 * */
+	if (ret < 0 || ret > TRACE)
 		bail("bad value for %s=%s (%d)", name, val, ret);
 
 	return ret;
 }
 
 /*
- * Sets up logging by getting log fd from the environment,
+ * Sets up logging by getting log fd and log level from the environment,
  * if available.
  */
 static void setup_logpipe(void)
@@ -415,6 +425,11 @@ static void setup_logpipe(void)
 		return;
 	}
 	logfd = i;
+
+	i = getenv_int("_LIBCONTAINER_LOGLEVEL");
+	if (i < 0)
+		return;
+	loglevel = i;
 }
 
 /* Returns the clone(2) flag for a namespace, given the name of a namespace. */

--- a/main.go
+++ b/main.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/seccomp"
@@ -177,6 +179,18 @@ func configLogrus(context *cli.Context) error {
 	if context.GlobalBool("debug") {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.SetReportCaller(true)
+		// Shorten function and file names reported by the logger, by
+		// trimming common "github.com/opencontainers/runc" prefix.
+		// This is only done for text formatter.
+		_, file, _, _ := runtime.Caller(0)
+		prefix := filepath.Dir(file) + "/"
+		logrus.SetFormatter(&logrus.TextFormatter{
+			CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+				function := strings.TrimPrefix(f.Function, prefix) + "()"
+				fileLine := strings.TrimPrefix(f.File, prefix) + ":" + strconv.Itoa(f.Line)
+				return function, fileLine
+			},
+		})
 	}
 
 	if file := context.GlobalString("log"); file != "" {

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -99,7 +99,7 @@ func getDefaultImagePath(context *cli.Context) string {
 
 // newProcess returns a new libcontainer Process with the arguments from the
 // spec and stdio from the current process.
-func newProcess(p specs.Process, init bool, logLevel string) (*libcontainer.Process, error) {
+func newProcess(p specs.Process) (*libcontainer.Process, error) {
 	lp := &libcontainer.Process{
 		Args: p.Args,
 		Env:  p.Env,
@@ -109,8 +109,6 @@ func newProcess(p specs.Process, init bool, logLevel string) (*libcontainer.Proc
 		Label:           p.SelinuxLabel,
 		NoNewPrivileges: &p.NoNewPrivileges,
 		AppArmorProfile: p.ApparmorProfile,
-		Init:            init,
-		LogLevel:        logLevel,
 	}
 
 	if p.ConsoleSize != nil {
@@ -272,10 +270,13 @@ func (r *runner) run(config *specs.Process) (int, error) {
 	if err = r.checkTerminal(config); err != nil {
 		return -1, err
 	}
-	process, err := newProcess(*config, r.init, r.logLevel)
+	process, err := newProcess(*config)
 	if err != nil {
 		return -1, err
 	}
+	// Populate the fields that come from runner.
+	process.Init = r.init
+	process.LogLevel = r.logLevel
 	if len(r.listenFDs) > 0 {
 		process.Env = append(process.Env, "LISTEN_FDS="+strconv.Itoa(len(r.listenFDs)), "LISTEN_PID=1")
 		process.ExtraFiles = append(process.ExtraFiles, r.listenFDs...)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -257,7 +257,6 @@ type runner struct {
 	action          CtAct
 	notifySocket    *notifySocket
 	criuOpts        *libcontainer.CriuOpts
-	logLevel        string
 }
 
 func (r *runner) run(config *specs.Process) (int, error) {
@@ -274,9 +273,9 @@ func (r *runner) run(config *specs.Process) (int, error) {
 	if err != nil {
 		return -1, err
 	}
+	process.LogLevel = strconv.Itoa(int(logrus.GetLevel()))
 	// Populate the fields that come from runner.
 	process.Init = r.init
-	process.LogLevel = r.logLevel
 	if len(r.listenFDs) > 0 {
 		process.Env = append(process.Env, "LISTEN_FDS="+strconv.Itoa(len(r.listenFDs)), "LISTEN_PID=1")
 		process.ExtraFiles = append(process.ExtraFiles, r.listenFDs...)
@@ -433,11 +432,6 @@ func startContainer(context *cli.Context, spec *specs.Spec, action CtAct, criuOp
 		listenFDs = activation.Files(false)
 	}
 
-	logLevel := "info"
-	if context.GlobalBool("debug") {
-		logLevel = "debug"
-	}
-
 	r := &runner{
 		enableSubreaper: !context.Bool("no-subreaper"),
 		shouldDestroy:   true,
@@ -451,7 +445,6 @@ func startContainer(context *cli.Context, spec *specs.Spec, action CtAct, criuOp
 		action:          action,
 		criuOpts:        criuOpts,
 		init:            true,
-		logLevel:        logLevel,
 	}
 	return r.run(spec.Process)
 }


### PR DESCRIPTION
This PR is mostly about runc init log refactoring. Makes the code more readable, improves its tests, fixes some issues.

1. Remove `logs.ConfigureLogging` whose existence always bugged me.
    - init.go, main.go: don't use logs.ConfigureLogging
    - libct/logs: remove ConfigureLogging

2. Improve libct/logs and its tests.
    - libct/logs: test: make more robust
    - libct/logs: parse log level implicitly
    - libct/logs: do not show caller in nsexec logs

3. Fix/improve libct/nsenter tests.
    - libct/nsenter: test: logging nits
    - libct/nsenter: test: improve newPipe
    - libct/nsenter: test: fix TestNsenterValidPaths
    - libct/nsenter: test: improve TestNsenterChildLogging
    - libct/nsenter: test: rm misleading comments

4. Make nsexec aware of the log level (i.e. do not emit logs that are to be discarded).
    - utils_linux: simplify newProcess
    - runc init: pass _LIBCONTAINER_LOGLEVEL as int
    - libct/nsenter/nsexec.c: improve bail
    - libct/nsenter/nsexec.c: factor out getenv_int
    - libct/nsenter/nsexec.c: honor _LIBCONTAINER_LOGLEVEL

5. Small improvement (not related to init logs)
    - runc --debug: shorter caller info

Update: split into a few smaller PRS:
 - [x] Items 1, 2, and 5 from the list above go to #3157
 - [x] Item 3 goes to #3158
 - [x] item 4 goes to #3201