### PR TITLE
rootless+cgroup2+systemd: improve error message when dbus-user-session is not installed

### DIFF
--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -4,6 +4,7 @@ package systemd
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
@@ -54,7 +55,10 @@ func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
 
 	conn, err := d.newConnection()
 	if err != nil {
-		return nil, err
+		// When dbus-user-session is not installed, we can't detect whether we should try to connect to user dbus or system dbus, so d.dbusRootless is set to false.
+		// This may fail with a cryptic error "read unix @->/run/systemd/private: read: connection reset by peer: unknown."
+		// https://github.com/moby/moby/issues/42793
+		return nil, fmt.Errorf("failed to connect to dbus (hint: for rootless containers, maybe you need to install dbus-user-session package, see https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md): %w", err)
 	}
 	dbusC = conn
 	return conn, nil


### PR DESCRIPTION
Wrap the error with `"failed to connect to dbus (hint: for rootless containers, maybe you need to install dbus-user-session package, see https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md): %w"`.


---
Before:

```console
$ docker --context=rootless run -it --rm alpine
docker: Error response from daemon: OCI runtime create failed: unable to start
container process: unable to apply cgroup configuration: unable to start unit
"docker-7ef2c29ccafc1ed9c7fd9859337e5b79870d8ccb282f560e43060a847a6c5310.scope"
(properties [{Name:Description Value:"libcontainer container
7ef2c29ccafc1ed9c7fd9859337e5b79870d8ccb282f560e43060a847a6c5310"} {Name:Slice
Value:"user.slice"} {Name:PIDs Value:@au [6286]} {Name:Delegate Value:true}
{Name:MemoryAccounting Value:true} {Name:CPUAccounting Value:true}
{Name:IOAccounting Value:true} {Name:TasksAccounting Value:true}
{Name:DefaultDependencies Value:false}]): read unix @->/run/systemd/private:
read: connection reset by peer: unknown.
```

After:

```console
$ docker --context=rootless run -it --rm alpine
docker: Error response from daemon: OCI runtime create failed: unable to start
container process: unable to apply cgroup configuration: unable to start unit
"docker-8527d83e046da46d1b56b1c6a89324e687da1c365e044b8dde52cfbf1c461c5a.scope"
(properties [{Name:Description Value:"libcontainer container
8527d83e046da46d1b56b1c6a89324e687da1c365e044b8dde52cfbf1c461c5a"} {Name:Slice
Value:"user.slice"} {Name:PIDs Value:@au [10012]} {Name:Delegate Value:true}
{Name:MemoryAccounting Value:true} {Name:CPUAccounting Value:true}
{Name:IOAccounting Value:true} {Name:TasksAccounting Value:true}
{Name:DefaultDependencies Value:false}]): failed to connect to dbus (hint: for
rootless containers, maybe you need to install dbus-user-session package, see
https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md): read
unix @->/run/systemd/private: read: connection reset by peer: unknown.
```

For moby/moby#42793
