### PR TITLE
libct/cg/sd/v1: add a knob to skip freeze on set

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -389,15 +389,6 @@ func resetFailedUnit(cm *dbusConnManager, name string) {
 	}
 }
 
-func getUnitProperty(cm *dbusConnManager, unitName string, propertyName string) (*systemdDbus.Property, error) {
-	var prop *systemdDbus.Property
-	err := cm.retryOnDisconnect(func(c *systemdDbus.Conn) (Err error) {
-		prop, Err = c.GetUnitPropertyContext(context.TODO(), unitName, propertyName)
-		return Err
-	})
-	return prop, err
-}
-
 func setUnitProperties(cm *dbusConnManager, name string, properties ...systemdDbus.Property) error {
 	return cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
 		return c.SetUnitPropertiesContext(context.TODO(), name, true, properties...)

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -131,4 +131,11 @@ type Resources struct {
 	//
 	// NOTE it is impossible to start a container which has this flag set.
 	SkipDevices bool `json:"-"`
+
+	// SkipFreezeOnSet is a flag for cgroup manager to skip the cgroup
+	// freeze when setting resources. Only applicable to systemd legacy
+	// (i.e. cgroup v1) manager (which uses freeze by default to avoid
+	// spurious permission errors caused by systemd inability to update
+	// device rules in a non-disruptive manner).
+	SkipFreezeOnSet bool `json:"-"`
 }


### PR DESCRIPTION
Commit b810da149008f added support for setting Device* properties to
systemd cgroup v1 controller (as otherwise systemd applied "allow-all" 
device rule).

Unfortunately, systemd re-applies device rules on every resource update,
and does so in a disruptive way, causing spurious device permission
errors.

To work around that, systemd cgroup v1 controller freezes the
cgroup before (and thaws it after) applying systemd properties.
This freeze fixes the issue for runc, but creates a problem for
kubernetes.

Kubernetes uses libcontainer/cgroups/systemd to manage pod slice
units. When kubelet updates a pod slice, all the containers under that
pod are unexpectedly frozen for some time, which leads to other issues.

One way to fix this was tried in commit f2db87986cab5a7c (PR #3082).
By looking into unit properties, we can predict whether systemd is going
to update device rules, and skip the freeze if it won't.

Unfortunately, the above commit contains a few bugs, resulting in
broken device rules check, so it's still not fixing the issue.

Upon fixing those bug (see PR #3143), a benchmark was created to assess
how expensive getting unit properties is. Turns out, it is -- `Set()`
times went from 200us to 500us ([see full benchmark results here](https://github.com/opencontainers/runc/pull/3143#issuecomment-898069187)).

An alternative approach was tried in PR #3151, in which we check
`devices.list` cgroup file to find out whether the cgroup has some rules or just
a single "allow-all". Alas, this approach is not working if a cgroup
has a parent with some device rules set.

Considering all this, it seems that the best approach is to add a
"do not freeze on set" flag, which kubernetes can use when it knows
the slice did not and does not have device rules, so freeze can safely
be skipped.

Remove the (expensive and currently broken) unit properties querying,
and add/use a `SkipFreezeOnSet` flag instead.

Since the logic is trivial, no tests are needed.

This is a stop-gap measure. Long term solution is for k8s to stop
using libcontainer/cgroups (kubernetes/kubernetes#104325).
