### PR TITLE
Add support for seccomp actions ActKillThread and ActKillProcess

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -50,6 +50,8 @@ const (
 	Trace
 	Log
 	Notify
+	KillThread
+	KillProcess
 )
 
 // Operator is a comparison operator to be used when matching syscall arguments in Seccomp

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -16,13 +16,8 @@ import (
 )
 
 var (
-	actAllow  = libseccomp.ActAllow
-	actTrap   = libseccomp.ActTrap
-	actKill   = libseccomp.ActKill
-	actTrace  = libseccomp.ActTrace.SetReturnCode(int16(unix.EPERM))
-	actLog    = libseccomp.ActLog
-	actErrno  = libseccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
-	actNotify = libseccomp.ActNotify
+	actTrace = libseccomp.ActTrace.SetReturnCode(int16(unix.EPERM))
+	actErrno = libseccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
 )
 
 const (
@@ -71,7 +66,7 @@ func InitSeccomp(config *configs.Seccomp) (int, error) {
 	}
 
 	// See comment on why write is not allowed. The same reason applies, as this can mean handling write too.
-	if defaultAction == actNotify {
+	if defaultAction == libseccomp.ActNotify {
 		return -1, errors.New("SCMP_ACT_NOTIFY cannot be used as default action")
 	}
 
@@ -119,25 +114,25 @@ func InitSeccomp(config *configs.Seccomp) (int, error) {
 func getAction(act configs.Action, errnoRet *uint) (libseccomp.ScmpAction, error) {
 	switch act {
 	case configs.Kill:
-		return actKill, nil
+		return libseccomp.ActKill, nil
 	case configs.Errno:
 		if errnoRet != nil {
 			return libseccomp.ActErrno.SetReturnCode(int16(*errnoRet)), nil
 		}
 		return actErrno, nil
 	case configs.Trap:
-		return actTrap, nil
+		return libseccomp.ActTrap, nil
 	case configs.Allow:
-		return actAllow, nil
+		return libseccomp.ActAllow, nil
 	case configs.Trace:
 		if errnoRet != nil {
 			return libseccomp.ActTrace.SetReturnCode(int16(*errnoRet)), nil
 		}
 		return actTrace, nil
 	case configs.Log:
-		return actLog, nil
+		return libseccomp.ActLog, nil
 	case configs.Notify:
-		return actNotify, nil
+		return libseccomp.ActNotify, nil
 	default:
 		return libseccomp.ActInvalid, errors.New("invalid action, cannot use in rule")
 	}

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -133,6 +133,10 @@ func getAction(act configs.Action, errnoRet *uint) (libseccomp.ScmpAction, error
 		return libseccomp.ActLog, nil
 	case configs.Notify:
 		return libseccomp.ActNotify, nil
+	case configs.KillThread:
+		return libseccomp.ActKillThread, nil
+	case configs.KillProcess:
+		return libseccomp.ActKillProcess, nil
 	default:
 		return libseccomp.ActInvalid, errors.New("invalid action, cannot use in rule")
 	}


### PR DESCRIPTION
Carry of #2564.

Two new seccomp actions have been added to the libseccomp-golang
dependency, which can be now supported by runc, too.

ActKillThread kills the thread that violated the rule. It is the same as
ActKill. All other threads from the same thread group will continue to
execute.

ActKillProcess kills the process that violated the rule. All threads in
the thread group are also terminated. This action is only usable when
libseccomp API level 3 or higher is supported.

Signed-off-by: Sascha Grunert <sgrunert@redhat.com>
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>