### PR TITLE
libct/cg: save systemd into state.json

### DIFF
--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -32,7 +32,7 @@ type Cgroup struct {
 	*Resources
 
 	// Systemd tells if systemd should be used to manage cgroups.
-	Systemd bool
+	Systemd bool `json:"systemd"`
 
 	// SystemdProps are any additional properties for systemd,
 	// derived from org.systemd.property.xxx annotations.


### PR DESCRIPTION
We will load container state.json to create LinuxFactory when we need to run some runc command.The systemd config in cgroup should be saved into state.json, so that we can get the same cgroups.Manager.

This issue was found when I inspected  https://github.com/opencontainers/runc/pull/3226#issuecomment-929316765.  `runc delete --force foo` uses `fs2.(*manager)` while I started container by `./runc.amd64 --systemd-cgroup  run foo`, but I think `runc delete` should use `systemd.(*unifiedManager)` to handle this systemd container.

Signed-off-by: Kang Chen <kongchen28@gmail.com>