### PR TITLE
Avoid non-op when the list of `Hooks` is empty

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -516,7 +516,7 @@ func (p *initProcess) start() (retErr error) {
 					}
 				}
 
-				if p.config.Config.Hooks != nil {
+				if len(p.config.Config.Hooks) != 0 {
 					s, err := p.container.currentOCIState()
 					if err != nil {
 						return err
@@ -571,7 +571,7 @@ func (p *initProcess) start() (retErr error) {
 					return fmt.Errorf("error setting Intel RDT config for procHooks process: %w", err)
 				}
 			}
-			if p.config.Config.Hooks != nil {
+			if len(p.config.Config.Hooks) != 0 {
 				s, err := p.container.currentOCIState()
 				if err != nil {
 					return err


### PR DESCRIPTION
There is no need to run hooks when `Config.Hooks` is just an empty map,

(dlv) p p.config.Config.Hooks
github.com/opencontainers/runc/libcontainer/configs.Hooks []

Signed-off-by: Dave Chen <dave.chen@arm.com>