### PR TITLE
CI: update Fedora to 35

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
     HOME: /root
     # yamllint disable rule:key-duplicates
     matrix:
-      DISTRO: fedora34
+      DISTRO: fedora
 
   name: vagrant DISTRO:$DISTRO
 

--- a/Vagrantfile.fedora
+++ b/Vagrantfile.fedora
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 # Fedora box is used for testing cgroup v2 support
-  config.vm.box = "fedora/34-cloud-base"
+  config.vm.box = "fedora/35-cloud-base"
   config.vm.provider :virtualbox do |v|
     v.memory = 2048
     v.cpus = 2


### PR DESCRIPTION
Also rename `Vagrantfile.fedora%d` to `Vagrantfile.fedora` so that we do not need to reset the commit log on upgrading the Fedora release.
