### PR TITLE
Vagrantfile.fedora: exclude systemd from upgrade

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,7 +46,7 @@ task:
   vagrant_up_script: |
     ln -sf Vagrantfile.$DISTRO Vagrantfile
     # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
-    vagrant up || vagrant up
+    vagrant up --no-tty || vagrant up --no-tty
     mkdir -p -m 0700 /root/.ssh
     vagrant ssh-config >> /root/.ssh/config
   guest_info_script: |

--- a/Vagrantfile.fedora
+++ b/Vagrantfile.fedora
@@ -17,8 +17,14 @@ Vagrant.configure("2") do |config|
     # Work around dnf mirror failures by retrying a few times
     for i in $(seq 0 2); do
       sleep $i
-      cat << EOF | dnf -y shell && break
-config exclude kernel,kernel-core
+      # 1. "config exclude" dnf shell command is not working in Fedora 35
+      # (see https://bugzilla.redhat.com/show_bug.cgi?id=2022571);
+      # the workaround is to specify it as an option.
+      # 2. systemd 249.6-2.fc35 has a bug preventing rootless containers
+      # from starting when --systemd-cgroup is used for runc run
+      # (see https://bugzilla.redhat.com/show_bug.cgi?id=2022041),
+      # the workaround is not to upgrade systemd.
+      cat << EOF | dnf -y --exclude=kernel,kernel-core,systemd,systemd-* shell && break
 config install_weak_deps false
 update
 install iptables gcc make golang-go glibc-static libseccomp-devel bats jq git-core criu


### PR DESCRIPTION
A bug in systemd-249.6-2.fc35.x86_64 prevents rootless containers from
start when systemd manager is used (see https://bugzilla.redhat.com/show_bug.cgi?id=2022571).

A possible workaround is to exclude the package from the update list;
unfortunately this revealed another bug: "config exclude" is not working
in dnf shell (see https://bugzilla.redhat.com/show_bug.cgi?id=2022041).
A workaround to that is specify excludes as an option.

This should fix our CI for the time being.

Fixes: #3266