### PR TITLE
libct/utils: ResolveRootfs: remove

### DIFF
--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -33,16 +33,6 @@ func init() {
 	}
 }
 
-// ResolveRootfs ensures that the current working directory is
-// not a symlink and returns the absolute path to the rootfs
-func ResolveRootfs(uncleanRootfs string) (string, error) {
-	rootfs, err := filepath.Abs(uncleanRootfs)
-	if err != nil {
-		return "", err
-	}
-	return filepath.EvalSymlinks(rootfs)
-}
-
 // ExitStatus returns the correct exit status for a process based on if it
 // was signaled or exited cleanly
 func ExitStatus(status unix.WaitStatus) int {

--- a/libcontainer/utils/utils_test.go
+++ b/libcontainer/utils/utils_test.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -27,51 +25,6 @@ func TestSearchLabels(t *testing.T) {
 		if v := SearchLabels(tt.labels, tt.query); v != tt.expectedValue {
 			t.Errorf("expected value '%s' for query '%s'; got '%s'", tt.expectedValue, tt.query, v)
 		}
-	}
-}
-
-func TestResolveRootfs(t *testing.T) {
-	dir := "rootfs"
-	if err := os.Mkdir(dir, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(dir)
-
-	path, err := ResolveRootfs(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if path != pwd+"/rootfs" {
-		t.Errorf("expected rootfs to be abs and was %s", path)
-	}
-}
-
-func TestResolveRootfsWithSymlink(t *testing.T) {
-	dir := "rootfs"
-	tmpDir, _ := filepath.EvalSymlinks(os.TempDir())
-	if err := os.Symlink(tmpDir, dir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(dir)
-
-	path, err := ResolveRootfs(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if path != tmpDir {
-		t.Errorf("expected rootfs to be the real path %s and was %s", path, os.TempDir())
-	}
-}
-
-func TestResolveRootfsWithNonExistingDir(t *testing.T) {
-	_, err := ResolveRootfs("foo")
-	if err == nil {
-		t.Error("expected error to happen but received nil")
 	}
 }
 


### PR DESCRIPTION
Since commit 8850636eb3df747f (February 2015) this function is no longer
used (replaced by (*ConfigValidator).rootfs), so let's remove it,
together with its unit tests (which were added by commit 917c1f6d6 in
April 2016).