### PR TITLE
userns test fixes for fedora 35

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -544,12 +544,39 @@ function setup_bundle() {
 	ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc.XXXXXX")
 	mkdir -p "$ROOT/state" "$ROOT/bundle/rootfs"
 
+	# Tests running inside userns need to traverse the path as different
+	# users to mount the rootfs.
+	# Give permissions for others, so they always work.
+	chmod_all 755 "$ROOT/bundle/rootfs" "$BATS_RUN_TMPDIR"
+
 	setup_recvtty
 	cd "$ROOT/bundle" || return
 
 	tar --exclude './dev/*' -C rootfs -xf "$image"
 
 	runc_spec
+}
+
+# Note path MUST be descendant of base, otherwise nothing will be done.
+function chmod_all() {
+	local perm=$1
+	local path=$2
+	local base=${3%/} # Remove the trailing slash if present.
+
+	# Validate path is descendant, otherwise the loop will not stop.
+	if [[ "$path" != "$base"/* ]]; then
+		return
+	fi
+
+	while [ "$path" != "$base" ]; do
+		chmod "$perm" "$path"
+
+		# Strip the last component of path
+		path=$(dirname "$path")
+	done
+
+	# Always chmod base too.
+	chmod "$perm" "$base"
 }
 
 function setup_busybox() {

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -7,6 +7,7 @@ function setup() {
 
 	# Prepare source folders for bind mount
 	mkdir -p source-{accessible,inaccessible-1,inaccessible-2}/dir
+	chmod 755 source-accessible source-accessible/dir
 	touch source-{accessible,inaccessible-1,inaccessible-2}/dir/foo.txt
 
 	# Permissions only to the owner, it is inaccessible to group/others
@@ -14,10 +15,6 @@ function setup() {
 
 	mkdir -p rootfs/{proc,sys,tmp}
 	mkdir -p rootfs/tmp/mount-{1,2}
-
-	# We need to give permissions for others so the uid inside the userns
-	# can mount the rootfs on itself. Otherwise the rootfs mount will fail.
-	chmod 755 "$ROOT"
 
 	if [ "$ROOTLESS" -eq 0 ]; then
 		update_config ' .linux.namespaces += [{"type": "user"}]


### PR DESCRIPTION
Upgrading to fedora 35 the CI fails, as @AkihiroSuda mentioned here: https://github.com/opencontainers/runc/pull/3258

One of the issues (the others might be flaky, will see) seems to be that in the userns tests we give 755 permissions to the only component path that lacks them. That worked fine for all the distros until we tried to upgrade to fedora 35, when there were other paths that lacked the permissions.

This patch (more in the commit details) just makes sure all the components in the path (from a certain base, to not change permissions for /tmp or other system paths) have 755 in all cases.

It carries the commit from #3258 to make sure it runs fine one last time, but I will remove as soon as the tests runs fine, so this can be merged. If you prefer feel free to take the commit from here to #3258 or what works best for you.