### PR TITLE
[1.0] script/release.sh: fix for opensuse

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -38,7 +38,8 @@ function build_project() {
 	tar xf "$tarball"
 	(
 		cd "libseccomp-${libseccomp_ver}"
-		./configure --prefix="$prefix" --enable-static --disable-shared
+		./configure --prefix="$prefix" --libdir="$prefix/lib" \
+			--enable-static --disable-shared
 		make install
 	)
 	mv "$tarball"{,.asc} "$builddir"


### PR DESCRIPTION
_backport of #3200 to release-1.0 branch_

openSUSE comes with site-config package, which makes configure select
${prefix}/lib64 as libdir on x86_64, unless explicitly specified.

Since release.sh relies on a particular libdir path (for pkgconfig), it
breaks things:

> + make -C /home/kir/git/runc PKG_CONFIG_PATH=/tmp/tmp.QgIJ1sR5c9/lib/pkgconfig COMMIT_NO= EXTRA_FLAGS=-a 'EXTRA_LDFLAGS=-w -s -buildid=' static
> make[1]: Entering directory '/home/kir/git/runc'
> CGO_ENABLED=1 go build -trimpath -a -tags "seccomp netgo osusergo" -ldflags "-extldflags -static -X main.gitCommit=v1.0.0-204-g963e0146 -X main.version=1.0.0+dev -w -s -buildid=" -o runc .
> Package libseccomp was not found in the pkg-config search path.
> Perhaps you should add the directory containing `libseccomp.pc'

To fix, we have to explicitly specify libdir.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit 39d0ee18e9d90da2ac876a6aa58e43041938eb7d)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>