### PR TITLE
runc run/create: refuse non-empty cgroup; runc exec: refuse frozen cgroup

### DIFF
--- a/contrib/cmd/sd-helper/helper.go
+++ b/contrib/cmd/sd-helper/helper.go
@@ -57,9 +57,9 @@ func main() {
 	}
 }
 
-func newManager(config *configs.Cgroup) cgroups.Manager {
+func newManager(config *configs.Cgroup) (cgroups.Manager, error) {
 	if cgroups.IsCgroup2UnifiedMode() {
-		return systemd.NewUnifiedManager(config, "", false)
+		return systemd.NewUnifiedManager(config, "")
 	}
 	return systemd.NewLegacyManager(config, nil)
 }
@@ -70,7 +70,10 @@ func unitCommand(cmd, name, parent string) error {
 		Parent:    parent,
 		Resources: &configs.Resources{},
 	}
-	pm := newManager(podConfig)
+	pm, err := newManager(podConfig)
+	if err != nil {
+		return err
+	}
 
 	switch cmd {
 	case "start":

--- a/exec.go
+++ b/exec.go
@@ -114,8 +114,8 @@ func execProcess(context *cli.Context) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	if status == libcontainer.Stopped {
-		return -1, errors.New("cannot exec a container that has stopped")
+	if status == libcontainer.Stopped || status == libcontainer.Paused {
+		return -1, fmt.Errorf("cannot exec in a %s container", status)
 	}
 	path := context.String("process")
 	if path == "" && len(context.Args()) == 1 {

--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -20,8 +20,8 @@ func (s *BlkioGroup) Name() string {
 	return "blkio"
 }
 
-func (s *BlkioGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *BlkioGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *BlkioGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -21,7 +21,7 @@ func (s *BlkioGroup) Name() string {
 }
 
 func (s *BlkioGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *BlkioGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -19,24 +19,19 @@ func (s *CpuGroup) Name() string {
 	return "cpu"
 }
 
-func (s *CpuGroup) Apply(path string, d *cgroupData) error {
-	// This might happen if we have no cpu cgroup mounted.
-	// Just do nothing and don't fail.
-	if path == "" {
-		return nil
-	}
+func (s *CpuGroup) Apply(path string, r *configs.Resources, pid int) error {
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return err
 	}
 	// We should set the real-Time group scheduling settings before moving
 	// in the process because if the process is already in SCHED_RR mode
 	// and no RT bandwidth is set, adding it will fail.
-	if err := s.SetRtSched(path, d.config.Resources); err != nil {
+	if err := s.SetRtSched(path, r); err != nil {
 		return err
 	}
-	// Since we are not using join(), we need to place the pid
-	// into the procs file unlike other subsystems.
-	return cgroups.WriteCgroupProc(path, d.pid)
+	// Since we are not using apply(), we need to place the pid
+	// into the procs file.
+	return cgroups.WriteCgroupProc(path, pid)
 }
 
 func (s *CpuGroup) SetRtSched(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -34,8 +34,8 @@ func (s *CpuacctGroup) Name() string {
 	return "cpuacct"
 }
 
-func (s *CpuacctGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *CpuacctGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *CpuacctGroup) Set(_ string, _ *configs.Resources) error {

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -35,7 +35,7 @@ func (s *CpuacctGroup) Name() string {
 }
 
 func (s *CpuacctGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *CpuacctGroup) Set(_ string, _ *configs.Resources) error {

--- a/libcontainer/cgroups/fs/cpuacct_test.go
+++ b/libcontainer/cgroups/fs/cpuacct_test.go
@@ -24,8 +24,8 @@ const (
 )
 
 func TestCpuacctStats(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuacct.", t)
-	helper.writeFileContents(map[string]string{
+	path := tempDir(t, "cpuacct")
+	writeFileContents(t, path, map[string]string{
 		"cpuacct.usage":        cpuAcctUsageContents,
 		"cpuacct.usage_percpu": cpuAcctUsagePerCPUContents,
 		"cpuacct.stat":         cpuAcctStatContents,
@@ -34,7 +34,7 @@ func TestCpuacctStats(t *testing.T) {
 
 	cpuacct := &CpuacctGroup{}
 	actualStats := *cgroups.NewStats()
-	err := cpuacct.GetStats(helper.CgroupPath, &actualStats)
+	err := cpuacct.GetStats(path, &actualStats)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,8 +64,8 @@ func TestCpuacctStats(t *testing.T) {
 }
 
 func TestCpuacctStatsWithoutUsageAll(t *testing.T) {
-	helper := NewCgroupTestUtil("cpuacct.", t)
-	helper.writeFileContents(map[string]string{
+	path := tempDir(t, "cpuacct")
+	writeFileContents(t, path, map[string]string{
 		"cpuacct.usage":        cpuAcctUsageContents,
 		"cpuacct.usage_percpu": cpuAcctUsagePerCPUContents,
 		"cpuacct.stat":         cpuAcctStatContents,
@@ -73,7 +73,7 @@ func TestCpuacctStatsWithoutUsageAll(t *testing.T) {
 
 	cpuacct := &CpuacctGroup{}
 	actualStats := *cgroups.NewStats()
-	err := cpuacct.GetStats(helper.CgroupPath, &actualStats)
+	err := cpuacct.GetStats(path, &actualStats)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -20,8 +20,8 @@ func (s *CpusetGroup) Name() string {
 	return "cpuset"
 }
 
-func (s *CpusetGroup) Apply(path string, d *cgroupData) error {
-	return s.ApplyDir(path, d.config.Resources, d.pid)
+func (s *CpusetGroup) Apply(path string, r *configs.Resources, pid int) error {
+	return s.ApplyDir(path, r, pid)
 }
 
 func (s *CpusetGroup) Set(path string, r *configs.Resources) error {
@@ -166,9 +166,8 @@ func (s *CpusetGroup) ApplyDir(dir string, r *configs.Resources, pid int) error 
 	if err := s.ensureCpusAndMems(dir, r); err != nil {
 		return err
 	}
-
-	// because we are not using d.join we need to place the pid into the procs file
-	// unlike the other subsystems
+	// Since we are not using apply(), we need to place the pid
+	// into the procs file.
 	return cgroups.WriteCgroupProc(dir, pid)
 }
 

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -20,8 +20,8 @@ func (s *DevicesGroup) Name() string {
 	return "devices"
 }
 
-func (s *DevicesGroup) Apply(path string, d *cgroupData) error {
-	if d.config.SkipDevices {
+func (s *DevicesGroup) Apply(path string, r *configs.Resources, pid int) error {
+	if r.SkipDevices {
 		return nil
 	}
 	if path == "" {
@@ -29,7 +29,8 @@ func (s *DevicesGroup) Apply(path string, d *cgroupData) error {
 		// is a hard requirement for container's security.
 		return errSubsystemDoesNotExist
 	}
-	return apply(path, d.pid)
+
+	return apply(path, pid)
 }
 
 func loadEmulator(path string) (*cgroupdevices.Emulator, error) {

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -29,7 +29,7 @@ func (s *DevicesGroup) Apply(path string, d *cgroupData) error {
 		// is a hard requirement for container's security.
 		return errSubsystemDoesNotExist
 	}
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func loadEmulator(path string) (*cgroupdevices.Emulator, error) {

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -20,7 +20,7 @@ func (s *FreezerGroup) Name() string {
 }
 
 func (s *FreezerGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -19,8 +19,8 @@ func (s *FreezerGroup) Name() string {
 	return "freezer"
 }
 
-func (s *FreezerGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *FreezerGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {

--- a/libcontainer/cgroups/fs/freezer_test.go
+++ b/libcontainer/cgroups/fs/freezer_test.go
@@ -8,19 +8,21 @@ import (
 )
 
 func TestFreezerSetState(t *testing.T) {
-	helper := NewCgroupTestUtil("freezer", t)
+	path := tempDir(t, "freezer")
 
-	helper.writeFileContents(map[string]string{
+	writeFileContents(t, path, map[string]string{
 		"freezer.state": string(configs.Frozen),
 	})
 
-	helper.CgroupData.config.Resources.Freezer = configs.Thawed
+	r := &configs.Resources{
+		Freezer: configs.Thawed,
+	}
 	freezer := &FreezerGroup{}
-	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := freezer.Set(path, r); err != nil {
 		t.Fatal(err)
 	}
 
-	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "freezer.state")
+	value, err := fscommon.GetCgroupParamString(path, "freezer.state")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,15 +32,15 @@ func TestFreezerSetState(t *testing.T) {
 }
 
 func TestFreezerSetInvalidState(t *testing.T) {
-	helper := NewCgroupTestUtil("freezer", t)
+	path := tempDir(t, "freezer")
 
-	const (
-		invalidArg configs.FreezerState = "Invalid"
-	)
+	const invalidArg configs.FreezerState = "Invalid"
 
-	helper.CgroupData.config.Resources.Freezer = invalidArg
+	r := &configs.Resources{
+		Freezer: invalidArg,
+	}
 	freezer := &FreezerGroup{}
-	if err := freezer.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err == nil {
+	if err := freezer.Set(path, r); err == nil {
 		t.Fatal("Failed to return invalid argument error")
 	}
 }

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -12,7 +11,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
 )
 
 var (
@@ -59,105 +57,6 @@ func NewManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Manager, e
 		cgroups: cg,
 		paths:   paths,
 	}, nil
-}
-
-// The absolute path to the root of the cgroup hierarchies.
-var (
-	cgroupRootLock sync.Mutex
-	cgroupRoot     string
-)
-
-const defaultCgroupRoot = "/sys/fs/cgroup"
-
-func tryDefaultCgroupRoot() string {
-	var st, pst unix.Stat_t
-
-	// (1) it should be a directory...
-	err := unix.Lstat(defaultCgroupRoot, &st)
-	if err != nil || st.Mode&unix.S_IFDIR == 0 {
-		return ""
-	}
-
-	// (2) ... and a mount point ...
-	err = unix.Lstat(filepath.Dir(defaultCgroupRoot), &pst)
-	if err != nil {
-		return ""
-	}
-
-	if st.Dev == pst.Dev {
-		// parent dir has the same dev -- not a mount point
-		return ""
-	}
-
-	// (3) ... of 'tmpfs' fs type.
-	var fst unix.Statfs_t
-	err = unix.Statfs(defaultCgroupRoot, &fst)
-	if err != nil || fst.Type != unix.TMPFS_MAGIC {
-		return ""
-	}
-
-	// (4) it should have at least 1 entry ...
-	dir, err := os.Open(defaultCgroupRoot)
-	if err != nil {
-		return ""
-	}
-	names, err := dir.Readdirnames(1)
-	if err != nil {
-		return ""
-	}
-	if len(names) < 1 {
-		return ""
-	}
-	// ... which is a cgroup mount point.
-	err = unix.Statfs(filepath.Join(defaultCgroupRoot, names[0]), &fst)
-	if err != nil || fst.Type != unix.CGROUP_SUPER_MAGIC {
-		return ""
-	}
-
-	return defaultCgroupRoot
-}
-
-// Gets the cgroupRoot.
-func getCgroupRoot() (string, error) {
-	cgroupRootLock.Lock()
-	defer cgroupRootLock.Unlock()
-
-	if cgroupRoot != "" {
-		return cgroupRoot, nil
-	}
-
-	// fast path
-	cgroupRoot = tryDefaultCgroupRoot()
-	if cgroupRoot != "" {
-		return cgroupRoot, nil
-	}
-
-	// slow path: parse mountinfo
-	mi, err := cgroups.GetCgroupMounts(false)
-	if err != nil {
-		return "", err
-	}
-	if len(mi) < 1 {
-		return "", errors.New("no cgroup mount found in mountinfo")
-	}
-
-	// Get the first cgroup mount (e.g. "/sys/fs/cgroup/memory"),
-	// use its parent directory.
-	root := filepath.Dir(mi[0].Mountpoint)
-
-	if _, err := os.Stat(root); err != nil {
-		return "", err
-	}
-
-	cgroupRoot = root
-	return cgroupRoot, nil
-}
-
-type cgroupData struct {
-	root      string
-	innerPath string
-	config    *configs.Cgroup
-	pid       int
 }
 
 // isIgnorableError returns whether err is a permission error (in the loose
@@ -311,68 +210,6 @@ func (m *manager) GetPids() ([]int, error) {
 
 func (m *manager) GetAllPids() ([]int, error) {
 	return cgroups.GetAllPids(m.Path("devices"))
-}
-
-func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
-	root, err := getCgroupRoot()
-	if err != nil {
-		return nil, err
-	}
-
-	if (c.Name != "" || c.Parent != "") && c.Path != "" {
-		return nil, errors.New("cgroup: either Path or Name and Parent should be used")
-	}
-
-	// XXX: Do not remove this code. Path safety is important! -- cyphar
-	cgPath := libcontainerUtils.CleanPath(c.Path)
-	cgParent := libcontainerUtils.CleanPath(c.Parent)
-	cgName := libcontainerUtils.CleanPath(c.Name)
-
-	innerPath := cgPath
-	if innerPath == "" {
-		innerPath = filepath.Join(cgParent, cgName)
-	}
-
-	return &cgroupData{
-		root:      root,
-		innerPath: innerPath,
-		config:    c,
-		pid:       pid,
-	}, nil
-}
-
-func (raw *cgroupData) path(subsystem string) (string, error) {
-	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
-	if filepath.IsAbs(raw.innerPath) {
-		mnt, err := cgroups.FindCgroupMountpoint(raw.root, subsystem)
-		// If we didn't mount the subsystem, there is no point we make the path.
-		if err != nil {
-			return "", err
-		}
-
-		// Sometimes subsystems can be mounted together as 'cpu,cpuacct'.
-		return filepath.Join(raw.root, filepath.Base(mnt), raw.innerPath), nil
-	}
-
-	// Use GetOwnCgroupPath instead of GetInitCgroupPath, because the creating
-	// process could in container and shared pid namespace with host, and
-	// /proc/1/cgroup could point to whole other world of cgroups.
-	parentPath, err := cgroups.GetOwnCgroupPath(subsystem)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(parentPath, raw.innerPath), nil
-}
-
-func join(path string, pid int) error {
-	if path == "" {
-		return nil
-	}
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		return err
-	}
-	return cgroups.WriteCgroupProc(path, pid)
 }
 
 func (m *manager) GetPaths() map[string]string {

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -49,18 +49,16 @@ type subsystem interface {
 }
 
 type manager struct {
-	mu       sync.Mutex
-	cgroups  *configs.Cgroup
-	rootless bool // ignore permission-related errors
-	paths    map[string]string
+	mu      sync.Mutex
+	cgroups *configs.Cgroup
+	paths   map[string]string
 }
 
-func NewManager(cg *configs.Cgroup, paths map[string]string, rootless bool) cgroups.Manager {
+func NewManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Manager, error) {
 	return &manager{
-		cgroups:  cg,
-		paths:    paths,
-		rootless: rootless,
-	}
+		cgroups: cg,
+		paths:   paths,
+	}, nil
 }
 
 // The absolute path to the root of the cgroup hierarchies.
@@ -218,7 +216,7 @@ func (m *manager) Apply(pid int) (err error) {
 			// explicit cgroup path hasn't been set, we don't bail on error in
 			// case of permission problems. Cases where limits have been set
 			// (and we couldn't create our own cgroup) are handled by Set.
-			if isIgnorableError(m.rootless, err) && m.cgroups.Path == "" {
+			if isIgnorableError(c.Rootless, err) && m.cgroups.Path == "" {
 				delete(m.paths, sys.Name())
 				continue
 			}
@@ -271,10 +269,10 @@ func (m *manager) Set(r *configs.Resources) error {
 	for _, sys := range subsystems {
 		path := m.paths[sys.Name()]
 		if err := sys.Set(path, r); err != nil {
-			if m.rootless && sys.Name() == "devices" {
+			if m.cgroups.Rootless && sys.Name() == "devices" {
 				continue
 			}
-			// When m.rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
+			// When rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
 			// However, errors from other subsystems are not ignored.
 			// see @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
 			if path == "" {
@@ -408,7 +406,7 @@ func OOMKillCount(path string) (uint64, error) {
 func (m *manager) OOMKillCount() (uint64, error) {
 	c, err := OOMKillCount(m.Path("memory"))
 	// Ignore ENOENT when rootless as it couldn't create cgroup.
-	if err != nil && m.rootless && os.IsNotExist(err) {
+	if err != nil && m.cgroups.Rootless && os.IsNotExist(err) {
 		err = nil
 	}
 

--- a/libcontainer/cgroups/fs/fs_test.go
+++ b/libcontainer/cgroups/fs/fs_test.go
@@ -1,107 +1,11 @@
 package fs
 
 import (
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
-
-func TestInvalidCgroupPath(t *testing.T) {
-	if cgroups.IsCgroup2UnifiedMode() {
-		t.Skip("cgroup v2 is not supported")
-	}
-
-	root, err := getCgroupRoot()
-	if err != nil {
-		t.Fatalf("couldn't get cgroup root: %v", err)
-	}
-
-	testCases := []struct {
-		test               string
-		path, name, parent string
-	}{
-		{
-			test: "invalid cgroup path",
-			path: "../../../../../../../../../../some/path",
-		},
-		{
-			test: "invalid absolute cgroup path",
-			path: "/../../../../../../../../../../some/path",
-		},
-		{
-			test:   "invalid cgroup parent",
-			parent: "../../../../../../../../../../some/path",
-			name:   "name",
-		},
-		{
-			test:   "invalid absolute cgroup parent",
-			parent: "/../../../../../../../../../../some/path",
-			name:   "name",
-		},
-		{
-			test:   "invalid cgroup name",
-			parent: "parent",
-			name:   "../../../../../../../../../../some/path",
-		},
-		{
-			test:   "invalid absolute cgroup name",
-			parent: "parent",
-			name:   "/../../../../../../../../../../some/path",
-		},
-		{
-			test:   "invalid cgroup name and parent",
-			parent: "../../../../../../../../../../some/path",
-			name:   "../../../../../../../../../../some/path",
-		},
-		{
-			test:   "invalid absolute cgroup name and parent",
-			parent: "/../../../../../../../../../../some/path",
-			name:   "/../../../../../../../../../../some/path",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.test, func(t *testing.T) {
-			config := &configs.Cgroup{Path: tc.path, Name: tc.name, Parent: tc.parent}
-
-			data, err := getCgroupData(config, 0)
-			if err != nil {
-				t.Fatalf("couldn't get cgroup data: %v", err)
-			}
-
-			// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-			if strings.HasPrefix(data.innerPath, "..") {
-				t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
-			}
-
-			// Double-check, using an actual cgroup.
-			deviceRoot := filepath.Join(root, "devices")
-			devicePath, err := data.path("devices")
-			if err != nil {
-				t.Fatalf("couldn't get cgroup path: %v", err)
-			}
-			if !strings.HasPrefix(devicePath, deviceRoot) {
-				t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
-			}
-		})
-	}
-}
-
-func TestTryDefaultCgroupRoot(t *testing.T) {
-	res := tryDefaultCgroupRoot()
-	exp := defaultCgroupRoot
-	if cgroups.IsCgroup2UnifiedMode() {
-		// checking that tryDefaultCgroupRoot does return ""
-		// in case /sys/fs/cgroup is not cgroup v1 root dir.
-		exp = ""
-	}
-	if res != exp {
-		t.Errorf("tryDefaultCgroupRoot: want %q, got %q", exp, res)
-	}
-}
 
 func BenchmarkGetStats(b *testing.B) {
 	if cgroups.IsCgroup2UnifiedMode() {

--- a/libcontainer/cgroups/fs/fs_test.go
+++ b/libcontainer/cgroups/fs/fs_test.go
@@ -119,8 +119,11 @@ func BenchmarkGetStats(b *testing.B) {
 		Path:      "/some/kind/of/a/path/here",
 		Resources: &configs.Resources{},
 	}
-	m := NewManager(cg, nil, false)
-	err := m.Apply(-1)
+	m, err := NewManager(cg, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = m.Apply(-1)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -15,7 +15,7 @@ func (s *HugetlbGroup) Name() string {
 }
 
 func (s *HugetlbGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *HugetlbGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -14,8 +14,8 @@ func (s *HugetlbGroup) Name() string {
 	return "hugetlb"
 }
 
-func (s *HugetlbGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *HugetlbGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *HugetlbGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -31,7 +31,7 @@ func (s *MemoryGroup) Name() string {
 }
 
 func (s *MemoryGroup) Apply(path string, d *cgroupData) (err error) {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func setMemory(path string, val int64) error {

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -30,8 +30,8 @@ func (s *MemoryGroup) Name() string {
 	return "memory"
 }
 
-func (s *MemoryGroup) Apply(path string, d *cgroupData) (err error) {
-	return apply(path, d.pid)
+func (s *MemoryGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func setMemory(path string, val int64) error {

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -14,10 +14,10 @@ func (s *NameGroup) Name() string {
 	return s.GroupName
 }
 
-func (s *NameGroup) Apply(path string, d *cgroupData) error {
+func (s *NameGroup) Apply(path string, _ *configs.Resources, pid int) error {
 	if s.Join {
-		// ignore errors if the named cgroup does not exist
-		_ = apply(path, d.pid)
+		// Ignore errors if the named cgroup does not exist.
+		_ = apply(path, pid)
 	}
 	return nil
 }

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -17,7 +17,7 @@ func (s *NameGroup) Name() string {
 func (s *NameGroup) Apply(path string, d *cgroupData) error {
 	if s.Join {
 		// ignore errors if the named cgroup does not exist
-		_ = join(path, d.pid)
+		_ = apply(path, d.pid)
 	}
 	return nil
 }

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -13,8 +13,8 @@ func (s *NetClsGroup) Name() string {
 	return "net_cls"
 }
 
-func (s *NetClsGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *NetClsGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *NetClsGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -14,7 +14,7 @@ func (s *NetClsGroup) Name() string {
 }
 
 func (s *NetClsGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *NetClsGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
+	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -13,22 +14,24 @@ const (
 )
 
 func TestNetClsSetClassid(t *testing.T) {
-	helper := NewCgroupTestUtil("net_cls", t)
+	path := tempDir(t, "net_cls")
 
-	helper.writeFileContents(map[string]string{
+	writeFileContents(t, path, map[string]string{
 		"net_cls.classid": strconv.FormatUint(classidBefore, 10),
 	})
 
-	helper.CgroupData.config.Resources.NetClsClassid = classidAfter
+	r := &configs.Resources{
+		NetClsClassid: classidAfter,
+	}
 	netcls := &NetClsGroup{}
-	if err := netcls.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := netcls.Set(path, r); err != nil {
 		t.Fatal(err)
 	}
 
 	// As we are in mock environment, we can't get correct value of classid from
 	// net_cls.classid.
 	// So. we just judge if we successfully write classid into file
-	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "net_cls.classid")
+	value, err := fscommon.GetCgroupParamUint(path, "net_cls.classid")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -12,7 +12,7 @@ func (s *NetPrioGroup) Name() string {
 }
 
 func (s *NetPrioGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *NetPrioGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -11,8 +11,8 @@ func (s *NetPrioGroup) Name() string {
 	return "net_prio"
 }
 
-func (s *NetPrioGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *NetPrioGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *NetPrioGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/net_prio_test.go
+++ b/libcontainer/cgroups/fs/net_prio_test.go
@@ -16,15 +16,17 @@ var prioMap = []*configs.IfPrioMap{
 }
 
 func TestNetPrioSetIfPrio(t *testing.T) {
-	helper := NewCgroupTestUtil("net_prio", t)
+	path := tempDir(t, "net_prio")
 
-	helper.CgroupData.config.Resources.NetPrioIfpriomap = prioMap
+	r := &configs.Resources{
+		NetPrioIfpriomap: prioMap,
+	}
 	netPrio := &NetPrioGroup{}
-	if err := netPrio.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := netPrio.Set(path, r); err != nil {
 		t.Fatal(err)
 	}
 
-	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "net_prio.ifpriomap")
+	value, err := fscommon.GetCgroupParamString(path, "net_prio.ifpriomap")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/cgroups/fs/paths.go
+++ b/libcontainer/cgroups/fs/paths.go
@@ -162,7 +162,7 @@ func (raw *cgroupData) path(subsystem string) (string, error) {
 	return filepath.Join(parentPath, raw.innerPath), nil
 }
 
-func join(path string, pid int) error {
+func apply(path string, pid int) error {
 	if path == "" {
 		return nil
 	}

--- a/libcontainer/cgroups/fs/paths.go
+++ b/libcontainer/cgroups/fs/paths.go
@@ -122,13 +122,11 @@ func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
 		return nil, errors.New("cgroup: either Path or Name and Parent should be used")
 	}
 
-	// XXX: Do not remove this code. Path safety is important! -- cyphar
-	cgPath := utils.CleanPath(c.Path)
-	cgParent := utils.CleanPath(c.Parent)
-	cgName := utils.CleanPath(c.Name)
-
-	innerPath := cgPath
+	// XXX: Do not remove CleanPath. Path safety is important! -- cyphar
+	innerPath := utils.CleanPath(c.Path)
 	if innerPath == "" {
+		cgParent := utils.CleanPath(c.Parent)
+		cgName := utils.CleanPath(c.Name)
 		innerPath = filepath.Join(cgParent, cgName)
 	}
 

--- a/libcontainer/cgroups/fs/paths.go
+++ b/libcontainer/cgroups/fs/paths.go
@@ -1,0 +1,175 @@
+package fs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/utils"
+)
+
+// The absolute path to the root of the cgroup hierarchies.
+var (
+	cgroupRootLock sync.Mutex
+	cgroupRoot     string
+)
+
+const defaultCgroupRoot = "/sys/fs/cgroup"
+
+func tryDefaultCgroupRoot() string {
+	var st, pst unix.Stat_t
+
+	// (1) it should be a directory...
+	err := unix.Lstat(defaultCgroupRoot, &st)
+	if err != nil || st.Mode&unix.S_IFDIR == 0 {
+		return ""
+	}
+
+	// (2) ... and a mount point ...
+	err = unix.Lstat(filepath.Dir(defaultCgroupRoot), &pst)
+	if err != nil {
+		return ""
+	}
+
+	if st.Dev == pst.Dev {
+		// parent dir has the same dev -- not a mount point
+		return ""
+	}
+
+	// (3) ... of 'tmpfs' fs type.
+	var fst unix.Statfs_t
+	err = unix.Statfs(defaultCgroupRoot, &fst)
+	if err != nil || fst.Type != unix.TMPFS_MAGIC {
+		return ""
+	}
+
+	// (4) it should have at least 1 entry ...
+	dir, err := os.Open(defaultCgroupRoot)
+	if err != nil {
+		return ""
+	}
+	names, err := dir.Readdirnames(1)
+	if err != nil {
+		return ""
+	}
+	if len(names) < 1 {
+		return ""
+	}
+	// ... which is a cgroup mount point.
+	err = unix.Statfs(filepath.Join(defaultCgroupRoot, names[0]), &fst)
+	if err != nil || fst.Type != unix.CGROUP_SUPER_MAGIC {
+		return ""
+	}
+
+	return defaultCgroupRoot
+}
+
+// Gets the cgroupRoot.
+func getCgroupRoot() (string, error) {
+	cgroupRootLock.Lock()
+	defer cgroupRootLock.Unlock()
+
+	if cgroupRoot != "" {
+		return cgroupRoot, nil
+	}
+
+	// fast path
+	cgroupRoot = tryDefaultCgroupRoot()
+	if cgroupRoot != "" {
+		return cgroupRoot, nil
+	}
+
+	// slow path: parse mountinfo
+	mi, err := cgroups.GetCgroupMounts(false)
+	if err != nil {
+		return "", err
+	}
+	if len(mi) < 1 {
+		return "", errors.New("no cgroup mount found in mountinfo")
+	}
+
+	// Get the first cgroup mount (e.g. "/sys/fs/cgroup/memory"),
+	// use its parent directory.
+	root := filepath.Dir(mi[0].Mountpoint)
+
+	if _, err := os.Stat(root); err != nil {
+		return "", err
+	}
+
+	cgroupRoot = root
+	return cgroupRoot, nil
+}
+
+type cgroupData struct {
+	root      string
+	innerPath string
+	config    *configs.Cgroup
+	pid       int
+}
+
+func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
+	root, err := getCgroupRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	if (c.Name != "" || c.Parent != "") && c.Path != "" {
+		return nil, errors.New("cgroup: either Path or Name and Parent should be used")
+	}
+
+	// XXX: Do not remove this code. Path safety is important! -- cyphar
+	cgPath := utils.CleanPath(c.Path)
+	cgParent := utils.CleanPath(c.Parent)
+	cgName := utils.CleanPath(c.Name)
+
+	innerPath := cgPath
+	if innerPath == "" {
+		innerPath = filepath.Join(cgParent, cgName)
+	}
+
+	return &cgroupData{
+		root:      root,
+		innerPath: innerPath,
+		config:    c,
+		pid:       pid,
+	}, nil
+}
+
+func (raw *cgroupData) path(subsystem string) (string, error) {
+	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
+	if filepath.IsAbs(raw.innerPath) {
+		mnt, err := cgroups.FindCgroupMountpoint(raw.root, subsystem)
+		// If we didn't mount the subsystem, there is no point we make the path.
+		if err != nil {
+			return "", err
+		}
+
+		// Sometimes subsystems can be mounted together as 'cpu,cpuacct'.
+		return filepath.Join(raw.root, filepath.Base(mnt), raw.innerPath), nil
+	}
+
+	// Use GetOwnCgroupPath instead of GetInitCgroupPath, because the creating
+	// process could in container and shared pid namespace with host, and
+	// /proc/1/cgroup could point to whole other world of cgroups.
+	parentPath, err := cgroups.GetOwnCgroupPath(subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(parentPath, raw.innerPath), nil
+}
+
+func join(path string, pid int) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return err
+	}
+	return cgroups.WriteCgroupProc(path, pid)
+}

--- a/libcontainer/cgroups/fs/paths_test.go
+++ b/libcontainer/cgroups/fs/paths_test.go
@@ -1,0 +1,104 @@
+package fs
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func TestInvalidCgroupPath(t *testing.T) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("cgroup v2 is not supported")
+	}
+
+	root, err := getCgroupRoot()
+	if err != nil {
+		t.Fatalf("couldn't get cgroup root: %v", err)
+	}
+
+	testCases := []struct {
+		test               string
+		path, name, parent string
+	}{
+		{
+			test: "invalid cgroup path",
+			path: "../../../../../../../../../../some/path",
+		},
+		{
+			test: "invalid absolute cgroup path",
+			path: "/../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid cgroup parent",
+			parent: "../../../../../../../../../../some/path",
+			name:   "name",
+		},
+		{
+			test:   "invalid absolute cgroup parent",
+			parent: "/../../../../../../../../../../some/path",
+			name:   "name",
+		},
+		{
+			test:   "invalid cgroup name",
+			parent: "parent",
+			name:   "../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid absolute cgroup name",
+			parent: "parent",
+			name:   "/../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid cgroup name and parent",
+			parent: "../../../../../../../../../../some/path",
+			name:   "../../../../../../../../../../some/path",
+		},
+		{
+			test:   "invalid absolute cgroup name and parent",
+			parent: "/../../../../../../../../../../some/path",
+			name:   "/../../../../../../../../../../some/path",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			config := &configs.Cgroup{Path: tc.path, Name: tc.name, Parent: tc.parent}
+
+			data, err := getCgroupData(config, 0)
+			if err != nil {
+				t.Fatalf("couldn't get cgroup data: %v", err)
+			}
+
+			// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
+			if strings.HasPrefix(data.innerPath, "..") {
+				t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
+			}
+
+			// Double-check, using an actual cgroup.
+			deviceRoot := filepath.Join(root, "devices")
+			devicePath, err := data.path("devices")
+			if err != nil {
+				t.Fatalf("couldn't get cgroup path: %v", err)
+			}
+			if !strings.HasPrefix(devicePath, deviceRoot) {
+				t.Errorf("SECURITY: cgroup path() is outside cgroup mountpoint!")
+			}
+		})
+	}
+}
+
+func TestTryDefaultCgroupRoot(t *testing.T) {
+	res := tryDefaultCgroupRoot()
+	exp := defaultCgroupRoot
+	if cgroups.IsCgroup2UnifiedMode() {
+		// checking that tryDefaultCgroupRoot does return ""
+		// in case /sys/fs/cgroup is not cgroup v1 root dir.
+		exp = ""
+	}
+	if res != exp {
+		t.Errorf("tryDefaultCgroupRoot: want %q, got %q", exp, res)
+	}
+}

--- a/libcontainer/cgroups/fs/paths_test.go
+++ b/libcontainer/cgroups/fs/paths_test.go
@@ -14,7 +14,7 @@ func TestInvalidCgroupPath(t *testing.T) {
 		t.Skip("cgroup v2 is not supported")
 	}
 
-	root, err := getCgroupRoot()
+	root, err := rootPath()
 	if err != nil {
 		t.Fatalf("couldn't get cgroup root: %v", err)
 	}
@@ -67,19 +67,19 @@ func TestInvalidCgroupPath(t *testing.T) {
 		t.Run(tc.test, func(t *testing.T) {
 			config := &configs.Cgroup{Path: tc.path, Name: tc.name, Parent: tc.parent}
 
-			data, err := getCgroupData(config, 0)
+			inner, err := innerPath(config)
 			if err != nil {
 				t.Fatalf("couldn't get cgroup data: %v", err)
 			}
 
-			// Make sure the final innerPath doesn't go outside the cgroup mountpoint.
-			if strings.HasPrefix(data.innerPath, "..") {
+			// Make sure the final inner path doesn't go outside the cgroup mountpoint.
+			if strings.HasPrefix(inner, "..") {
 				t.Errorf("SECURITY: cgroup innerPath is outside cgroup mountpoint!")
 			}
 
 			// Double-check, using an actual cgroup.
 			deviceRoot := filepath.Join(root, "devices")
-			devicePath, err := data.path("devices")
+			devicePath, err := subsysPath(root, inner, "devices")
 			if err != nil {
 				t.Fatalf("couldn't get cgroup path: %v", err)
 			}

--- a/libcontainer/cgroups/fs/perf_event.go
+++ b/libcontainer/cgroups/fs/perf_event.go
@@ -11,8 +11,8 @@ func (s *PerfEventGroup) Name() string {
 	return "perf_event"
 }
 
-func (s *PerfEventGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *PerfEventGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *PerfEventGroup) Set(_ string, _ *configs.Resources) error {

--- a/libcontainer/cgroups/fs/perf_event.go
+++ b/libcontainer/cgroups/fs/perf_event.go
@@ -12,7 +12,7 @@ func (s *PerfEventGroup) Name() string {
 }
 
 func (s *PerfEventGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *PerfEventGroup) Set(_ string, _ *configs.Resources) error {

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -15,8 +15,8 @@ func (s *PidsGroup) Name() string {
 	return "pids"
 }
 
-func (s *PidsGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *PidsGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *PidsGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -16,7 +16,7 @@ func (s *PidsGroup) Name() string {
 }
 
 func (s *PidsGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *PidsGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
+	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -14,19 +15,21 @@ const (
 )
 
 func TestPidsSetMax(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	path := tempDir(t, "pids")
 
-	helper.writeFileContents(map[string]string{
+	writeFileContents(t, path, map[string]string{
 		"pids.max": "max",
 	})
 
-	helper.CgroupData.config.Resources.PidsLimit = maxLimited
+	r := &configs.Resources{
+		PidsLimit: maxLimited,
+	}
 	pids := &PidsGroup{}
-	if err := pids.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := pids.Set(path, r); err != nil {
 		t.Fatal(err)
 	}
 
-	value, err := fscommon.GetCgroupParamUint(helper.CgroupPath, "pids.max")
+	value, err := fscommon.GetCgroupParamUint(path, "pids.max")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,19 +39,21 @@ func TestPidsSetMax(t *testing.T) {
 }
 
 func TestPidsSetUnlimited(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	path := tempDir(t, "pids")
 
-	helper.writeFileContents(map[string]string{
+	writeFileContents(t, path, map[string]string{
 		"pids.max": strconv.Itoa(maxLimited),
 	})
 
-	helper.CgroupData.config.Resources.PidsLimit = maxUnlimited
+	r := &configs.Resources{
+		PidsLimit: maxUnlimited,
+	}
 	pids := &PidsGroup{}
-	if err := pids.Set(helper.CgroupPath, helper.CgroupData.config.Resources); err != nil {
+	if err := pids.Set(path, r); err != nil {
 		t.Fatal(err)
 	}
 
-	value, err := fscommon.GetCgroupParamString(helper.CgroupPath, "pids.max")
+	value, err := fscommon.GetCgroupParamString(path, "pids.max")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,16 +63,16 @@ func TestPidsSetUnlimited(t *testing.T) {
 }
 
 func TestPidsStats(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	path := tempDir(t, "pids")
 
-	helper.writeFileContents(map[string]string{
+	writeFileContents(t, path, map[string]string{
 		"pids.current": strconv.Itoa(1337),
 		"pids.max":     strconv.Itoa(maxLimited),
 	})
 
 	pids := &PidsGroup{}
 	stats := *cgroups.NewStats()
-	if err := pids.GetStats(helper.CgroupPath, &stats); err != nil {
+	if err := pids.GetStats(path, &stats); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,16 +86,16 @@ func TestPidsStats(t *testing.T) {
 }
 
 func TestPidsStatsUnlimited(t *testing.T) {
-	helper := NewCgroupTestUtil("pids", t)
+	path := tempDir(t, "pids")
 
-	helper.writeFileContents(map[string]string{
+	writeFileContents(t, path, map[string]string{
 		"pids.current": strconv.Itoa(4096),
 		"pids.max":     "max",
 	})
 
 	pids := &PidsGroup{}
 	stats := *cgroups.NewStats()
-	if err := pids.GetStats(helper.CgroupPath, &stats); err != nil {
+	if err := pids.GetStats(path, &stats); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libcontainer/cgroups/fs/rdma.go
+++ b/libcontainer/cgroups/fs/rdma.go
@@ -13,7 +13,7 @@ func (s *RdmaGroup) Name() string {
 }
 
 func (s *RdmaGroup) Apply(path string, d *cgroupData) error {
-	return join(path, d.pid)
+	return apply(path, d.pid)
 }
 
 func (s *RdmaGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/rdma.go
+++ b/libcontainer/cgroups/fs/rdma.go
@@ -12,8 +12,8 @@ func (s *RdmaGroup) Name() string {
 	return "rdma"
 }
 
-func (s *RdmaGroup) Apply(path string, d *cgroupData) error {
-	return apply(path, d.pid)
+func (s *RdmaGroup) Apply(path string, _ *configs.Resources, pid int) error {
+	return apply(path, pid)
 }
 
 func (s *RdmaGroup) Set(path string, r *configs.Resources) error {

--- a/libcontainer/cgroups/fs/util_test.go
+++ b/libcontainer/cgroups/fs/util_test.go
@@ -11,45 +11,29 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func init() {
 	cgroups.TestMode = true
 }
 
-type cgroupTestUtil struct {
-	// cgroup data to use in tests.
-	CgroupData *cgroupData
-
-	// Path to the mock cgroup directory.
-	CgroupPath string
-
-	t *testing.T
-}
-
-// Creates a new test util for the specified subsystem
-func NewCgroupTestUtil(subsystem string, t *testing.T) *cgroupTestUtil {
-	d := &cgroupData{
-		config: &configs.Cgroup{
-			Resources: &configs.Resources{},
-		},
-		root: t.TempDir(),
-	}
-	testCgroupPath := filepath.Join(d.root, subsystem)
+// tempDir creates a new test directory for the specified subsystem.
+func tempDir(t *testing.T, subsystem string) string {
+	path := filepath.Join(t.TempDir(), subsystem)
 	// Ensure the full mock cgroup path exists.
-	if err := os.MkdirAll(testCgroupPath, 0o755); err != nil {
+	if err := os.Mkdir(path, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	return &cgroupTestUtil{CgroupData: d, CgroupPath: testCgroupPath, t: t}
+	return path
 }
 
-// Write the specified contents on the mock of the specified cgroup files.
-func (c *cgroupTestUtil) writeFileContents(fileContents map[string]string) {
+// writeFileContents writes the specified contents on the mock of the specified
+// cgroup files.
+func writeFileContents(t *testing.T, path string, fileContents map[string]string) {
 	for file, contents := range fileContents {
-		err := cgroups.WriteFile(c.CgroupPath, file, contents)
+		err := cgroups.WriteFile(path, file, contents)
 		if err != nil {
-			c.t.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 }

--- a/libcontainer/cgroups/fs2/defaultpath.go
+++ b/libcontainer/cgroups/fs2/defaultpath.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
-	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 const UnifiedMountpoint = "/sys/fs/cgroup"
@@ -36,20 +36,19 @@ func defaultDirPath(c *configs.Cgroup) (string, error) {
 		return "", fmt.Errorf("cgroup: either Path or Name and Parent should be used, got %+v", c)
 	}
 
-	// XXX: Do not remove this code. Path safety is important! -- cyphar
-	cgPath := libcontainerUtils.CleanPath(c.Path)
-	cgParent := libcontainerUtils.CleanPath(c.Parent)
-	cgName := libcontainerUtils.CleanPath(c.Name)
-
-	return _defaultDirPath(UnifiedMountpoint, cgPath, cgParent, cgName)
+	return _defaultDirPath(UnifiedMountpoint, c.Path, c.Parent, c.Name)
 }
 
 func _defaultDirPath(root, cgPath, cgParent, cgName string) (string, error) {
 	if (cgName != "" || cgParent != "") && cgPath != "" {
 		return "", errors.New("cgroup: either Path or Name and Parent should be used")
 	}
-	innerPath := cgPath
+
+	// XXX: Do not remove CleanPath. Path safety is important! -- cyphar
+	innerPath := utils.CleanPath(cgPath)
 	if innerPath == "" {
+		cgParent := utils.CleanPath(cgParent)
+		cgName := utils.CleanPath(cgName)
 		innerPath = filepath.Join(cgParent, cgName)
 	}
 	if filepath.IsAbs(innerPath) {

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -20,16 +20,12 @@ type manager struct {
 	// controllers is content of "cgroup.controllers" file.
 	// excludes pseudo-controllers ("devices" and "freezer").
 	controllers map[string]struct{}
-	rootless    bool
 }
 
 // NewManager creates a manager for cgroup v2 unified hierarchy.
 // dirPath is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope".
 // If dirPath is empty, it is automatically set using config.
-func NewManager(config *configs.Cgroup, dirPath string, rootless bool) (cgroups.Manager, error) {
-	if config == nil {
-		config = &configs.Cgroup{}
-	}
+func NewManager(config *configs.Cgroup, dirPath string) (cgroups.Manager, error) {
 	if dirPath == "" {
 		var err error
 		dirPath, err = defaultDirPath(config)
@@ -39,9 +35,8 @@ func NewManager(config *configs.Cgroup, dirPath string, rootless bool) (cgroups.
 	}
 
 	m := &manager{
-		config:   config,
-		dirPath:  dirPath,
-		rootless: rootless,
+		config:  config,
+		dirPath: dirPath,
 	}
 	return m, nil
 }
@@ -53,7 +48,7 @@ func (m *manager) getControllers() error {
 
 	data, err := cgroups.ReadFile(m.dirPath, "cgroup.controllers")
 	if err != nil {
-		if m.rootless && m.config.Path == "" {
+		if m.config.Rootless && m.config.Path == "" {
 			return nil
 		}
 		return err
@@ -73,7 +68,7 @@ func (m *manager) Apply(pid int) error {
 		// - "runc create (no limits + no cgrouppath + no permission) succeeds"
 		// - "runc create (rootless + no limits + cgrouppath + no permission) fails with permission error"
 		// - "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
-		if m.rootless {
+		if m.config.Rootless {
 			if m.config.Path == "" {
 				if blNeed, nErr := needAnyControllers(m.config.Resources); nErr == nil && !blNeed {
 					return nil
@@ -127,7 +122,7 @@ func (m *manager) GetStats() (*cgroups.Stats, error) {
 	if err := fscommon.RdmaGetStats(m.dirPath, st); err != nil && !os.IsNotExist(err) {
 		errs = append(errs, err)
 	}
-	if len(errs) > 0 && !m.rootless {
+	if len(errs) > 0 && !m.config.Rootless {
 		return st, fmt.Errorf("error while statting cgroup v2: %+v", errs)
 	}
 	return st, nil
@@ -171,10 +166,10 @@ func (m *manager) Set(r *configs.Resources) error {
 	}
 	// devices (since kernel 4.15, pseudo-controller)
 	//
-	// When m.rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
+	// When rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
 	// However, errors from other subsystems are not ignored.
 	// see @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
-	if err := setDevices(m.dirPath, r); err != nil && !m.rootless {
+	if err := setDevices(m.dirPath, r); err != nil && !m.config.Rootless {
 		return err
 	}
 	// cpuset (since kernel 5.0)
@@ -250,7 +245,7 @@ func OOMKillCount(path string) (uint64, error) {
 
 func (m *manager) OOMKillCount() (uint64, error) {
 	c, err := OOMKillCount(m.dirPath)
-	if err != nil && m.rootless && os.IsNotExist(err) {
+	if err != nil && m.config.Rootless && os.IsNotExist(err) {
 		err = nil
 	}
 

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -129,6 +129,9 @@ func (m *manager) GetStats() (*cgroups.Stats, error) {
 }
 
 func (m *manager) Freeze(state configs.FreezerState) error {
+	if m.config.Resources == nil {
+		return errors.New("cannot toggle freezer: cgroups not configured for container")
+	}
 	if err := setFreezer(m.dirPath, state); err != nil {
 		return err
 	}
@@ -145,6 +148,9 @@ func (m *manager) Path(_ string) string {
 }
 
 func (m *manager) Set(r *configs.Resources) error {
+	if r == nil {
+		return nil
+	}
 	if err := m.getControllers(); err != nil {
 		return err
 	}

--- a/libcontainer/cgroups/manager/manager_test.go
+++ b/libcontainer/cgroups/manager/manager_test.go
@@ -1,0 +1,45 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+// TestNilResources checks that a cgroup manager do not panic when
+// config.Resources is nil. While it does not make sense to use a
+// manager with no resources, it should not result in a panic.
+//
+// This tests either v1 or v2 managers (both fs and systemd)
+// depending on what cgroup version is available on the host.
+
+func TestNilResources(t *testing.T) {
+	for _, sd := range []bool{false, true} {
+		cg := &configs.Cgroup{} // .Resources is nil
+		cg.Systemd = sd
+		mgr, err := New(cg)
+		if err != nil {
+			// Some managers require non-nil Resources during
+			// instantiation -- provide and retry. In such case
+			// we're mostly testing Set(nil) below.
+			cg.Resources = &configs.Resources{}
+			mgr, err = New(cg)
+			if err != nil {
+				t.Error(err)
+				continue
+			}
+		}
+		_ = mgr.Apply(-1)
+		_ = mgr.Set(nil)
+		_ = mgr.Freeze(configs.Thawed)
+		_ = mgr.Exists()
+		_, _ = mgr.GetAllPids()
+		_, _ = mgr.GetCgroups()
+		_, _ = mgr.GetFreezerState()
+		_ = mgr.Path("")
+		_ = mgr.GetPaths()
+		_, _ = mgr.GetStats()
+		_, _ = mgr.OOMKillCount()
+		_ = mgr.Destroy()
+	}
+}

--- a/libcontainer/cgroups/manager/new.go
+++ b/libcontainer/cgroups/manager/new.go
@@ -1,0 +1,78 @@
+package manager
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+// New returns the instance of a cgroup manager, which is chosen
+// based on the local environment (whether cgroup v1 or v2 is used)
+// and the config (whether config.Systemd is set or not).
+func New(config *configs.Cgroup) (cgroups.Manager, error) {
+	return NewWithPaths(config, nil)
+}
+
+// NewWithPaths is similar to New, and can be used in case cgroup paths
+// are already well known, which can save some resources.
+//
+// For cgroup v1, the keys are controller/subsystem name, and the values
+// are absolute filesystem paths to the appropriate cgroups.
+//
+// For cgroup v2, the only key allowed is "" (empty string), and the value
+// is the unified cgroup path.
+func NewWithPaths(config *configs.Cgroup, paths map[string]string) (cgroups.Manager, error) {
+	if config == nil {
+		return nil, errors.New("cgroups/manager.New: config is nil")
+	}
+	if config.Systemd && !systemd.IsRunningSystemd() {
+		return nil, errors.New("systemd not running on this host, can't use systemd cgroups manager")
+	}
+
+	// Cgroup v2 aka unified hierarchy.
+	if cgroups.IsCgroup2UnifiedMode() {
+		path, err := getUnifiedPath(paths)
+		if err != nil {
+			return nil, fmt.Errorf("manager.NewWithPaths: inconsistent paths: %w", err)
+		}
+		if config.Systemd {
+			return systemd.NewUnifiedManager(config, path)
+		}
+		return fs2.NewManager(config, path)
+	}
+
+	// Cgroup v1.
+	if config.Systemd {
+		return systemd.NewLegacyManager(config, paths)
+	}
+
+	return fs.NewManager(config, paths)
+}
+
+// getUnifiedPath is an implementation detail of libcontainer factory.
+// Historically, it saves cgroup paths as per-subsystem path map (as returned
+// by cm.GetPaths(""), but with v2 we only have one single unified path
+// (with "" as a key).
+//
+// This function converts from that map to string (using "" as a key),
+// and also checks that the map itself is sane.
+func getUnifiedPath(paths map[string]string) (string, error) {
+	if len(paths) > 1 {
+		return "", fmt.Errorf("expected a single path, got %+v", paths)
+	}
+	path := paths[""]
+	// can be empty
+	if path != "" {
+		if filepath.Clean(path) != path || !filepath.IsAbs(path) {
+			return "", fmt.Errorf("invalid path: %q", path)
+		}
+	}
+
+	return path, nil
+}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -389,6 +389,9 @@ func (m *legacyManager) freezeBeforeSet(unitName string, r *configs.Resources) (
 }
 
 func (m *legacyManager) Set(r *configs.Resources) error {
+	if r == nil {
+		return nil
+	}
 	if r.Unified != nil {
 		return cgroups.ErrV1NoUnified
 	}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -109,14 +109,13 @@ func (m *legacyManager) initPaths() error {
 
 	slice := "system.slice"
 	if c.Parent != "" {
-		slice = c.Parent
+		var err error
+		slice, err = ExpandSlice(c.Parent)
+		if err != nil {
+			return err
+		}
 	}
 
-	var err error
-	slice, err = ExpandSlice(slice)
-	if err != nil {
-		return err
-	}
 	unit := getUnitName(c)
 
 	paths := make(map[string]string)

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -24,12 +24,15 @@ type legacyManager struct {
 	dbus    *dbusConnManager
 }
 
-func NewLegacyManager(cg *configs.Cgroup, paths map[string]string) cgroups.Manager {
+func NewLegacyManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Manager, error) {
+	if cg.Rootless {
+		return nil, errors.New("can't use rootless systemd cgroups manager on cgroup v1")
+	}
 	return &legacyManager{
 		cgroups: cg,
 		paths:   paths,
 		dbus:    newDbusConnManager(false),
-	}
+	}, nil
 }
 
 type subsystem interface {

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -28,6 +28,16 @@ func NewLegacyManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Mana
 	if cg.Rootless {
 		return nil, errors.New("can't use rootless systemd cgroups manager on cgroup v1")
 	}
+	if cg.Resources != nil && cg.Resources.Unified != nil {
+		return nil, cgroups.ErrV1NoUnified
+	}
+	if paths == nil {
+		var err error
+		paths, err = initPaths(cg)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &legacyManager{
 		cgroups: cg,
 		paths:   paths,
@@ -102,20 +112,14 @@ func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]syst
 	return properties, nil
 }
 
-// initPaths initializes m.paths. Supposed to be called under m.mu held.
-func (m *legacyManager) initPaths() error {
-	if m.paths != nil {
-		return nil
-	}
-
-	c := m.cgroups
-
+// initPaths figures out and returns paths to cgroups.
+func initPaths(c *configs.Cgroup) (map[string]string, error) {
 	slice := "system.slice"
 	if c.Parent != "" {
 		var err error
 		slice, err = ExpandSlice(c.Parent)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -129,18 +133,17 @@ func (m *legacyManager) initPaths() error {
 			// because devices cgroup is hard requirement for
 			// container security.
 			if s.Name() == "devices" {
-				return err
+				return nil, err
 			}
 			// Don't fail if a cgroup hierarchy was not found, just skip this subsystem
 			if cgroups.IsNotFound(err) {
 				continue
 			}
-			return err
+			return nil, err
 		}
 		paths[s.Name()] = subsystemPath
 	}
-	m.paths = paths
-	return nil
+	return paths, nil
 }
 
 func (m *legacyManager) Apply(pid int) error {
@@ -150,10 +153,6 @@ func (m *legacyManager) Apply(pid int) error {
 		slice      = "system.slice"
 		properties []systemdDbus.Property
 	)
-
-	if c.Resources.Unified != nil {
-		return cgroups.ErrV1NoUnified
-	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -198,9 +197,6 @@ func (m *legacyManager) Apply(pid int) error {
 		return err
 	}
 
-	if err := m.initPaths(); err != nil {
-		return err
-	}
 	if err := m.joinCgroups(pid); err != nil {
 		return err
 	}

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -99,6 +99,34 @@ func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]syst
 	return properties, nil
 }
 
+// initPaths initializes m.paths. Supposed to be called under m.mu held.
+func (m *legacyManager) initPaths() error {
+	if m.paths != nil {
+		return nil
+	}
+
+	paths := make(map[string]string)
+	for _, s := range legacySubsystems {
+		subsystemPath, err := getSubsystemPath(m.cgroups, s.Name())
+		if err != nil {
+			// Even if it's `not found` error, we'll return err
+			// because devices cgroup is hard requirement for
+			// container security.
+			if s.Name() == "devices" {
+				return err
+			}
+			// Don't fail if a cgroup hierarchy was not found, just skip this subsystem
+			if cgroups.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		paths[s.Name()] = subsystemPath
+	}
+	m.paths = paths
+	return nil
+}
+
 func (m *legacyManager) Apply(pid int) error {
 	var (
 		c          = m.cgroups
@@ -158,26 +186,9 @@ func (m *legacyManager) Apply(pid int) error {
 		return err
 	}
 
-	paths := make(map[string]string)
-	for _, s := range legacySubsystems {
-		subsystemPath, err := getSubsystemPath(m.cgroups, s.Name())
-		if err != nil {
-			// Even if it's `not found` error, we'll return err
-			// because devices cgroup is hard requirement for
-			// container security.
-			if s.Name() == "devices" {
-				return err
-			}
-			// Don't fail if a cgroup hierarchy was not found, just skip this subsystem
-			if cgroups.IsNotFound(err) {
-				continue
-			}
-			return err
-		}
-		paths[s.Name()] = subsystemPath
+	if err := m.initPaths(); err != nil {
+		return err
 	}
-	m.paths = paths
-
 	if err := m.joinCgroups(pid); err != nil {
 		return err
 	}

--- a/libcontainer/cgroups/systemd/v1_test.go
+++ b/libcontainer/cgroups/systemd/v1_test.go
@@ -133,7 +133,10 @@ func TestFreezeBeforeSet(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			m := NewLegacyManager(tc.cg, nil)
+			m, err := NewLegacyManager(tc.cg, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 			defer m.Destroy() //nolint:errcheck
 			lm := m.(*legacyManager)
 

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -384,6 +384,9 @@ func (m *unifiedManager) GetStats() (*cgroups.Stats, error) {
 }
 
 func (m *unifiedManager) Set(r *configs.Resources) error {
+	if r == nil {
+		return nil
+	}
 	properties, err := genV2ResourcesProperties(r, m.dbus)
 	if err != nil {
 		return err

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -242,23 +242,19 @@ func (m *unifiedManager) Apply(pid int) error {
 
 	properties = append(properties, systemdDbus.PropDescription("libcontainer container "+c.Name))
 
-	// if we create a slice, the parent is defined via a Wants=
 	if strings.HasSuffix(unitName, ".slice") {
+		// If we create a slice, the parent is defined via a Wants=.
 		properties = append(properties, systemdDbus.PropWants(slice))
 	} else {
-		// otherwise, we use Slice=
+		// Otherwise it's a scope, which we put into a Slice=.
 		properties = append(properties, systemdDbus.PropSlice(slice))
+		// Assume scopes always support delegation (supported since systemd v218).
+		properties = append(properties, newProp("Delegate", true))
 	}
 
 	// only add pid if its valid, -1 is used w/ general slice creation.
 	if pid != -1 {
 		properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
-	}
-
-	// Check if we can delegate. This is only supported on systemd versions 218 and above.
-	if !strings.HasSuffix(unitName, ".slice") {
-		// Assume scopes always support delegation.
-		properties = append(properties, newProp("Delegate", true))
 	}
 
 	// Always enable accounting, this gets us the same behaviour as the fs implementation,

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -31,10 +31,16 @@ type Cgroup struct {
 	// Resources contains various cgroups settings to apply
 	*Resources
 
+	// Systemd tells if systemd should be used to manage cgroups.
+	Systemd bool
+
 	// SystemdProps are any additional properties for systemd,
 	// derived from org.systemd.property.xxx annotations.
 	// Ignored unless systemd is used for managing cgroups.
 	SystemdProps []systemdDbus.Property `json:"-"`
+
+	// Rootless tells if rootless cgroups should be used.
+	Rootless bool
 }
 
 type Resources struct {

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -138,9 +138,11 @@ func TestFactoryLoadContainer(t *testing.T) {
 			},
 		}
 		expectedConfig = &configs.Config{
-			Rootfs:  "/mycontainer/root",
-			Hooks:   expectedHooks,
-			Cgroups: &configs.Cgroup{},
+			Rootfs: "/mycontainer/root",
+			Hooks:  expectedHooks,
+			Cgroups: &configs.Cgroup{
+				Resources: &configs.Resources{},
+			},
 		}
 		expectedState = &State{
 			BaseState: BaseState{

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestFactoryNew(t *testing.T) {
 	root := t.TempDir()
-	factory, err := New(root, Cgroupfs)
+	factory, err := New(root)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestFactoryNew(t *testing.T) {
 
 func TestFactoryNewIntelRdt(t *testing.T) {
 	root := t.TempDir()
-	factory, err := New(root, Cgroupfs, IntelRdtFs)
+	factory, err := New(root, IntelRdtFs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestFactoryNewIntelRdt(t *testing.T) {
 
 func TestFactoryNewTmpfs(t *testing.T) {
 	root := t.TempDir()
-	factory, err := New(root, Cgroupfs, TmpfsRoot)
+	factory, err := New(root, TmpfsRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestFactoryNewTmpfs(t *testing.T) {
 }
 
 func TestFactoryLoadNotExists(t *testing.T) {
-	factory, err := New(t.TempDir(), Cgroupfs)
+	factory, err := New(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,8 +138,9 @@ func TestFactoryLoadContainer(t *testing.T) {
 			},
 		}
 		expectedConfig = &configs.Config{
-			Rootfs: "/mycontainer/root",
-			Hooks:  expectedHooks,
+			Rootfs:  "/mycontainer/root",
+			Hooks:   expectedHooks,
+			Cgroups: &configs.Cgroup{},
 		}
 		expectedState = &State{
 			BaseState: BaseState{
@@ -154,7 +155,7 @@ func TestFactoryLoadContainer(t *testing.T) {
 	if err := marshal(filepath.Join(root, id, stateFilename), expectedState); err != nil {
 		t.Fatal(err)
 	}
-	factory, err := New(root, Cgroupfs, IntelRdtFs)
+	factory, err := New(root, IntelRdtFs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -62,7 +62,7 @@ func testCheckpoint(t *testing.T, userns bool) {
 	}
 
 	config := newTemplateConfig(t, &tParam{userns: userns})
-	factory, err := libcontainer.New(t.TempDir(), libcontainer.Cgroupfs)
+	factory, err := libcontainer.New(t.TempDir())
 	ok(t, err)
 
 	container, err := factory.Create("test", config)

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -132,6 +132,7 @@ func newTemplateConfig(t *testing.T, p *tParam) *configs.Config {
 			{Type: configs.NEWNET},
 		}),
 		Cgroups: &configs.Cgroup{
+			Systemd: p.systemd,
 			Resources: &configs.Resources{
 				MemorySwappiness: nil,
 				Devices:          allowedDevices,
@@ -221,7 +222,6 @@ func newTemplateConfig(t *testing.T, p *tParam) *configs.Config {
 	if p.systemd {
 		id := strconv.FormatInt(-int64(time.Now().Nanosecond()), 36)
 		config.Cgroups.Name = strings.ReplaceAll(t.Name(), "/", "_") + id
-		// do not change Parent (see newContainer)
 		config.Cgroups.Parent = "system.slice"
 		config.Cgroups.ScopePrefix = "runc-test"
 	} else {

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -126,15 +126,9 @@ func newContainer(t *testing.T, config *configs.Config) (libcontainer.Container,
 	name := strings.ReplaceAll(t.Name(), "/", "_") + strconv.FormatInt(-int64(time.Now().Nanosecond()), 35)
 	root := t.TempDir()
 
-	f, err := libcontainer.New(root, libcontainer.Cgroupfs)
+	f, err := libcontainer.New(root)
 	if err != nil {
 		return nil, err
-	}
-	if config.Cgroups != nil && config.Cgroups.Parent == "system.slice" {
-		f, err = libcontainer.New(root, libcontainer.SystemdCgroups)
-		if err != nil {
-			return nil, err
-		}
 	}
 	return f.Create(name, config)
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -429,6 +429,8 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
 	)
 
 	c := &configs.Cgroup{
+		Systemd:   useSystemdCgroup,
+		Rootless:  opts.RootlessCgroups,
 		Resources: &configs.Resources{},
 	}
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -301,3 +301,24 @@ function setup() {
 	[ "$status" -eq 255 ]
 	[[ "$output" == *"cannot exec in a paused container"* ]]
 }
+
+@test "runc run/create should refuse a non-empty cgroup" {
+	if [[ "$ROOTLESS" -ne 0 ]]; then
+		requires rootless_cgroup
+	fi
+
+	set_cgroups_path
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
+	[ "$status" -eq 0 ]
+
+	# Run a second container sharing the cgroup with the first one.
+	runc --debug run -d --console-socket "$CONSOLE_SOCKET" ct2
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"container's cgroup is not empty"* ]]
+
+	# Same but using runc create.
+	runc create --console-socket "$CONSOLE_SOCKET" ct3
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"container's cgroup is not empty"* ]]
+}

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -322,3 +322,44 @@ function setup() {
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"container's cgroup is not empty"* ]]
 }
+
+@test "runc run/create should refuse pre-existing frozen cgroup" {
+	requires cgroups_freezer
+	if [[ "$ROOTLESS" -ne 0 ]]; then
+		requires rootless_cgroup
+	fi
+
+	set_cgroups_path
+
+	case $CGROUP_UNIFIED in
+	no)
+		FREEZER_DIR="${CGROUP_FREEZER_BASE_PATH}/${REL_CGROUPS_PATH}"
+		FREEZER="${FREEZER_DIR}/freezer.state"
+		STATE="FROZEN"
+		;;
+	yes)
+		FREEZER_DIR="${CGROUP_PATH}"
+		FREEZER="${FREEZER_DIR}/cgroup.freeze"
+		STATE="1"
+		;;
+	esac
+
+	# Create and freeze the cgroup.
+	mkdir -p "$FREEZER_DIR"
+	echo "$STATE" >"$FREEZER"
+
+	# Start a container.
+	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
+	[ "$status" -eq 1 ]
+	# A warning should be printed.
+	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
+
+	# Same check for runc create.
+	runc create --console-socket "$CONSOLE_SOCKET" ct2
+	[ "$status" -eq 1 ]
+	# A warning should be printed.
+	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
+
+	# Cleanup.
+	rmdir "$FREEZER_DIR"
+}

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -50,6 +50,16 @@ function teardown() {
 	[ "$status" -eq 0 ]
 }
 
+@test "runc delete --force [paused container]" {
+	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
+	[ "$status" -eq 0 ]
+	testcontainer ct1 running
+
+	runc pause ct1
+	runc delete --force ct1
+	[ "$status" -eq 0 ]
+}
+
 @test "runc delete --force in cgroupv1 with subcgroups" {
 	requires cgroups_v1 root cgroupns
 	set_cgroups_path


### PR DESCRIPTION
OK, this is being split into a few more digestible PRs:
 - [x] #3214
 - [x] #3215
 - [x] #3216
 - [x] #3217
 - [x] #3223 

### I. cgroup manager refactoring

Very high level overview:
 * allow cgroup instantiation (`NewManager`) to return errors;
 * initialize cgroup paths during instantiation, so paths are always available
   (and now we can use a new instance for e.g. `Destroy` or `Exists`,
    which was not possible before);
 * simplifies cgroup manager instantiation, replacing the complicated
    logic of choosing a cgroup manager with a simple `manager.New()` call.
 * fixes some panics in cgroup manager (with `Resources==nil`).

This helps further commits, and makes cgroup manager easier to use
from e.g. Kubernetes.

Fixes: https://github.com/opencontainers/runc/issues/3177
Fixes: https://github.com/opencontainers/runc/issues/3178

### II. runc run/create: refuse non-empty cgroup

Currently runc allows multiple containers to share the same cgroup (for
example, by having the same `cgroupPath` in config.json).  While such
shared configuration might be OK, there are some issues:
    
- When each container has its own resource limits, the order of
    containers start determines whose limits will be effectively applied.
    
- When one of containers is paused, all others are paused, too.
    
- When a container is paused, any attempt to do runc create/run/exec
      end up with runc init stuck inside a frozen cgroup.
    
- When a systemd cgroup manager is used, this becomes even worse -- such
      as, stop (or even failed start) of any container results in
      "stopTransientUnit" command being sent to systemd, and so (depending
      on unit properties) other containers can receive SIGTERM, be killed
      after a timeout etc.
      
All this may lead to various hard-to-debug situations in production
(runc init stuck, cgroup removal error, wrong resource limits, container
init not working as zombie reaper, etc).
    
One obvious solution is to require a non-existent or empty cgroup
for the new container, and fail otherwise.
    
This is exactly what this PR implements.

### III. runc delete -f: don't hang on a paused container

runc delete -f used to hang if a container is paused (on cgroup v1).
Fix this, add a test case.

Fixes: https://github.com/opencontainers/runc/issues/3134

### IV. runc exec: refuse paused container
    
This bugged me a few times during runc development. A new container is
run, and suddenly runc init is stuck, 🎶 and nothing ever happens, and
I wonder... 🎶
    
Figuring out that the cause of it is (pre-created) frozen cgroup is not
very obvious (to say at least).
    
The fix is to add a check that refuses to exec in a paused container.
A (very bad) alternative to that would be to thaw the cgroup.
    
Implement the fix, add a test case.

### V. runc run: refuse cgroup if frozen
    
Sometimes a container cgroup already exists but is frozen.
When this happens, runc init hangs, and it's not clear what is going on.

Refuse to run in a frozen cgroup; add a test case.

----

Fixes: https://github.com/opencontainers/runc/issues/3132

### Proposed changelog entry
```
libcontainer API changes:
* New configs.Cgroup structure fields (#3177):
  * Systemd (whether to use systemd cgroup manager);
  * Rootless (whether to use rootless cgroups).
* New cgroups/manager package aiming to simplify cgroup manager instantiation. (#3177)
* All cgroup managers' instantiation methods now initialize cgroup paths and can return errors.
  This allows to use any cgroup manager method (e.g. Exists, Destroy, Set, GetStats) right after
  instantiation, which was not possible before (as paths were initialized in Apply only). (#3178)
Bugfixes:
* runc delete -f now succeeds (rather than timeouts) on a paused container (#3134)
* runc exec now refuses a paused container (#3132)
* runc run/start now refuses to start a container in a non-empty cgroup (#3132)
* runc run/start now refuses to start a container if its cgroup is frozen (#3132)