### PR TITLE
libct/specconv: reduce init allocations, use global maps, refactor

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -781,6 +781,7 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 		data     []string
 		extFlags int
 	)
+	initMaps()
 	flags := map[string]struct {
 		clear bool
 		flag  int
@@ -819,16 +820,6 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 		"suid":          {true, unix.MS_NOSUID},
 		"sync":          {false, unix.MS_SYNCHRONOUS},
 	}
-	propagationFlags := map[string]int{
-		"private":     unix.MS_PRIVATE,
-		"shared":      unix.MS_SHARED,
-		"slave":       unix.MS_SLAVE,
-		"unbindable":  unix.MS_UNBINDABLE,
-		"rprivate":    unix.MS_PRIVATE | unix.MS_REC,
-		"rshared":     unix.MS_SHARED | unix.MS_REC,
-		"rslave":      unix.MS_SLAVE | unix.MS_REC,
-		"runbindable": unix.MS_UNBINDABLE | unix.MS_REC,
-	}
 	extensionFlags := map[string]struct {
 		clear bool
 		flag  int
@@ -845,7 +836,7 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 			} else {
 				flag |= f.flag
 			}
-		} else if f, exists := propagationFlags[o]; exists && f != 0 {
+		} else if f, exists := mountPropagationMapping[o]; exists && f != 0 {
 			pgflag = append(pgflag, f)
 		} else if f, exists := extensionFlags[o]; exists && f.flag != 0 {
 			if f.clear {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -411,8 +410,21 @@ func createLibcontainerMount(cwd string, m specs.Mount) (*configs.Mount, error) 
 	return mnt, nil
 }
 
-// systemd property name check: latin letters only, at least 3 of them
-var isValidName = regexp.MustCompile(`^[a-zA-Z]{3,}$`).MatchString
+// isValidName checks if systemd property name is valid. It should consists
+// of latin letters only, and have least 3 of them.
+func isValidName(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	// Check ASCII characters rather than Unicode runes.
+	for _, ch := range s {
+		if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
+			continue
+		}
+		return false
+	}
+	return true
+}
 
 // Some systemd properties are documented as having "Sec" suffix
 // (e.g. TimeoutStopSec) but are expected to have "USec" suffix

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -26,9 +26,13 @@ import (
 )
 
 var (
-	initMapsOnce            sync.Once
-	namespaceMapping        map[specs.LinuxNamespaceType]configs.NamespaceType
-	mountPropagationMapping map[string]int
+	initMapsOnce               sync.Once
+	namespaceMapping           map[specs.LinuxNamespaceType]configs.NamespaceType
+	mountPropagationMapping    map[string]int
+	mountFlags, extensionFlags map[string]struct {
+		clear bool
+		flag  int
+	}
 )
 
 func initMaps() {
@@ -53,6 +57,51 @@ func initMaps() {
 			"runbindable": unix.MS_UNBINDABLE | unix.MS_REC,
 			"unbindable":  unix.MS_UNBINDABLE,
 			"":            0,
+		}
+
+		mountFlags = map[string]struct {
+			clear bool
+			flag  int
+		}{
+			"acl":           {false, unix.MS_POSIXACL},
+			"async":         {true, unix.MS_SYNCHRONOUS},
+			"atime":         {true, unix.MS_NOATIME},
+			"bind":          {false, unix.MS_BIND},
+			"defaults":      {false, 0},
+			"dev":           {true, unix.MS_NODEV},
+			"diratime":      {true, unix.MS_NODIRATIME},
+			"dirsync":       {false, unix.MS_DIRSYNC},
+			"exec":          {true, unix.MS_NOEXEC},
+			"iversion":      {false, unix.MS_I_VERSION},
+			"lazytime":      {false, unix.MS_LAZYTIME},
+			"loud":          {true, unix.MS_SILENT},
+			"mand":          {false, unix.MS_MANDLOCK},
+			"noacl":         {true, unix.MS_POSIXACL},
+			"noatime":       {false, unix.MS_NOATIME},
+			"nodev":         {false, unix.MS_NODEV},
+			"nodiratime":    {false, unix.MS_NODIRATIME},
+			"noexec":        {false, unix.MS_NOEXEC},
+			"noiversion":    {true, unix.MS_I_VERSION},
+			"nolazytime":    {true, unix.MS_LAZYTIME},
+			"nomand":        {true, unix.MS_MANDLOCK},
+			"norelatime":    {true, unix.MS_RELATIME},
+			"nostrictatime": {true, unix.MS_STRICTATIME},
+			"nosuid":        {false, unix.MS_NOSUID},
+			"rbind":         {false, unix.MS_BIND | unix.MS_REC},
+			"relatime":      {false, unix.MS_RELATIME},
+			"remount":       {false, unix.MS_REMOUNT},
+			"ro":            {false, unix.MS_RDONLY},
+			"rw":            {true, unix.MS_RDONLY},
+			"silent":        {false, unix.MS_SILENT},
+			"strictatime":   {false, unix.MS_STRICTATIME},
+			"suid":          {true, unix.MS_NOSUID},
+			"sync":          {false, unix.MS_SYNCHRONOUS},
+		}
+		extensionFlags = map[string]struct {
+			clear bool
+			flag  int
+		}{
+			"tmpcopyup": {false, configs.EXT_COPYUP},
 		}
 	})
 }
@@ -782,55 +831,11 @@ func parseMountOptions(options []string) (int, []int, string, int) {
 		extFlags int
 	)
 	initMaps()
-	flags := map[string]struct {
-		clear bool
-		flag  int
-	}{
-		"acl":           {false, unix.MS_POSIXACL},
-		"async":         {true, unix.MS_SYNCHRONOUS},
-		"atime":         {true, unix.MS_NOATIME},
-		"bind":          {false, unix.MS_BIND},
-		"defaults":      {false, 0},
-		"dev":           {true, unix.MS_NODEV},
-		"diratime":      {true, unix.MS_NODIRATIME},
-		"dirsync":       {false, unix.MS_DIRSYNC},
-		"exec":          {true, unix.MS_NOEXEC},
-		"iversion":      {false, unix.MS_I_VERSION},
-		"lazytime":      {false, unix.MS_LAZYTIME},
-		"loud":          {true, unix.MS_SILENT},
-		"mand":          {false, unix.MS_MANDLOCK},
-		"noacl":         {true, unix.MS_POSIXACL},
-		"noatime":       {false, unix.MS_NOATIME},
-		"nodev":         {false, unix.MS_NODEV},
-		"nodiratime":    {false, unix.MS_NODIRATIME},
-		"noexec":        {false, unix.MS_NOEXEC},
-		"noiversion":    {true, unix.MS_I_VERSION},
-		"nolazytime":    {true, unix.MS_LAZYTIME},
-		"nomand":        {true, unix.MS_MANDLOCK},
-		"norelatime":    {true, unix.MS_RELATIME},
-		"nostrictatime": {true, unix.MS_STRICTATIME},
-		"nosuid":        {false, unix.MS_NOSUID},
-		"rbind":         {false, unix.MS_BIND | unix.MS_REC},
-		"relatime":      {false, unix.MS_RELATIME},
-		"remount":       {false, unix.MS_REMOUNT},
-		"ro":            {false, unix.MS_RDONLY},
-		"rw":            {true, unix.MS_RDONLY},
-		"silent":        {false, unix.MS_SILENT},
-		"strictatime":   {false, unix.MS_STRICTATIME},
-		"suid":          {true, unix.MS_NOSUID},
-		"sync":          {false, unix.MS_SYNCHRONOUS},
-	}
-	extensionFlags := map[string]struct {
-		clear bool
-		flag  int
-	}{
-		"tmpcopyup": {false, configs.EXT_COPYUP},
-	}
 	for _, o := range options {
-		// If the option does not exist in the flags table or the flag
-		// is not supported on the platform,
-		// then it is a data value for a specific fs type
-		if f, exists := flags[o]; exists && f.flag != 0 {
+		// If the option does not exist in the mountFlags table,
+		// or the flag is not supported on the platform,
+		// then it is a data value for a specific fs type.
+		if f, exists := mountFlags[o]; exists && f.flag != 0 {
 			if f.clear {
 				flag &= ^f.flag
 			} else {

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -762,6 +762,39 @@ func TestInitSystemdProps(t *testing.T) {
 	}
 }
 
+func TestIsValidName(t *testing.T) {
+	testCases := []struct {
+		in    string
+		valid bool
+	}{
+		{"", false},   // too short
+		{"xx", false}, // too short
+		{"xxx", true},
+		{"someValidName", true},
+		{"A name", false},  // space
+		{"3335", false},    // numbers
+		{"Name1", false},   // numbers
+		{"Кир", false},     // non-ascii
+		{"მადლობა", false}, // non-ascii
+		{"合い言葉", false},    // non-ascii
+	}
+
+	for _, tc := range testCases {
+		valid := isValidName(tc.in)
+		if valid != tc.valid {
+			t.Errorf("case %q: expected %v, got %v", tc.in, tc.valid, valid)
+		}
+	}
+}
+
+func BenchmarkIsValidName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, s := range []string{"", "xx", "xxx", "someValidName", "A name", "Кир", "მადლობა", "合い言葉"} {
+			_ = isValidName(s)
+		}
+	}
+}
+
 func TestNullProcess(t *testing.T) {
 	spec := Example()
 	spec.Process = nil

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -698,6 +698,11 @@ func TestInitSystemdProps(t *testing.T) {
 			exp:  expT{true, "", ""},
 		},
 		{
+			desc: "convert USec to Sec (bad variable name, no conversion)",
+			in:   inT{"org.systemd.property.FOOSec", "123"},
+			exp:  expT{false, "FOOSec", 123},
+		},
+		{
 			in:  inT{"org.systemd.property.CollectMode", "'inactive-or-failed'"},
 			exp: expT{false, "CollectMode", "inactive-or-failed"},
 		},


### PR DESCRIPTION
This is a set of improvements for libct/specconv. See individual commits for details.

The refactoring should help #3227 