### PR TITLE
Run gosec against runc

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,5 +7,11 @@ run:
 linters:
   enable:
     - gofumpt
+    - gosec
     - errorlint
     - unconvert
+
+linters-settings:
+  gosec:
+    confidence: medium
+    severity: medium

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -118,7 +118,7 @@ func setPageServer(context *cli.Context, options *libcontainer.CriuOpts) {
 		if err != nil || address == "" || port == "" {
 			fatal(errors.New("Use --page-server ADDRESS:PORT to specify page server"))
 		}
-		portInt, err := strconv.Atoi(port)
+		portInt, err := strconv.ParseInt(port, 10, 32)
 		if err != nil {
 			fatal(errors.New("Invalid port number"))
 		}

--- a/contrib/cmd/recvtty/recvtty.go
+++ b/contrib/cmd/recvtty/recvtty.go
@@ -224,7 +224,7 @@ func main() {
 		pidPath := ctx.String("pid-file")
 		if pidPath != "" {
 			pid := fmt.Sprintf("%d\n", os.Getpid())
-			if err := os.WriteFile(pidPath, []byte(pid), 0o644); err != nil {
+			if err := os.WriteFile(pidPath, []byte(pid), 0o644); err != nil { //nolint:gosec
 				return err
 			}
 		}

--- a/contrib/cmd/seccompagent/seccompagent.go
+++ b/contrib/cmd/seccompagent/seccompagent.go
@@ -245,7 +245,7 @@ func main() {
 
 	if pidFile != "" {
 		pid := fmt.Sprintf("%d", os.Getpid())
-		if err := os.WriteFile(pidFile, []byte(pid), 0o644); err != nil {
+		if err := os.WriteFile(pidFile, []byte(pid), 0o644); err != nil { //nolint:gosec
 			logrus.Fatalf("Cannot write pid file: %v", err)
 		}
 	}

--- a/libcontainer/cgroups/fs2/io_test.go
+++ b/libcontainer/cgroups/fs2/io_test.go
@@ -62,7 +62,7 @@ func TestStatIo(t *testing.T) {
 	fakeCgroupDir := t.TempDir()
 	statPath := filepath.Join(fakeCgroupDir, "io.stat")
 
-	if err := os.WriteFile(statPath, []byte(exampleIoStatData), 0o644); err != nil {
+	if err := os.WriteFile(statPath, []byte(exampleIoStatData), 0o644); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
 

--- a/libcontainer/cgroups/fscommon/utils_test.go
+++ b/libcontainer/cgroups/fscommon/utils_test.go
@@ -26,7 +26,7 @@ func TestGetCgroupParamsInt(t *testing.T) {
 	tempFile := filepath.Join(tempDir, cgroupFile)
 
 	// Success.
-	if err := os.WriteFile(tempFile, []byte(floatString), 0o755); err != nil {
+	if err := os.WriteFile(tempFile, []byte(floatString), 0o755); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
 	value, err := GetCgroupParamUint(tempDir, cgroupFile)
@@ -37,7 +37,7 @@ func TestGetCgroupParamsInt(t *testing.T) {
 	}
 
 	// Success with new line.
-	err = os.WriteFile(tempFile, []byte(floatString+"\n"), 0o755)
+	err = os.WriteFile(tempFile, []byte(floatString+"\n"), 0o755) //nolint:gosec
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestGetCgroupParamsInt(t *testing.T) {
 	}
 
 	// Success with negative values
-	err = os.WriteFile(tempFile, []byte("-12345"), 0o755)
+	err = os.WriteFile(tempFile, []byte("-12345"), 0o755) //nolint:gosec
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestGetCgroupParamsInt(t *testing.T) {
 
 	// Success with negative values lesser than min int64
 	s := strconv.FormatFloat(math.MinInt64, 'f', -1, 64)
-	err = os.WriteFile(tempFile, []byte(s), 0o755)
+	err = os.WriteFile(tempFile, []byte(s), 0o755) //nolint:gosec
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestGetCgroupParamsInt(t *testing.T) {
 	}
 
 	// Not a float.
-	err = os.WriteFile(tempFile, []byte("not-a-float"), 0o755)
+	err = os.WriteFile(tempFile, []byte("not-a-float"), 0o755) //nolint:gosec
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -189,7 +189,7 @@ exit 0
 	verifyCommand := fmt.Sprintf(verifyCommandTemplate, stateJson)
 	filename := "/tmp/runc-hooktest.sh"
 	os.Remove(filename)
-	if err := os.WriteFile(filename, []byte(verifyCommand), 0o700); err != nil {
+	if err := os.WriteFile(filename, []byte(verifyCommand), 0o700); err != nil { //nolint:gosec
 		t.Fatalf("Failed to create tmp file: %v", err)
 	}
 	defer os.Remove(filename)

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -482,7 +482,7 @@ func (c *linuxContainer) newParentProcess(p *Process) (parentProcess, error) {
 }
 
 func (c *linuxContainer) commandTemplate(p *Process, childInitPipe *os.File, childLogPipe *os.File) *exec.Cmd {
-	cmd := exec.Command(c.initPath, c.initArgs[1:]...)
+	cmd := exec.Command(c.initPath, c.initArgs[1:]...) //nolint:gosec // G204 (Subprocess launched with a potential tainted input or cmd arguments)
 	cmd.Args[0] = c.initArgs[0]
 	cmd.Stdin = p.Stdin
 	cmd.Stdout = p.Stdout
@@ -1608,7 +1608,7 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 		// the initial CRIU run to detect the version. Skip it.
 		logrus.Debugf("Using CRIU %d at: %s", c.criuVersion, c.criuPath)
 	}
-	cmd := exec.Command(c.criuPath, args...)
+	cmd := exec.Command(c.criuPath, args...) //nolint:gosec // G204 (Subprocess launched with a potential tainted input or cmd arguments)
 	if process != nil {
 		cmd.Stdin = process.Stdin
 		cmd.Stdout = process.Stdout

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1425,7 +1425,7 @@ func TestRootfsPropagationSharedMount(t *testing.T) {
 	defer unmountOp(dir2host)
 
 	// Check if mount is visible on host or not.
-	out, err := exec.Command("findmnt", "-n", "-f", "-oTARGET", dir2host).CombinedOutput()
+	out, err := exec.Command("findmnt", "-n", "-f", "-oTARGET", dir2host).CombinedOutput() //nolint:gosec // G204 (Subprocess launched with variable)
 	outtrim := string(bytes.TrimSpace(out))
 	if err != nil {
 		t.Logf("findmnt error %q: %q", err, outtrim)
@@ -1861,7 +1861,7 @@ func TestBindMountAndUser(t *testing.T) {
 	err := os.MkdirAll(dirhost, 0o755)
 	ok(t, err)
 
-	err = os.WriteFile(filepath.Join(dirhost, "foo.txt"), []byte("Hello"), 0o755)
+	err = os.WriteFile(filepath.Join(dirhost, "foo.txt"), []byte("Hello"), 0o755) //nolint:gosec
 	ok(t, err)
 
 	// Make this dir inaccessible to "group,others".

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -32,7 +32,7 @@ func init() {
 		panic(err)
 	}
 	// Call it to make sure images are downloaded, and to get the paths.
-	out, err := exec.Command(getImages).CombinedOutput()
+	out, err := exec.Command(getImages).CombinedOutput() //nolint:gosec // G204 (Subprocess launched with variable)
 	if err != nil {
 		panic(fmt.Errorf("getImages error %w (output: %s)", err, out))
 	}
@@ -158,7 +158,7 @@ func remove(dir string) {
 // copyBusybox copies the rootfs for a busybox container created for the test image
 // into the new directory for the specific test
 func copyBusybox(dest string) error {
-	out, err := exec.Command("sh", "-c", fmt.Sprintf("tar --exclude './dev/*' -C %q -xf %q", dest, busyboxTar)).CombinedOutput()
+	out, err := exec.Command("sh", "-c", fmt.Sprintf("tar --exclude './dev/*' -C %q -xf %q", dest, busyboxTar)).CombinedOutput() //nolint:gosec // G204 (Subprocess launched with variable)
 	if err != nil {
 		return fmt.Errorf("untar error %w: %q", err, out)
 	}

--- a/libcontainer/intelrdt/monitoring_test.go
+++ b/libcontainer/intelrdt/monitoring_test.go
@@ -50,7 +50,7 @@ func mockResctrlL3_MON(t *testing.T, NUMANodes []string, mocks map[string]uint64
 		}
 
 		for fileName, value := range mocks {
-			err := os.WriteFile(filepath.Join(numaPath, fileName), []byte(strconv.FormatUint(value, 10)), 0o644)
+			err := os.WriteFile(filepath.Join(numaPath, fileName), []byte(strconv.FormatUint(value, 10)), 0o644) //nolint:gosec
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/libcontainer/notify_linux.go
+++ b/libcontainer/notify_linux.go
@@ -32,7 +32,7 @@ func registerMemoryEvent(cgDir string, evName string, arg string) (<-chan struct
 
 	eventControlPath := filepath.Join(cgDir, "cgroup.event_control")
 	data := fmt.Sprintf("%d %d %s", eventfd.Fd(), evFile.Fd(), arg)
-	if err := os.WriteFile(eventControlPath, []byte(data), 0o700); err != nil {
+	if err := os.WriteFile(eventControlPath, []byte(data), 0o700); err != nil { //nolint:gosec
 		eventfd.Close()
 		evFile.Close()
 		return nil, err

--- a/libcontainer/notify_linux_test.go
+++ b/libcontainer/notify_linux_test.go
@@ -17,10 +17,10 @@ func testMemoryNotification(t *testing.T, evName string, notify notifyFunc, targ
 	memoryPath := t.TempDir()
 	evFile := filepath.Join(memoryPath, evName)
 	eventPath := filepath.Join(memoryPath, "cgroup.event_control")
-	if err := os.WriteFile(evFile, []byte{}, 0o700); err != nil {
+	if err := os.WriteFile(evFile, []byte{}, 0o700); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(eventPath, []byte{}, 0o700); err != nil {
+	if err := os.WriteFile(eventPath, []byte{}, 0o700); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
 	ch, err := notify(memoryPath)

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -212,7 +212,7 @@ func cleanupTmp(tmpdir string) {
 }
 
 func mountCmd(cmd configs.Command) error {
-	command := exec.Command(cmd.Path, cmd.Args[:]...)
+	command := exec.Command(cmd.Path, cmd.Args[:]...) //nolint:gosec // G204 (Subprocess launched with a potential tainted input or cmd arguments)
 	command.Env = cmd.Env
 	command.Dir = cmd.Dir
 	if out, err := command.CombinedOutput(); err != nil {
@@ -1055,7 +1055,7 @@ func maskPath(path string, mountLabel string) error {
 // For e.g. net.ipv4.ip_forward translated to /proc/sys/net/ipv4/ip_forward.
 func writeSystemProperty(key, value string) error {
 	keyPath := strings.Replace(key, ".", "/", -1)
-	return os.WriteFile(path.Join("/proc/sys", keyPath), []byte(value), 0o644)
+	return os.WriteFile(path.Join("/proc/sys", keyPath), []byte(value), 0o644) //nolint:gosec
 }
 
 func remount(m *configs.Mount, rootfs string, mountFd *int) error {

--- a/libcontainer/user/user_test.go
+++ b/libcontainer/user/user_test.go
@@ -99,6 +99,7 @@ this is just some garbage data
 }
 
 func TestValidGetExecUser(t *testing.T) {
+	// #nosec G101 (Potentially hardcoded credentials)
 	const passwdContent = `
 root:x:0:0:root user:/root:/bin/bash
 adm:x:42:43:adm:/var/adm:/bin/false
@@ -253,6 +254,7 @@ this is just some garbage data
 }
 
 func TestInvalidGetExecUser(t *testing.T) {
+	// #nosec G101 (Potentially hardcoded credentials)
 	const passwdContent = `
 root:x:0:0:root user:/root:/bin/bash
 adm:x:42:43:adm:/var/adm:/bin/false
@@ -297,6 +299,7 @@ this is just some garbage data
 }
 
 func TestGetExecUserNilSources(t *testing.T) {
+	// #nosec G101 (Potentially hardcoded credentials)
 	const passwdContent = `
 root:x:0:0:root user:/root:/bin/bash
 adm:x:42:43:adm:/var/adm:/bin/false

--- a/ps.go
+++ b/ps.go
@@ -63,7 +63,7 @@ var psCommand = cli.Command{
 			psArgs = []string{"-ef"}
 		}
 
-		cmd := exec.Command("ps", psArgs...)
+		cmd := exec.Command("ps", psArgs...) //nolint:gosec // G204 (Subprocess launched with variable)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%w: %s", err, output)

--- a/spec.go
+++ b/spec.go
@@ -108,7 +108,7 @@ created by an unprivileged user.
 		if err != nil {
 			return err
 		}
-		return os.WriteFile(specConfig, data, 0o666)
+		return os.WriteFile(specConfig, data, 0o666) //nolint:gosec
 	},
 }
 


### PR DESCRIPTION
I extended the GitHub action to run gosec as part of a build. I mitigated the one finding:

* In checkpoint.go there was a `Atoi` followed by a cast to `int32`. I changed this to `ParseInt` with the correct bit size. Mitigates *G109: Potential Integer overflow made by strconv.Atoi result conversion to int16/32*

And I added ignores to those places where it complains about file write permissions, and commands using variables.