### PR TITLE
CI/GHA: switch to OBS criu repo, bring in criu 3.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
-    - name: Dump matrix context
-      env:
-        MATRIX_CONTEXT: ${{ toJSON(matrix) }}
-      run: echo "$MATRIX_CONTEXT"
-
     - name: install deps
       if: matrix.criu == ''
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         criu: [""]
         include:
           # Also test against latest criu-dev
-          - go-version: 1.16.x
+          - go-version: 1.17.x
             rootless: ""
             race: ""
             criu: "criu-dev"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,14 @@ jobs:
 
     - name: install deps
       if: matrix.criu == ''
+      env:
+        REPO: https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_20.04
       run: |
         # criu repo
-        sudo add-apt-repository -y ppa:criu/ppa
-        # apt-add-repository runs apt update so we don't have to
-        sudo apt -q install libseccomp-dev criu
+        curl -fSsl $REPO/Release.key | sudo apt-key add -
+        echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
+        sudo apt update
+        sudo apt install libseccomp-dev criu
 
     - name: install deps (criu ${{ matrix.criu }})
       if: matrix.criu != ''

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ ARG LIBSECCOMP_VERSION=2.5.2
 
 FROM golang:${GO_VERSION}-bullseye
 ARG DEBIAN_FRONTEND=noninteractive
+ARG CRIU_REPO=https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11
 
-RUN echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11/ /' > /etc/apt/sources.list.d/criu.list \
-    && wget -nv https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11/Release.key -O- | apt-key add - \
+RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
+    wget -nv $CRIU_REPO/Release.key -O- | gpg --dearmor > "$KEYFILE" \
+    && echo "deb [signed-by=$KEYFILE] $CRIU_REPO/ /" > /etc/apt/sources.list.d/criu.list \
     && dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \
     && dpkg --add-architecture arm64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG LIBSECCOMP_VERSION=2.5.2
 FROM golang:${GO_VERSION}-bullseye
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/ /' > /etc/apt/sources.list.d/criu.list \
-    && wget -nv https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/Release.key -O- | apt-key add - \
+RUN echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11/ /' > /etc/apt/sources.list.d/criu.list \
+    && wget -nv https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11/Release.key -O- | apt-key add - \
     && dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \
     && dpkg --add-architecture arm64 \


### PR DESCRIPTION
Apparently (https://criu.org/index.php?title=Packages&diff=5197&oldid=5196) criu PPA repo, used for GHA CI, is replaced with the OBS repo (already used by Dockerfile), so let's use it.

While at it, modify the Dockefile to
 * update the repo URL to use Debian_11 (which was not available before);
 * fix the apt-key deprecation warning from Dockerfile.

See individual commits for more details.

This brings criu 3.16 to the table! 🎉 