### PR TITLE
Refuse to build runc without nsenter

### DIFF
--- a/libcontainer/nsenter/nsenter_unsupported.go
+++ b/libcontainer/nsenter/nsenter_unsupported.go
@@ -1,4 +1,0 @@
-//go:build !linux || !cgo
-// +build !linux !cgo
-
-package nsenter


### PR DESCRIPTION
Commit 4d1d6185abda6a5d43eac75f77242488b81f8937 added this
nsenter_unsupported.go file in order for nsenter to be a valid (but
empty, non-functional) Go package on unsupported platforms.

As a result, runc can be build successfully without CGO, which results
in a non-working and hard-to-debug binary (see issue #3330).

As the functionality of being able to compile a package which is
definitely not working is questionable, and I can't think of any use
cases, let's remove the file.

With this, runc can no longer be build without CGO:

	[kir@kir-rhat runc]$ CGO_ENABLED=0 make runc
	go build -trimpath "-buildmode=pie"  -tags "seccomp" -ldflags "-X main.gitCommit=v1.0.0-452-g00f56786-dirty -X main.version=1.1.0-rc.1+dev " -o runc .
	go build github.com/opencontainers/runc/libcontainer/nsenter: build constraints exclude all Go files in /home/kir/go/src/github.com/opencontainers/runc/libcontainer/nsenter