### PR TITLE
libct/intelrdt: remove unused type

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -197,10 +197,6 @@ var (
 	errNotFound = errors.New("Intel RDT resctrl mount point not found")
 )
 
-type intelRdtData struct {
-	config *configs.Config
-}
-
 // Check if Intel RDT sub-features are enabled in featuresInit()
 func featuresInit() {
 	initOnce.Do(func() {

--- a/libcontainer/intelrdt/intelrdt_test.go
+++ b/libcontainer/intelrdt/intelrdt_test.go
@@ -21,9 +21,9 @@ func TestIntelRdtSetL3CacheSchema(t *testing.T) {
 		"schemata": l3CacheSchemaBefore + "\n",
 	})
 
-	helper.IntelRdtData.config.IntelRdt.L3CacheSchema = l3CacheSchemeAfter
-	intelrdt := NewManager(helper.IntelRdtData.config, "", helper.IntelRdtPath)
-	if err := intelrdt.Set(helper.IntelRdtData.config); err != nil {
+	helper.config.IntelRdt.L3CacheSchema = l3CacheSchemeAfter
+	intelrdt := NewManager(helper.config, "", helper.IntelRdtPath)
+	if err := intelrdt.Set(helper.config); err != nil {
 		t.Fatal(err)
 	}
 
@@ -51,9 +51,9 @@ func TestIntelRdtSetMemBwSchema(t *testing.T) {
 		"schemata": memBwSchemaBefore + "\n",
 	})
 
-	helper.IntelRdtData.config.IntelRdt.MemBwSchema = memBwSchemeAfter
-	intelrdt := NewManager(helper.IntelRdtData.config, "", helper.IntelRdtPath)
-	if err := intelrdt.Set(helper.IntelRdtData.config); err != nil {
+	helper.config.IntelRdt.MemBwSchema = memBwSchemeAfter
+	intelrdt := NewManager(helper.config, "", helper.IntelRdtPath)
+	if err := intelrdt.Set(helper.config); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,9 +81,9 @@ func TestIntelRdtSetMemBwScSchema(t *testing.T) {
 		"schemata": memBwScSchemaBefore + "\n",
 	})
 
-	helper.IntelRdtData.config.IntelRdt.MemBwSchema = memBwScSchemeAfter
-	intelrdt := NewManager(helper.IntelRdtData.config, "", helper.IntelRdtPath)
-	if err := intelrdt.Set(helper.IntelRdtData.config); err != nil {
+	helper.config.IntelRdt.MemBwSchema = memBwScSchemeAfter
+	intelrdt := NewManager(helper.config, "", helper.IntelRdtPath)
+	if err := intelrdt.Set(helper.config); err != nil {
 		t.Fatal(err)
 	}
 
@@ -104,8 +104,8 @@ func TestApply(t *testing.T) {
 
 	const closID = "test-clos"
 
-	helper.IntelRdtData.config.IntelRdt.ClosID = closID
-	intelrdt := NewManager(helper.IntelRdtData.config, "", helper.IntelRdtPath)
+	helper.config.IntelRdt.ClosID = closID
+	intelrdt := NewManager(helper.config, "", helper.IntelRdtPath)
 	if err := intelrdt.Apply(1234); err == nil {
 		t.Fatal("unexpected success when applying pid")
 	}

--- a/libcontainer/intelrdt/util_test.go
+++ b/libcontainer/intelrdt/util_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 type intelRdtTestUtil struct {
-	// intelRdt data to use in tests
-	IntelRdtData *intelRdtData
+	config *configs.Config
 
 	// Path to the mock Intel RDT "resource control" filesystem directory
 	IntelRdtPath string
@@ -24,10 +23,8 @@ type intelRdtTestUtil struct {
 
 // Creates a new test util
 func NewIntelRdtTestUtil(t *testing.T) *intelRdtTestUtil {
-	d := &intelRdtData{
-		config: &configs.Config{
-			IntelRdt: &configs.IntelRdt{},
-		},
+	config := &configs.Config{
+		IntelRdt: &configs.IntelRdt{},
 	}
 	intelRdtRoot = t.TempDir()
 	testIntelRdtPath := filepath.Join(intelRdtRoot, "resctrl")
@@ -36,7 +33,7 @@ func NewIntelRdtTestUtil(t *testing.T) *intelRdtTestUtil {
 	if err := os.MkdirAll(testIntelRdtPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	return &intelRdtTestUtil{IntelRdtData: d, IntelRdtPath: testIntelRdtPath, t: t}
+	return &intelRdtTestUtil{config: config, IntelRdtPath: testIntelRdtPath, t: t}
 }
 
 // Write the specified contents on the mock of the specified Intel RDT "resource control" files


### PR DESCRIPTION
Since PR #2920, type `intelRdtData` is only used by tests,
and its only member is `config`.

Change the test to use config directly, and remove the type.

Partially generated by
```bash
sed -i -e 's/helper.IntelRdtData.config/helper.config/g' intelrdt_test.go
```