### PR TITLE
[1.0] fix logging race in nsexec (regression in rc94)

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -142,7 +142,7 @@ int setns(int fd, int nstype)
 
 static void write_log(const char *level, const char *format, ...)
 {
-	char *message = NULL, *stage = NULL;
+	char *message = NULL, *stage = NULL, *json = NULL;
 	va_list args;
 	int ret;
 
@@ -164,11 +164,18 @@ static void write_log(const char *level, const char *format, ...)
 	if (ret < 0)
 		goto out;
 
-	dprintf(logfd, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n", level, stage, getpid(), message);
+	ret = asprintf(&json, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n", level, stage, getpid(), message);
+	if (ret < 0) {
+		json = NULL;
+		goto out;
+	}
+
+	write(logfd, json, ret);
 
 out:
 	free(message);
 	free(stage);
+	free(json);
 }
 
 /* XXX: This is ugly. */


### PR DESCRIPTION
This is a backport of https://github.com/opencontainers/runc/pull/3120 to release-1.0 branch,
fixing rare but critical issue #3119.

----

As reported in issue #3119, there is a race in nsexec logging
that can lead to garbled json received by log forwarder, which
complains about it with a "failed to decode" error.

This happens because dprintf (used since the very beginning of nsexec
logging introduced in commit ba3cabf932943) relies on multiple write(2)
calls, and with additional logging added by 64bb59f5920b15d (appeared in rc94)
a race is possible between runc init parent and its children.

The fix is to prepare a string and write it using a single call to
write(2).

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit fb6ba046b999f3fcb5bab2aa5048a4a66fdf1526)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>