### PR TITLE
libct/system: Exec: wrap the error

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -239,7 +239,7 @@ func (l *linuxStandardInit) Init() error {
 	}
 
 	if err := system.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
-		return fmt.Errorf("can't exec user process: %w", err)
+		return err
 	}
 	return nil
 }

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -4,6 +4,7 @@
 package system
 
 import (
+	"os"
 	"os/exec"
 	"unsafe"
 
@@ -43,7 +44,7 @@ func Exec(cmd string, args []string, env []string) error {
 	for {
 		err := unix.Exec(cmd, args, env)
 		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
-			return err
+			return &os.PathError{Op: "exec", Path: cmd, Err: err}
 		}
 	}
 }


### PR DESCRIPTION
If the container binary to be run is removed in between runc create
and runc start, the latter spits the following error:

    can't exec user process: no such file or directory

This is a bit confusing since we don't see what file is missing.

Wrap the unix.Exec error into os.PathError, like in many other cases,
to provide some context. Remove the error wrapping from
(*linuxStandardInit).Init as it is now redundant.

With this patch, the error is now:

    exec /bin/false: no such file or directory

Closes: #3237