### PR TITLE
[1.0]: ci: add go 1.17, drop go 1.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Docker/Moby still builds runc with Go 1.13, so we should still support Go 1.13.
-        go-version: [1.13.x, 1.15.x, 1.16.x]
+        go-version: [1.13.x, 1.16.x, 1.17.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
 


### PR DESCRIPTION
_This is the same as https://github.com/opencontainers/runc/pull/3021 but for release-1.0._

Add Go 1.17, grop 1.15 from CI; since 1.17 release 1.15 is unsupported.
    
Keep 1.13 in 1.0 branch, since an older version of Docker/Moby might use it.

Keep 1.16 in Dockerfile, since this is a stable branch.