### PR TITLE
[1.0] libct/nsenter: fix unused-result warning

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -170,7 +170,10 @@ static void write_log(const char *level, const char *format, ...)
 		goto out;
 	}
 
-	write(logfd, json, ret);
+	/* This logging is on a best-effort basis. In case of a short or failed
+	 * write there is nothing we can do, so just ignore write() errors.
+	 */
+	ssize_t __attribute__((unused)) __res = write(logfd, json, ret);
 
 out:
 	free(message);


### PR DESCRIPTION
_Backport of #3168 to release-1.0. Draft until that one is merged._

Commit 2bab4a5 resulted in a warning from gcc:

	nsexec.c: In function ‘write_log’:
	nsexec.c:171:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
	  171 |  write(logfd, json, ret);
	      |  ^~~~~~~~~~~~~~~~~~~~~~~

As there's nothing we can or want to do in case write fails,
let's just tell the compiler we're not going to use it.

Fixes: 2bab4a5
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit db8330c9e516ac359e199b999c5321c73aaffabf)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>