### PR TITLE
runc: remove --criu option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+ * `runc` option `--criu` is now ignored (with a warning), and the option will
+   be removed entirely in a future release. Users who need a non-standard
+   `criu` binary should rely on the standard way of looking up binaries in
+   `$PATH`. (#3316)
+
 ### Changed
 
  * When Intel RDT feature is not available, its initialization is skipped,

--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -231,12 +231,11 @@ _runc_runc() {
 		--log
 		--log-format
 		--root
-		--criu
 		--rootless
 	"
 
 	case "$prev" in
-	--log | --root | --criu)
+	--log | --root)
 		case "$cur" in
 		*:*) ;; # TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)
 		'')

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -45,7 +45,6 @@ type linuxContainer struct {
 	initArgs             []string
 	initProcess          parentProcess
 	initProcessStartTime uint64
-	criuPath             string
 	newuidmapPath        string
 	newgidmapPath        string
 	m                    sync.Mutex
@@ -829,7 +828,6 @@ func (c *linuxContainer) checkCriuVersion(minVersion int) error {
 	}
 
 	criu := criu.MakeCriu()
-	criu.SetCriuPath(c.criuPath)
 	var err error
 	c.criuVersion, err = criu.GetCriuVersion()
 	if err != nil {
@@ -1602,13 +1600,12 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 	criuServer := os.NewFile(uintptr(fds[1]), "criu-transport-server")
 	defer criuServer.Close()
 
-	args := []string{"swrk", "3"}
 	if c.criuVersion != 0 {
 		// If the CRIU Version is still '0' then this is probably
 		// the initial CRIU run to detect the version. Skip it.
-		logrus.Debugf("Using CRIU %d at: %s", c.criuVersion, c.criuPath)
+		logrus.Debugf("Using CRIU %d", c.criuVersion)
 	}
-	cmd := exec.Command(c.criuPath, args...)
+	cmd := exec.Command("criu", "swrk", "3")
 	if process != nil {
 		cmd.Stdin = process.Stdin
 		cmd.Stdout = process.Stdout

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -76,15 +76,6 @@ func TmpfsRoot(l *LinuxFactory) error {
 	return nil
 }
 
-// CriuPath returns an option func to configure a LinuxFactory with the
-// provided criupath
-func CriuPath(criupath string) func(*LinuxFactory) error {
-	return func(l *LinuxFactory) error {
-		l.CriuPath = criupath
-		return nil
-	}
-}
-
 // New returns a linux based container factory based in the root directory and
 // configures the factory with the provided option funcs.
 func New(root string, options ...func(*LinuxFactory) error) (Factory, error) {
@@ -98,7 +89,6 @@ func New(root string, options ...func(*LinuxFactory) error) (Factory, error) {
 		InitPath:  "/proc/self/exe",
 		InitArgs:  []string{os.Args[0], "init"},
 		Validator: validate.New(),
-		CriuPath:  "criu",
 	}
 
 	for _, opt := range options {
@@ -124,10 +114,6 @@ type LinuxFactory struct {
 	// InitArgs are arguments for calling the init responsibilities for spawning
 	// a container.
 	InitArgs []string
-
-	// CriuPath is the path to the criu binary used for checkpoint and restore of
-	// containers.
-	CriuPath string
 
 	// New{u,g}idmapPath is the path to the binaries used for mapping with
 	// rootless containers.
@@ -204,7 +190,6 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		config:        config,
 		initPath:      l.InitPath,
 		initArgs:      l.InitArgs,
-		criuPath:      l.CriuPath,
 		newuidmapPath: l.NewuidmapPath,
 		newgidmapPath: l.NewgidmapPath,
 		cgroupManager: cm,
@@ -248,7 +233,6 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		config:               &state.Config,
 		initPath:             l.InitPath,
 		initArgs:             l.InitArgs,
-		criuPath:             l.CriuPath,
 		newuidmapPath:        l.NewuidmapPath,
 		newgidmapPath:        l.NewgidmapPath,
 		cgroupManager:        cm,

--- a/main.go
+++ b/main.go
@@ -101,9 +101,9 @@ func main() {
 			Usage: "root directory for storage of container state (this should be located in tmpfs)",
 		},
 		cli.StringFlag{
-			Name:  "criu",
-			Value: "criu",
-			Usage: "path to the criu binary used for checkpoint and restore",
+			Name:   "criu",
+			Usage:  "(obsoleted; do not use)",
+			Hidden: true,
 		},
 		cli.BoolFlag{
 			Name:  "systemd-cgroup",
@@ -150,6 +150,10 @@ func main() {
 		}
 		if err := reviseRootDir(context); err != nil {
 			return err
+		}
+		// TODO: remove this in runc 1.3.0.
+		if context.IsSet("criu") {
+			fmt.Fprintln(os.Stderr, "WARNING: --criu ignored (criu binary from $PATH is used); do not use")
 		}
 
 		return configLogrus(context)

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -110,10 +110,6 @@ These options can be used with any command, and must precede the **command**.
 located on tmpfs. Default is */run/runc*, or *$XDG_RUNTIME_DIR/runc* for
 rootless containers.
 
-**--criu** _path_
-: Set the path to the **criu**(8) binary used for checkpoint and restore.
-Default is **criu**.
-
 **--systemd-cgroup**
 : Enable systemd cgroup support. If this is set, the container spec
 (_config.json_) is expected to have **cgroupsPath** value in the

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -23,8 +23,8 @@ SECCOMP_AGENT="${INTEGRATION_ROOT}/../../contrib/cmd/seccompagent/seccompagent"
 # shellcheck disable=SC2034
 TESTDATA="${INTEGRATION_ROOT}/testdata"
 
-# CRIU PATH
-CRIU="$(which criu 2>/dev/null || true)"
+# Whether we have criu binary.
+command -v criu &>/dev/null && HAVE_CRIU=yes
 
 # Kernel version
 KERNEL_VERSION="$(uname -r)"
@@ -350,7 +350,7 @@ function requires() {
 		local skip_me
 		case $var in
 		criu)
-			if [ ! -e "$CRIU" ]; then
+			if [ -n "$HAVE_CRIU" ]; then
 				skip_me=1
 			fi
 			;;

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -47,7 +47,6 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	}
 
 	return libcontainer.New(abs, intelRdtManager,
-		libcontainer.CriuPath(context.GlobalString("criu")),
 		libcontainer.NewuidmapPath(newuidmap),
 		libcontainer.NewgidmapPath(newgidmap))
 }


### PR DESCRIPTION
This was introduced in an initial commit, back in the day when criu was
a highly experimental thing. Today it's not; most users who need it have
it packaged by their distro vendor.

The usual way to run a binary is to look it up in directories listed in
$PATH. This is flexible enough and allows for multiple scenarios (custom
binaries, extra binaries, etc.). This is the way criu should be run.

Make `--criu` a hidden option (thus removing it from help). Remove the
option from man pages, integration tests, etc. Remove all traces of
CriuPath from data structures.

Add a warning that `--criu` is ignored and will be removed.

_This used to be part of #3316._