### PR TITLE
.cirrus.yml: simplify for centos, retry yum

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,7 +85,6 @@ task:
     memory: 8G
 
   install_dependencies_script: |
-    yum install -y -q epel-release
     case $DISTRO in
     centos-7)
       (cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/adrian/criu-el7/repo/epel-7/adrian-criu-el7-epel-7.repo)
@@ -94,8 +93,7 @@ task:
       sysctl --system
       ;;
     centos-stream-8)
-      yum install -y -q dnf-plugins-core
-      yum config-manager --set-enabled powertools
+      yum config-manager --set-enabled powertools # for glibc-static
       ;;
     esac
     yum install -y -q gcc git iptables jq glibc-static libseccomp-devel make criu

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,7 +96,12 @@ task:
       yum config-manager --set-enabled powertools # for glibc-static
       ;;
     esac
-    yum install -y -q gcc git iptables jq glibc-static libseccomp-devel make criu
+    # Work around dnf mirror failures by retrying a few times.
+    for i in $(seq 0 2); do
+      sleep $i
+      yum install -y -q gcc git iptables jq glibc-static libseccomp-devel make criu && break
+    done
+    [ $? -eq 0 ] # fail if yum failed
     # install Go
     curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar Cxz /usr/local
     # install bats


### PR DESCRIPTION
The reason for this PR is CI fails on yum sometimes (seen twice today, last time at https://github.com/opencontainers/runc/pull/3151#issuecomment-897377886).

1. Remove redundant yum commands.
2. Add a sleep+retry on fail loop to yum.

See individual commits for details.