### PR TITLE
Mark `runc features` experimental; clarify that MountOptions does not contain `const void *data` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ WantedBy=multi-user.target
 * [Checkpoint and restore](./docs/checkpoint-restore.md)
 * [systemd cgroup driver](./docs/systemd.md)
 * [Terminals and standard IO](./docs/terminals.md)
+* [Experimental features](./docs/experimental.md)
 
 ## License
 

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,0 +1,11 @@
+# Experimental features
+
+The following features are experimental and subject to change:
+
+- The `runc features` command (since runc v1.1.0)
+
+The following features were experimental in the past:
+
+Feature                                  | Experimental release | Graduation release
+---------------------------------------- | -------------------- | ------------------
+cgroup v2                                | v1.0.0-rc91          | v1.0.0-rc93

--- a/features.go
+++ b/features.go
@@ -20,6 +20,7 @@ var featuresCommand = cli.Command{
 	Description: `Show the enabled features.
    The result is parsable as a JSON.
    See https://pkg.go.dev/github.com/opencontainers/runc/types/features for the type definition.
+   The types are experimental and subject to change.
 `,
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 0, exactArgs); err != nil {

--- a/types/features/features.go
+++ b/types/features/features.go
@@ -1,4 +1,5 @@
 // Package features provides the JSON structure that is printed by `runc features` (since runc v1.1.0).
+// The types in this package are experimental and subject to change.
 package features
 
 // Features represents the supported features of the runtime.

--- a/types/features/features.go
+++ b/types/features/features.go
@@ -16,6 +16,7 @@ type Features struct {
 
 	// MountOptions is the list of the recognized mount options, e.g., "ro".
 	// Nil value means "unknown", not "no support for any mount option".
+	// This list does not contain filesystem-specific options passed to mount(2) syscall as (const void *).
 	MountOptions []string `json:"mountOptions,omitempty"`
 
 	// Linux is specific to Linux.


### PR DESCRIPTION
- Commit 1: Mark `runc features` experimental
- Commit 2: types/features: clarify that MountOptions does not contain `const void *data` options

Follow-up to #3296 