### PR TITLE
libct/fs: mv fs.{cgroupTestUtils, helper, CgroupData} to cgroups.

### DIFF
--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -22,8 +22,8 @@ func (s *BlkioGroup) Name() string {
 	return "blkio"
 }
 
-func (s *BlkioGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *BlkioGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *BlkioGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/blkio_test.go
+++ b/libcontainer/cgroups/fs/blkio_test.go
@@ -178,18 +178,18 @@ func TestBlkioSetWeight(t *testing.T) {
 
 	for _, legacyIOScheduler := range []bool{false, true} {
 		// Populate cgroup
-		helper := NewCgroupTestUtil("blkio", t)
+		helper := cgroups.NewCgroupTestUtil("blkio", t)
 		weightFilename := "blkio.bfq.weight"
 		if legacyIOScheduler {
 			weightFilename = "blkio.weight"
 		}
-		helper.writeFileContents(map[string]string{
+		helper.WriteFileContents(map[string]string{
 			weightFilename: strconv.Itoa(weightBefore),
 		})
 		// Apply new configuration
-		helper.CgroupData.config.Resources.BlkioWeight = weightAfter
+		helper.CgroupData.Config.Resources.BlkioWeight = weightAfter
 		blkio := &BlkioGroup{}
-		if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+		if err := blkio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 			t.Fatal(err)
 		}
 		// Verify results
@@ -213,23 +213,23 @@ func TestBlkioSetWeightDevice(t *testing.T) {
 
 	for _, legacyIOScheduler := range []bool{false, true} {
 		// Populate cgroup
-		helper := NewCgroupTestUtil("blkio", t)
+		helper := cgroups.NewCgroupTestUtil("blkio", t)
 		weightFilename := "blkio.bfq.weight"
 		weightDeviceFilename := "blkio.bfq.weight_device"
 		if legacyIOScheduler {
 			weightFilename = "blkio.weight"
 			weightDeviceFilename = "blkio.weight_device"
 		}
-		helper.writeFileContents(map[string]string{
+		helper.WriteFileContents(map[string]string{
 			weightFilename:       "",
 			weightDeviceFilename: weightDeviceBefore,
 		})
 		// Apply new configuration
 		wd := configs.NewWeightDevice(8, 0, 500, 0)
 		weightDeviceAfter := wd.WeightString()
-		helper.CgroupData.config.Resources.BlkioWeightDevice = []*configs.WeightDevice{wd}
+		helper.CgroupData.Config.Resources.BlkioWeightDevice = []*configs.WeightDevice{wd}
 		blkio := &BlkioGroup{}
-		if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+		if err := blkio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 			t.Fatal(err)
 		}
 		// Verify results
@@ -248,7 +248,7 @@ func TestBlkioSetWeightDevice(t *testing.T) {
 
 // regression #274
 func TestBlkioSetMultipleWeightDevice(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
 
 	const (
 		weightDeviceBefore = "8:0 400"
@@ -267,12 +267,12 @@ func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 	if blkio.weightDeviceFilename != "blkio.bfq.weight_device" {
 		t.Fatalf("when blkio controller is unavailable, expected to use \"blkio.bfq.weight_device\", tried to use %q", blkio.weightDeviceFilename)
 	}
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		blkio.weightDeviceFilename: weightDeviceBefore,
 	})
 
-	helper.CgroupData.config.Resources.BlkioWeightDevice = []*configs.WeightDevice{wd1, wd2}
-	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	helper.CgroupData.Config.Resources.BlkioWeightDevice = []*configs.WeightDevice{wd1, wd2}
+	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -286,8 +286,8 @@ func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 }
 
 func TestBlkioBFQDebugStats(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(blkioBFQDebugStatsTestFiles)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(blkioBFQDebugStatsTestFiles)
 	blkio := &BlkioGroup{}
 	actualStats := *cgroups.NewStats()
 	err := blkio.GetStats(helper.CgroupPath, &actualStats)
@@ -340,9 +340,9 @@ func TestBlkioBFQDebugStats(t *testing.T) {
 }
 
 func TestBlkioMultipleStatsFiles(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(blkioBFQDebugStatsTestFiles)
-	helper.writeFileContents(blkioCFQStatsTestFiles)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(blkioBFQDebugStatsTestFiles)
+	helper.WriteFileContents(blkioCFQStatsTestFiles)
 	blkio := &BlkioGroup{}
 	actualStats := *cgroups.NewStats()
 	err := blkio.GetStats(helper.CgroupPath, &actualStats)
@@ -395,8 +395,8 @@ func TestBlkioMultipleStatsFiles(t *testing.T) {
 }
 
 func TestBlkioBFQStats(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(blkioBFQStatsTestFiles)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(blkioBFQStatsTestFiles)
 	blkio := &BlkioGroup{}
 	actualStats := *cgroups.NewStats()
 	err := blkio.GetStats(helper.CgroupPath, &actualStats)
@@ -461,7 +461,7 @@ func TestBlkioStatsNoFilesBFQDebug(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		helper := NewCgroupTestUtil("cpuset", t)
+		helper := cgroups.NewCgroupTestUtil("cpuset", t)
 
 		tempBlkioTestFiles := map[string]string{}
 		for i, v := range blkioBFQDebugStatsTestFiles {
@@ -469,7 +469,7 @@ func TestBlkioStatsNoFilesBFQDebug(t *testing.T) {
 		}
 		delete(tempBlkioTestFiles, testCase.filename)
 
-		helper.writeFileContents(tempBlkioTestFiles)
+		helper.WriteFileContents(tempBlkioTestFiles)
 		cpuset := &CpusetGroup{}
 		actualStats := *cgroups.NewStats()
 		err := cpuset.GetStats(helper.CgroupPath, &actualStats)
@@ -480,8 +480,8 @@ func TestBlkioStatsNoFilesBFQDebug(t *testing.T) {
 }
 
 func TestBlkioCFQStats(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(blkioCFQStatsTestFiles)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(blkioCFQStatsTestFiles)
 
 	blkio := &BlkioGroup{}
 	actualStats := *cgroups.NewStats()
@@ -575,7 +575,7 @@ func TestBlkioStatsNoFilesCFQ(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		helper := NewCgroupTestUtil("cpuset", t)
+		helper := cgroups.NewCgroupTestUtil("cpuset", t)
 
 		tempBlkioTestFiles := map[string]string{}
 		for i, v := range blkioCFQStatsTestFiles {
@@ -583,7 +583,7 @@ func TestBlkioStatsNoFilesCFQ(t *testing.T) {
 		}
 		delete(tempBlkioTestFiles, testCase.filename)
 
-		helper.writeFileContents(tempBlkioTestFiles)
+		helper.WriteFileContents(tempBlkioTestFiles)
 		cpuset := &CpusetGroup{}
 		actualStats := *cgroups.NewStats()
 		err := cpuset.GetStats(helper.CgroupPath, &actualStats)
@@ -594,8 +594,8 @@ func TestBlkioStatsNoFilesCFQ(t *testing.T) {
 }
 
 func TestBlkioStatsUnexpectedNumberOfFields(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "8:0 Read 100 100",
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
@@ -615,8 +615,8 @@ func TestBlkioStatsUnexpectedNumberOfFields(t *testing.T) {
 }
 
 func TestBlkioStatsUnexpectedFieldType(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "8:0 Read Write",
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
@@ -636,8 +636,8 @@ func TestBlkioStatsUnexpectedFieldType(t *testing.T) {
 }
 
 func TestThrottleRecursiveBlkioStats(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive":          "",
 		"blkio.io_serviced_recursive":               "",
 		"blkio.io_queued_recursive":                 "",
@@ -686,8 +686,8 @@ func TestThrottleRecursiveBlkioStats(t *testing.T) {
 }
 
 func TestThrottleBlkioStats(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
+	helper.WriteFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "",
 		"blkio.io_serviced_recursive":      "",
 		"blkio.io_queued_recursive":        "",
@@ -736,7 +736,7 @@ func TestThrottleBlkioStats(t *testing.T) {
 }
 
 func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
 
 	const (
 		throttleBefore = `8:0 1024`
@@ -745,13 +745,13 @@ func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
 	td := configs.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"blkio.throttle.read_bps_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.Resources.BlkioThrottleReadBpsDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.Config.Resources.BlkioThrottleReadBpsDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
-	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -765,7 +765,7 @@ func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
 }
 
 func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
 
 	const (
 		throttleBefore = `8:0 1024`
@@ -774,13 +774,13 @@ func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
 	td := configs.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"blkio.throttle.write_bps_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.Resources.BlkioThrottleWriteBpsDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.Config.Resources.BlkioThrottleWriteBpsDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
-	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -794,7 +794,7 @@ func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
 }
 
 func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
 
 	const (
 		throttleBefore = `8:0 1024`
@@ -803,13 +803,13 @@ func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
 	td := configs.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"blkio.throttle.read_iops_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.Resources.BlkioThrottleReadIOPSDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.Config.Resources.BlkioThrottleReadIOPSDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
-	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -823,7 +823,7 @@ func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
 }
 
 func TestBlkioSetThrottleWriteIOpsDevice(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
+	helper := cgroups.NewCgroupTestUtil("blkio", t)
 
 	const (
 		throttleBefore = `8:0 1024`
@@ -832,13 +832,13 @@ func TestBlkioSetThrottleWriteIOpsDevice(t *testing.T) {
 	td := configs.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"blkio.throttle.write_iops_device": throttleBefore,
 	})
 
-	helper.CgroupData.config.Resources.BlkioThrottleWriteIOPSDevice = []*configs.ThrottleDevice{td}
+	helper.CgroupData.Config.Resources.BlkioThrottleWriteIOPSDevice = []*configs.ThrottleDevice{td}
 	blkio := &BlkioGroup{}
-	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := blkio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -19,7 +19,7 @@ func (s *CpuGroup) Name() string {
 	return "cpu"
 }
 
-func (s *CpuGroup) Apply(path string, d *cgroupData) error {
+func (s *CpuGroup) Apply(path string, d *cgroups.CgroupData) error {
 	// This might happen if we have no cpu cgroup mounted.
 	// Just do nothing and don't fail.
 	if path == "" {
@@ -31,12 +31,12 @@ func (s *CpuGroup) Apply(path string, d *cgroupData) error {
 	// We should set the real-Time group scheduling settings before moving
 	// in the process because if the process is already in SCHED_RR mode
 	// and no RT bandwidth is set, adding it will fail.
-	if err := s.SetRtSched(path, d.config.Resources); err != nil {
+	if err := s.SetRtSched(path, d.Config.Resources); err != nil {
 		return err
 	}
 	// Since we are not using join(), we need to place the pid
 	// into the procs file unlike other subsystems.
-	return cgroups.WriteCgroupProc(path, d.pid)
+	return cgroups.WriteCgroupProc(path, d.Pid)
 }
 
 func (s *CpuGroup) SetRtSched(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -12,20 +12,20 @@ import (
 )
 
 func TestCpuSetShares(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
+	helper := cgroups.NewCgroupTestUtil("cpu", t)
 
 	const (
 		sharesBefore = 1024
 		sharesAfter  = 512
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"cpu.shares": strconv.Itoa(sharesBefore),
 	})
 
-	helper.CgroupData.config.Resources.CpuShares = sharesAfter
+	helper.CgroupData.Config.Resources.CpuShares = sharesAfter
 	cpu := &CpuGroup{}
-	if err := cpu.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := cpu.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -39,7 +39,7 @@ func TestCpuSetShares(t *testing.T) {
 }
 
 func TestCpuSetBandWidth(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
+	helper := cgroups.NewCgroupTestUtil("cpu", t)
 
 	const (
 		quotaBefore     = 8000
@@ -52,19 +52,19 @@ func TestCpuSetBandWidth(t *testing.T) {
 		rtPeriodAfter   = 7000
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"cpu.cfs_quota_us":  strconv.Itoa(quotaBefore),
 		"cpu.cfs_period_us": strconv.Itoa(periodBefore),
 		"cpu.rt_runtime_us": strconv.Itoa(rtRuntimeBefore),
 		"cpu.rt_period_us":  strconv.Itoa(rtPeriodBefore),
 	})
 
-	helper.CgroupData.config.Resources.CpuQuota = quotaAfter
-	helper.CgroupData.config.Resources.CpuPeriod = periodAfter
-	helper.CgroupData.config.Resources.CpuRtRuntime = rtRuntimeAfter
-	helper.CgroupData.config.Resources.CpuRtPeriod = rtPeriodAfter
+	helper.CgroupData.Config.Resources.CpuQuota = quotaAfter
+	helper.CgroupData.Config.Resources.CpuPeriod = periodAfter
+	helper.CgroupData.Config.Resources.CpuRtRuntime = rtRuntimeAfter
+	helper.CgroupData.Config.Resources.CpuRtPeriod = rtPeriodAfter
 	cpu := &CpuGroup{}
-	if err := cpu.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := cpu.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,7 +102,7 @@ func TestCpuSetBandWidth(t *testing.T) {
 }
 
 func TestCpuStats(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
+	helper := cgroups.NewCgroupTestUtil("cpu", t)
 
 	const (
 		nrPeriods     = 2000
@@ -112,7 +112,7 @@ func TestCpuStats(t *testing.T) {
 
 	cpuStatContent := fmt.Sprintf("nr_periods %d\nnr_throttled %d\nthrottled_time %d\n",
 		nrPeriods, nrThrottled, throttledTime)
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"cpu.stat": cpuStatContent,
 	})
 
@@ -133,7 +133,7 @@ func TestCpuStats(t *testing.T) {
 }
 
 func TestNoCpuStatFile(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
+	helper := cgroups.NewCgroupTestUtil("cpu", t)
 
 	cpu := &CpuGroup{}
 	actualStats := *cgroups.NewStats()
@@ -144,12 +144,12 @@ func TestNoCpuStatFile(t *testing.T) {
 }
 
 func TestInvalidCpuStat(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
+	helper := cgroups.NewCgroupTestUtil("cpu", t)
 
 	cpuStatContent := `nr_periods 2000
 	nr_throttled 200
 	throttled_time fortytwo`
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"cpu.stat": cpuStatContent,
 	})
 
@@ -162,7 +162,7 @@ func TestInvalidCpuStat(t *testing.T) {
 }
 
 func TestCpuSetRtSchedAtApply(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
+	helper := cgroups.NewCgroupTestUtil("cpu", t)
 
 	const (
 		rtRuntimeBefore = 0
@@ -171,16 +171,16 @@ func TestCpuSetRtSchedAtApply(t *testing.T) {
 		rtPeriodAfter   = 7000
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"cpu.rt_runtime_us": strconv.Itoa(rtRuntimeBefore),
 		"cpu.rt_period_us":  strconv.Itoa(rtPeriodBefore),
 	})
 
-	helper.CgroupData.config.Resources.CpuRtRuntime = rtRuntimeAfter
-	helper.CgroupData.config.Resources.CpuRtPeriod = rtPeriodAfter
+	helper.CgroupData.Config.Resources.CpuRtRuntime = rtRuntimeAfter
+	helper.CgroupData.Config.Resources.CpuRtPeriod = rtPeriodAfter
 	cpu := &CpuGroup{}
 
-	helper.CgroupData.pid = 1234
+	helper.CgroupData.Pid = 1234
 	if err := cpu.Apply(helper.CgroupPath, helper.CgroupData); err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -36,8 +36,8 @@ func (s *CpuacctGroup) Name() string {
 	return "cpuacct"
 }
 
-func (s *CpuacctGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *CpuacctGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *CpuacctGroup) Set(_ string, _ *configs.Resources) error {

--- a/libcontainer/cgroups/fs/cpuacct_test.go
+++ b/libcontainer/cgroups/fs/cpuacct_test.go
@@ -26,8 +26,8 @@ const (
 )
 
 func TestCpuacctStats(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuacct.", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("cpuacct.", t)
+	helper.WriteFileContents(map[string]string{
 		"cpuacct.usage":        cpuAcctUsageContents,
 		"cpuacct.usage_percpu": cpuAcctUsagePerCPUContents,
 		"cpuacct.stat":         cpuAcctStatContents,
@@ -66,8 +66,8 @@ func TestCpuacctStats(t *testing.T) {
 }
 
 func TestCpuacctStatsWithoutUsageAll(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuacct.", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("cpuacct.", t)
+	helper.WriteFileContents(map[string]string{
 		"cpuacct.usage":        cpuAcctUsageContents,
 		"cpuacct.usage_percpu": cpuAcctUsagePerCPUContents,
 		"cpuacct.stat":         cpuAcctStatContents,

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -22,8 +22,8 @@ func (s *CpusetGroup) Name() string {
 	return "cpuset"
 }
 
-func (s *CpusetGroup) Apply(path string, d *cgroupData) error {
-	return s.ApplyDir(path, d.config.Resources, d.pid)
+func (s *CpusetGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return s.ApplyDir(path, d.Config.Resources, d.Pid)
 }
 
 func (s *CpusetGroup) Set(path string, r *configs.Resources) error {
@@ -162,7 +162,7 @@ func (s *CpusetGroup) ApplyDir(dir string, r *configs.Resources, pid int) error 
 	// to ensure cpuset configs are set before moving task into the
 	// cgroup.
 	// The logic is, if user specified cpuset configs, use these
-	// specified configs, otherwise, inherit from parent. This makes
+	// specified.Configs, otherwise, inherit from parent. This makes
 	// cpuset configs work correctly with 'cpuset.cpu_exclusive', and
 	// keep backward compatibility.
 	if err := s.ensureCpusAndMems(dir, r); err != nil {

--- a/libcontainer/cgroups/fs/cpuset_test.go
+++ b/libcontainer/cgroups/fs/cpuset_test.go
@@ -39,20 +39,20 @@ var cpusetTestFiles = map[string]string{
 }
 
 func TestCPUSetSetCpus(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuset", t)
+	helper := cgroups.NewCgroupTestUtil("cpuset", t)
 
 	const (
 		cpusBefore = "0"
 		cpusAfter  = "1-3"
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"cpuset.cpus": cpusBefore,
 	})
 
-	helper.CgroupData.config.Resources.CpusetCpus = cpusAfter
+	helper.CgroupData.Config.Resources.CpusetCpus = cpusAfter
 	cpuset := &CpusetGroup{}
-	if err := cpuset.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := cpuset.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -66,20 +66,20 @@ func TestCPUSetSetCpus(t *testing.T) {
 }
 
 func TestCPUSetSetMems(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuset", t)
+	helper := cgroups.NewCgroupTestUtil("cpuset", t)
 
 	const (
 		memsBefore = "0"
 		memsAfter  = "1"
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"cpuset.mems": memsBefore,
 	})
 
-	helper.CgroupData.config.Resources.CpusetMems = memsAfter
+	helper.CgroupData.Config.Resources.CpusetMems = memsAfter
 	cpuset := &CpusetGroup{}
-	if err := cpuset.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := cpuset.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -93,8 +93,8 @@ func TestCPUSetSetMems(t *testing.T) {
 }
 
 func TestCPUSetStatsCorrect(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuset", t)
-	helper.writeFileContents(cpusetTestFiles)
+	helper := cgroups.NewCgroupTestUtil("cpuset", t)
+	helper.WriteFileContents(cpusetTestFiles)
 
 	cpuset := &CpusetGroup{}
 	actualStats := *cgroups.NewStats()
@@ -207,7 +207,7 @@ func TestCPUSetStatsMissingFiles(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.desc, func(t *testing.T) {
-			helper := NewCgroupTestUtil("cpuset", t)
+			helper := cgroups.NewCgroupTestUtil("cpuset", t)
 
 			tempCpusetTestFiles := map[string]string{}
 			for i, v := range cpusetTestFiles {
@@ -216,7 +216,7 @@ func TestCPUSetStatsMissingFiles(t *testing.T) {
 
 			if testCase.removeFile {
 				delete(tempCpusetTestFiles, testCase.filename)
-				helper.writeFileContents(tempCpusetTestFiles)
+				helper.WriteFileContents(tempCpusetTestFiles)
 				cpuset := &CpusetGroup{}
 				actualStats := *cgroups.NewStats()
 				err := cpuset.GetStats(helper.CgroupPath, &actualStats)
@@ -225,7 +225,7 @@ func TestCPUSetStatsMissingFiles(t *testing.T) {
 				}
 			} else {
 				tempCpusetTestFiles[testCase.filename] = testCase.contents
-				helper.writeFileContents(tempCpusetTestFiles)
+				helper.WriteFileContents(tempCpusetTestFiles)
 				cpuset := &CpusetGroup{}
 				actualStats := *cgroups.NewStats()
 				err := cpuset.GetStats(helper.CgroupPath, &actualStats)

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -22,8 +22,8 @@ func (s *DevicesGroup) Name() string {
 	return "devices"
 }
 
-func (s *DevicesGroup) Apply(path string, d *cgroupData) error {
-	if d.config.SkipDevices {
+func (s *DevicesGroup) Apply(path string, d *cgroups.CgroupData) error {
+	if d.Config.SkipDevices {
 		return nil
 	}
 	if path == "" {
@@ -31,7 +31,7 @@ func (s *DevicesGroup) Apply(path string, d *cgroupData) error {
 		// is a hard requirement for container's security.
 		return errSubsystemDoesNotExist
 	}
-	return join(path, d.pid)
+	return join(path, d.Pid)
 }
 
 func loadEmulator(path string) (*cgroupdevices.Emulator, error) {

--- a/libcontainer/cgroups/fs/devices_test.go
+++ b/libcontainer/cgroups/fs/devices_test.go
@@ -5,20 +5,21 @@ package fs
 import (
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
 func TestDevicesSetAllow(t *testing.T) {
-	helper := NewCgroupTestUtil("devices", t)
+	helper := cgroups.NewCgroupTestUtil("devices", t)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"devices.allow": "",
 		"devices.deny":  "",
 		"devices.list":  "a *:* rwm",
 	})
 
-	helper.CgroupData.config.Resources.Devices = []*devices.Rule{
+	helper.CgroupData.Config.Resources.Devices = []*devices.Rule{
 		{
 			Type:        devices.CharDevice,
 			Major:       1,
@@ -29,7 +30,7 @@ func TestDevicesSetAllow(t *testing.T) {
 	}
 
 	d := &DevicesGroup{testingSkipFinalCheck: true}
-	if err := d.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := d.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -21,8 +21,8 @@ func (s *FreezerGroup) Name() string {
 	return "freezer"
 }
 
-func (s *FreezerGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *FreezerGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {

--- a/libcontainer/cgroups/fs/freezer_test.go
+++ b/libcontainer/cgroups/fs/freezer_test.go
@@ -5,20 +5,21 @@ package fs
 import (
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func TestFreezerSetState(t *testing.T) {
-	helper := NewCgroupTestUtil("freezer", t)
+	helper := cgroups.NewCgroupTestUtil("freezer", t)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"freezer.state": string(configs.Frozen),
 	})
 
-	helper.CgroupData.config.Resources.Freezer = configs.Thawed
+	helper.CgroupData.Config.Resources.Freezer = configs.Thawed
 	freezer := &FreezerGroup{}
-	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -32,15 +33,15 @@ func TestFreezerSetState(t *testing.T) {
 }
 
 func TestFreezerSetInvalidState(t *testing.T) {
-	helper := NewCgroupTestUtil("freezer", t)
+	helper := cgroups.NewCgroupTestUtil("freezer", t)
 
 	const (
 		invalidArg configs.FreezerState = "Invalid"
 	)
 
-	helper.CgroupData.config.Resources.Freezer = invalidArg
+	helper.CgroupData.Config.Resources.Freezer = invalidArg
 	freezer := &FreezerGroup{}
-	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err == nil {
+	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err == nil {
 		t.Fatal("Failed to return invalid argument error")
 	}
 }

--- a/libcontainer/cgroups/fs/fs_test.go
+++ b/libcontainer/cgroups/fs/fs_test.go
@@ -74,14 +74,14 @@ func TestInvalidCgroupPath(t *testing.T) {
 				t.Fatalf("couldn't get cgroup data: %v", err)
 			}
 
-			// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-			if strings.HasPrefix(data.innerPath, "..") {
-				t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
+			// Make sure the final InnerPath doesn't go outside the cgroup mountpoint.
+			if strings.HasPrefix(data.InnerPath, "..") {
+				t.Errorf("SECURITY: cgroup InnerPath is outside cgroup mountpoint!")
 			}
 
 			// Double-check, using an actual cgroup.
 			deviceRoot := filepath.Join(root, "devices")
-			devicePath, err := data.path("devices")
+			devicePath, err := data.Path("devices")
 			if err != nil {
 				t.Fatalf("couldn't get cgroup path: %v", err)
 			}

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -16,8 +16,8 @@ func (s *HugetlbGroup) Name() string {
 	return "hugetlb"
 }
 
-func (s *HugetlbGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *HugetlbGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *HugetlbGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 func TestHugetlbSetHugetlb(t *testing.T) {
-	helper := NewCgroupTestUtil("hugetlb", t)
+	helper := cgroups.NewCgroupTestUtil("hugetlb", t)
 
 	const (
 		hugetlbBefore = 256
@@ -34,20 +34,20 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 	)
 
 	for _, pageSize := range HugePageSizes {
-		helper.writeFileContents(map[string]string{
+		helper.WriteFileContents(map[string]string{
 			fmt.Sprintf(limit, pageSize): strconv.Itoa(hugetlbBefore),
 		})
 	}
 
 	for _, pageSize := range HugePageSizes {
-		helper.CgroupData.config.Resources.HugetlbLimit = []*configs.HugepageLimit{
+		helper.CgroupData.Config.Resources.HugetlbLimit = []*configs.HugepageLimit{
 			{
 				Pagesize: pageSize,
 				Limit:    hugetlbAfter,
 			},
 		}
 		hugetlb := &HugetlbGroup{}
-		if err := hugetlb.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+		if err := hugetlb.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -65,9 +65,9 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 }
 
 func TestHugetlbStats(t *testing.T) {
-	helper := NewCgroupTestUtil("hugetlb", t)
+	helper := cgroups.NewCgroupTestUtil("hugetlb", t)
 	for _, pageSize := range HugePageSizes {
-		helper.writeFileContents(map[string]string{
+		helper.WriteFileContents(map[string]string{
 			fmt.Sprintf(usage, pageSize):    hugetlbUsageContents,
 			fmt.Sprintf(maxUsage, pageSize): hugetlbMaxUsageContents,
 			fmt.Sprintf(failcnt, pageSize):  hugetlbFailcnt,
@@ -87,8 +87,8 @@ func TestHugetlbStats(t *testing.T) {
 }
 
 func TestHugetlbStatsNoUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("hugetlb", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("hugetlb", t)
+	helper.WriteFileContents(map[string]string{
 		maxUsage: hugetlbMaxUsageContents,
 	})
 
@@ -101,9 +101,9 @@ func TestHugetlbStatsNoUsageFile(t *testing.T) {
 }
 
 func TestHugetlbStatsNoMaxUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("hugetlb", t)
+	helper := cgroups.NewCgroupTestUtil("hugetlb", t)
 	for _, pageSize := range HugePageSizes {
-		helper.writeFileContents(map[string]string{
+		helper.WriteFileContents(map[string]string{
 			fmt.Sprintf(usage, pageSize): hugetlbUsageContents,
 		})
 	}
@@ -117,9 +117,9 @@ func TestHugetlbStatsNoMaxUsageFile(t *testing.T) {
 }
 
 func TestHugetlbStatsBadUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("hugetlb", t)
+	helper := cgroups.NewCgroupTestUtil("hugetlb", t)
 	for _, pageSize := range HugePageSizes {
-		helper.writeFileContents(map[string]string{
+		helper.WriteFileContents(map[string]string{
 			fmt.Sprintf(usage, pageSize): "bad",
 			maxUsage:                     hugetlbMaxUsageContents,
 		})
@@ -134,8 +134,8 @@ func TestHugetlbStatsBadUsageFile(t *testing.T) {
 }
 
 func TestHugetlbStatsBadMaxUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("hugetlb", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("hugetlb", t)
+	helper.WriteFileContents(map[string]string{
 		usage:    hugetlbUsageContents,
 		maxUsage: "bad",
 	})

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -32,8 +32,8 @@ func (s *MemoryGroup) Name() string {
 	return "memory"
 }
 
-func (s *MemoryGroup) Apply(path string, d *cgroupData) (err error) {
-	return join(path, d.pid)
+func (s *MemoryGroup) Apply(path string, d *cgroups.CgroupData) (err error) {
+	return join(path, d.Pid)
 }
 
 func setMemory(path string, val int64) error {

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -40,7 +40,7 @@ whatever=100 N0=0
 )
 
 func TestMemorySetMemory(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 
 	const (
 		memoryBefore      = 314572800 // 300M
@@ -49,15 +49,15 @@ func TestMemorySetMemory(t *testing.T) {
 		reservationAfter  = 314572800 // 300M
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"memory.limit_in_bytes":      strconv.Itoa(memoryBefore),
 		"memory.soft_limit_in_bytes": strconv.Itoa(reservationBefore),
 	})
 
-	helper.CgroupData.config.Resources.Memory = memoryAfter
-	helper.CgroupData.config.Resources.MemoryReservation = reservationAfter
+	helper.CgroupData.Config.Resources.Memory = memoryAfter
+	helper.CgroupData.Config.Resources.MemoryReservation = reservationAfter
 	memory := &MemoryGroup{}
-	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -79,20 +79,20 @@ func TestMemorySetMemory(t *testing.T) {
 }
 
 func TestMemorySetMemoryswap(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 
 	const (
 		memoryswapBefore = 314572800 // 300M
 		memoryswapAfter  = 524288000 // 500M
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"memory.memsw.limit_in_bytes": strconv.Itoa(memoryswapBefore),
 	})
 
-	helper.CgroupData.config.Resources.MemorySwap = memoryswapAfter
+	helper.CgroupData.Config.Resources.MemorySwap = memoryswapAfter
 	memory := &MemoryGroup{}
-	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -106,7 +106,7 @@ func TestMemorySetMemoryswap(t *testing.T) {
 }
 
 func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 
 	const (
 		memoryBefore     = 314572800 // 300M
@@ -115,7 +115,7 @@ func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
 		memoryswapAfter  = 838860800 // 800M
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"memory.limit_in_bytes":       strconv.Itoa(memoryBefore),
 		"memory.memsw.limit_in_bytes": strconv.Itoa(memoryswapBefore),
 		// Set will call getMemoryData when memory and swap memory are
@@ -125,10 +125,10 @@ func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
 		"memory.failcnt":            "0",
 	})
 
-	helper.CgroupData.config.Resources.Memory = memoryAfter
-	helper.CgroupData.config.Resources.MemorySwap = memoryswapAfter
+	helper.CgroupData.Config.Resources.Memory = memoryAfter
+	helper.CgroupData.Config.Resources.MemorySwap = memoryswapAfter
 	memory := &MemoryGroup{}
-	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -150,7 +150,7 @@ func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
 }
 
 func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 
 	const (
 		memoryBefore     = 629145600 // 600M
@@ -159,15 +159,15 @@ func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
 		memoryswapAfter  = 524288000 // 500M
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"memory.limit_in_bytes":       strconv.Itoa(memoryBefore),
 		"memory.memsw.limit_in_bytes": strconv.Itoa(memoryswapBefore),
 	})
 
-	helper.CgroupData.config.Resources.Memory = memoryAfter
-	helper.CgroupData.config.Resources.MemorySwap = memoryswapAfter
+	helper.CgroupData.Config.Resources.Memory = memoryAfter
+	helper.CgroupData.Config.Resources.MemorySwap = memoryswapAfter
 	memory := &MemoryGroup{}
-	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,18 +189,18 @@ func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
 }
 
 func TestMemorySetMemorySwappinessDefault(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 
 	swappinessBefore := 60 // default is 60
 	swappinessAfter := uint64(0)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"memory.swappiness": strconv.Itoa(swappinessBefore),
 	})
 
-	helper.CgroupData.config.Resources.MemorySwappiness = &swappinessAfter
+	helper.CgroupData.Config.Resources.MemorySwappiness = &swappinessAfter
 	memory := &MemoryGroup{}
-	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -214,8 +214,8 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 }
 
 func TestMemoryStats(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":                     memoryStatContents,
 		"memory.usage_in_bytes":           memoryUsageContents,
 		"memory.limit_in_bytes":           memoryLimitContents,
@@ -265,8 +265,8 @@ func TestMemoryStats(t *testing.T) {
 }
 
 func TestMemoryStatsNoStatFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
 		"memory.limit_in_bytes":     memoryLimitContents,
@@ -281,8 +281,8 @@ func TestMemoryStatsNoStatFile(t *testing.T) {
 }
 
 func TestMemoryStatsNoUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
 		"memory.limit_in_bytes":     memoryLimitContents,
@@ -297,8 +297,8 @@ func TestMemoryStatsNoUsageFile(t *testing.T) {
 }
 
 func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":           memoryStatContents,
 		"memory.usage_in_bytes": memoryUsageContents,
 		"memory.limit_in_bytes": memoryLimitContents,
@@ -313,8 +313,8 @@ func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
 }
 
 func TestMemoryStatsNoLimitInBytesFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -329,8 +329,8 @@ func TestMemoryStatsNoLimitInBytesFile(t *testing.T) {
 }
 
 func TestMemoryStatsBadStatFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":               "rss rss",
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -346,8 +346,8 @@ func TestMemoryStatsBadStatFile(t *testing.T) {
 }
 
 func TestMemoryStatsBadUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     "bad",
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -363,8 +363,8 @@ func TestMemoryStatsBadUsageFile(t *testing.T) {
 }
 
 func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": "bad",
@@ -380,8 +380,8 @@ func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
 }
 
 func TestMemoryStatsBadLimitInBytesFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -397,18 +397,18 @@ func TestMemoryStatsBadLimitInBytesFile(t *testing.T) {
 }
 
 func TestMemorySetOomControl(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 
 	const (
 		oomKillDisable = 1 // disable oom killer, default is 0
 	)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"memory.oom_control": strconv.Itoa(oomKillDisable),
 	})
 
 	memory := &MemoryGroup{}
-	if err := memory.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -422,8 +422,8 @@ func TestMemorySetOomControl(t *testing.T) {
 }
 
 func TestNoHierarchicalNumaStat(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	helper.writeFileContents(map[string]string{
+	helper := cgroups.NewCgroupTestUtil("memory", t)
+	helper.WriteFileContents(map[string]string{
 		"memory.numa_stat": memoryNUMAStatNoHierarchyContents + memoryNUMAStatExtraContents,
 	})
 
@@ -472,9 +472,9 @@ anon=183 N0=12 badone
 `,
 		},
 	}
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 	for _, c := range memoryNUMAStatBadContents {
-		helper.writeFileContents(map[string]string{
+		helper.WriteFileContents(map[string]string{
 			"memory.numa_stat": c.contents,
 		})
 
@@ -486,7 +486,7 @@ anon=183 N0=12 badone
 }
 
 func TestWithoutNumaStat(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
+	helper := cgroups.NewCgroupTestUtil("memory", t)
 
 	actualStats, err := getPageUsageByNUMA(helper.CgroupPath)
 	if err != nil {

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -16,10 +16,10 @@ func (s *NameGroup) Name() string {
 	return s.GroupName
 }
 
-func (s *NameGroup) Apply(path string, d *cgroupData) error {
+func (s *NameGroup) Apply(path string, d *cgroups.CgroupData) error {
 	if s.Join {
 		// ignore errors if the named cgroup does not exist
-		_ = join(path, d.pid)
+		_ = join(path, d.Pid)
 	}
 	return nil
 }

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -15,8 +15,8 @@ func (s *NetClsGroup) Name() string {
 	return "net_cls"
 }
 
-func (s *NetClsGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *NetClsGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *NetClsGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 )
 
@@ -15,15 +16,15 @@ const (
 )
 
 func TestNetClsSetClassid(t *testing.T) {
-	helper := NewCgroupTestUtil("net_cls", t)
+	helper := cgroups.NewCgroupTestUtil("net_cls", t)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"net_cls.classid": strconv.FormatUint(classidBefore, 10),
 	})
 
-	helper.CgroupData.config.Resources.NetClsClassid = classidAfter
+	helper.CgroupData.Config.Resources.NetClsClassid = classidAfter
 	netcls := &NetClsGroup{}
-	if err := netcls.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := netcls.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -13,8 +13,8 @@ func (s *NetPrioGroup) Name() string {
 	return "net_prio"
 }
 
-func (s *NetPrioGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *NetPrioGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *NetPrioGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/net_prio_test.go
+++ b/libcontainer/cgroups/fs/net_prio_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
@@ -18,11 +19,11 @@ var prioMap = []*configs.IfPrioMap{
 }
 
 func TestNetPrioSetIfPrio(t *testing.T) {
-	helper := NewCgroupTestUtil("net_prio", t)
+	helper := cgroups.NewCgroupTestUtil("net_prio", t)
 
-	helper.CgroupData.config.Resources.NetPrioIfpriomap = prioMap
+	helper.CgroupData.Config.Resources.NetPrioIfpriomap = prioMap
 	netPrio := &NetPrioGroup{}
-	if err := netPrio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := netPrio.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libcontainer/cgroups/fs/perf_event.go
+++ b/libcontainer/cgroups/fs/perf_event.go
@@ -13,8 +13,8 @@ func (s *PerfEventGroup) Name() string {
 	return "perf_event"
 }
 
-func (s *PerfEventGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *PerfEventGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *PerfEventGroup) Set(_ string, _ *configs.Resources) error {

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -17,8 +17,8 @@ func (s *PidsGroup) Name() string {
 	return "pids"
 }
 
-func (s *PidsGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+func (s *PidsGroup) Apply(path string, d *cgroups.CgroupData) error {
+	return join(path, d.Pid)
 }
 
 func (s *PidsGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -16,15 +16,15 @@ const (
 )
 
 func TestPidsSetMax(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	helper := cgroups.NewCgroupTestUtil("pids", t)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"pids.max": "max",
 	})
 
-	helper.CgroupData.config.Resources.PidsLimit = maxLimited
+	helper.CgroupData.Config.Resources.PidsLimit = maxLimited
 	pids := &PidsGroup{}
-	if err := pids.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := pids.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -38,15 +38,15 @@ func TestPidsSetMax(t *testing.T) {
 }
 
 func TestPidsSetUnlimited(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	helper := cgroups.NewCgroupTestUtil("pids", t)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"pids.max": strconv.Itoa(maxLimited),
 	})
 
-	helper.CgroupData.config.Resources.PidsLimit = maxUnlimited
+	helper.CgroupData.Config.Resources.PidsLimit = maxUnlimited
 	pids := &PidsGroup{}
-	if err := pids.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := pids.Set(helper.CgroupPath, helper.CgroupData.Config.Resources); err != nil {
 		t.Fatal(err)
 	}
 
@@ -60,9 +60,9 @@ func TestPidsSetUnlimited(t *testing.T) {
 }
 
 func TestPidsStats(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	helper := cgroups.NewCgroupTestUtil("pids", t)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"pids.current": strconv.Itoa(1337),
 		"pids.max":     strconv.Itoa(maxLimited),
 	})
@@ -83,9 +83,9 @@ func TestPidsStats(t *testing.T) {
 }
 
 func TestPidsStatsUnlimited(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	helper := cgroups.NewCgroupTestUtil("pids", t)
 
-	helper.writeFileContents(map[string]string{
+	helper.WriteFileContents(map[string]string{
 		"pids.current": strconv.Itoa(4096),
 		"pids.max":     "max",
 	})

--- a/libcontainer/cgroups/fs/util_test.go
+++ b/libcontainer/cgroups/fs/util_test.go
@@ -8,50 +8,9 @@ Creates a mock of the cgroup filesystem for the duration of the test.
 package fs
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
-
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func init() {
 	cgroups.TestMode = true
-}
-
-type cgroupTestUtil struct {
-	// cgroup data to use in tests.
-	CgroupData *cgroupData
-
-	// Path to the mock cgroup directory.
-	CgroupPath string
-
-	t *testing.T
-}
-
-// Creates a new test util for the specified subsystem
-func NewCgroupTestUtil(subsystem string, t *testing.T) *cgroupTestUtil {
-	d := &cgroupData{
-		config: &configs.Cgroup{
-			Resources: &configs.Resources{},
-		},
-		root: t.TempDir(),
-	}
-	testCgroupPath := filepath.Join(d.root, subsystem)
-	// Ensure the full mock cgroup path exists.
-	if err := os.MkdirAll(testCgroupPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return &cgroupTestUtil{CgroupData: d, CgroupPath: testCgroupPath, t: t}
-}
-
-// Write the specified contents on the mock of the specified cgroup files.
-func (c *cgroupTestUtil) writeFileContents(fileContents map[string]string) {
-	for file, contents := range fileContents {
-		err := cgroups.WriteFile(c.CgroupPath, file, contents)
-		if err != nil {
-			c.t.Fatal(err)
-		}
-	}
 }


### PR DESCRIPTION
Hi team,

Following PR is moving `cgroupTestUtils, CgroupData` from `fs` -> `cgroups` so that it can be used by `fscommon`, `fs2` and other dependent packages in future. 
PR https://github.com/opencontainers/runc/pull/2883 is blocked on this , refer to thread https://github.com/opencontainers/runc/pull/2883#discussion_r679585981 for origin discussion. 