### PR TITLE
RFC: Set arbitrary uid gid in user namespace

### DIFF
--- a/libcontainer/configs/config_linux.go
+++ b/libcontainer/configs/config_linux.go
@@ -26,12 +26,6 @@ func (c Config) HostUID(containerId int) (int, error) {
 	return containerId, nil
 }
 
-// HostRootUID gets the root uid for the process on host which could be non-zero
-// when user namespaces are enabled.
-func (c Config) HostRootUID() (int, error) {
-	return c.HostUID(0)
-}
-
 // HostGID gets the translated gid for the process on host which could be
 // different when user namespaces are enabled.
 func (c Config) HostGID(containerId int) (int, error) {
@@ -47,12 +41,6 @@ func (c Config) HostGID(containerId int) (int, error) {
 	}
 	// Return unchanged id.
 	return containerId, nil
-}
-
-// HostRootGID gets the root gid for the process on host which could be non-zero
-// when user namespaces are enabled.
-func (c Config) HostRootGID() (int, error) {
-	return c.HostGID(0)
 }
 
 // Utility function that gets a host ID for a container ID from user namespace map

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -232,7 +232,7 @@ func (c *linuxContainer) Start(process *Process) error {
 		return errors.New("can't start container with SkipDevices set")
 	}
 	if process.Init {
-		if err := c.createExecFifo(); err != nil {
+		if err := c.createExecFifo(process.UID, process.GID); err != nil {
 			return err
 		}
 	}
@@ -406,12 +406,12 @@ func (c *linuxContainer) Signal(s os.Signal, all bool) error {
 	return ErrNotRunning
 }
 
-func (c *linuxContainer) createExecFifo() error {
-	rootuid, err := c.Config().HostRootUID()
+func (c *linuxContainer) createExecFifo(uid int, gid int) error {
+	hostuid, err := c.Config().HostUID(uid)
 	if err != nil {
 		return err
 	}
-	rootgid, err := c.Config().HostRootGID()
+	hostgid, err := c.Config().HostGID(gid)
 	if err != nil {
 		return err
 	}
@@ -426,7 +426,7 @@ func (c *linuxContainer) createExecFifo() error {
 		return err
 	}
 	unix.Umask(oldMask)
-	return os.Chown(fifoName, rootuid, rootgid)
+	return os.Chown(fifoName, hostuid, hostgid)
 }
 
 func (c *linuxContainer) deleteExecFifo() {
@@ -556,7 +556,7 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, messageSockPa
 		}
 	}
 	_, sharePidns := nsMaps[configs.NEWPID]
-	data, err := c.bootstrapData(c.config.Namespaces.CloneFlags(), nsMaps, initStandard)
+	data, err := c.bootstrapData(c.config.Namespaces.CloneFlags(), nsMaps, initStandard, p.UID, p.GID)
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +614,7 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, messageSockP
 	}
 	// for setns process, we don't have to set cloneflags as the process namespaces
 	// will only be set via setns syscall
-	data, err := c.bootstrapData(0, state.NamespacePaths, initSetns)
+	data, err := c.bootstrapData(0, state.NamespacePaths, initSetns, -1, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -2113,7 +2113,7 @@ type netlinkError struct{ error }
 // such as one that uses nsenter package to bootstrap the container's
 // init process correctly, i.e. with correct namespaces, uid/gid
 // mapping etc.
-func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.NamespaceType]string, it initType) (_ io.Reader, Err error) {
+func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.NamespaceType]string, it initType, uid int, gid int) (_ io.Reader, Err error) {
 	// create the netlink message
 	r := nl.NewNetlinkRequest(int(InitMsg), 0)
 
@@ -2191,6 +2191,18 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 					Value: true,
 				})
 			}
+		}
+		if uid >= 0 {
+			r.AddData(&Int32msg{
+				Type:  UserUIDAttr,
+				Value: uint32(uid),
+			})
+		}
+		if gid >= 0 {
+			r.AddData(&Int32msg{
+				Type:  UserGIDAttr,
+				Value: uint32(gid),
+			})
 		}
 	}
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -660,7 +660,7 @@ func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 		Config:           c.config,
 		Args:             process.Args,
 		Env:              process.Env,
-		User:             process.User,
+		User:             fmt.Sprintf("%d:%d", process.UID, process.GID),
 		AdditionalGroups: process.AdditionalGroups,
 		Cwd:              process.Cwd,
 		Capabilities:     process.Capabilities,

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -22,6 +22,8 @@ const (
 	UidmapPathAttr   uint16 = 27288
 	GidmapPathAttr   uint16 = 27289
 	MountSourcesAttr uint16 = 27290
+	UserUIDAttr      uint16 = 27291
+	UserGIDAttr      uint16 = 27292
 )
 
 type Int32msg struct {

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -28,7 +28,8 @@ type Process struct {
 
 	// User will set the uid and gid of the executing process running inside the container
 	// local to the container's user and group configuration.
-	User string
+	UID int
+	GID int
 
 	// AdditionalGroups specifies the gids that should be added to supplementary groups
 	// in addition to those that the user belongs to.

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -938,17 +938,17 @@ func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
 			config.GidMappings = append(config.GidMappings, create(m))
 		}
 	}
-	rootUID, err := config.HostRootUID()
+	hostUID, err := config.HostUID(int(spec.Process.User.UID))
 	if err != nil {
 		return err
 	}
-	rootGID, err := config.HostRootGID()
+	hostGID, err := config.HostGID(int(spec.Process.User.GID))
 	if err != nil {
 		return err
 	}
 	for _, node := range config.Devices {
-		node.Uid = uint32(rootUID)
-		node.Gid = uint32(rootGID)
+		node.Uid = uint32(hostUID)
+		node.Gid = uint32(hostGID)
 	}
 	return nil
 }

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -81,7 +81,8 @@ func newProcess(p specs.Process) (*libcontainer.Process, error) {
 		Args: p.Args,
 		Env:  p.Env,
 		// TODO: fix libcontainer's API to better support uid/gid in a typesafe way.
-		User:            fmt.Sprintf("%d:%d", p.User.UID, p.User.GID),
+		UID:             int(p.User.UID),
+		GID:             int(p.User.GID),
 		Cwd:             p.Cwd,
 		Label:           p.SelinuxLabel,
 		NoNewPrivileges: &p.NoNewPrivileges,

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -266,11 +266,11 @@ func (r *runner) run(config *specs.Process) (int, error) {
 		}
 		process.ExtraFiles = append(process.ExtraFiles, os.NewFile(uintptr(i), "PreserveFD:"+strconv.Itoa(i)))
 	}
-	rootuid, err := r.container.Config().HostRootUID()
+	rootuid, err := r.container.Config().HostUID(int(config.User.UID))
 	if err != nil {
 		return -1, err
 	}
-	rootgid, err := r.container.Config().HostRootGID()
+	rootgid, err := r.container.Config().HostGID(int(config.User.GID))
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Currently in case of rootless scenario which implies usernamespace creation. The only one user inside user namespace which is allowed - it's root user.

But for scenarios with higher level of security hardening more fine grained restriction could be required. For example none root in user namespace.

This PR removes hardcoded 0 uid in setresuid/setuid.
It uses config.process.user.[uid|gid] as uid|gid inside usernamesace.
But using process.user. is questionable.

Since it's RFC, unit tests arn't affected.