### PR TITLE
libct/nsenter: ignore unused return value of write

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -163,8 +163,10 @@ static void write_log(const char *level, const char *format, ...)
 		json = NULL;
 		goto out;
 	}
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
 	write(logfd, json, ret);
+#pragma GCC diagnostic pop
 
 out:
 	free(message);


### PR DESCRIPTION
A warning (warn_unused_result) may show up during compilation if a
function returns a result that is never used.
```
nsexec.c: In function ‘write_log’:
nsexec.c:165:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
  165 |  write(logfd, json, ret);
      |  ^~~~~~~~~~~~~~~~~~~~~~~
```

This patch explicitly disables/ignores this "-Wunused-result" warning
for write() by using gcc diagnostic pragmas.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>