### PR TITLE
[1.0] fix ci

### DIFF
--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -133,10 +133,12 @@ func testCheckpoint(t *testing.T, userns bool) {
 	ok(t, err)
 	defer remove(imagesDir)
 
+	relParentDir, err := filepath.Rel(imagesDir, parentDir)
+	ok(t, err)
 	checkpointOpts := &libcontainer.CriuOpts{
 		ImagesDirectory: imagesDir,
 		WorkDirectory:   imagesDir,
-		ParentImage:     "../criu-parent",
+		ParentImage:     relParentDir,
 	}
 	dumpLog := filepath.Join(checkpointOpts.WorkDirectory, "dump.log")
 	restoreLog := filepath.Join(checkpointOpts.WorkDirectory, "restore.log")

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -38,6 +38,10 @@ function teardown() {
 
 	update_config ' .linux.resources.devices = [{"allow": false, "access": "rwm"}]
 			| .linux.devices = [{"path": "/dev/kmsg", "type": "c", "major": 1, "minor": 11}]
+			| .process.capabilities.bounding += ["CAP_SYSLOG"]
+			| .process.capabilities.effective += ["CAP_SYSLOG"]
+			| .process.capabilities.inheritable += ["CAP_SYSLOG"]
+			| .process.capabilities.permitted += ["CAP_SYSLOG"]
 			| .process.args |= ["sh"]'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_deny
@@ -72,6 +76,10 @@ function teardown() {
 	update_config ' .linux.resources.devices = [{"allow": false, "access": "rwm"},{"allow": true, "type": "c", "major": 1, "minor": 11, "access": "rw"}]
 			| .linux.devices = [{"path": "/dev/kmsg", "type": "c", "major": 1, "minor": 11}]
 			| .process.args |= ["sh"]
+			| .process.capabilities.bounding += ["CAP_SYSLOG"]
+			| .process.capabilities.effective += ["CAP_SYSLOG"]
+			| .process.capabilities.inheritable += ["CAP_SYSLOG"]
+			| .process.capabilities.permitted += ["CAP_SYSLOG"]
 			| .hostname = "myhostname"'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_allow_char


### PR DESCRIPTION
_TL;DR: backports of #3112 and #3069 to release-1.0 branch to fix CI broken by upstream updates._

### 1. libct/int/checkpoint_test: fix ParentImage

The ParentImage set by the test should be a path relative to
ImagesDirectory, pointing to a parent images directory (created
by pre-dump).

The parent directory is created by TempDir and so its name is not
constant but has a variable suffix. So, the config was pointing to
a non-existent directory.

This left unnoticed by criu as it assumed the parent image does not
exist, and performed a full dump.

Since criu PR https://github.com/checkpoint-restore/criu/pull/1403 (will be a part of criu 3.16) that is no longer the
case -- the invalid parent path is treated as an error, and so our
test fails like this:

```
== RUN   TestCheckpoint
    checkpoint_test.go:145: === /tmp/criu070876105/dump.log ===
    checkpoint_test.go:145: open /tmp/criu070876105/dump.log: no such file or directory
    checkpoint_test.go:146: criu failed: type DUMP errno 56
        log file: /tmp/criu070876105/dump.log
--- FAIL: TestCheckpoint (0.26s)
```

Fix this by using the actual name of the parent image dir.

This fixes release-1.0 CI against criu 3.16.

Fixes: 98f004182b9a23245
Fixes: #3278

NOTE
* this is a clean backport of #3112 to release-1.0
* in master, this was fixed implicitly by https://github.com/opencontainers/runc/pull/3100/commits/3bc606e9d30e5e616e4602bd5b1b1610cc3b8fbe

### 2. tests/int/dev: add CAP_SYSLOG to /dev/kmsg tests

Add CAP_SYSLOG to ensure that /dev/kmsg can be accesses on systems where
the sysctl kernel.dmesg_restrict = 1.

(This is a backport of #3069 to release-1.0)