### PR TITLE
[1.0] libct/seccomp: skip redundant rules

### DIFF
--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -67,7 +67,7 @@ func InitSeccomp(config *configs.Seccomp) error {
 		if call == nil {
 			return errors.New("encountered nil syscall while initializing Seccomp")
 		}
-		if err := matchCall(filter, call); err != nil {
+		if err := matchCall(filter, call, defaultAction); err != nil {
 			return err
 		}
 	}
@@ -142,7 +142,7 @@ func getCondition(arg *configs.Arg) (libseccomp.ScmpCondition, error) {
 }
 
 // Add a rule to match a single syscall
-func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall) error {
+func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall, defAct libseccomp.ScmpAction) error {
 	if call == nil || filter == nil {
 		return errors.New("cannot use nil as syscall to block")
 	}
@@ -151,17 +151,22 @@ func matchCall(filter *libseccomp.ScmpFilter, call *configs.Syscall) error {
 		return errors.New("empty string is not a valid syscall")
 	}
 
+	// Convert the call's action to the libseccomp equivalent
+	callAct, err := getAction(call.Action, call.ErrnoRet)
+	if err != nil {
+		return fmt.Errorf("action in seccomp profile is invalid: %w", err)
+	}
+	if callAct == defAct {
+		// This rule is redundant, silently skip it
+		// to avoid error from AddRule.
+		return nil
+	}
+
 	// If we can't resolve the syscall, assume it's not supported on this kernel
 	// Ignore it, don't error out
 	callNum, err := libseccomp.GetSyscallFromName(call.Name)
 	if err != nil {
 		return nil
-	}
-
-	// Convert the call's action to the libseccomp equivalent
-	callAct, err := getAction(call.Action, call.ErrnoRet)
-	if err != nil {
-		return fmt.Errorf("action in seccomp profile is invalid: %s", err)
 	}
 
 	// Unconditional match - just add the rule

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -76,3 +76,15 @@ function teardown() {
 	runc run test_hello
 	[ "$status" -eq 0 ]
 }
+
+@test "runc run [redundant seccomp rules]" {
+	update_config '	  .linux.seccomp = {
+				"defaultAction": "SCMP_ACT_ALLOW",
+				"syscalls": [{
+					"names": ["bdflush"],
+					"action": "SCMP_ACT_ALLOW",
+				}]
+			    }'
+	runc run test_hello
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Backport of #3109 (partial -- last commit only) to release-1.0 branch. Original description follows.

----

This fixes using runc with podman on my system (Fedora 34).

> $ podman --runtime `pwd`/runc run --rm --memory 4M fedora echo it works
> Error: unable to start container process: error adding seccomp filter rule for syscall bdflush: permission denied: OCI permission denied

The problem is, libseccomp returns EPERM when a redundant rule (i.e. the
rule with the same action as the default one) is added, and podman (on
my machine) sets the following rules in config.json:

    <....>
    "seccomp": {
      "defaultAction": "SCMP_ACT_ERRNO",
      "architectures": [
        "SCMP_ARCH_X86_64",
        "SCMP_ARCH_X86",
        "SCMP_ARCH_X32"
      ],
      "syscalls": [
        {
          "names": [
            "bdflush",
            "io_pgetevents",
            <....>
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        <....>

(Note that defaultErrnoRet is not set, but it defaults to 1).

With this commit, it works:

> $ podman --runtime `pwd`/runc run --memory 4M fedora echo it works
> it works

Add an integration test (that fails without the fix).

Similar crun commit:
 * https://github.com/containers/crun/commit/08229f3fb904c5ea19a7d9

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

Cherry picked from commit 5dd92fd9b454e35ee543ced670f84344de67c902.
Minor conflict in libcontainer/seccomp/seccomp_linux.go due to
missing commit e44bee1026f83beec3f0aad64566fa9e6bfe6a0.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>