### PR TITLE
cgroups: Add support for `cgroup.kill` added in Linux Kernel 5.14

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -41,6 +41,10 @@ type Manager interface {
 	// Destroy removes cgroup.
 	Destroy() error
 
+	// Leverages "cgroup.kill" added in kernel 5.14.
+	// Kills all the process listed in cgroup.
+	Kill() error
+
 	// Path returns a cgroup path to the specified controller/subsystem.
 	// For cgroupv2, the argument is unused and can be empty.
 	Path(string) string

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -150,6 +150,16 @@ func (m *Manager) Path(subsys string) string {
 	return m.paths[subsys]
 }
 
+func (m *Manager) Kill() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Since "cgroup.kill" is not available for v1 check for cgroup mode hybrid+v1
+	if cgroups.IsCgroup2HybridMode() {
+		return fscommon.Kill(m.paths[""])
+	}
+	return errors.New("cgroup.kill not supported")
+}
+
 func (m *Manager) GetStats() (*cgroups.Stats, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -143,6 +143,10 @@ func (m *Manager) Destroy() error {
 	return cgroups.RemovePath(m.dirPath)
 }
 
+func (m *Manager) Kill() error {
+	return fscommon.Kill(m.dirPath)
+}
+
 func (m *Manager) Path(_ string) string {
 	return m.dirPath
 }

--- a/libcontainer/cgroups/fscommon/kill.go
+++ b/libcontainer/cgroups/fscommon/kill.go
@@ -1,0 +1,11 @@
+package fscommon
+
+import (
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+// Linux 5.14 supports the file "cgroup.kill" to kill all the processes
+// in a cgroup. Check https://lwn.net/Articles/855924/
+func Kill(path string) error {
+	return cgroups.WriteFile(path, "cgroup.kill", "1")
+}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -368,6 +369,12 @@ func (m *UnifiedManager) Destroy() error {
 
 func (m *UnifiedManager) Path(_ string) string {
 	return m.path
+}
+
+func (m *UnifiedManager) Kill() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return fscommon.Kill(m.path)
 }
 
 // getSliceFull value is used in initPath.

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -1,6 +1,7 @@
 package libcontainer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -38,6 +39,10 @@ func (m *mockCgroupManager) Set(_ *configs.Resources) error {
 
 func (m *mockCgroupManager) Destroy() error {
 	return nil
+}
+
+func (m *mockCgroupManager) Kill() error {
+	return errors.New("Not supported for mock devices")
 }
 
 func (m *mockCgroupManager) Exists() bool {


### PR DESCRIPTION
Following PR adds support for `cgroup.kill` to kill all the processes in
a cgroup instead of iterating over each process to save cost if
possible.

Linux kernel 5.14 adds support for `cgroup.kill`.

Ref
* https://lwn.net/Articles/855049/
* https://lwn.net/Articles/855924/