### PR TITLE
libct/cg/sd: simplify DetectUserDbusSessionBusAddress

### DIFF
--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -77,9 +77,8 @@ func DetectUID() (int, error) {
 	return -1, errors.New("could not detect the OwnerUID")
 }
 
-// DetectUserDbusSessionBusAddress returns $DBUS_SESSION_BUS_ADDRESS if set.
-// Otherwise returns "unix:path=$XDG_RUNTIME_DIR/bus" if $XDG_RUNTIME_DIR/bus exists.
-// Otherwise parses the value from `systemctl --user show-environment` .
+// DetectUserDbusSessionBusAddress returns $DBUS_SESSION_BUS_ADDRESS, if set.
+// Otherwise it returns "unix:path=$XDG_RUNTIME_DIR/bus", if $XDG_RUNTIME_DIR/bus exists.
 func DetectUserDbusSessionBusAddress() (string, error) {
 	if env := os.Getenv("DBUS_SESSION_BUS_ADDRESS"); env != "" {
 		return env, nil
@@ -91,16 +90,5 @@ func DetectUserDbusSessionBusAddress() (string, error) {
 			return busAddress, nil
 		}
 	}
-	b, err := exec.Command("systemctl", "--user", "--no-pager", "show-environment").CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("could not execute `systemctl --user --no-pager show-environment` (output=%q): %w", string(b), err)
-	}
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	for scanner.Scan() {
-		s := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(s, "DBUS_SESSION_BUS_ADDRESS=") {
-			return strings.TrimPrefix(s, "DBUS_SESSION_BUS_ADDRESS="), nil
-		}
-	}
-	return "", errors.New("could not detect DBUS_SESSION_BUS_ADDRESS from `systemctl --user --no-pager show-environment`. Make sure you have installed the dbus-user-session or dbus-daemon package and then run: `systemctl --user start dbus`")
+	return "", errors.New("could not detect DBUS_SESSION_BUS_ADDRESS from the environment; make sure you have installed the dbus-user-session or dbus-daemon package; note you may need to re-login")
 }

--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -87,7 +87,7 @@ func DetectUserDbusSessionBusAddress() (string, error) {
 	if xdr := os.Getenv("XDG_RUNTIME_DIR"); xdr != "" {
 		busPath := filepath.Join(xdr, "bus")
 		if _, err := os.Stat(busPath); err == nil {
-			busAddress := "unix:path=" + busPath
+			busAddress := "unix:path=" + dbus.EscapeBusAddressValue(busPath)
 			return busAddress, nil
 		}
 	}


### PR DESCRIPTION
1. Properly escape the value of dbus address spec.

2. Remove using `systemctl --user --no-pager show-environment` because:
      - is does the same thing we do (get address from `DBUS_SESSION_BUS_ADDRESS` or try to construct it from `XDG_RUNTIME_DIR`);
      - it fails when both those variables are unset:

	$ echo $DBUS_SESSION_BUS_ADDRESS, $XDG_RUNTIME_DIR
	unix:path=/run/user/1000/bus, /run/user/1000
	$ systemctl --user --no-pager show-environment | grep DBUS_SESS
	DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
	$ unset DBUS_SESSION_BUS_ADDRESS
	$ systemctl --user --no-pager show-environment | grep DBUS_SESS
	DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
	$ unset XDG_RUNTIME_DIR
	$ systemctl --user --no-pager show-environment | grep DBUS_SESS
	Failed to connect to bus: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined (consider using --machine=<user>@.host --user to connect to bus of other user)

3. Since it does not make sense to suggest `systemctl --user start dbus`
if the proper environment is not set, remove that suggestion from the error
message text. Since `DBUS_SESSION_BUS_ADDRESS` environment variable
is set by dbus-run-session (or dbus-launch, or something similar that is
supposed to be run during the login process), add a suggestion to
re-login.