### PR TITLE
libct/intelrdt: add Root()

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -185,10 +185,6 @@ const (
 )
 
 var (
-	// The absolute root path of the Intel RDT "resource control" filesystem
-	intelRdtRoot     string
-	intelRdtRootLock sync.Mutex
-
 	// The flag to indicate if Intel RDT/CAT is enabled
 	catEnabled bool
 	// The flag to indicate if Intel RDT/MBA is enabled
@@ -215,9 +211,10 @@ func featuresInit() {
 			return
 		}
 
-		// 2. Check if Intel RDT "resource control" filesystem is mounted
-		// The user guarantees to mount the filesystem
-		if !isIntelRdtMounted() {
+		// 2. Check if Intel RDT "resource control" filesystem is available.
+		// The user guarantees to mount the filesystem.
+		root, err := Root()
+		if err != nil {
 			return
 		}
 
@@ -226,7 +223,7 @@ func featuresInit() {
 		// selectively disabled or enabled by kernel command line
 		// (e.g., rdt=!l3cat,mba) in 4.14 and newer kernel
 		if flagsSet.CAT {
-			if _, err := os.Stat(filepath.Join(intelRdtRoot, "info", "L3")); err == nil {
+			if _, err := os.Stat(filepath.Join(root, "info", "L3")); err == nil {
 				catEnabled = true
 			}
 		}
@@ -236,15 +233,15 @@ func featuresInit() {
 			// depends on MBA
 			mbaEnabled = true
 		} else if flagsSet.MBA {
-			if _, err := os.Stat(filepath.Join(intelRdtRoot, "info", "MB")); err == nil {
+			if _, err := os.Stat(filepath.Join(root, "info", "MB")); err == nil {
 				mbaEnabled = true
 			}
 		}
 		if flagsSet.MBMTotal || flagsSet.MBMLocal || flagsSet.CMT {
-			if _, err := os.Stat(filepath.Join(intelRdtRoot, "info", "L3_MON")); err != nil {
+			if _, err := os.Stat(filepath.Join(root, "info", "L3_MON")); err != nil {
 				return
 			}
-			enabledMonFeatures, err = getMonFeatures(intelRdtRoot)
+			enabledMonFeatures, err = getMonFeatures(root)
 			if err != nil {
 				return
 			}
@@ -282,10 +279,16 @@ func findIntelRdtMountpointDir(f io.Reader) (string, error) {
 	return mi[0].Mountpoint, nil
 }
 
-// Gets the root path of Intel RDT "resource control" filesystem
-func getIntelRdtRoot() (string, error) {
-	intelRdtRootLock.Lock()
-	defer intelRdtRootLock.Unlock()
+// For Root() use only.
+var (
+	intelRdtRoot string
+	rootMu       sync.Mutex
+)
+
+// Root returns the Intel RDT "resource control" filesystem mount point.
+func Root() (string, error) {
+	rootMu.Lock()
+	defer rootMu.Unlock()
 
 	if intelRdtRoot != "" {
 		return intelRdtRoot, nil
@@ -307,11 +310,6 @@ func getIntelRdtRoot() (string, error) {
 
 	intelRdtRoot = root
 	return intelRdtRoot, nil
-}
-
-func isIntelRdtMounted() bool {
-	_, err := getIntelRdtRoot()
-	return err == nil
 }
 
 type cpuInfoFlags struct {
@@ -405,7 +403,7 @@ func writeFile(dir, file, data string) error {
 func getL3CacheInfo() (*L3CacheInfo, error) {
 	l3CacheInfo := &L3CacheInfo{}
 
-	rootPath, err := getIntelRdtRoot()
+	rootPath, err := Root()
 	if err != nil {
 		return l3CacheInfo, err
 	}
@@ -435,7 +433,7 @@ func getL3CacheInfo() (*L3CacheInfo, error) {
 func getMemBwInfo() (*MemBwInfo, error) {
 	memBwInfo := &MemBwInfo{}
 
-	rootPath, err := getIntelRdtRoot()
+	rootPath, err := Root()
 	if err != nil {
 		return memBwInfo, err
 	}
@@ -468,7 +466,7 @@ func getMemBwInfo() (*MemBwInfo, error) {
 
 // Get diagnostics for last filesystem operation error from file info/last_cmd_status
 func getLastCmdStatus() (string, error) {
-	rootPath, err := getIntelRdtRoot()
+	rootPath, err := Root()
 	if err != nil {
 		return "", err
 	}
@@ -517,7 +515,7 @@ func IsMBAScEnabled() bool {
 
 // Get the path of the clos group in "resource control" filesystem that the container belongs to
 func (m *intelRdtManager) getIntelRdtPath() (string, error) {
-	rootPath, err := getIntelRdtRoot()
+	rootPath, err := Root()
 	if err != nil {
 		return "", err
 	}
@@ -601,7 +599,7 @@ func (m *intelRdtManager) GetStats() (*Stats, error) {
 	defer m.mu.Unlock()
 	stats := newStats()
 
-	rootPath, err := getIntelRdtRoot()
+	rootPath, err := Root()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I have started looking into using the upcoming runc 1.1 libcontainer
by packages that use it already, and came across this (thus the 1.1 milestone).

-----

Export getIntelRdtRoot function as Root.

This is needed by google/cadvisor, which is (ab)using GetIntelRdtPath,
removed by commit 7296dc171238291f4.

While at it, do some minimal refactoring to always use Root()
internally, not relying on variable value. Other than that it's just
some renaming.