### PR TITLE
libct/standard_init: fix linter warning

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -250,8 +250,5 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	if err := system.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
-		return err
-	}
-	return nil
+	return system.Exec(name, l.config.Args[0:], os.Environ())
 }


### PR DESCRIPTION
The staticcheck linter points out that the `err != nil` comparison
after `system.Exec` is always true (see https://github.com/opencontainers/runc/runs/4248411930?check_suite_focus=true; for some reason it is only shown in there):

> libcontainer/standard_init_linux.go#L253
> SA4023: this comparison is always true (staticcheck)
> libcontainer/system/linux.go#L43
> SA4023(related information): github.com/opencontainers/runc/libcontainer/system.Exec never returns a nil interface value (staticcheck)

Indeed, Exec either returns an error or does not return at all.

Remove the (useless) check.

This should unblock #3286 