### PR TITLE
[WIP] Better error messages on failed to exec

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -239,7 +239,7 @@ func (l *linuxStandardInit) Init() error {
 	}
 
 	if err := system.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
-		return fmt.Errorf("can't exec user process: %w", err)
+		return fmt.Errorf("can't exec user process $q: %w", name, err)
 	}
 	return nil
 }

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -4,6 +4,7 @@
 package system
 
 import (
+	"fmt"
 	"os/exec"
 	"unsafe"
 
@@ -43,7 +44,7 @@ func Exec(cmd string, args []string, env []string) error {
 	for {
 		err := unix.Exec(cmd, args, env)
 		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
-			return err
+			return fmt.Errorf("failed to exec %q", cmd, err)
 		}
 	}
 }


### PR DESCRIPTION
We often get Podman error messages where container images fail to exec.

standard_init_linux.go:228: exec user process caused: no such file or directory

It would be much better to know which executable was not found.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>