### PR TITLE
libct/cg: add CFS bandwidth burst for CPU

### DIFF
--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -732,6 +732,7 @@ _runc_update() {
 	   --blkio-weight
 	   --cpu-period
 	   --cpu-quota
+	   --cpu-burst
 	   --cpu-rt-period
 	   --cpu-rt-runtime
 	   --cpu-share

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -45,6 +45,8 @@ func TestCpuSetBandWidth(t *testing.T) {
 	const (
 		quotaBefore     = 8000
 		quotaAfter      = 5000
+		burstBefore     = 2000
+		burstAfter      = 1000
 		periodBefore    = 10000
 		periodAfter     = 7000
 		rtRuntimeBefore = 8000
@@ -55,6 +57,7 @@ func TestCpuSetBandWidth(t *testing.T) {
 
 	writeFileContents(t, path, map[string]string{
 		"cpu.cfs_quota_us":  strconv.Itoa(quotaBefore),
+		"cpu.cfs_burst_us":  strconv.Itoa(burstBefore),
 		"cpu.cfs_period_us": strconv.Itoa(periodBefore),
 		"cpu.rt_runtime_us": strconv.Itoa(rtRuntimeBefore),
 		"cpu.rt_period_us":  strconv.Itoa(rtPeriodBefore),
@@ -62,6 +65,7 @@ func TestCpuSetBandWidth(t *testing.T) {
 
 	r := &configs.Resources{
 		CpuQuota:     quotaAfter,
+		CpuBurst:     burstAfter,
 		CpuPeriod:    periodAfter,
 		CpuRtRuntime: rtRuntimeAfter,
 		CpuRtPeriod:  rtPeriodAfter,
@@ -77,6 +81,14 @@ func TestCpuSetBandWidth(t *testing.T) {
 	}
 	if quota != quotaAfter {
 		t.Fatal("Got the wrong value, set cpu.cfs_quota_us failed.")
+	}
+
+	burst, err := fscommon.GetCgroupParamUint(path, "cpu.cfs_burst_us")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if burst != burstAfter {
+		t.Fatal("Got the wrong value, set cpu.cfs_burst_us failed.")
 	}
 
 	period, err := fscommon.GetCgroupParamUint(path, "cpu.cfs_period_us")

--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -2,16 +2,18 @@ package fs2
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
 )
 
 func isCpuSet(r *configs.Resources) bool {
-	return r.CpuWeight != 0 || r.CpuQuota != 0 || r.CpuPeriod != 0
+	return r.CpuWeight != 0 || r.CpuQuota != 0 || r.CpuPeriod != 0 || r.CpuBurst != 0
 }
 
 func setCpu(dirPath string, r *configs.Resources) error {
@@ -24,6 +26,22 @@ func setCpu(dirPath string, r *configs.Resources) error {
 		if err := cgroups.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(r.CpuWeight, 10)); err != nil {
 			return err
 		}
+	}
+
+	var burst string
+	burst = strconv.FormatUint(r.CpuBurst, 10)
+	if err := cgroups.WriteFile(dirPath, "cpu.max.burst", burst); err != nil {
+		// Sometimes when the burst to be set is larger
+		// than the current one, it is rejected by the kernel
+		// (EINVAL) as old_quota/new_burst exceeds the parent
+		// cgroup quota limit. If this happens and the quota is
+		// going to be set, ignore the error for now and retry
+		// after setting the quota.
+		if !errors.Is(err, unix.EINVAL) || r.CpuQuota == 0 {
+			return err
+		}
+	} else {
+		burst = ""
 	}
 
 	if r.CpuQuota != 0 || r.CpuPeriod != 0 {
@@ -40,6 +58,11 @@ func setCpu(dirPath string, r *configs.Resources) error {
 		str += " " + strconv.FormatUint(period, 10)
 		if err := cgroups.WriteFile(dirPath, "cpu.max", str); err != nil {
 			return err
+		}
+		if burst != "" {
+			if err := cgroups.WriteFile(dirPath, "cpu.max.burst", burst); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -69,6 +69,9 @@ type Resources struct {
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
 	CpuQuota int64 `json:"cpu_quota"`
 
+	// CPU hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst in a given period.
+	CpuBurst uint64 `json:"cpu_burst"`
+
 	// CPU period to be used for hardcapping (in usecs). 0 to use system default.
 	CpuPeriod uint64 `json:"cpu_period"`
 

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -737,6 +737,9 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
 				if r.CPU.Quota != nil {
 					c.Resources.CpuQuota = *r.CPU.Quota
 				}
+				if r.CPU.Burst != nil {
+					c.Resources.CpuBurst = *r.CPU.Burst
+				}
 				if r.CPU.Period != nil {
 					c.Resources.CpuPeriod = *r.CPU.Period
 				}

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -28,6 +28,7 @@ In case **-r** is used, the JSON format is like this:
 			"cpu": {
 				"shares": 0,
 				"quota": 0,
+				"burst": 0,
 				"period": 0,
 				"realtimeRuntime": 0,
 				"realtimePeriod": 0,
@@ -52,6 +53,9 @@ stdin. If this option is used, all other options are ignored.
 
 **--cpu-quota** _num_
 : Set CPU usage limit within a given period (in microseconds).
+
+**--cpu-burst** _num_
+: Set CPU burst limit within a given period (in microseconds).
 
 **--cpu-rt-period** _num_
 : Set CPU realtime period to be used for hardcapping (in microseconds).

--- a/update.go
+++ b/update.go
@@ -44,6 +44,7 @@ The accepted format is as follow (unchanged values can be omitted):
   "cpu": {
     "shares": 0,
     "quota": 0,
+    "burst": 0,
     "period": 0,
     "realtimeRuntime": 0,
     "realtimePeriod": 0,
@@ -71,6 +72,10 @@ other options are ignored.
 		cli.StringFlag{
 			Name:  "cpu-quota",
 			Usage: "CPU CFS hardcap limit (in usecs). Allowed cpu time in a given period",
+		},
+		cli.StringFlag{
+			Name:  "cpu-burst",
+			Usage: "CPU CFS hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst a given period",
 		},
 		cli.StringFlag{
 			Name:  "cpu-share",
@@ -148,6 +153,7 @@ other options are ignored.
 			CPU: &specs.LinuxCPU{
 				Shares:          u64Ptr(0),
 				Quota:           i64Ptr(0),
+				Burst:           u64Ptr(0),
 				Period:          u64Ptr(0),
 				RealtimeRuntime: i64Ptr(0),
 				RealtimePeriod:  u64Ptr(0),
@@ -197,6 +203,7 @@ other options are ignored.
 				opt  string
 				dest *uint64
 			}{
+				{"cpu-burst", r.CPU.Burst},
 				{"cpu-period", r.CPU.Period},
 				{"cpu-rt-period", r.CPU.RealtimePeriod},
 				{"cpu-share", r.CPU.Shares},
@@ -285,6 +292,12 @@ other options are ignored.
 				config.Cgroups.Resources.CpuQuota = q
 			}
 		}
+
+		b := *r.CPU.Burst
+		if config.Cgroups.Resources.CpuPeriod == 0 && b != 0 {
+			return errors.New("period is not set when setting burst")
+		}
+		config.Cgroups.Resources.CpuBurst = b
 
 		config.Cgroups.Resources.CpuShares = *r.CPU.Shares
 		// CpuWeight is used for cgroupv2 and should be converted


### PR DESCRIPTION
Burstable CFS controller is introduced in Linux 5.14. This helps with
parallel workloads that might be bursty. They can get throttled even
when their average utilization is under quota. And they may be latency
sensitive at the same time so that throttling them is undesired.

This feature borrows time now against the future underrun, at the cost
of increased interference against the other system users, by introducing
cfs_burst_us into CFS bandwidth control to enact the cap on unused
bandwidth accumulation, which will then used additionally for burst.

The patch adds the support/control for CFS bandwidth burst.

runtime-spec: https://github.com/opencontainers/runtime-spec/pull/1120

Signed-off-by: Kailun Qin <kailun.qin@intel.com>