### PR TITLE
runc delete -f: fix for cg v1 + paused container

### DIFF
--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -50,6 +50,16 @@ function teardown() {
 	[ "$status" -eq 0 ]
 }
 
+@test "runc delete --force [paused container]" {
+	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
+	[ "$status" -eq 0 ]
+	testcontainer ct1 running
+
+	runc pause ct1
+	runc delete --force ct1
+	[ "$status" -eq 0 ]
+}
+
 @test "runc delete --force in cgroupv1 with subcgroups" {
 	requires cgroups_v1 root cgroupns
 	set_cgroups_path


### PR DESCRIPTION
runc delete -f is not working for a paused container, since in cgroup v1
SIGKILL does nothing if a process is frozen (unlike cgroup v2, in which
you can kill a frozen process with a fatal signal).

Theoretically, we only need this for v1, but doing it for v2 as well is
OK.

## Proposed changelog entry
```
Bugfixes:
* runc delete -f now succeeds (rather than timeouts) on a paused container (#3134)
```