### PR TITLE
tests/int/delete: drop root req from v2 subcgroup test

### DIFF
--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -111,7 +111,8 @@ EOF
 }
 
 @test "runc delete --force in cgroupv2 with subcgroups" {
-	requires cgroups_v2 root
+	requires cgroups_v2
+	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 	set_cgroups_path
 	set_cgroup_mount_writable
 


### PR DESCRIPTION
"runc delete --force in cgroupv2 with subcgroups" can be run as
non-root, too, and might reveal a bug in systemd + centos 8.

Related to #3225/#3226.