### PR TITLE
cgroups: Check that the given blkioThrottle.Rate isn't 0

### DIFF
--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -50,23 +50,31 @@ func (s *BlkioGroup) Set(path string, r *configs.Resources) error {
 		}
 	}
 	for _, td := range r.BlkioThrottleReadBpsDevice {
-		if err := cgroups.WriteFile(path, "blkio.throttle.read_bps_device", td.String()); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(path, "blkio.throttle.read_bps_device", td.String()); err != nil {
+				return err
+			}
 		}
 	}
 	for _, td := range r.BlkioThrottleWriteBpsDevice {
-		if err := cgroups.WriteFile(path, "blkio.throttle.write_bps_device", td.String()); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(path, "blkio.throttle.write_bps_device", td.String()); err != nil {
+				return err
+			}
 		}
 	}
 	for _, td := range r.BlkioThrottleReadIOPSDevice {
-		if err := cgroups.WriteFile(path, "blkio.throttle.read_iops_device", td.String()); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(path, "blkio.throttle.read_iops_device", td.String()); err != nil {
+				return err
+			}
 		}
 	}
 	for _, td := range r.BlkioThrottleWriteIOPSDevice {
-		if err := cgroups.WriteFile(path, "blkio.throttle.write_iops_device", td.String()); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(path, "blkio.throttle.write_iops_device", td.String()); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/libcontainer/cgroups/fs2/io.go
+++ b/libcontainer/cgroups/fs2/io.go
@@ -75,23 +75,31 @@ func setIo(dirPath string, r *configs.Resources) error {
 		}
 	}
 	for _, td := range r.BlkioThrottleReadBpsDevice {
-		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("rbps")); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("rbps")); err != nil {
+				return err
+			}
 		}
 	}
 	for _, td := range r.BlkioThrottleWriteBpsDevice {
-		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("wbps")); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("wbps")); err != nil {
+				return err
+			}
 		}
 	}
 	for _, td := range r.BlkioThrottleReadIOPSDevice {
-		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("riops")); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("riops")); err != nil {
+				return err
+			}
 		}
 	}
 	for _, td := range r.BlkioThrottleWriteIOPSDevice {
-		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("wiops")); err != nil {
-			return err
+		if td.Rate != 0 {
+			if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("wiops")); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Following PR add verification to cgroup fs manager, avoid errors like `numerical result out of range` when writing cgroup file related to blkio throttle.