### PR TITLE
libct/nsenter: fix memory leak on asprintf() error

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -159,10 +159,8 @@ static void write_log(const char *level, const char *format, ...)
 		goto out;
 
 	ret = asprintf(&json, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n", level, stage, getpid(), message);
-	if (ret < 0) {
-		json = NULL;
+	if (ret < 0)
 		goto out;
-	}
 
 	write(logfd, json, ret);
 


### PR DESCRIPTION
On asprintf() error, setting strp to NULL before free() may cause
memory leak as the contents of strp are undefined.

Setting the unused local pointer json to NULL is not a must as it
won't be accessed anymore after being freed.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>