### PR TITLE
Logging improvements

### DIFF
--- a/libcontainer/logs/logs.go
+++ b/libcontainer/logs/logs.go
@@ -34,18 +34,13 @@ func processEntry(text []byte) {
 	}
 
 	var jl struct {
-		Level string `json:"level"`
-		Msg   string `json:"msg"`
+		Level logrus.Level `json:"level"`
+		Msg   string       `json:"msg"`
 	}
 	if err := json.Unmarshal(text, &jl); err != nil {
 		logrus.Errorf("failed to decode %q to json: %v", text, err)
 		return
 	}
 
-	lvl, err := logrus.ParseLevel(jl.Level)
-	if err != nil {
-		logrus.Errorf("failed to parse log level %q: %v", jl.Level, err)
-		return
-	}
-	logrus.StandardLogger().Logf(lvl, jl.Msg)
+	logrus.StandardLogger().Logf(jl.Level, jl.Msg)
 }

--- a/libcontainer/logs/logs_linux_test.go
+++ b/libcontainer/logs/logs_linux_test.go
@@ -11,44 +11,51 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const msgErr = `"level":"error"`
+
 func TestLoggingToFile(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"kitten"}`)
+	msg := `"level":"info","msg":"kitten"`
+	logToLogWriter(t, l, msg)
 	finish(t, l)
-	check(t, l, "kitten")
+	check(t, l, msg, msgErr)
 }
 
 func TestLogForwardingDoesNotStopOnJsonDecodeErr(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, "invalid-json-with-kitten")
-	checkWait(t, l, "failed to decode")
+	logToLogWriter(t, l, `"invalid-json-with-kitten"`)
+	checkWait(t, l, msgErr, "")
 
 	truncateLogFile(t, l.file)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"puppy"}`)
+	msg := `"level":"info","msg":"puppy"`
+	logToLogWriter(t, l, msg)
 	finish(t, l)
-	check(t, l, "puppy")
+	check(t, l, msg, msgErr)
 }
 
 func TestLogForwardingDoesNotStopOnLogLevelParsingErr(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, `{"level": "alert","msg":"puppy"}`)
-	checkWait(t, l, "failed to parse log level")
+	msg := `"level":"alert","msg":"puppy"`
+	logToLogWriter(t, l, msg)
+	checkWait(t, l, msgErr, msg)
 
 	truncateLogFile(t, l.file)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"puppy"}`)
+	msg = `"level":"info","msg":"puppy"`
+	logToLogWriter(t, l, msg)
 	finish(t, l)
-	check(t, l, "puppy")
+	check(t, l, msg, msgErr)
 }
 
 func TestLogForwardingStopsAfterClosingTheWriter(t *testing.T) {
 	l := runLogForwarding(t)
 
-	logToLogWriter(t, l, `{"level": "info","msg":"sync"}`)
+	msg := `"level":"info","msg":"sync"`
+	logToLogWriter(t, l, msg)
 
 	// Do not use finish() here as we check done pipe ourselves.
 	l.w.Close()
@@ -58,12 +65,12 @@ func TestLogForwardingStopsAfterClosingTheWriter(t *testing.T) {
 		t.Fatal("log forwarding did not stop after closing the pipe")
 	}
 
-	check(t, l, "sync")
+	check(t, l, msg, msgErr)
 }
 
 func logToLogWriter(t *testing.T, l *log, message string) {
 	t.Helper()
-	_, err := l.w.Write([]byte(message + "\n"))
+	_, err := l.w.Write([]byte("{" + message + "}\n"))
 	if err != nil {
 		t.Fatalf("failed to write %q to log writer: %v", message, err)
 	}
@@ -119,21 +126,24 @@ func truncateLogFile(t *testing.T, file *os.File) {
 	}
 }
 
-// check checks that file contains txt
-func check(t *testing.T, l *log, txt string) {
+// check checks that the file contains txt and does not contain notxt.
+func check(t *testing.T, l *log, txt, notxt string) {
 	t.Helper()
 	contents, err := ioutil.ReadFile(l.file.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(contents, []byte(txt)) {
-		t.Fatalf("%q does not contain %q", string(contents), txt)
+	if txt != "" && !bytes.Contains(contents, []byte(txt)) {
+		t.Fatalf("%s does not contain %s", contents, txt)
+	}
+	if notxt != "" && bytes.Contains(contents, []byte(notxt)) {
+		t.Fatalf("%s does contain %s", contents, notxt)
 	}
 }
 
-// checkWait checks that file contains txt. If the file is empty,
+// checkWait is like check, but if the file is empty,
 // it waits until it's not.
-func checkWait(t *testing.T, l *log, txt string) {
+func checkWait(t *testing.T, l *log, txt string, notxt string) {
 	t.Helper()
 	const (
 		delay = 100 * time.Millisecond
@@ -153,5 +163,5 @@ func checkWait(t *testing.T, l *log, txt string) {
 		time.Sleep(delay)
 	}
 
-	check(t, l, txt)
+	check(t, l, txt, notxt)
 }

--- a/main.go
+++ b/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"runtime"
 	"strings"
 
-	"github.com/opencontainers/runc/libcontainer/logs"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
@@ -149,7 +149,7 @@ func main() {
 			return err
 		}
 
-		return logs.ConfigureLogging(createLogConfig(context))
+		return configLogrus(context)
 	}
 
 	// If the command returns an error, cli takes upon itself to print
@@ -173,22 +173,30 @@ func (f *FatalWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func createLogConfig(context *cli.Context) logs.Config {
-	logFilePath := context.GlobalString("log")
-	logPipeFd := 0
-	if logFilePath == "" {
-		logPipeFd = 2
-	}
-	config := logs.Config{
-		LogPipeFd:   logPipeFd,
-		LogLevel:    logrus.InfoLevel,
-		LogFilePath: logFilePath,
-		LogFormat:   context.GlobalString("log-format"),
-		LogCaller:   context.GlobalBool("debug"),
-	}
+func configLogrus(context *cli.Context) error {
 	if context.GlobalBool("debug") {
-		config.LogLevel = logrus.DebugLevel
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetReportCaller(true)
 	}
 
-	return config
+	switch f := context.GlobalString("log-format"); f {
+	case "":
+		// do nothing
+	case "text":
+		// do nothing
+	case "json":
+		logrus.SetFormatter(new(logrus.JSONFormatter))
+	default:
+		return errors.New("invalid log-format: " + f)
+	}
+
+	if file := context.GlobalString("log"); file != "" {
+		f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0o644)
+		if err != nil {
+			return err
+		}
+		logrus.SetOutput(f)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This makes `runc --debug` logs more readable, along with some refactoring and logs tests improvements (originally part of #3114).

- init.go, main.go: don't use logs.ConfigureLogging
- libct/logs: remove ConfigureLogging
- Improve libct/logs and its tests
- libct/logs: test: make more robust
- libct/logs: parse log level implicitly
- libct/logs: do not show caller in nsexec logs
- runc --debug: shorter caller info

The biggest user-facing change is how debug logs are more clean / less cluttered:

```console
$ runc --debug run x
ERRO[0000]github.com/opencontainers/runc/utils.go:61 main.fatalWithCode() JSON specification file config.json not found

$ runc --debug run -d x
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec[2360844]: => nsexec container setup   
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec[2360844]: update /proc/self/oom_score_adj to '30' 
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec-0[2360844]: ~> nsexec stage-0         
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec-0[2360844]: spawn stage-1             
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec-0[2360844]: -> stage-1 synchronisation loop 
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec-1[2360846]: ~> nsexec stage-1         
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec-1[2360846]: unshare remaining namespace (except cgroupns) 
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec-1[2360846]: spawn stage-2             
DEBU[0000]github.com/opencontainers/runc/libcontainer/logs/logs.go:69 github.com/opencontainers/runc/libcontainer/logs.processEntry() nsexec-1[2360846]: request stage-0 to forward stage-2 pid (2360848) 
```

After:
```console
$ runc --debug run x
ERRO[0000]utils.go:61 main.fatalWithCode() JSON specification file config.json not found

$ runc --debug run -d x
DEBU[0000] nsexec[2359952]: => nsexec container setup   
DEBU[0000] nsexec[2359952]: update /proc/self/oom_score_adj to '30' 
DEBU[0000] nsexec-0[2359952]: ~> nsexec stage-0         
DEBU[0000] nsexec-0[2359952]: spawn stage-1             
DEBU[0000] nsexec-0[2359952]: -> stage-1 synchronisation loop 
DEBU[0000] nsexec-1[2359954]: ~> nsexec stage-1         
DEBU[0000] nsexec-1[2359954]: unshare remaining namespace (except cgroupns) 
DEBU[0000] nsexec-1[2359954]: spawn stage-2             
DEBU[0000] nsexec-1[2359954]: request stage-0 to forward stage-2 pid (2359955) 
...
```

Fixes: #3183
Fixes: #3184