### PR TITLE
libct/intelrdt: explain why mountinfo is required

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -291,6 +291,8 @@ func Root() (string, error) {
 			return
 		}
 
+		// NB: ideally, we could just do statfs and RDTGROUP_SUPER_MAGIC check, but
+		// we have to parse mountinfo since we're also interested in mount options.
 		root, err := findIntelRdtMountpointDir()
 		if err != nil {
 			intelRdtRootErr = err


### PR DESCRIPTION
For the Nth time I wanted to replace parsing mountinfo with
statfs and the check for superblock magic, but it is not possible
since some code relies of mount options check which can only
be obtained via mountinfo.
    
Add a note about it.

Currently a draft, pending #3306 merge.