### PR TITLE
contrib: rm init from bash completion

### DIFF
--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -771,7 +771,6 @@ _runc() {
 		delete
 		events
 		exec
-		init
 		kill
 		list
 		pause


### PR DESCRIPTION
Commit 7a0302f0d79 already removed "runc init" from runc help output,
as this is an internal option not supposed to be used by the end user.

Let's remove runc init completion, too.