### PR TITLE
libct/nsenter: fix logging race in nsexec (regression in rc94)

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -136,7 +136,7 @@ int setns(int fd, int nstype)
 
 static void write_log(const char *level, const char *format, ...)
 {
-	char *message = NULL, *stage = NULL;
+	char *message = NULL, *stage = NULL, *json = NULL;
 	va_list args;
 	int ret;
 
@@ -158,11 +158,18 @@ static void write_log(const char *level, const char *format, ...)
 	if (ret < 0)
 		goto out;
 
-	dprintf(logfd, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n", level, stage, getpid(), message);
+	ret = asprintf(&json, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n", level, stage, getpid(), message);
+	if (ret < 0) {
+		json = NULL;
+		goto out;
+	}
+
+	write(logfd, json, ret);
 
 out:
 	free(message);
 	free(stage);
+	free(json);
 }
 
 /* XXX: This is ugly. */


### PR DESCRIPTION
As reported in issue #3119, there is a race in nsexec logging
that can lead to garbled json received by log forwarder, which
complains about it with a "failed to decode" error.

This happens because dprintf (used since the very beginning of nsexec
logging introduced in commit ba3cabf932943) relies on multiple write(2)
calls, and with additional logging added by 64bb59f5920b15d (appeared in rc94)
a race is possible between runc init parent and its children.

The fix is to prepare a string and write it using a single call to
write(2).

Fixes: #3119

Practically, though, debug logging is not needed in 99.9% of all cases,
and so PR #3114 (commit https://github.com/opencontainers/runc/pull/3114/commits/b1bc76248c642660269a0764b02bf7ed2aa77605) eliminates the possibility
of it having this race in the first place. Yet I think this fix makes sense.