### PR TITLE
Dockerfile: fix for seccomp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
         crossbuild-essential-armel \
         crossbuild-essential-armhf \
         crossbuild-essential-ppc64el \
+        crossbuild-essential-s390x \
         curl \
         gawk \
         gcc \
@@ -54,7 +55,7 @@ RUN cd /tmp \
 ARG LIBSECCOMP_VERSION
 COPY script/* /tmp/script/
 RUN mkdir -p /opt/libseccomp \
-    && /tmp/script/seccomp.sh "$LIBSECCOMP_VERSION" /opt/libseccomp arm64 armel armhf ppc64le
+    && /tmp/script/seccomp.sh "$LIBSECCOMP_VERSION" /opt/libseccomp arm64 armel armhf ppc64le s390x
 ENV LIBSECCOMP_VERSION=$LIBSECCOMP_VERSION
 ENV LD_LIBRARY_PATH=/opt/libseccomp/lib
 ENV PKG_CONFIG_PATH=/opt/libseccomp/lib/pkgconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,10 @@ RUN cd /tmp \
 # install libseccomp
 ARG LIBSECCOMP_VERSION
 COPY script/* /tmp/script/
-RUN mkdir -p /usr/local/src/libseccomp \
-    && /tmp/script/seccomp.sh "$LIBSECCOMP_VERSION" /usr/local/src/libseccomp /usr/local/src/libseccomp/.env-file arm64 armel armhf ppc64le
+RUN mkdir -p /opt/libseccomp \
+    && /tmp/script/seccomp.sh "$LIBSECCOMP_VERSION" /opt/libseccomp arm64 armel armhf ppc64le
+ENV LIBSECCOMP_VERSION=$LIBSECCOMP_VERSION
+ENV LD_LIBRARY_PATH=/opt/libseccomp/lib
+ENV PKG_CONFIG_PATH=/opt/libseccomp/lib/pkgconfig
 
 WORKDIR /go/src/github.com/opencontainers/runc

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ recvtty sd-helper seccompagent:
 static:
 	$(GO_BUILD_STATIC) -o runc .
 
-releaseall: RELEASE_ARGS := "-a arm64 -a armel -a armhf -a ppc64le"
+releaseall: RELEASE_ARGS := "-a arm64 -a armel -a armhf -a ppc64le -a s390x"
 releaseall: release
 
 release: runcimage

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -23,6 +23,9 @@ function set_cross_vars() {
 	ppc64le)
 		HOST=powerpc64le-linux-gnu
 		;;
+	s390x)
+		HOST=s390x-linux-gnu
+		;;
 	*)
 		echo "set_cross_vars: unsupported architecture: $1" >&2
 		exit 1


### PR DESCRIPTION
Commit f30244ee1b22223cf (PR #3197) broke the scenario of using Dockefile for
anything but making a release. This happened because it installed
native libseccomp build to a temporary directory, and so linking against
libseccomp required setting a few environment variables.

Let's fix this, and simplify libseccomp installation. Instead of using
temporary directories, let's install native libseccomp to a specified
directory, all the cross-builds to its subdirectories, and set
PKG_CONFIG_PATH and LD_LIBRARY_PATH in Dockerfile so that the built
library will found by pkg-config and the dynamic linker (without setting
LD_LIBRARY_PATH, ld picks up distro-provided libseccomp.so).

While at it, fix some nit picks introduced by the abovementioned commit.

This fixes building runc in  make targets like shell, dbuild,
integration, unittest -- i.e. those that depend on runcimage.

Fixes: f30244ee1b22223cf38b505b42
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>