### PR TITLE
Minor cleanups in libcontainer and loadFactory

### DIFF
--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -48,16 +48,14 @@ func InitArgs(args ...string) func(*LinuxFactory) error {
 	}
 }
 
-// IntelRdtfs is an options func to configure a LinuxFactory to return
+// IntelRdtFs is an options func to configure a LinuxFactory to return
 // containers that use the Intel RDT "resource control" filesystem to
 // create and manage Intel RDT resources (e.g., L3 cache, memory bandwidth).
 func IntelRdtFs(l *LinuxFactory) error {
-	if !intelrdt.IsCATEnabled() && !intelrdt.IsMBAEnabled() {
-		l.NewIntelRdtManager = nil
+	if intelrdt.IsCATEnabled() || intelrdt.IsMBAEnabled() {
+		l.NewIntelRdtManager = intelrdt.NewManager
 	} else {
-		l.NewIntelRdtManager = func(config *configs.Config, id string, path string) intelrdt.Manager {
-			return intelrdt.NewManager(config, id, path)
-		}
+		l.NewIntelRdtManager = nil
 	}
 	return nil
 }

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -32,8 +32,6 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 		return nil, err
 	}
 
-	intelRdtManager := libcontainer.IntelRdtFs
-
 	// We resolve the paths for {newuidmap,newgidmap} from the context of runc,
 	// to avoid doing a path lookup in the nsexec context. TODO: The binary
 	// names are not currently configurable.
@@ -46,7 +44,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 		newgidmap = ""
 	}
 
-	return libcontainer.New(abs, intelRdtManager,
+	return libcontainer.New(abs, libcontainer.IntelRdtFs,
 		libcontainer.CriuPath(context.GlobalString("criu")),
 		libcontainer.NewuidmapPath(newuidmap),
 		libcontainer.NewgidmapPath(newgidmap))


### PR DESCRIPTION
#### libct.IntelRdtFs(): simplify

- remove unneeded wrapping func, as intelrdt.NewManager already has the correct signature.
- reverse the if/else to be clearer that either "IsCATEnabled()" and/or  "IsMBAEnabled()" need to be enabled (and to allow skipping one of those checks in the condition).


#### loadFactory(): remove unneeded intermediate variable