### PR TITLE
Enable unparam linter; fix/mute existing warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,3 +9,4 @@ linters:
     - gofumpt
     - errorlint
     - unconvert
+    - unparam

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -80,7 +80,7 @@ checkpointed.`,
 func prepareImagePaths(context *cli.Context) (string, string, error) {
 	imagePath := context.String("image-path")
 	if imagePath == "" {
-		imagePath = getDefaultImagePath(context)
+		imagePath = getDefaultImagePath()
 	}
 
 	if err := os.MkdirAll(imagePath, 0o600); err != nil {

--- a/libcontainer/cgroups/devices/devices_emulator.go
+++ b/libcontainer/cgroups/devices/devices_emulator.go
@@ -139,7 +139,7 @@ func parseLine(line string) (*deviceRule, error) {
 	return &rule, nil
 }
 
-func (e *Emulator) addRule(rule deviceRule) error {
+func (e *Emulator) addRule(rule deviceRule) error { //nolint:unparam
 	if e.rules == nil {
 		e.rules = make(map[deviceMeta]devices.Permissions)
 	}

--- a/libcontainer/cgroups/ebpf/devicefilter/devicefilter.go
+++ b/libcontainer/cgroups/ebpf/devicefilter/devicefilter.go
@@ -65,8 +65,7 @@ func DeviceFilter(rules []*devices.Rule) (asm.Instructions, string, error) {
 			return nil, "", err
 		}
 	}
-	insts, err := p.finalize()
-	return insts, license, err
+	return p.finalize(), license, nil
 }
 
 type program struct {
@@ -181,7 +180,7 @@ func (p *program) appendRule(rule *devices.Rule) error {
 	return nil
 }
 
-func (p *program) finalize() (asm.Instructions, error) {
+func (p *program) finalize() asm.Instructions {
 	var v int32
 	if p.defaultAllow {
 		v = 1
@@ -193,7 +192,7 @@ func (p *program) finalize() (asm.Instructions, error) {
 		asm.Return(),
 	)
 	p.blockID = -1
-	return p.insts, nil
+	return p.insts
 }
 
 func acceptBlock(accept bool) asm.Instructions {

--- a/libcontainer/cgroups/fs/blkio_test.go
+++ b/libcontainer/cgroups/fs/blkio_test.go
@@ -164,7 +164,7 @@ type blkioStatFailureTestCase struct {
 	filename string
 }
 
-func appendBlkioStatEntry(blkioStatEntries *[]cgroups.BlkioStatEntry, major, minor, value uint64, op string) {
+func appendBlkioStatEntry(blkioStatEntries *[]cgroups.BlkioStatEntry, major, minor, value uint64, op string) { //nolint:unparam
 	*blkioStatEntries = append(*blkioStatEntries, cgroups.BlkioStatEntry{Major: major, Minor: minor, Value: value, Op: op})
 }
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -231,7 +231,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	state, err := l.loadState(containerRoot, id)
+	state, err := l.loadState(containerRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	return i.Init()
 }
 
-func (l *LinuxFactory) loadState(root, id string) (*State, error) {
+func (l *LinuxFactory) loadState(root string) (*State, error) {
 	stateFilePath, err := securejoin.SecureJoin(root, stateFilename)
 	if err != nil {
 		return nil, err

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -360,7 +360,7 @@ func setupUser(config *initConfig) error {
 
 	// Before we change to the container's user make sure that the processes
 	// STDIO is correctly owned by the user that we are switching to.
-	if err := fixStdioPermissions(config, execUser); err != nil {
+	if err := fixStdioPermissions(execUser); err != nil {
 		return err
 	}
 
@@ -401,7 +401,7 @@ func setupUser(config *initConfig) error {
 // fixStdioPermissions fixes the permissions of PID 1's STDIO within the container to the specified user.
 // The ownership needs to match because it is created outside of the container and needs to be
 // localized.
-func fixStdioPermissions(config *initConfig, u *user.ExecUser) error {
+func fixStdioPermissions(u *user.ExecUser) error {
 	var null unix.Stat_t
 	if err := unix.Stat("/dev/null", &null); err != nil {
 		return &os.PathError{Op: "stat", Path: "/dev/null", Err: err}

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -282,7 +282,7 @@ func TestSeccompPermitWriteMultipleConditions(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(t, config, "", "ls", "/")
+	buffers, exitCode, err := runContainer(t, config, "ls", "/")
 	if err != nil {
 		t.Fatalf("%s: %s", buffers, err)
 	}
@@ -331,7 +331,7 @@ func TestSeccompDenyWriteMultipleConditions(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(t, config, "", "ls", "/does_not_exist")
+	buffers, exitCode, err := runContainer(t, config, "ls", "/does_not_exist")
 	if err == nil {
 		t.Fatalf("Expecting error return, instead got 0")
 	}
@@ -375,7 +375,7 @@ func TestSeccompMultipleConditionSameArgDeniesStdout(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(t, config, "", "ls", "/")
+	buffers, exitCode, err := runContainer(t, config, "ls", "/")
 	if err != nil {
 		t.Fatalf("%s: %s", buffers, err)
 	}
@@ -417,7 +417,7 @@ func TestSeccompMultipleConditionSameArgDeniesStderr(t *testing.T) {
 		},
 	}
 
-	buffers, exitCode, err := runContainer(t, config, "", "ls", "/does_not_exist")
+	buffers, exitCode, err := runContainer(t, config, "ls", "/does_not_exist")
 	if err == nil {
 		t.Fatalf("Expecting error return, instead got 0")
 	}

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -180,7 +180,7 @@ func newContainer(t *testing.T, config *configs.Config) (libcontainer.Container,
 //
 // buffers are returned containing the STDOUT and STDERR output for the run
 // along with the exit code and any go error
-func runContainer(t *testing.T, config *configs.Config, console string, args ...string) (buffers *stdBuffers, exitCode int, err error) {
+func runContainer(t *testing.T, config *configs.Config, args ...string) (buffers *stdBuffers, exitCode int, err error) {
 	container, err := newContainer(t, config)
 	if err != nil {
 		return nil, -1, err

--- a/notify_socket.go
+++ b/notify_socket.go
@@ -43,7 +43,7 @@ func (s *notifySocket) Close() error {
 
 // If systemd is supporting sd_notify protocol, this function will add support
 // for sd_notify protocol from within the container.
-func (s *notifySocket) setupSpec(context *cli.Context, spec *specs.Spec) error {
+func (s *notifySocket) setupSpec(spec *specs.Spec) {
 	pathInContainer := filepath.Join("/run/notify", path.Base(s.socketPath))
 	mount := specs.Mount{
 		Destination: path.Dir(pathInContainer),
@@ -52,7 +52,6 @@ func (s *notifySocket) setupSpec(context *cli.Context, spec *specs.Spec) error {
 	}
 	spec.Mounts = append(spec.Mounts, mount)
 	spec.Process.Env = append(spec.Process.Env, "NOTIFY_SOCKET="+pathInContainer)
-	return nil
 }
 
 func (s *notifySocket) bindSocket() error {

--- a/tty.go
+++ b/tty.go
@@ -167,7 +167,7 @@ func (t *tty) ClosePostStart() {
 
 // Close closes all open fds for the tty and/or restores the original
 // stdin state to what it was prior to the container execution
-func (t *tty) Close() error {
+func (t *tty) Close() {
 	// ensure that our side of the fds are always closed
 	for _, c := range t.postStart {
 		_ = c.Close()
@@ -184,7 +184,6 @@ func (t *tty) Close() error {
 	if t.hostConsole != nil {
 		_ = t.hostConsole.Reset()
 	}
-	return nil
 }
 
 func (t *tty) resize() error {

--- a/tty.go
+++ b/tty.go
@@ -99,7 +99,7 @@ func (t *tty) initHostConsole() error {
 	return nil
 }
 
-func (t *tty) recvtty(process *libcontainer.Process, socket *os.File) (Err error) {
+func (t *tty) recvtty(socket *os.File) (Err error) {
 	f, err := utils.RecvFd(socket)
 	if err != nil {
 		return err

--- a/tty.go
+++ b/tty.go
@@ -63,11 +63,10 @@ func setupProcessPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, err
 	return t, nil
 }
 
-func inheritStdio(process *libcontainer.Process) error {
+func inheritStdio(process *libcontainer.Process) {
 	process.Stdin = os.Stdin
 	process.Stdout = os.Stdout
 	process.Stderr = os.Stderr
-	return nil
 }
 
 func (t *tty) initHostConsole() error {

--- a/tty.go
+++ b/tty.go
@@ -159,11 +159,10 @@ func (t *tty) waitConsole() error {
 
 // ClosePostStart closes any fds that are provided to the container and dup2'd
 // so that we no longer have copy in our process.
-func (t *tty) ClosePostStart() error {
+func (t *tty) ClosePostStart() {
 	for _, c := range t.postStart {
 		_ = c.Close()
 	}
-	return nil
 }
 
 // Close closes all open fds for the tty and/or restores the original

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -301,10 +301,7 @@ func (r *runner) run(config *specs.Process) (int, error) {
 		r.terminate(process)
 		return -1, err
 	}
-	if err = tty.ClosePostStart(); err != nil {
-		r.terminate(process)
-		return -1, err
-	}
+	tty.ClosePostStart()
 	if r.pidFile != "" {
 		if err = createPidFile(r.pidFile, process); err != nil {
 			r.terminate(process)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -66,7 +66,7 @@ func getContainer(context *cli.Context) (libcontainer.Container, error) {
 	return factory.Load(id)
 }
 
-func getDefaultImagePath(context *cli.Context) string {
+func getDefaultImagePath() string {
 	cwd, err := os.Getwd()
 	if err != nil {
 		panic(err)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -164,9 +164,7 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, det
 	// when runc will detach the caller provides the stdio to runc via runc's 0,1,2
 	// and the container's process inherits runc's stdio.
 	if detach {
-		if err := inheritStdio(process); err != nil {
-			return nil, err
-		}
+		inheritStdio(process)
 		return &tty{}, nil
 	}
 	return setupProcessPipes(process, rootuid, rootgid)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -139,7 +139,7 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, det
 			t.postStart = append(t.postStart, parent, child)
 			t.consoleC = make(chan error, 1)
 			go func() {
-				t.consoleC <- t.recvtty(process, parent)
+				t.consoleC <- t.recvtty(parent)
 			}()
 		} else {
 			// the caller of runc will handle receiving the console master

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -387,9 +387,7 @@ func startContainer(context *cli.Context, action CtAct, criuOpts *libcontainer.C
 
 	notifySocket := newNotifySocket(context, os.Getenv("NOTIFY_SOCKET"), id)
 	if notifySocket != nil {
-		if err := notifySocket.setupSpec(context, spec); err != nil {
-			return -1, err
-		}
+		notifySocket.setupSpec(spec)
 	}
 
 	container, err := createContainer(context, id, spec)


### PR DESCRIPTION
It looks like unparam is a meaningful linter.

All commits except one are small and easy to review.