### PR TITLE
ci: enable extra linters for new code

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,26 @@ jobs:
           # must be specified without patch version
           version: v1.42
 
+  lint-extra:
+    # Extra linters, only checking new code from pull requests.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - name: install deps
+        run: |
+          sudo apt -q update
+          sudo apt -q install libseccomp-dev
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          only-new-issues: true
+          args: --config .golangci-extra.yml
+          # must be specified without patch version
+          version: v1.43
+
+
   compile-buildtags:
     runs-on: ubuntu-20.04
     env:

--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -1,0 +1,15 @@
+# This is golangci-lint config file which is used to check new code in
+# github PRs only (see lint-extra job in .github/workflows/validate.yml).
+#
+# For the default linter config, see .golangci.yml. This config should
+# only enable additional linters not enabled in the default config.
+
+run:
+  build-tags:
+    - seccomp
+
+linters:
+  disable-all: true
+  enable:
+    - godot
+    - revive


### PR DESCRIPTION
This adds a new GHA CI job which runs a few extra linters. This is only
done for pull requests, and should only warn about new code.

The justification is simple: we want more linters, but since this is not
a new project, adding a new linter meaning we have to fix all the
existing warnings. In some cases having all the warnings fixed is
difficult and takes time, plus it is usually a low priority task.

Therefore, we are stuck with inability to add new linters because we
can't fix all their warnings. Meanwhile, new pull requests add more
code which is not linted.

This is an attempt to break this vicious cycle. Let's enable godot
and revive for now and see how it is going.