### PR TITLE
libct/cg/fs2: fix GetStats for unsupported hugetlb

### DIFF
--- a/libcontainer/cgroups/fs2/hugetlb.go
+++ b/libcontainer/cgroups/fs2/hugetlb.go
@@ -1,7 +1,6 @@
 package fs2
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -27,10 +26,7 @@ func setHugeTlb(dirPath string, r *configs.Resources) error {
 }
 
 func statHugeTlb(dirPath string, stats *cgroups.Stats) error {
-	hugePageSizes, err := cgroups.GetHugePageSize()
-	if err != nil {
-		return fmt.Errorf("failed to fetch hugetlb info: %w", err)
-	}
+	hugePageSizes, _ := cgroups.GetHugePageSize()
 	hugetlbStats := cgroups.HugetlbStats{}
 
 	for _, pagesize := range hugePageSizes {


### PR DESCRIPTION
In case hugetlb is not supported, GetStats() should not error out,
and yet it does.

Assume that if `GetHugePageSize` return an error, hugetlb is
not supported (this is what cgroup v1 manager do).

NOTE this code is not used by the runc itself, only by external users
like kubernetes and cadvisor that import libcontainer/cgroup/...

Fixes: 89a87adb
Fixes: #3232