### PR TITLE
Use go1.16 "embed" to set version from VERSION file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILDTAGS += $(EXTRA_BUILDTAGS)
 
 COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION ?= $(shell cat ./VERSION)
-LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
+LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT)
 
 GOARCH := $(shell $(GO) env GOARCH)
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -19,9 +20,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-// version must be set from the contents of VERSION file by go build's
-// -X main.version= option in the Makefile.
-var version = "unknown"
+// version is automatically set from the contents of VERSION file on go1.16+.
+//go:embed VERSION
+var version string
 
 // gitCommit will be the hash that the binary was built from
 // and will be populated by the Makefile
@@ -59,7 +60,7 @@ func main() {
 	app.Name = "runc"
 	app.Usage = usage
 
-	v := []string{version}
+	v := []string{strings.TrimSpace(version)}
 
 	if gitCommit != "" {
 		v = append(v, "commit: "+gitCommit)


### PR DESCRIPTION
This allows building runc without passing the VERSION build-arg, but requires
go 1.16 or up.

Unfortunately, there's no easy way to get the git-commit from the filesystem
(possibly through `.git/logs/HEAD`, which is a large file); a proposal has been
accepted to add git information ([1]), but not yet implemented.

For users building through `go install github.com/opencontainers/runc@version`),
we may be able to use runtime/debug.BuildInfo() ([2]). BuildInfo provides the
module version and checksum, but only when building using `go install`. When
building from a local module (git clone), the version is alway set to `(devel)`,
see [3].

We could consider add module (optional) if available, e.g.:

```go
    // Print module information if available. When built from local source,
    // (using git clone), module version is not available, and version is
    // set to "(devel)"; see golang/go#29814, and golang/go#37475.
    if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "(devel)" {
        v = append(v, "module version: "+bi.Main.Version+", sum: "+bi.Main.Sum)
    }
```

With this patch (on go1.16):

    make
    go build -trimpath "-buildmode=pie"  -tags "seccomp" -ldflags "-X main.gitCommit=v1.0.0-133-g27d75cca " -o runc .

    ./runc --version
    runc version 1.0.0+dev

    commit: v1.0.0-133-g27d75cca
    spec: 1.0.2-dev
    go: go1.16.7
    libseccomp: 2.3.3

[1]: https://github.com/golang/go/issues/37475
[2]: https://pkg.go.dev/runtime/debug#BuildInfo
[3]: https://github.com/golang/go/issues/29814
