### PR TITLE
Make runc work on ChromeOS

### DIFF
--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -26,12 +26,12 @@ func (s *CpusetGroup) Apply(path string, d *cgroupData) error {
 
 func (s *CpusetGroup) Set(path string, r *configs.Resources) error {
 	if r.CpusetCpus != "" {
-		if err := cgroups.WriteFile(path, "cpuset.cpus", r.CpusetCpus); err != nil {
+		if err := cgroups.WriteFile(path, "cpus", r.CpusetCpus); err != nil {
 			return err
 		}
 	}
 	if r.CpusetMems != "" {
-		if err := cgroups.WriteFile(path, "cpuset.mems", r.CpusetMems); err != nil {
+		if err := cgroups.WriteFile(path, "mems", r.CpusetMems); err != nil {
 			return err
 		}
 	}
@@ -83,7 +83,7 @@ func getCpusetStat(path string, file string) ([]uint16, error) {
 func (s *CpusetGroup) GetStats(path string, stats *cgroups.Stats) error {
 	var err error
 
-	stats.CPUSetStats.CPUs, err = getCpusetStat(path, "cpuset.cpus")
+	stats.CPUSetStats.CPUs, err = getCpusetStat(path, "cpus")
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -93,7 +93,7 @@ func (s *CpusetGroup) GetStats(path string, stats *cgroups.Stats) error {
 		return err
 	}
 
-	stats.CPUSetStats.Mems, err = getCpusetStat(path, "cpuset.mems")
+	stats.CPUSetStats.Mems, err = getCpusetStat(path, "mems")
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -173,10 +173,10 @@ func (s *CpusetGroup) ApplyDir(dir string, r *configs.Resources, pid int) error 
 }
 
 func getCpusetSubsystemSettings(parent string) (cpus, mems string, err error) {
-	if cpus, err = cgroups.ReadFile(parent, "cpuset.cpus"); err != nil {
+	if cpus, err = cgroups.ReadFile(parent, "cpus"); err != nil {
 		return
 	}
-	if mems, err = cgroups.ReadFile(parent, "cpuset.mems"); err != nil {
+	if mems, err = cgroups.ReadFile(parent, "mems"); err != nil {
 		return
 	}
 	return cpus, mems, nil
@@ -222,12 +222,12 @@ func cpusetCopyIfNeeded(current, parent string) error {
 	}
 
 	if isEmptyCpuset(currentCpus) {
-		if err := cgroups.WriteFile(current, "cpuset.cpus", parentCpus); err != nil {
+		if err := cgroups.WriteFile(current, "cpus", parentCpus); err != nil {
 			return err
 		}
 	}
 	if isEmptyCpuset(currentMems) {
-		if err := cgroups.WriteFile(current, "cpuset.mems", parentMems); err != nil {
+		if err := cgroups.WriteFile(current, "mems", parentMems); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -608,6 +608,7 @@ void join_namespaces(char *nslist)
 	 * follow the order given to us.
 	 */
 
+	char rootfs[30] = "";
 	for (i = 0; i < num; i++) {
 		struct namespace_t *ns = &namespaces[i];
 		int flag = nsflag(ns->type);
@@ -617,9 +618,23 @@ void join_namespaces(char *nslist)
 			bail("failed to setns into %s namespace", ns->type);
 
 		close(ns->fd);
+
+		if (!strcmp(ns->type, "mnt")) {
+			strcpy(rootfs, ns->path);
+			for (int i = 6; i < 30; i++)
+				if (rootfs[i] == 'n') {
+					strcpy(rootfs + i, "root");
+					break;
+				}
+		}
 	}
 
 	free(namespaces);
+
+	if (strlen(rootfs)) {
+		write_log(DEBUG, "chroot to %s", rootfs);
+		chroot(rootfs);
+	}
 }
 
 /* Defined in cloned_binary.c. */

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -406,6 +406,7 @@ func mountToRootfs(m *configs.Mount, c *mountConfig) error {
 		if err := os.MkdirAll(dest, 0o755); err != nil {
 			return err
 		}
+		return nil // for systems without /dev/mqueue (ChromeOS)
 		if err := mountPropagate(m, rootfs, ""); err != nil {
 			return err
 		}

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -139,7 +139,7 @@ func WithProcfd(root, unsafePath string, fn func(procfd string) error) error {
 	}
 
 	// Run the closure.
-	return fn(procfd)
+	return fn(path)
 }
 
 // SearchLabels searches a list of key-value pairs for the provided key and


### PR DESCRIPTION
The goal is to be able to tun podman rootfull containers on ChromeOS in chroot (via Crouton).

Each commit works around a particular obstacle:

**ChromeOS: correct paths to cpuset.cpus and cpuset.mems**
My understanding is that between cgroups v1 and v2 paths for `cpus` and `mems` files changed to include `cpuset.` prefix, but ChromeOS uses a "legacy" mode of cgroups v2 where the old file names are used.

**ChromeOS: Skip mounting /dev/mqueue in the container**
ChromeOS doesn't seem to have support for mqueue, but it also doesn't seem to be a big deal for the containers to just run without it.

**ChromeOS: execute mounts without going through procfd**
Mounting filesystems via procfd (see 0ca91f44) doesn't seem to work in ChromeOS (at least within a chroot managed by Crouton).

**ChromeOS: chroot to the desired dir after entering mnt namespace**
For some reason, after entering the mnt namespace of a running container the root directory reported is the ChromeOS root, so the commands are not limited to only seeing the container's rootfs, but they even manage to escape the Crouton chroot.