### PR TITLE
[1.0] libct/cg/fs2: fix GetStats for unsupported hugetlb

### DIFF
--- a/libcontainer/cgroups/fs2/hugetlb.go
+++ b/libcontainer/cgroups/fs2/hugetlb.go
@@ -30,10 +30,7 @@ func setHugeTlb(dirPath string, r *configs.Resources) error {
 }
 
 func statHugeTlb(dirPath string, stats *cgroups.Stats) error {
-	hugePageSizes, err := cgroups.GetHugePageSize()
-	if err != nil {
-		return errors.Wrap(err, "failed to fetch hugetlb info")
-	}
+	hugePageSizes, _ := cgroups.GetHugePageSize()
 	hugetlbStats := cgroups.HugetlbStats{}
 
 	for _, pagesize := range hugePageSizes {


### PR DESCRIPTION
Cherry-pick https://github.com/opencontainers/runc/pull/3233

(I assume cherry-picking https://github.com/opencontainers/runc/pull/3234 is not necessary)
