### PR TITLE
libct/int: minor improvements

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -74,7 +74,7 @@ function runc_spec() {
 
 # Helper function to reformat config.json file. Input uses jq syntax.
 function update_config() {
-	jq "$1" "./config.json" | awk 'BEGIN{RS="";getline<"-";print>ARGV[1]}' "./config.json"
+	jq "$@" "./config.json" | awk 'BEGIN{RS="";getline<"-";print>ARGV[1]}' "./config.json"
 }
 
 # Shortcut to add additional uids and gids, based on the values set as part of

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -14,7 +14,7 @@ IMAGES=$("${INTEGRATION_ROOT}"/get-images.sh)
 eval "$IMAGES"
 unset IMAGES
 
-RUNC="${INTEGRATION_ROOT}/../../runc"
+: "${RUNC:="${INTEGRATION_ROOT}/../../runc"}"
 RECVTTY="${INTEGRATION_ROOT}/../../contrib/cmd/recvtty/recvtty"
 SD_HELPER="${INTEGRATION_ROOT}/../../contrib/cmd/sd-helper/sd-helper"
 SECCOMP_AGENT="${INTEGRATION_ROOT}/../../contrib/cmd/seccompagent/seccompagent"
@@ -47,7 +47,7 @@ function runc() {
 	# Some debug information to make life easier. bats will only print it if the
 	# test failed, in which case the output is useful.
 	# shellcheck disable=SC2154
-	echo "runc $* (status=$status):" >&2
+	echo "$(basename "$RUNC") $* (status=$status):" >&2
 	# shellcheck disable=SC2154
 	echo "$output" >&2
 }

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -39,13 +39,13 @@ function teardown() {
 
 	create_container_hook="touch ./lib/$HOOKLIBCC.1.0.0 && mount --bind $bundle/$HOOKLIBCC.1.0.0 ./lib/$HOOKLIBCC.1.0.0"
 
-	CONFIG=$(jq --arg create_runtime_hook "$create_runtime_hook" --arg create_container_hook "$create_container_hook" '
+	# shellcheck disable=SC2016
+	update_config --arg create_runtime_hook "$create_runtime_hook" --arg create_container_hook "$create_container_hook" '
 		.hooks |= . + {"createRuntime": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_runtime_hook]}]} |
 		.hooks |= . + {"createContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", $create_container_hook]}]} |
 		.hooks |= . + {"startContainer": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", "ldconfig"]}]} |
 		.root.readonly |= false |
-		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]' "$bundle"/config.json)
-	echo "${CONFIG}" >config.json
+		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]'
 
 	runc run test_debian
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
1. tests/int: ability to specify binary

    This can be used to specify a different runc binary, for example:
    
            sudo -E RUNC=$PWD/runc.mine tests/integration/cwd.bats
    
    A different (but compatible enough) runtime also works:
    
            sudo -E RUNC=/usr/local/bin/crun tests/integration/cwd.bats

2. tests/int: use update_config in hooks test
    
    Using "$@" instead of $1 in update_config() allows us to use it from
    hooks.bats, where jq is used with more options than usual.
