### PR TITLE
run create/run/exec: refuse bad cgroup

### DIFF
--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -173,6 +173,7 @@ _runc_exec() {
 	   --apparmor
 	   --cap, -c
 	   --preserve-fds
+	   --ignore-paused
 	"
 
 	local all_options="$options_with_args $boolean_options"

--- a/exec.go
+++ b/exec.go
@@ -91,6 +91,10 @@ following will output a list of processes running in the container:
 			Name:  "cgroup",
 			Usage: "run the process in an (existing) sub-cgroup(s). Format is [<controller>:]<cgroup>.",
 		},
+		cli.BoolFlag{
+			Name:  "ignore-paused",
+			Usage: "allow exec in a paused container",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 1, minArgs); err != nil {
@@ -145,7 +149,10 @@ func execProcess(context *cli.Context) (int, error) {
 		return -1, err
 	}
 	if status == libcontainer.Stopped {
-		return -1, errors.New("cannot exec a container that has stopped")
+		return -1, errors.New("cannot exec in a stopped container")
+	}
+	if status == libcontainer.Paused && !context.Bool("ignore-paused") {
+		return -1, errors.New("cannot exec in a paused container (use --ignore-paused to override)")
 	}
 	path := context.String("process")
 	if path == "" && len(context.Args()) == 1 {

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -160,14 +160,35 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	} else if !os.IsNotExist(err) {
 		return nil, err
 	}
+
+	cm, err := manager.New(config.Cgroups)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that cgroup does not exist or empty (no processes).
+	// Note for cgroup v1 this check is not thorough, as there are multiple
+	// separate hierarchies, while both Exists() and GetAllPids() only use
+	// one for "devices" controller (assuming others are the same, which is
+	// probably true in almost all scenarios). Checking all the hierarchies
+	// would be too expensive.
+	if cm.Exists() {
+		pids, err := cm.GetAllPids()
+		// Reading PIDs can race with cgroups removal, so ignore ENOENT and ENODEV.
+		if err != nil && !errors.Is(err, os.ErrNotExist) && !errors.Is(err, unix.ENODEV) {
+			return nil, fmt.Errorf("unable to get cgroup PIDs: %w", err)
+		}
+		if len(pids) != 0 {
+			// TODO: return an error.
+			logrus.Warnf("container's cgroup is not empty: %d process(es) found", len(pids))
+			logrus.Warn("DEPRECATED: running container in a non-empty cgroup won't be supported in runc 1.2; https://github.com/opencontainers/runc/issues/3132")
+		}
+	}
+
 	if err := os.MkdirAll(containerRoot, 0o711); err != nil {
 		return nil, err
 	}
 	if err := os.Chown(containerRoot, unix.Geteuid(), unix.Getegid()); err != nil {
-		return nil, err
-	}
-	cm, err := manager.New(config.Cgroups)
-	if err != nil {
 		return nil, err
 	}
 	c := &linuxContainer{

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -185,6 +185,16 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		}
 	}
 
+	// Check that cgroup is not frozen. Do not use Exists() here
+	// since in cgroup v1 it only checks "devices" controller.
+	st, err := cm.GetFreezerState()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cgroup freezer state: %w", err)
+	}
+	if st == configs.Frozen {
+		return nil, errors.New("container's cgroup unexpectedly frozen")
+	}
+
 	if err := os.MkdirAll(containerRoot, 0o711); err != nil {
 		return nil, err
 	}

--- a/man/runc-exec.8.md
+++ b/man/runc-exec.8.md
@@ -59,6 +59,11 @@ multiple times.
 : Pass _N_ additional file descriptors to the container (**stdio** +
 **$LISTEN_FDS** + _N_ in total). Default is **0**.
 
+**--ignore-paused**
+: Allow exec in a paused container. By default, if a container is paused,
+**runc exec** errors out; this option can be used to override it.
+A paused container needs to be resumed for the exec to complete.
+
 **--cgroup** _path_ | _controller_[,_controller_...]:_path_
 : Execute a process in a sub-cgroup. If the specified cgroup does not exist, an
 error is returned. Default is empty path, which means to use container's top

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -347,3 +347,24 @@ function setup() {
 	[ "$status" -eq 0 ]
 	[ "$output" = "ok" ]
 }
+
+@test "runc run/create should warn about a non-empty cgroup" {
+	if [[ "$ROOTLESS" -ne 0 ]]; then
+		requires rootless_cgroup
+	fi
+
+	set_cgroups_path
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
+	[ "$status" -eq 0 ]
+
+	# Run a second container sharing the cgroup with the first one.
+	runc --debug run -d --console-socket "$CONSOLE_SOCKET" ct2
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"container's cgroup is not empty"* ]]
+
+	# Same but using runc create.
+	runc create --console-socket "$CONSOLE_SOCKET" ct3
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"container's cgroup is not empty"* ]]
+}


### PR DESCRIPTION
_This is the final part of changes from #3131, depending on (already merged) #3214, #3215, #3216, #3217._

### I. runc exec: refuse paused container
    
This bugged me a few times during runc development. A new container is
run, and suddenly runc init is stuck, 🎶 and nothing ever happens, and
I wonder... 🎶
    
Figuring out that the cause of it is (pre-created) frozen cgroup is not
very obvious (to say at least), and neither Ctrl-C nor Ctrl-Z work.
    
The fix is to add a check that refuses to exec in a paused container.
A (very bad) alternative to that would be to thaw the cgroup.
    
Implement the fix, add a test case.

Update: it has been noted that exec in a paused container might be
a legitimate use case. Added `--ignore-paused` flag, documented, tested.

### II. runc run/create: warn about non-empty cgroup

Currently runc allows multiple containers to share the same cgroup (for
example, by having the same `cgroupPath` in config.json).  While such
shared configuration might be OK, there are some issues:
    
- When each container has its own resource limits, the order of
    containers start determines whose limits will be effectively applied.
    
- When one of containers is paused, all others are paused, too.
    
- When a container is paused, any attempt to do runc create/run/exec
      end up with runc init stuck inside a frozen cgroup.
    
- When a systemd cgroup manager is used, this becomes even worse -- such
      as, stop (or even failed start) of any container results in
      "stopTransientUnit" command being sent to systemd, and so (depending
      on unit properties) other containers can receive SIGTERM, be killed
      after a timeout etc.
      
All this may lead to various hard-to-debug situations in production
(runc init stuck, cgroup removal error, wrong resource limits, container
init not working as zombie reaper, etc).
    
One obvious solution is to refuse a non-empty cgroup when starting a new
container. This would be a breaking change though, so let's make it in
steps, with the first step is issue a warning and a deprecated notice
about a non-empty cgroup.
    
Later (in runc 1.2) we will replace this warning with an error.
    
### III. runc run: refuse cgroup if frozen
    
Sometimes a container cgroup already exists but is frozen.
When this happens, runc init hangs, and it's not clear what is going on.

Refuse to run in a frozen cgroup; add a test case.

### Proposed changelog entry
```
Bugfixes:
* runc run/start/exec now refuses a frozen cgroup (paused container in case of exec) (#3132, #3223)
* runc run/start now warns if a new container cgroup is non-empty or frozen;
  this warning will become an error in runc 1.2 (#3132, #3223)
```

Fixes: #3132 