### PR TITLE
Fix codespell warnings, add codespell to ci

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./vendor,./.git
+ignore-words-list = clos,creat

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,16 @@ jobs:
       - name: compile with no build tags
         run: make BUILDTAGS=""
 
+  codespell:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install deps
+      # Version of codespell bundled with Ubuntu is way old, so use pip.
+      run: pip install codespell
+    - name: run codespell
+      run: codespell
+
   shfmt:
     runs-on: ubuntu-20.04
     steps:

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -3,7 +3,7 @@
 By default, runc creates cgroups and sets cgroup limits on its own (this mode
 is known as fs cgroup driver). When `--systemd-cgroup` global option is given
 (as in e.g. `runc --systemd-cgroup run ...`), runc switches to systemd cgroup
-driver. This document describes its features and pecularities.
+driver. This document describes its features and peculiarities.
 
 ### systemd unit name and placement
 

--- a/libcontainer/cgroups/devices/devices_emulator.go
+++ b/libcontainer/cgroups/devices/devices_emulator.go
@@ -305,7 +305,7 @@ func EmulatorFromList(list io.Reader) (*Emulator, error) {
 // necessary.
 //
 // This function is the sole reason for all of Emulator -- to allow us
-// to figure out how to update a containers' cgroups without causing spurrious
+// to figure out how to update a containers' cgroups without causing spurious
 // device errors (if possible).
 func (source *Emulator) Transition(target *Emulator) ([]*devices.Rule, error) {
 	var transitionRules []*devices.Rule

--- a/libcontainer/cgroups/ebpf/ebpf_linux.go
+++ b/libcontainer/cgroups/ebpf/ebpf_linux.go
@@ -134,7 +134,7 @@ func haveBpfProgReplace() bool {
 			// not supported
 			return
 		}
-		// attach_flags test succeded.
+		// attach_flags test succeeded.
 		if !errors.Is(err, unix.EBADF) {
 			logrus.Debugf("checking for BPF_F_REPLACE: got unexpected (not EBADF or EINVAL) error: %v", err)
 		}

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -51,16 +51,16 @@ func getCpusetStat(path string, file string) ([]uint16, error) {
 	}
 
 	for _, s := range strings.Split(fileContent, ",") {
-		splitted := strings.SplitN(s, "-", 3)
-		switch len(splitted) {
+		sp := strings.SplitN(s, "-", 3)
+		switch len(sp) {
 		case 3:
 			return extracted, &parseError{Path: path, File: file, Err: errors.New("extra dash")}
 		case 2:
-			min, err := strconv.ParseUint(splitted[0], 10, 16)
+			min, err := strconv.ParseUint(sp[0], 10, 16)
 			if err != nil {
 				return extracted, &parseError{Path: path, File: file, Err: err}
 			}
-			max, err := strconv.ParseUint(splitted[1], 10, 16)
+			max, err := strconv.ParseUint(sp[1], 10, 16)
 			if err != nil {
 				return extracted, &parseError{Path: path, File: file, Err: err}
 			}

--- a/libcontainer/cgroups/fs/stats_util_test.go
+++ b/libcontainer/cgroups/fs/stats_util_test.go
@@ -51,7 +51,7 @@ func expectBlkioStatsEquals(t *testing.T, expected, actual cgroups.BlkioStats) {
 	}
 
 	if err := blkioStatEntryEquals(expected.IoMergedRecursive, actual.IoMergedRecursive); err != nil {
-		t.Errorf("blkio IoMergedRecursive do not match: expcted: %v, actual: %v", expected.IoMergedRecursive, actual.IoMergedRecursive)
+		t.Errorf("blkio IoMergedRecursive do not match: expected: %v, actual: %v", expected.IoMergedRecursive, actual.IoMergedRecursive)
 	}
 
 	if err := blkioStatEntryEquals(expected.IoTimeRecursive, actual.IoTimeRecursive); err != nil {

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -126,7 +126,7 @@ type BlkioStatEntry struct {
 }
 
 type BlkioStats struct {
-	// number of bytes tranferred to and from the block device
+	// number of bytes transferred to and from the block device
 	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive,omitempty"`
 	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recursive,omitempty"`
 	IoQueuedRecursive       []BlkioStatEntry `json:"io_queue_recursive,omitempty"`

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -198,7 +198,7 @@ func generateDeviceProperties(r *configs.Resources) ([]systemdDbus.Property, err
 	}
 	// systemd doesn't support blacklists. So we log a warning, and tell
 	// systemd to act as a deny-all whitelist. This ruleset will be replaced
-	// with our normal fallback code. This may result in spurrious errors, but
+	// with our normal fallback code. This may result in spurious errors, but
 	// the only other option is to error out here.
 	if configEmu.IsBlacklist() {
 		// However, if we're dealing with an allow-all rule then we can do it.

--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -341,7 +341,7 @@ func TestFreezePodCgroup(t *testing.T) {
 	containerConfig := &configs.Cgroup{
 		Parent:      "system-runc_test_pod.slice",
 		ScopePrefix: "test",
-		Name:        "inner-contianer",
+		Name:        "inner-container",
 		Resources:   &configs.Resources{},
 	}
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2100,7 +2100,7 @@ func ignoreTerminateErrors(err error) error {
 	if err == nil {
 		return nil
 	}
-	// terminate() might return an error from ether Kill or Wait.
+	// terminate() might return an error from either Kill or Wait.
 	// The (*Cmd).Wait documentation says: "If the command fails to run
 	// or doesn't complete successfully, the error is of type *ExitError".
 	// Filter out such errors (like "exit status 1" or "signal: killed").

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -224,7 +224,7 @@ func TestNsenterChildLogging(t *testing.T) {
 		t.Fatalf("child log: %v", err)
 	}
 	if logentry.Level == "" || logentry.Msg == "" {
-		t.Fatalf("child log: empty log fileds: level=\"%s\" msg=\"%s\"", logentry.Level, logentry.Msg)
+		t.Fatalf("child log: empty log fields: level=\"%s\" msg=\"%s\"", logentry.Level, logentry.Msg)
 	}
 
 	if err := cmd.Wait(); err != nil {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -864,7 +864,7 @@ func pivotRoot(rootfs string) error {
 	if err := mount("", ".", "", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
 		return err
 	}
-	// Preform the unmount. MNT_DETACH allows us to unmount /proc/self/cwd.
+	// Perform the unmount. MNT_DETACH allows us to unmount /proc/self/cwd.
 	if err := unmount(".", unix.MNT_DETACH); err != nil {
 		return err
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -71,7 +71,7 @@ func (l *linuxStandardInit) Init() error {
 				return fmt.Errorf("unable to join session keyring: %w", err)
 			}
 		} else {
-			// Make session keyring searcheable. If we've gotten this far we
+			// Make session keyring searchable. If we've gotten this far we
 			// bail on any error -- we don't want to have a keyring with bad
 			// permissions.
 			if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -6,7 +6,7 @@ function setup() {
 	requires root no_systemd
 
 	setup_debian
-	# CR = CreateRuntime, CC = CreataContainer
+	# CR = CreateRuntime, CC = CreateContainer
 	HOOKLIBCR=librunc-hooks-create-runtime.so
 	HOOKLIBCC=librunc-hooks-create-container.so
 	LIBPATH="$(pwd)/rootfs/lib/"

--- a/update.go
+++ b/update.go
@@ -260,7 +260,7 @@ other options are ignored.
 		// Update the values
 		config.Cgroups.Resources.BlkioWeight = *r.BlockIO.Weight
 
-		// Seting CPU quota and period independently does not make much sense,
+		// Setting CPU quota and period independently does not make much sense,
 		// but historically runc allowed it and this needs to be supported
 		// to not break compatibility.
 		//


### PR DESCRIPTION
Fix a bunch of warnings from codespell, and add a CI job to validate to automate it.


Note that
1. I had to use pip to install codespell, as the version provided with Ubuntu 20.04 is way old.
2. The two exceptions I had to add to codespellrc are:
 - `CLOS` (a term used by intelrtd);
 - `creat `(syscall name used in tests/integration/testdata/seccomp_*.json).