### PR TITLE
CI: Validate compilation without buildtags

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,13 @@ jobs:
           # must be specified without patch version
           version: v1.40
 
+  compile-buildtags:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: compile with no build tags
+        run: make BUILDTAGS=""
+
   shfmt:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Today we support the seccomp build tag only that is used by default.
However, we are not testing that compiling without any build tag works.

I found the CI didn't catch this when working on #2682, that the CI was
green but compilation without build tags was broken.

We test compilation without build tags only, compilation with the only
build tag supported is done extensively in other actions.

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>