### PR TITLE
Remove sub cgroup when container exits

### DIFF
--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -3,7 +3,6 @@ package systemd
 import (
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -301,9 +300,10 @@ func (m *unifiedManager) Destroy() error {
 		return err
 	}
 
-	// XXX this is probably not needed, systemd should handle it
-	err := os.Remove(m.path)
-	if err != nil && !os.IsNotExist(err) {
+	// systemd 239 do not remove sub-cgroups.
+	err := m.fsMgr.Destroy()
+	// fsMgr.Destroy has handled ErrNotExist
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Delete all child cgroup in container cgroup, otherwise it will failed to delete the container cgroup.

Close https://github.com/opencontainers/runc/issues/3225

Signed-off-by: Kang Chen <kongchen28@gmail.com>

### Proposed changelog entry

(by @kolyshkin)

```
Bugfixes:
* cgroup v2 systemd manager: delete sub-cgroups on cgroup delete
```