### PR TITLE
`linux`: Support setting execution domain via linux `personality`.

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -206,6 +206,9 @@ type Config struct {
 	// RootlessCgroups is set when unlikely to have the full access to cgroups.
 	// When RootlessCgroups is set, cgroups errors are ignored.
 	RootlessCgroups bool `json:"rootless_cgroups,omitempty"`
+
+	// Personality contains configuration for the Linux personality syscall.
+	Personality *LinuxPersonality `json:"personality,omitempty"`
 }
 
 type (

--- a/libcontainer/configs/config_linux.go
+++ b/libcontainer/configs/config_linux.go
@@ -9,6 +9,19 @@ var (
 	errNoGroupMap = errors.New("User namespaces enabled, but no group mapping found.")
 )
 
+// Please check https://man7.org/linux/man-pages/man2/personality.2.html for const details.
+// https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/personality.h
+const (
+	PER_LINUX   = 0x0000
+	PER_LINUX32 = 0x0008
+)
+
+type LinuxPersonality struct {
+	// Domain for the personality
+	// can only contain values "LINUX" and "LINUX32"
+	Domain int `json:"domain"`
+}
+
 // HostUID gets the translated uid for the process on host which could be
 // different when user namespaces are enabled.
 func (c Config) HostUID(containerId int) (int, error) {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -230,6 +230,13 @@ func (c *linuxContainer) Set(config configs.Config) error {
 func (c *linuxContainer) Start(process *Process) error {
 	c.m.Lock()
 	defer c.m.Unlock()
+	// configure linux personality before starting the process
+	if c.config.Personality != nil {
+		err := system.SetLinuxPersonality(c.config.Personality.Domain)
+		if err != nil {
+			return err
+		}
+	}
 	if c.config.Cgroups.Resources.SkipDevices {
 		return &ConfigError{"can't start container with SkipDevices set"}
 	}

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -137,6 +137,26 @@ func TestIPCBadPath(t *testing.T) {
 	}
 }
 
+func TestPersonality(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	config := newTemplateConfig(t, &tParam{})
+
+	// change execution domain to i686
+	config.Personality = &configs.LinuxPersonality{
+		Domain: configs.PER_LINUX32,
+	}
+
+	out, _, err := runContainer(t, config, "", "/bin/sh", "-c", "uname -a")
+	ok(t, err)
+	// output must contain kernel architecture configured as i686
+	if !strings.Contains(out.Stdout.String(), "i686") {
+		t.Fatalf("expected kernel architecture i686 configured via personality")
+	}
+}
+
 func TestRlimit(t *testing.T) {
 	testRlimit(t, false)
 }

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -3,7 +3,9 @@
 package system
 
 import (
+	"os"
 	"os/exec"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -107,4 +109,14 @@ func GetSubreaper() (int, error) {
 	}
 
 	return int(i), nil
+}
+
+// SetLinuxPersonality sets the Linux execution personality. For more information see the personality syscall documentation.
+// checkout getLinuxPersonalityFromStr() from libcontainer/specconv/spec_linux.go for type conversion.
+func SetLinuxPersonality(persona int) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_PERSONALITY, uintptr(persona), 0, 0)
+	if errno != 0 {
+		return &os.SyscallError{Syscall: "set_personality", Err: errno}
+	}
+	return nil
 }


### PR DESCRIPTION
Hi Team,

Following PR allows users to configure execution domain via `syscall.SYS_PERSONALITY`.
Valid inputs supported via spec are limited to `LINUX` and `LINUX32`.

References:
https://man7.org/linux/man-pages/man2/personality.2.html
https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/personality.h