### PR TITLE
[DNM] Revert "ci/cirrus: update to Go 1.17.3"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,7 @@ task:
   env:
     HOME: /root
     CIRRUS_WORKING_DIR: /home/runc
-    GO_VERSION: "1.17.3"
+    GO_VERSION: "1.16.6"
     BATS_VERSION: "v1.3.0"
     # yamllint disable rule:key-duplicates
     matrix:


### PR DESCRIPTION
Debugging https://github.com/opencontainers/runc/issues/3266

This reverts commit 12a36265c00babbcf40f2b8ddae1f377f4a209f9.