### PR TITLE
Support fetching PSI stats for cgroupv2 containers

### DIFF
--- a/events.go
+++ b/events.go
@@ -111,6 +111,13 @@ information is displayed once every 5 seconds.`,
 	},
 }
 
+func convertPSI(from *cgroups.PSIData, to *types.PSIData) {
+	to.Avg10 = from.Avg10
+	to.Avg60 = from.Avg60
+	to.Avg300 = from.Avg300
+	to.Total = from.Total
+}
+
 func convertLibcontainerStats(ls *libcontainer.Stats) *types.Stats {
 	cg := ls.CgroupStats
 	if cg == nil {
@@ -129,6 +136,8 @@ func convertLibcontainerStats(ls *libcontainer.Stats) *types.Stats {
 	s.CPU.Throttling.Periods = cg.CpuStats.ThrottlingData.Periods
 	s.CPU.Throttling.ThrottledPeriods = cg.CpuStats.ThrottlingData.ThrottledPeriods
 	s.CPU.Throttling.ThrottledTime = cg.CpuStats.ThrottlingData.ThrottledTime
+	convertPSI(&cg.CpuStats.PSI.Some, &s.CPU.PSI.Some)
+	convertPSI(&cg.CpuStats.PSI.Full, &s.CPU.PSI.Full)
 
 	s.CPUSet = types.CPUSet(cg.CPUSetStats)
 
@@ -138,6 +147,8 @@ func convertLibcontainerStats(ls *libcontainer.Stats) *types.Stats {
 	s.Memory.Swap = convertMemoryEntry(cg.MemoryStats.SwapUsage)
 	s.Memory.Usage = convertMemoryEntry(cg.MemoryStats.Usage)
 	s.Memory.Raw = cg.MemoryStats.Stats
+	convertPSI(&cg.MemoryStats.PSI.Some, &s.Memory.PSI.Some)
+	convertPSI(&cg.MemoryStats.PSI.Full, &s.Memory.PSI.Full)
 
 	s.Blkio.IoServiceBytesRecursive = convertBlkioEntry(cg.BlkioStats.IoServiceBytesRecursive)
 	s.Blkio.IoServicedRecursive = convertBlkioEntry(cg.BlkioStats.IoServicedRecursive)
@@ -147,6 +158,8 @@ func convertLibcontainerStats(ls *libcontainer.Stats) *types.Stats {
 	s.Blkio.IoMergedRecursive = convertBlkioEntry(cg.BlkioStats.IoMergedRecursive)
 	s.Blkio.IoTimeRecursive = convertBlkioEntry(cg.BlkioStats.IoTimeRecursive)
 	s.Blkio.SectorsRecursive = convertBlkioEntry(cg.BlkioStats.SectorsRecursive)
+	convertPSI(&cg.BlkioStats.PSI.Some, &s.Blkio.PSI.Some)
+	convertPSI(&cg.BlkioStats.PSI.Full, &s.Blkio.PSI.Full)
 
 	s.Hugetlb = make(map[string]types.Hugetlb)
 	for k, v := range cg.HugetlbStats {

--- a/libcontainer/cgroups/fs2/psi.go
+++ b/libcontainer/cgroups/fs2/psi.go
@@ -1,0 +1,78 @@
+package fs2
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+func statPSI(dirPath string, file string, stats *cgroups.PSIStats) error {
+	f, err := cgroups.OpenFile(dirPath, file, os.O_RDONLY)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		parts := strings.Fields(sc.Text())
+		switch parts[0] {
+		case "some":
+			data, err := parsePSIData(parts[1:])
+			if err != nil {
+				return err
+			}
+			stats.Some = data
+		case "full":
+			data, err := parsePSIData(parts[1:])
+			if err != nil {
+				return err
+			}
+			stats.Full = data
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return &parseError{Path: dirPath, File: file, Err: err}
+	}
+	return nil
+}
+
+func parsePSIData(psi []string) (data cgroups.PSIData, err error) {
+	for _, f := range psi {
+		kv := strings.SplitN(f, "=", 2)
+		if len(kv) != 2 {
+			return data, fmt.Errorf("invalid psi data: %q", f)
+		}
+		switch kv[0] {
+		case "avg10":
+			v, err := strconv.ParseFloat(kv[1], 64)
+			if err != nil {
+				return data, fmt.Errorf("invalid psi value: %q", f)
+			}
+			data.Avg10 = v
+		case "avg60":
+			v, err := strconv.ParseFloat(kv[1], 64)
+			if err != nil {
+				return data, fmt.Errorf("invalid psi value: %q", f)
+			}
+			data.Avg60 = v
+		case "avg300":
+			v, err := strconv.ParseFloat(kv[1], 64)
+			if err != nil {
+				return data, fmt.Errorf("invalid psi value: %q", f)
+			}
+			data.Avg300 = v
+		case "total":
+			v, err := strconv.ParseUint(kv[1], 10, 64)
+			if err != nil {
+				return data, fmt.Errorf("invalid psi value: %q", f)
+			}
+			data.Total = v
+		}
+	}
+	return data, nil
+}

--- a/libcontainer/cgroups/fs2/psi_test.go
+++ b/libcontainer/cgroups/fs2/psi_test.go
@@ -1,0 +1,47 @@
+package fs2
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+const examplePSIData = `some avg10=1.71 avg60=2.36 avg300=2.57 total=230548833
+full avg10=1.00 avg60=1.01 avg300=1.00 total=157622356`
+
+func TestStatCPUPsi(t *testing.T) {
+	// We're using a fake cgroupfs.
+	cgroups.TestMode = true
+
+	fakeCgroupDir := t.TempDir()
+	statPath := filepath.Join(fakeCgroupDir, "cpu.pressure")
+
+	if err := os.WriteFile(statPath, []byte(examplePSIData), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var psi cgroups.PSIStats
+	if err := statPSI(fakeCgroupDir, "cpu.pressure", &psi); err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(psi, cgroups.PSIStats{
+		Some: cgroups.PSIData{
+			Avg10:  1.71,
+			Avg60:  2.36,
+			Avg300: 2.57,
+			Total:  230548833,
+		},
+		Full: cgroups.PSIData{
+			Avg10:  1.00,
+			Avg60:  1.01,
+			Avg300: 1.00,
+			Total:  157622356,
+		},
+	}) {
+		t.Errorf("unexpected psi result: %+v", psi)
+	}
+}

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -32,9 +32,22 @@ type CpuUsage struct {
 	UsageInUsermode uint64 `json:"usage_in_usermode"`
 }
 
+type PSIData struct {
+	Avg10  float64 `json:"avg10"`
+	Avg60  float64 `json:"avg60"`
+	Avg300 float64 `json:"avg300"`
+	Total  uint64  `json:"total"`
+}
+
+type PSIStats struct {
+	Some PSIData `json:"some,omitempty"`
+	Full PSIData `json:"full,omitempty"`
+}
+
 type CpuStats struct {
 	CpuUsage       CpuUsage       `json:"cpu_usage,omitempty"`
 	ThrottlingData ThrottlingData `json:"throttling_data,omitempty"`
+	PSI            PSIStats       `json:"psi,omitempty"`
 }
 
 type CPUSetStats struct {
@@ -89,6 +102,7 @@ type MemoryStats struct {
 	UseHierarchy bool `json:"use_hierarchy"`
 
 	Stats map[string]uint64 `json:"stats,omitempty"`
+	PSI   PSIStats          `json:"psi,omitempty"`
 }
 
 type PageUsageByNUMA struct {
@@ -133,6 +147,7 @@ type BlkioStats struct {
 	IoMergedRecursive       []BlkioStatEntry `json:"io_merged_recursive,omitempty"`
 	IoTimeRecursive         []BlkioStatEntry `json:"io_time_recursive,omitempty"`
 	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive,omitempty"`
+	PSI                     PSIStats         `json:"psi,omitempty"`
 }
 
 type HugetlbStats struct {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -450,6 +450,13 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		psi)
+			# If PSI is not compiled in the kernel, the file will not exist.
+			# If PSI is compiled, but not enabled, read will fail with ENOTSUPP.
+			if [[ ! $(cat /sys/fs/cgroup/cpu.pressure) ]]; then
+				skip_me=1
+			fi
+			;;
 		*)
 			fail "BUG: Invalid requires $var."
 			;;

--- a/types/events.go
+++ b/types/events.go
@@ -21,6 +21,18 @@ type Stats struct {
 	NetworkInterfaces []*NetworkInterface `json:"network_interfaces"`
 }
 
+type PSIData struct {
+	Avg10  float64 `json:"avg10"`
+	Avg60  float64 `json:"avg60"`
+	Avg300 float64 `json:"avg300"`
+	Total  uint64  `json:"total"`
+}
+
+type PSIStats struct {
+	Some PSIData `json:"some,omitempty"`
+	Full PSIData `json:"full,omitempty"`
+}
+
 type Hugetlb struct {
 	Usage   uint64 `json:"usage,omitempty"`
 	Max     uint64 `json:"max,omitempty"`
@@ -43,6 +55,7 @@ type Blkio struct {
 	IoMergedRecursive       []BlkioEntry `json:"ioMergedRecursive,omitempty"`
 	IoTimeRecursive         []BlkioEntry `json:"ioTimeRecursive,omitempty"`
 	SectorsRecursive        []BlkioEntry `json:"sectorsRecursive,omitempty"`
+	PSI                     PSIStats     `json:"psi,omitempty"`
 }
 
 type Pids struct {
@@ -69,6 +82,7 @@ type CpuUsage struct {
 type Cpu struct {
 	Usage      CpuUsage   `json:"usage,omitempty"`
 	Throttling Throttling `json:"throttling,omitempty"`
+	PSI        PSIStats   `json:"psi,omitempty"`
 }
 
 type CPUSet struct {
@@ -99,6 +113,7 @@ type Memory struct {
 	Kernel    MemoryEntry       `json:"kernel,omitempty"`
 	KernelTCP MemoryEntry       `json:"kernelTCP,omitempty"`
 	Raw       map[string]uint64 `json:"raw,omitempty"`
+	PSI       PSIStats          `json:"psi,omitempty"`
 }
 
 type L3CacheInfo struct {


### PR DESCRIPTION
This supports fetching PSI stats for cgroupv2 containers. We read the PSI metrics if they are available from:
- cpu.pressure
- memory.pressure
- io.pressure

See more about PSI at https://www.kernel.org/doc/html/latest/accounting/psi.html