### PR TITLE
libct/devices: change devices.Type to be a string

### DIFF
--- a/libcontainer/cgroups/ebpf/devicefilter/devicefilter.go
+++ b/libcontainer/cgroups/ebpf/devicefilter/devicefilter.go
@@ -119,7 +119,7 @@ func (p *program) appendRule(rule *devices.Rule) error {
 		bpfType = int32(unix.BPF_DEVCG_DEV_BLOCK)
 	default:
 		// We do not permit 'a', nor any other types we don't know about.
-		return fmt.Errorf("invalid type %q", string(rule.Type))
+		return fmt.Errorf("invalid type %q", rule.Type)
 	}
 	if rule.Major > math.MaxUint32 {
 		return fmt.Errorf("invalid major %d", rule.Major)

--- a/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
+++ b/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
@@ -146,7 +146,7 @@ block-11:
 func TestDeviceFilter_Privileged(t *testing.T) {
 	devices := []*devices.Rule{
 		{
-			Type:        'a',
+			Type:        devices.WildcardDevice,
 			Major:       -1,
 			Minor:       -1,
 			Permissions: "rwm",
@@ -173,14 +173,14 @@ block-0:
 func TestDeviceFilter_PrivilegedExceptSingleDevice(t *testing.T) {
 	devices := []*devices.Rule{
 		{
-			Type:        'a',
+			Type:        devices.WildcardDevice,
 			Major:       -1,
 			Minor:       -1,
 			Permissions: "rwm",
 			Allow:       true,
 		},
 		{
-			Type:        'b',
+			Type:        devices.BlockDevice,
 			Major:       8,
 			Minor:       0,
 			Permissions: "rwm",
@@ -213,21 +213,21 @@ block-1:
 func TestDeviceFilter_Weird(t *testing.T) {
 	devices := []*devices.Rule{
 		{
-			Type:        'b',
+			Type:        devices.BlockDevice,
 			Major:       8,
 			Minor:       1,
 			Permissions: "rwm",
 			Allow:       false,
 		},
 		{
-			Type:        'a',
+			Type:        devices.WildcardDevice,
 			Major:       -1,
 			Minor:       -1,
 			Permissions: "rwm",
 			Allow:       true,
 		},
 		{
-			Type:        'b',
+			Type:        devices.BlockDevice,
 			Major:       8,
 			Minor:       2,
 			Permissions: "rwm",

--- a/libcontainer/devices/device.go
+++ b/libcontainer/devices/device.go
@@ -100,13 +100,13 @@ func (p Permissions) IsValid() bool {
 	return p == fromSet(p.toSet())
 }
 
-type Type rune
+type Type string
 
 const (
-	WildcardDevice Type = 'a'
-	BlockDevice    Type = 'b'
-	CharDevice     Type = 'c' // or 'u'
-	FifoDevice     Type = 'p'
+	WildcardDevice Type = "a"
+	BlockDevice    Type = "b"
+	CharDevice     Type = "c" // or 'u'
+	FifoDevice     Type = "p"
 )
 
 func (t Type) IsValid() bool {
@@ -166,7 +166,7 @@ func (d *Rule) CgroupString() string {
 	if d.Minor == Wildcard {
 		minor = "*"
 	}
-	return fmt.Sprintf("%c %s:%s %s", d.Type, major, minor, d.Permissions)
+	return fmt.Sprintf("%s %s:%s %s", d.Type, major, minor, d.Permissions)
 }
 
 func (d *Rule) Mkdev() (uint64, error) {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -710,7 +710,7 @@ func mknodDevice(dest string, node *devices.Device) error {
 	case devices.FifoDevice:
 		fileMode |= unix.S_IFIFO
 	default:
-		return fmt.Errorf("%c is not a valid device type for device %s", node.Type, node.Path)
+		return fmt.Errorf("%s is not a valid device type for device %s", node.Type, node.Path)
 	}
 	dev, err := node.Mkdev()
 	if err != nil {


### PR DESCRIPTION
> I noticed this while reviewing https://github.com/opencontainers/runc/pull/3110. Opening as draft to see if there's any failures in CI, and because this will conflict with that PR

Possibly there was a specific reason to use a rune for this, but I noticed
that there's various parts in the code that has to convert values from a
string to this type. Using a string as type for this can simplify some of
that code.
