### PR TITLE
Fix failure with read-only /dev in spec

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -164,15 +164,16 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds []int) (err
 // finalizeRootfs sets anything to ro if necessary. You must call
 // prepareRootfs first.
 func finalizeRootfs(config *configs.Config) (err error) {
-	// remount dev as ro if specified
+	// All tmpfs mounts and /dev were previously mounted as rw
+	// by mountPropagate. Remount them read-only as requested.
 	for _, m := range config.Mounts {
-		if utils.CleanPath(m.Destination) == "/dev" {
-			if m.Flags&unix.MS_RDONLY == unix.MS_RDONLY {
-				if err := remountReadonly(m); err != nil {
-					return err
-				}
+		if m.Flags&unix.MS_RDONLY != unix.MS_RDONLY {
+			continue
+		}
+		if m.Device == "tmpfs" || utils.CleanPath(m.Destination) == "/dev" {
+			if err := remountReadonly(m); err != nil {
+				return err
 			}
-			break
 		}
 	}
 
@@ -449,12 +450,6 @@ func mountToRootfs(m *configs.Mount, c *mountConfig) error {
 
 		if stat != nil {
 			if err = os.Chmod(dest, stat.Mode()); err != nil {
-				return err
-			}
-		}
-		// Initially mounted rw in mountPropagate, remount to ro if flag set.
-		if m.Flags&unix.MS_RDONLY != 0 {
-			if err := remount(m, rootfs, mountFd); err != nil {
 				return err
 			}
 		}
@@ -1077,10 +1072,10 @@ func mountPropagate(m *configs.Mount, rootfs string, mountLabel string, mountFd 
 		flags = m.Flags
 	)
 	// Delay mounting the filesystem read-only if we need to do further
-	// operations on it. We need to set up files in "/dev" and tmpfs mounts may
-	// need to be chmod-ed after mounting. The mount will be remounted ro later
-	// in finalizeRootfs() if necessary.
-	if utils.CleanPath(m.Destination) == "/dev" || m.Device == "tmpfs" {
+	// operations on it. We need to set up files in "/dev", and other tmpfs
+	// mounts may need to be chmod-ed after mounting. These mounts will be
+	// remounted ro later in finalizeRootfs(), if necessary.
+	if m.Device == "tmpfs" || utils.CleanPath(m.Destination) == "/dev" {
 		flags &= ^unix.MS_RDONLY
 	}
 

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -23,6 +23,7 @@ function teardown() {
 	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
 }
 
+# https://github.com/opencontainers/runc/issues/2246
 @test "runc run [ro tmpfs mount]" {
 	update_config '	  .mounts += [{
 					source: "tmpfs",

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -38,6 +38,16 @@ function teardown() {
 	[[ "${lines[0]}" == *'ro,'* ]]
 }
 
+# https://github.com/opencontainers/runc/issues/3248
+@test "runc run [ro /dev mount]" {
+	update_config '   .mounts |= map((select(.destination == "/dev") | .options += ["ro"]) // .)
+			| .process.args |= ["grep", "^tmpfs /dev", "/proc/mounts"]'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == *'ro,'* ]]
+}
+
 # https://github.com/opencontainers/runc/issues/2683
 @test "runc run [tmpfs mount with absolute symlink]" {
 	# in container, /conf -> /real/conf


### PR DESCRIPTION
Commit fb4c27c4b79c7d (PR #2570, went into v1.0.0-rc93) fixed a bug with
read-only tmpfs, but introduced a bug with read-only /dev (#3248).

This happens because /dev is a tmpfs mount and is therefore remounted
read-only a bit earlier than before.

To fix,

1. Revert the part of the above commit which remounts all tmpfs mounts
   as read-only in mountToRootfs.

2. Reuse finalizeRootfs (which is already used to remount /dev
   read-only) to also remount all ro tmpfs mounts that were previously
   mounted rw in mountPropagate.

Add a test case to validate the fix and prevent future regressions;
make sure it fails before the fix:
```
 ✗ runc run [ro /dev mount]
   (in test file tests/integration/mounts.bats, line 45)
     `[ "$status" -eq 0 ]' failed
   runc spec (status=0):

   runc run test_busybox (status=1):
   time="2021-11-12T12:19:48-08:00" level=error msg="runc run failed: unable to start container process: error during container init: error mounting \"devpts\" to rootfs at \"/dev/pts\": mkdir /tmp/bats-run-VJXQk7/runc.0Fj70w/bundle/rootfs/dev/pts: read-only file system"
```
Fixes: #3248

1.0 backport: #3277