### PR TITLE
ci: add go 1.18beta1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.0-beta1]
         rootless: ["rootless", ""]
         race: ["-race", ""]
         criu: [""]

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -338,7 +338,12 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 
 	defer func() {
 		if e := recover(); e != nil {
-			err = fmt.Errorf("panic from initialization: %w, %v", e, string(debug.Stack()))
+			if e, ok := e.(error); ok {
+				err = fmt.Errorf("panic from initialization: %w, %s", e, debug.Stack())
+			} else {
+				//nolint:errorlint // here e is not of error type
+				err = fmt.Errorf("panic from initialization: %v, %s", e, debug.Stack())
+			}
 		}
 	}()
 


### PR DESCRIPTION
Release notes: https://go.dev/blog/go1.18beta1

This is just for CI.