### PR TITLE
script/release.sh: bump libseccomp to 2.5.2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -173,6 +173,8 @@ jobs:
       run: |
         sudo apt -qq update
         sudo apt -qq install gperf gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+    - name: install go
+      uses: actions/setup-go@v2
     - name: make release
       run: make RELEASE_ARGS="-a arm64" release
     - name: upload artifacts

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -172,9 +172,9 @@ jobs:
     - name: install deps
       run: |
         sudo apt -qq update
-        sudo apt -qq install gperf
+        sudo apt -qq install gperf gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
     - name: make release
-      run: make release
+      run: make RELEASE_ARGS="-a arm64" release
     - name: upload artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ static:
 	$(GO_BUILD_STATIC) -o contrib/cmd/sd-helper/sd-helper ./contrib/cmd/sd-helper
 
 release:
-	script/release.sh -r release/$(VERSION) -v $(VERSION)
+	script/release.sh -r release/$(VERSION) -v $(VERSION) $(RELEASE_ARGS)
 
 dbuild: runcimage
 	$(CONTAINER_ENGINE) run $(CONTAINER_ENGINE_RUN_FLAGS) \

--- a/script/release.sh
+++ b/script/release.sh
@@ -42,7 +42,7 @@ function setHOST() {
 #  $* -- additional architectures to cross-compile for
 #        (currently only arm64 is supported).
 function build_libseccomp() {
-	local ver="2.5.1"
+	local ver="2.5.2"
 	local tar="libseccomp-${ver}.tar.gz"
 	local dest="$1"
 	shift


### PR DESCRIPTION
Release notes: https://github.com/seccomp/libseccomp/releases/tag/v2.5.2

_(this PR depends on and includes https://github.com/opencontainers/runc/pull/3197, thus draft for now; will be rebased once #3197 is merged)_