### PR TITLE
ci: temporarily disable criu repo gpg check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         # criu repo
         curl -fSsl $REPO/Release.key | sudo apt-key add -
-        echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
+        echo "deb [allow-insecure=yes trusted=yes] $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
         sudo apt install libseccomp-dev criu
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG CRIU_REPO=https://download.opensuse.org/repositories/devel:/tools:/criu/Debi
 
 RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
     wget -nv $CRIU_REPO/Release.key -O- | gpg --dearmor > "$KEYFILE" \
-    && echo "deb [signed-by=$KEYFILE] $CRIU_REPO/ /" > /etc/apt/sources.list.d/criu.list \
+    && echo "deb [allow-insecure=yes trusted=yes signed-by=$KEYFILE] $CRIU_REPO/ /" > /etc/apt/sources.list.d/criu.list \
     && dpkg --add-architecture armel \
     && dpkg --add-architecture armhf \
     && dpkg --add-architecture arm64 \


### PR DESCRIPTION
This unblocks our CI, which is broken by the repo's expired signing key
(see e.g. https://github.com/opencontainers/runc/actions/runs/1342820859)

Stolen-from: https://github.com/moby/moby/pull/42935

Cc: @adrianreber 