### PR TITLE
ci/cirrus: use Fedora 35

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
     HOME: /root
     # yamllint disable rule:key-duplicates
     matrix:
-      DISTRO: fedora34
+      DISTRO: fedora
 
   name: vagrant DISTRO:$DISTRO
 

--- a/Vagrantfile.fedora
+++ b/Vagrantfile.fedora
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 # Fedora box is used for testing cgroup v2 support
-  config.vm.box = "fedora/34-cloud-base"
+  config.vm.box = "fedora/35-cloud-base"
   config.vm.provider :virtualbox do |v|
     v.memory = 2048
     v.cpus = 2

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -49,8 +49,8 @@ function setup() {
 			if [ "$(id -u)" = "0" ]; then
 				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
 			else
-				# Filter out hugetlb as systemd is unable to delegate it.
-				check_cgroup_value "cgroup.controllers" "$(sed 's/ hugetlb//' </sys/fs/cgroup/user.slice/user-"$(id -u)".slice/cgroup.controllers)"
+				# Filter out hugetlb and misc as systemd is unable to delegate them.
+				check_cgroup_value "cgroup.controllers" "$(sed -e 's/ hugetlb//' -e 's/ misc//' </sys/fs/cgroup/user.slice/user-"$(id -u)".slice/cgroup.controllers)"
 			fi
 		else
 			check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -544,6 +544,12 @@ function setup_bundle() {
 	ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc.XXXXXX")
 	mkdir -p "$ROOT/state" "$ROOT/bundle/rootfs"
 
+	# Directories created by mktemp -d have 0700 permission bits. Tests
+	# running inside userns (see userns.bats) need to access the directory
+	# as a different user to mount the rootfs. Since kernel v5.12, parent
+	# directories are also checked. Give a+x for these tests to work.
+	chmod a+x "$ROOT" "$BATS_RUN_TMPDIR"
+
 	setup_recvtty
 	cd "$ROOT/bundle" || return
 

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -15,10 +15,6 @@ function setup() {
 	mkdir -p rootfs/{proc,sys,tmp}
 	mkdir -p rootfs/tmp/mount-{1,2}
 
-	# We need to give permissions for others so the uid inside the userns
-	# can mount the rootfs on itself. Otherwise the rootfs mount will fail.
-	chmod 755 "$ROOT"
-
 	if [ "$ROOTLESS" -eq 0 ]; then
 		update_config ' .linux.namespaces += [{"type": "user"}]
 			| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}]


### PR DESCRIPTION
Use Fedora 35 for testing; fix two test issues caused by the newer kernel.

This includes/carries #3258 and obsoletes #3260.

Closes: #3258
Closes: #3260
