### PR TITLE
[1.0] Remove sub cgroup when container exits

### DIFF
--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -5,7 +5,6 @@ package systemd
 import (
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -307,9 +306,10 @@ func (m *unifiedManager) Destroy() error {
 		return err
 	}
 
-	// XXX this is probably not needed, systemd should handle it
-	err := os.Remove(m.path)
-	if err != nil && !os.IsNotExist(err) {
+	// systemd 239 do not remove sub-cgroups.
+	err := cgroups.RemovePath(m.path)
+	// cgroups.RemovePath has handled ErrNotExist
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is a backport of https://github.com/opencontainers/runc/pull/3226 to release-1.0 branch, fixing issue #3225.

Note it's not a clean backport as 1.0 lacks fsMgr field, and we do not want to instantiate one, so the commit was changed:
```diff
-       err := m.fsMgr.Destroy()
-       // fsMgr.Destroy has handled ErrNotExist
+       err := cgroups.RemovePath(m.path)
+       // cgroups.RemovePath has handled ErrNotExist
```

### Proposed changelog entry

```
Bugfixes:
* cgroup v2 systemd manager: delete sub-cgroups on cgroup delete
```