### PR TITLE
libct: Init: remove LockOSThread

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"strconv"
 
 	"github.com/opencontainers/selinux/go-selinux"
@@ -31,9 +30,6 @@ func (l *linuxSetnsInit) getSessionRingName() string {
 }
 
 func (l *linuxSetnsInit) Init() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	if !l.config.Config.NoNewKeyring {
 		if err := selinux.SetKeyLabel(l.config.ProcessLabel); err != nil {
 			return err

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strconv"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -46,8 +45,6 @@ func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
 }
 
 func (l *linuxStandardInit) Init() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	if !l.config.Config.NoNewKeyring {
 		if err := selinux.SetKeyLabel(l.config.ProcessLabel); err != nil {
 			return err


### PR DESCRIPTION
This call is already made in init.go, no need for a duplicate.
