### PR TITLE
libct/cg: GetAllPids: optimize for go 1.16+ (3x to 3.5x speed improvement)

### DIFF
--- a/libcontainer/cgroups/getallpids.go
+++ b/libcontainer/cgroups/getallpids.go
@@ -1,0 +1,30 @@
+// +build linux
+
+package cgroups
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GetAllPids returns all pids, that were added to cgroup at path and to all its
+// subcgroups.
+func GetAllPids(path string) ([]int, error) {
+	var pids []int
+	// collect pids from all sub-cgroups
+	err := filepath.Walk(path, func(p string, info os.FileInfo, iErr error) error {
+		if iErr != nil {
+			return iErr
+		}
+		if info.IsDir() || info.Name() != CgroupProcesses {
+			return nil
+		}
+		cPids, err := readProcsFile(p)
+		if err != nil {
+			return err
+		}
+		pids = append(pids, cPids...)
+		return nil
+	})
+	return pids, err
+}

--- a/libcontainer/cgroups/getallpids.go
+++ b/libcontainer/cgroups/getallpids.go
@@ -16,7 +16,7 @@ func GetAllPids(path string) ([]int, error) {
 		if iErr != nil {
 			return iErr
 		}
-		if info.IsDir() || info.Name() != CgroupProcesses {
+		if !info.IsDir() {
 			return nil
 		}
 		cPids, err := readProcsFile(p)

--- a/libcontainer/cgroups/getallpids_go115.go
+++ b/libcontainer/cgroups/getallpids_go115.go
@@ -1,21 +1,22 @@
-// +build linux,go1.16
+// +build linux,!go1.16
 
 package cgroups
 
 import (
-	"io/fs"
+	"os"
 	"path/filepath"
 )
 
-// GetAllPids returns all pids from the cgroup identified by path, and all its
-// sub-cgroups.
+// GetAllPids returns all pids, that were added to cgroup at path and to all its
+// subcgroups.
 func GetAllPids(path string) ([]int, error) {
 	var pids []int
-	err := filepath.WalkDir(path, func(p string, d fs.DirEntry, iErr error) error {
+	// collect pids from all sub-cgroups
+	err := filepath.Walk(path, func(p string, info os.FileInfo, iErr error) error {
 		if iErr != nil {
 			return iErr
 		}
-		if !d.IsDir() {
+		if !info.IsDir() {
 			return nil
 		}
 		cPids, err := readProcsFile(p)

--- a/libcontainer/cgroups/getallpids_test.go
+++ b/libcontainer/cgroups/getallpids_test.go
@@ -1,0 +1,19 @@
+// +build linux
+
+package cgroups
+
+import (
+	"testing"
+)
+
+func BenchmarkGetAllPids(b *testing.B) {
+	total := 0
+	for i := 0; i < b.N; i++ {
+		i, err := GetAllPids("/sys/fs/cgroup")
+		if err != nil {
+			b.Fatal(err)
+		}
+		total += len(i)
+	}
+	b.Logf("iter: %d, total: %d", b.N, total)
+}

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -118,8 +118,8 @@ func GetAllSubsystems() ([]string, error) {
 	return subsystems, nil
 }
 
-func readProcsFile(file string) ([]int, error) {
-	f, err := os.Open(file)
+func readProcsFile(dir string) ([]int, error) {
+	f, err := OpenFile(dir, CgroupProcesses, os.O_RDONLY)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +336,7 @@ func getHugePageSizeFromFilenames(fileNames []string) ([]string, error) {
 
 // GetPids returns all pids, that were added to cgroup at path.
 func GetPids(dir string) ([]int, error) {
-	return readProcsFile(filepath.Join(dir, CgroupProcesses))
+	return readProcsFile(dir)
 }
 
 // WriteCgroupProc writes the specified pid into the cgroup's cgroup.procs file

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -339,28 +339,6 @@ func GetPids(dir string) ([]int, error) {
 	return readProcsFile(filepath.Join(dir, CgroupProcesses))
 }
 
-// GetAllPids returns all pids, that were added to cgroup at path and to all its
-// subcgroups.
-func GetAllPids(path string) ([]int, error) {
-	var pids []int
-	// collect pids from all sub-cgroups
-	err := filepath.Walk(path, func(p string, info os.FileInfo, iErr error) error {
-		if iErr != nil {
-			return iErr
-		}
-		if info.IsDir() || info.Name() != CgroupProcesses {
-			return nil
-		}
-		cPids, err := readProcsFile(p)
-		if err != nil {
-			return err
-		}
-		pids = append(pids, cPids...)
-		return nil
-	})
-	return pids, err
-}
-
 // WriteCgroupProc writes the specified pid into the cgroup's cgroup.procs file
 func WriteCgroupProc(dir string, pid int) error {
 	// Normally dir should not be empty, one case is that cgroup subsystem


### PR DESCRIPTION
### I. libct/cg: improve GetAllPids and readProcsFile

* GetAllPids: skip non-directories, remove filename comparison.
* readProcsFile: accept directory, use own OpenFile.

### II. libct/cg: GetAllPids: optimize for go 1.16+

The `filepath.WalkDir` function, introduced in Go 1.16, doesn't do `stat(2)`
on every entry, and is therefore somewhat faster (see below).

Since we have to support Go 1.15, keep the old version for backward
compatibility.

Add a quick benchmark, which shows approximately 3x improvement:

        $ go1.15.15 test -bench AllPid -run xxx .
        BenchmarkGetAllPids-4                 48          23528839 ns/op

        $ go version
        go version go1.16.6 linux/amd64
        $ go test -bench AllPid -run xxx .
        BenchmarkGetAllPids-4                147           7700170 ns/op

(Unrelated but worth noting -- go 1.17rc2 is pushing it even further)

        $ go1.17rc2 test -bench AllPid -run xxx .
        BenchmarkGetAllPids-4                164           6820994 ns/op

So, 3.5x faster with go 1.17 but still compatible with go 1.15.