### PR TITLE
libct/cg/sd: optimize and test findDeviceGroup

### DIFF
--- a/libcontainer/cgroups/devices/systemd_test.go
+++ b/libcontainer/cgroups/devices/systemd_test.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -238,6 +239,32 @@ func TestSkipDevicesFalse(t *testing.T) {
 		"/dev/full: Operation not permitted",
 		"cat: /dev/null: Operation not permitted",
 	})
+}
+
+func testFindDeviceGroup() error {
+	const (
+		major = 136
+		group = "char-pts"
+	)
+	res, err := findDeviceGroup(devices.CharDevice, major)
+	if res != group || err != nil {
+		return fmt.Errorf("expected %v, nil, got %v, %w", group, res, err)
+	}
+	return nil
+}
+
+func TestFindDeviceGroup(t *testing.T) {
+	if err := testFindDeviceGroup(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func BenchmarkFindDeviceGroup(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		if err := testFindDeviceGroup(); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 func newManager(t *testing.T, config *configs.Cgroup) (m cgroups.Manager) {


### PR DESCRIPTION
~~_This includes/depends on #3356, draft until merged._~~

1. Using strings.TrimPrefix instead of fmt.Sscanf.

2. Add a test case and a benchmark.

The benchmark shows some improvement, compared to the old
implementation:
```
    name               old time/op    new time/op    delta
    FindDeviceGroup-4    39.7µs ± 2%    26.8µs ± 2%  -32.63%  (p=0.008 n=5+5)
    
    name               old alloc/op   new alloc/op   delta
    FindDeviceGroup-4    6.08kB ± 0%    4.23kB ± 0%  -30.39%  (p=0.008 n=5+5)
    
    name               old allocs/op  new allocs/op  delta
    FindDeviceGroup-4       117 ± 0%         6 ± 0%  -94.87%  (p=0.008 n=5+5)

```