### PR TITLE
libct: wrap more unix errors

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"unsafe"
 
@@ -377,7 +378,7 @@ func setupUser(config *initConfig) error {
 	if allowSupGroups {
 		suppGroups := append(execUser.Sgids, addGroups...)
 		if err := unix.Setgroups(suppGroups); err != nil {
-			return err
+			return &os.SyscallError{Syscall: "setgroups", Err: err}
 		}
 	}
 
@@ -403,7 +404,7 @@ func setupUser(config *initConfig) error {
 func fixStdioPermissions(config *initConfig, u *user.ExecUser) error {
 	var null unix.Stat_t
 	if err := unix.Stat("/dev/null", &null); err != nil {
-		return err
+		return &os.PathError{Op: "stat", Path: "/dev/null", Err: err}
 	}
 	for _, fd := range []uintptr{
 		os.Stdin.Fd(),
@@ -412,7 +413,7 @@ func fixStdioPermissions(config *initConfig, u *user.ExecUser) error {
 	} {
 		var s unix.Stat_t
 		if err := unix.Fstat(int(fd), &s); err != nil {
-			return err
+			return &os.PathError{Op: "fstat", Path: "fd " + strconv.Itoa(int(fd)), Err: err}
 		}
 
 		// Skip chown of /dev/null if it was used as one of the STDIO fds.
@@ -438,7 +439,7 @@ func fixStdioPermissions(config *initConfig, u *user.ExecUser) error {
 			if err == unix.EINVAL || err == unix.EPERM {
 				continue
 			}
-			return err
+			return &os.PathError{Op: "fchown", Path: "fd " + strconv.Itoa(int(fd)), Err: err}
 		}
 	}
 	return nil
@@ -518,7 +519,7 @@ func isWaitable(pid int) (bool, error) {
 	si := &siginfo{}
 	_, _, e := unix.Syscall6(unix.SYS_WAITID, _P_PID, uintptr(pid), uintptr(unsafe.Pointer(si)), unix.WEXITED|unix.WNOWAIT|unix.WNOHANG, 0, 0)
 	if e != 0 {
-		return false, os.NewSyscallError("waitid", e)
+		return false, &os.SyscallError{Syscall: "waitid", Err: e}
 	}
 
 	return si.si_pid != 0, nil

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -793,7 +793,7 @@ func (p *Process) InitializeIO(rootuid, rootgid int) (i *IO, err error) {
 	// change ownership of the pipes in case we are in a user namespace
 	for _, fd := range fds {
 		if err := unix.Fchown(int(fd), rootuid, rootgid); err != nil {
-			return nil, err
+			return nil, &os.PathError{Op: "fchown", Path: "fd " + strconv.Itoa(int(fd)), Err: err}
 		}
 	}
 	return i, nil


### PR DESCRIPTION
When I tried to start a rootless container under a different/wrong user,
I got:
```console
$ ../runc/runc --systemd-cgroup --root /tmp/runc.$$ run 445
ERRO[0000] runc run failed: operation not permitted
```
This is obviously not good enough. With this commit, the error is:
```console
ERRO[0000] runc run failed: fchown fd 9: operation not permitted
```
Alas, there are still some code that returns unwrapped errnos from
various unix calls.

This is a followup to commit d8ba4128b299a8 (part of PR #3011) which wrapped
many, but not all, bare unix errors. Do wrap some more, using either os.PathError
or os.SyscallError.

While at it,
 - use os.SyscallError instead of os.NewSyscallError;
 - use errors.Is(err, os.ErrXxx) instead of os.IsXxx(err).

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>