### PR TITLE
[backport] chown cgroup to process uid in container namespace

### DIFF
--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -3,8 +3,10 @@
 package systemd
 
 import (
+	"bufio"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -291,7 +293,44 @@ func (m *unifiedManager) Apply(pid int) error {
 	if err := fs2.CreateCgroupPath(m.path, m.cgroups); err != nil {
 		return err
 	}
+
+	if c.OwnerUID != nil {
+		filesToChown, err := cgroupFilesToChown()
+		if err != nil {
+			return err
+		}
+
+		for _, v := range filesToChown {
+			err := os.Chown(m.path+"/"+v, *c.OwnerUID, -1)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
+}
+
+// The kernel exposes a list of files that should be chowned to the delegate
+// uid in /sys/kernel/cgroup/delegate.  If the file is not present
+// (Linux < 4.15), use the initial values mentioned in cgroups(7).
+func cgroupFilesToChown() ([]string, error) {
+	filesToChown := []string{"."} // the directory itself must be chowned
+	const cgroupDelegateFile = "/sys/kernel/cgroup/delegate"
+	f, err := os.Open(cgroupDelegateFile)
+	if err == nil {
+		defer f.Close()
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			filesToChown = append(filesToChown, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("error reading %s: %w", cgroupDelegateFile, err)
+		}
+	} else {
+		filesToChown = append(filesToChown, "cgroup.procs", "cgroup.subtree_control", "cgroup.threads")
+	}
+	return filesToChown, nil
 }
 
 func (m *unifiedManager) Destroy() error {

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -39,6 +39,12 @@ type Cgroup struct {
 	// derived from org.systemd.property.xxx annotations.
 	// Ignored unless systemd is used for managing cgroups.
 	SystemdProps []systemdDbus.Property `json:"-"`
+	// The host UID that should own the cgroup, or nil to accept
+	// the default ownership.  This should only be set when the
+	// cgroupfs is to be mounted read/write.
+	// Not all cgroup manager implementations support changing
+	// the ownership.
+	OwnerUID *int `json:"owner_uid,omitempty"`
 }
 
 type Resources struct {

--- a/tests/integration/cgroup_delegation.bats
+++ b/tests/integration/cgroup_delegation.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function teardown() {
+	teardown_bundle
+}
+
+function setup() {
+	requires root cgroups_v2 systemd
+
+	setup_busybox
+
+	# chown test temp dir to allow host user to read it
+	chown 100000 "$ROOT"
+
+	# chown rootfs to allow host user to mkdir mount points
+	chown 100000 "$ROOT"/bundle/rootfs
+
+	set_cgroups_path
+
+	# configure a user namespace
+	update_config '   .linux.namespaces += [{"type": "user"}]
+			| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65536}]
+			| .linux.gidMappings += [{"hostID": 100000, "containerID": 0, "size": 65536}]
+			'
+}
+
+@test "runc exec (cgroup v2, ro cgroupfs, new cgroupns) does not chown cgroup" {
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
+	[ "$status" -eq 0 ]
+
+	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
+	[ "$status" -eq 0 ]
+	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
+}
+
+@test "runc exec (cgroup v2, rw cgroupfs, inh cgroupns) does not chown cgroup" {
+	set_cgroup_mount_writable
+
+	# inherit cgroup namespace (remove cgroup from namespaces list)
+	update_config '.linux.namespaces |= map(select(.type != "cgroup"))'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
+	[ "$status" -eq 0 ]
+
+	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
+	[ "$status" -eq 0 ]
+	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
+}
+
+@test "runc exec (cgroup v2, rw cgroupfs, new cgroupns) does chown cgroup" {
+	set_cgroup_mount_writable
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
+	[ "$status" -eq 0 ]
+
+	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
+	[ "$status" -eq 0 ]
+	[ "$output" = "root" ] # /sys/fs/cgroup owned by root (of user namespace)
+}


### PR DESCRIPTION
(backport of https://github.com/opencontainers/runc/pull/3057)

Delegating cgroups to the container enables more complex workloads,
including systemd-based workloads.  The OCI runtime-spec was
recently updated to explicitly admit such delegation, through
specification of cgroup ownership semantics:

  https://github.com/opencontainers/runtime-spec/pull/1123

Pursuant to the updated OCI runtime-spec, change the ownership of
the container's cgroup directory and particular files therein, when
using cgroups v2 and when the cgroupfs is to be mounted read/write.

As a result of this change, systemd workloads can run in isolated
user namespaces on OpenShift when the sandbox's cgroupfs is mounted
read/write.

It might be possible to implement this feature in other cgroup
managers, but that work is deferred.