### PR TITLE
fix `libcontainer/integration/exec_test.go:1859:8: undefined: ioutil`

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1856,7 +1856,7 @@ func TestBindMountAndUser(t *testing.T) {
 	err := os.MkdirAll(dirhost, 0o755)
 	ok(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(dirhost, "foo.txt"), []byte("Hello"), 0o755)
+	err = os.WriteFile(filepath.Join(dirhost, "foo.txt"), []byte("Hello"), 0o755)
 	ok(t, err)
 
 	// Make this dir inaccessible to "group,others".


### PR DESCRIPTION
Fix 4d176544794c0a75f4dd58fe9e971361c66a4756
