### PR TITLE
cpuset: option for updating cpus and mems in child groups

### DIFF
--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -139,4 +139,8 @@ type Resources struct {
 	// during Set() to figure out whether the freeze is required. Those
 	// methods may be relatively slow, thus this flag.
 	SkipFreezeOnSet bool `json:"-"`
+
+	// ChildPolicy defines how to handle child groups when updating
+	// resources. The default ("") does not handle children at all.
+	ChildPolicy string `json:"child_policy,omitempty"`
 }

--- a/update.go
+++ b/update.go
@@ -126,6 +126,10 @@ other options are ignored.
 			Name:  "mem-bw-schema",
 			Usage: "The string of Intel RDT/MBA memory bandwidth schema",
 		},
+		cli.StringFlag{
+			Name: "child-policy",
+			Usage: "How to handle subgroups: 'copy' sets the same values recursively, 'none' does nothing.",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, exactArgs); err != nil {
@@ -251,6 +255,13 @@ other options are ignored.
 			}
 
 			r.Pids.Limit = int64(context.Int("pids-limit"))
+		}
+		if val := context.String("child-policy"); val != "" {
+			if val == "copy" || val == "none" {
+				config.Cgroups.Resources.ChildPolicy = val
+			} else {
+				return fmt.Errorf("invalid value for child-policy")
+			}
 		}
 
 		if *r.Memory.Kernel != 0 || *r.Memory.KernelTCP != 0 {


### PR DESCRIPTION
Trying to set cpuset.cpus of a cgroup so that cpus of a child is not a subset of cpus of the cgroup causes an error (device or resource busy).

New option --child-policy="copy" sets cpuset.cpus of the group and all its children to the same value. Introducing a string-valued policy for this purpose leaves room for alternative policies in the future. Other sensible policies include, but are not limited to, modifying only children that already share the same values with the group, and keeping the relative number and intersections of cpus unchanged in all child groups.

cpuset.mems is handled similarly to cpuset.cpus.

This patch continues work started by @Ace-Tang in PR #1636, including the original commit that is rebased and modified to support the child policy option.

This patch fixes #1635.