### PR TITLE
[1.0] script/release.sh: make builds reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 GO_BUILD := $(GO) build -trimpath $(MOD_VENDOR) $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
 	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(MOD_VENDOR) $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
-	-ldflags "-w -extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
+	-ldflags "-extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 
 .DEFAULT: runc
 

--- a/script/release.sh
+++ b/script/release.sh
@@ -43,11 +43,17 @@ function build_project() {
 	)
 	mv "$tarball"{,.asc} "$builddir"
 
+	# For reproducible builds, add these to EXTRA_LDFLAGS:
+	#  -w to disable DWARF generation;
+	#  -s to disable symbol table;
+	#  -buildid= to remove variable build id.
+	local ldflags="-w -s -buildid="
 	# Add -a to go build flags to make sure it links against
 	# the provided libseccomp, not the system one (otherwise
 	# it can reuse cached pkg-config results).
-	make -C "$root" PKG_CONFIG_PATH="${prefix}/lib/pkgconfig" COMMIT_NO= EXTRA_FLAGS="-a" static
+	make -C "$root" PKG_CONFIG_PATH="${prefix}/lib/pkgconfig" COMMIT_NO= EXTRA_FLAGS="-a" EXTRA_LDFLAGS="${ldflags}" static
 	rm -rf "$prefix"
+	strip "$root/$project"
 	mv "$root/$project" "$1"
 }
 


### PR DESCRIPTION
This is a manual backport of PR #3099 (commits 61e201abb2d5e4c and
18f434e10a7ebb4a) to release-1.0 branch.

Done manually as the changes are small, and cherry-picking results
in a conflict due to commit 015fa29afd missing from release-1.0 branch.