### PR TITLE
runc list: fix race with runc delete + nits

### DIFF
--- a/list.go
+++ b/list.go
@@ -127,50 +127,51 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 
 	var s []containerState
 	for _, item := range list {
-		if item.IsDir() {
-			st, err := os.Stat(filepath.Join(absRoot, item.Name()))
-			if err != nil {
-				fatal(err)
-			}
-			// This cast is safe on Linux.
-			uid := st.Sys().(*syscall.Stat_t).Uid
-			owner, err := user.LookupUid(int(uid))
-			if err != nil {
-				owner.Name = fmt.Sprintf("#%d", uid)
-			}
-
-			container, err := factory.Load(item.Name())
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "load container %s: %v\n", item.Name(), err)
-				continue
-			}
-			containerStatus, err := container.Status()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "status for %s: %v\n", item.Name(), err)
-				continue
-			}
-			state, err := container.State()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "state for %s: %v\n", item.Name(), err)
-				continue
-			}
-			pid := state.BaseState.InitProcessPid
-			if containerStatus == libcontainer.Stopped {
-				pid = 0
-			}
-			bundle, annotations := utils.Annotations(state.Config.Labels)
-			s = append(s, containerState{
-				Version:        state.BaseState.Config.Version,
-				ID:             state.BaseState.ID,
-				InitProcessPid: pid,
-				Status:         containerStatus.String(),
-				Bundle:         bundle,
-				Rootfs:         state.BaseState.Config.Rootfs,
-				Created:        state.BaseState.Created,
-				Annotations:    annotations,
-				Owner:          owner.Name,
-			})
+		if !item.IsDir() {
+			continue
 		}
+		st, err := os.Stat(filepath.Join(absRoot, item.Name()))
+		if err != nil {
+			fatal(err)
+		}
+		// This cast is safe on Linux.
+		uid := st.Sys().(*syscall.Stat_t).Uid
+		owner, err := user.LookupUid(int(uid))
+		if err != nil {
+			owner.Name = fmt.Sprintf("#%d", uid)
+		}
+
+		container, err := factory.Load(item.Name())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load container %s: %v\n", item.Name(), err)
+			continue
+		}
+		containerStatus, err := container.Status()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "status for %s: %v\n", item.Name(), err)
+			continue
+		}
+		state, err := container.State()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "state for %s: %v\n", item.Name(), err)
+			continue
+		}
+		pid := state.BaseState.InitProcessPid
+		if containerStatus == libcontainer.Stopped {
+			pid = 0
+		}
+		bundle, annotations := utils.Annotations(state.Config.Labels)
+		s = append(s, containerState{
+			Version:        state.BaseState.Config.Version,
+			ID:             state.BaseState.ID,
+			InitProcessPid: pid,
+			Status:         containerStatus.String(),
+			Bundle:         bundle,
+			Rootfs:         state.BaseState.Config.Rootfs,
+			Created:        state.BaseState.Created,
+			Annotations:    annotations,
+			Owner:          owner.Name,
+		})
 	}
 	return s, nil
 }

--- a/list.go
+++ b/list.go
@@ -130,8 +130,12 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 		if !item.IsDir() {
 			continue
 		}
-		st, err := os.Stat(filepath.Join(absRoot, item.Name()))
+		st, err := item.Info()
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// Possible race with runc delete.
+				continue
+			}
 			fatal(err)
 		}
 		// This cast is safe on Linux.


### PR DESCRIPTION
It is possible that parallel execution of `runc list` with `runc delete` will result in `runc list` fatal failure. Fix this.

Bonus: some refactoring.

Please review with --ignore-all-space ("Hide whitespace" checked on GH).