### PR TITLE
ci/cirrus: update to Go 1.17.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,7 @@ task:
   env:
     HOME: /root
     CIRRUS_WORKING_DIR: /home/runc
-    GO_VERSION: "1.16.6"
+    GO_VERSION: "1.17.3"
     BATS_VERSION: "v1.3.0"
     # yamllint disable rule:key-duplicates
     matrix:


### PR DESCRIPTION
noticed that this was using an older version of Go 1.16