### PR TITLE
Fix working with read-only /dev

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -426,11 +426,12 @@ func fixStdioPermissions(u *user.ExecUser) error {
 			// If we've hit an EINVAL then s.Gid isn't mapped in the user
 			// namespace. If we've hit an EPERM then the inode's current owner
 			// is not mapped in our user namespace (in particular,
-			// privileged_wrt_inode_uidgid() has failed). In either case, we
-			// are in a configuration where it's better for us to just not
-			// touch the stdio rather than bail at this point.
+			// privileged_wrt_inode_uidgid() has failed). Read-only
+			// /dev can result in EROFS error. In any case, it's
+			// better for us to just not touch the stdio rather
+			// than bail at this point.
 
-			if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
+			if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) || errors.Is(err, unix.EROFS) {
 				continue
 			}
 			return err

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -411,12 +411,12 @@ func fixStdioPermissions(u *user.ExecUser) error {
 			return &os.PathError{Op: "fstat", Path: file.Name(), Err: err}
 		}
 
-		// Skip chown of /dev/null if it was used as one of the STDIO fds.
-		if s.Rdev == null.Rdev {
+		// Skip chown if uid is already the one we want.
+		if int(s.Uid) == u.Uid {
 			continue
 		}
 
-		// We only change the uid owner (as it is possible for the mount to
+		// We only change the uid (as it is possible for the mount to
 		// prefer a different gid, and there's no reason for us to change it).
 		// The reason why we don't just leave the default uid=X mount setup is
 		// that users expect to be able to actually use their console. Without


### PR DESCRIPTION
TL;DR: do not chown `/dev/std{in,out,err}` if there's no need; ignore EROFS when chown fails.

For the context, see https://github.com/containers/podman/pull/12954

Please review commit-by-commit.