### PR TITLE
[1.0] rootless+cgroup2+systemd: improve error message when dbus-user-session is not installed #3186

### DIFF
--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -4,6 +4,7 @@ package systemd
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
@@ -54,7 +55,10 @@ func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
 
 	conn, err := d.newConnection()
 	if err != nil {
-		return nil, err
+		// When dbus-user-session is not installed, we can't detect whether we should try to connect to user dbus or system dbus, so d.dbusRootless is set to false.
+		// This may fail with a cryptic error "read unix @->/run/systemd/private: read: connection reset by peer: unknown."
+		// https://github.com/moby/moby/issues/42793
+		return nil, fmt.Errorf("failed to connect to dbus (hint: for rootless containers, maybe you need to install dbus-user-session package, see https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md): %w", err)
 	}
 	dbusC = conn
 	return conn, nil


### PR DESCRIPTION
Cherry-pick https://github.com/opencontainers/runc/pull/3186 (clean)