### PR TITLE
nsexec: Don't ignore write failures

### DIFF
--- a/libcontainer/nsenter/nsenter.go
+++ b/libcontainer/nsenter/nsenter.go
@@ -3,7 +3,7 @@
 package nsenter
 
 /*
-#cgo CFLAGS: -Wall
+#cgo CFLAGS: -Wall -Werror
 extern void nsexec();
 void __attribute__((constructor)) init(void) {
 	nsexec();

--- a/libcontainer/nsenter/nsenter_gccgo.go
+++ b/libcontainer/nsenter/nsenter_gccgo.go
@@ -3,7 +3,7 @@
 package nsenter
 
 /*
-#cgo CFLAGS: -Wall
+#cgo CFLAGS: -Wall -Werror
 extern void nsexec();
 void __attribute__((constructor)) init(void) {
 	nsexec();

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -138,7 +138,7 @@ static void write_log(const char *level, const char *format, ...)
 {
 	char *message = NULL, *stage = NULL, *json = NULL;
 	va_list args;
-	int ret;
+	int ret, len;
 
 	if (logfd < 0 || level == NULL)
 		goto out;
@@ -164,7 +164,11 @@ static void write_log(const char *level, const char *format, ...)
 		goto out;
 	}
 
-	write(logfd, json, ret);
+	len = write(logfd, json, ret);
+	if (len != ret) {
+		ret = -1;
+		goto out;
+	}
 
 out:
 	free(message);


### PR DESCRIPTION
If write fails for some reason or manages to write less than what we
requested (e.g. disk is full), report an error.

This silence the warning when compiling on github CI, as now the
write(2) return code is not ignored.

While we could do:
	ret = write(.., ret)
	if (ret < 0)

as other parts of the code does, there was recently a race condition
fixed in "libct/nsenter: fix logging race in nsexec" (2bab4a56f) and
seems fragile to just test for -1. Let's check that we wrote exactly
what we expect, otherwise it won't be valid json written.

For the same reason, the race condition fixed, we don't retry if we
write partial data, as that uses two different write(2) calls which
might hit the same race. Therefore, if we failed to write what we
expect, we just let the caller know.

Note that if the write fails, it is possible for the (partial) json
written to not be valid.

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>