### PR TITLE
ci/gha: add latest criu-dev test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,42 @@ jobs:
         go-version: [1.15.x, 1.16.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
+        criu: [""]
+        include:
+          # Also test against latest criu-dev
+          - go-version: 1.16.x
+            rootless: ""
+            race: ""
+            criu: "criu-dev"
 
     steps:
 
     - name: checkout
       uses: actions/checkout@v2
 
+    - name: Dump matrix context
+      env:
+        MATRIX_CONTEXT: ${{ toJSON(matrix) }}
+      run: echo "$MATRIX_CONTEXT"
+
     - name: install deps
+      if: matrix.criu == ''
       run: |
         # criu repo
         sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to
         sudo apt -q install libseccomp-dev criu
+
+    - name: install deps (criu ${{ matrix.criu }})
+      if: matrix.criu != ''
+      run: |
+        sudo apt -q update
+        sudo apt -q install libseccomp-dev \
+          libcap-dev libnet1-dev libnl-3-dev \
+          libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
+        git clone https://github.com/checkpoint-restore/criu.git ~/criu
+        (cd ~/criu && git checkout ${{ matrix.criu }} && sudo make install-criu)
+        rm -rf ~/criu
 
     - name: install go ${{ matrix.go-version }}
       uses: actions/setup-go@v2


### PR DESCRIPTION
Add testing against criu-dev branch instead of a released version
(happens to be criu v3.15 at the moment), to check how it works.

This is just a single job, and it is not required (i.e. its success is not needed to get a PR merged).

Maybe we need to add a similar one for fedora (to better test cgroup v2).
