### PR TITLE
libct/cg: rm dead code to improve clarity

### DIFF
--- a/libcontainer/cgroups/fs2/defaultpath.go
+++ b/libcontainer/cgroups/fs2/defaultpath.go
@@ -35,10 +35,6 @@ func defaultDirPath(c *configs.Cgroup) (string, error) {
 	if (c.Name != "" || c.Parent != "") && c.Path != "" {
 		return "", fmt.Errorf("cgroup: either Path or Name and Parent should be used, got %+v", c)
 	}
-	if len(c.Paths) != 0 {
-		// never set by specconv
-		return "", fmt.Errorf("cgroup: Paths is unsupported, use Path, got %+v", c)
-	}
 
 	// XXX: Do not remove this code. Path safety is important! -- cyphar
 	cgPath := libcontainerUtils.CleanPath(c.Path)

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -113,21 +113,6 @@ func (m *legacyManager) Apply(pid int) error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if c.Paths != nil {
-		paths := make(map[string]string)
-		cgMap, err := cgroups.ParseCgroupFile("/proc/self/cgroup")
-		if err != nil {
-			return err
-		}
-		// XXX(kolyshkin@): why this check is needed?
-		for name, path := range c.Paths {
-			if _, ok := cgMap[name]; ok {
-				paths[name] = path
-			}
-		}
-		m.paths = paths
-		return cgroups.EnterPid(m.paths, pid)
-	}
 
 	if c.Parent != "" {
 		slice = c.Parent
@@ -201,9 +186,6 @@ func (m *legacyManager) Apply(pid int) error {
 }
 
 func (m *legacyManager) Destroy() error {
-	if m.cgroups.Paths != nil {
-		return nil
-	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -388,11 +370,6 @@ func (m *legacyManager) freezeBeforeSet(unitName string, r *configs.Resources) (
 }
 
 func (m *legacyManager) Set(r *configs.Resources) error {
-	// If Paths are set, then we are just joining cgroups paths
-	// and there is no need to set any values.
-	if m.cgroups.Paths != nil {
-		return nil
-	}
 	if r.Unified != nil {
 		return cgroups.ErrV1NoUnified
 	}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -234,10 +234,6 @@ func (m *unifiedManager) Apply(pid int) error {
 		properties []systemdDbus.Property
 	)
 
-	if c.Paths != nil {
-		return cgroups.WriteCgroupProc(m.path, pid)
-	}
-
 	slice := "system.slice"
 	if m.rootless {
 		slice = "user.slice"
@@ -296,9 +292,6 @@ func (m *unifiedManager) Apply(pid int) error {
 }
 
 func (m *unifiedManager) Destroy() error {
-	if m.cgroups.Paths != nil {
-		return nil
-	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -28,10 +28,6 @@ type Cgroup struct {
 	// ScopePrefix describes prefix for the scope name
 	ScopePrefix string `json:"scope_prefix"`
 
-	// Paths represent the absolute cgroups paths to join.
-	// This takes precedence over Path.
-	Paths map[string]string
-
 	// Resources contains various cgroups settings to apply
 	*Resources
 


### PR DESCRIPTION
This was initially added by commits 41d9d2651301a2 and 4a8f0b4db492,
apparently to implement `docker run --cgroup container:ID` (https://github.com/moby/moby/pull/19244),
which was never merged. Therefore, this code is not and was never used.

It needs to be removed mainly because having it makes it much harder to
understand how cgroup manager works (because with this in place we have
not one or two but three sets of cgroup paths to think about).

Note if the paths are known and there is a need to add a PID to existing
cgroup, cgroup manager is not needed at all -- something like
cgroups.WriteCgroupProc or cgroups.EnterPid is sufficient (and the
latter is what runc exec uses in (*setnsProcess).start). If, for some reason,
the cgroup manager is still needed, it's better to write a separate shallow
implementation that would only do WriteCgroupProc/EnterPid in Apply and
have other methods empty.