### PR TITLE
libcontainer: remove "pausing" state

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -20,8 +20,6 @@ const (
 	Created Status = iota
 	// Running is the status that denotes the container exists and is running.
 	Running
-	// Pausing is the status that denotes the container exists, it is in the process of being paused.
-	Pausing
 	// Paused is the status that denotes the container exists, but all its processes are paused.
 	Paused
 	// Stopped is the status that denotes the container does not have a created or running process.
@@ -34,8 +32,6 @@ func (s Status) String() string {
 		return "created"
 	case Running:
 		return "running"
-	case Pausing:
-		return "pausing"
 	case Paused:
 		return "paused"
 	case Stopped:

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -100,7 +100,7 @@ type Container interface {
 	// Restore restores the checkpointed container to a running state using the criu(8) utility.
 	Restore(process *Process, criuOpts *CriuOpts) error
 
-	// If the Container state is RUNNING or CREATED, sets the Container state to PAUSING and pauses
+	// If the Container state is RUNNING or CREATED, sets the Container state to PAUSED and pauses
 	// the execution of any user processes. Asynchronously, when the container finished being paused the
 	// state is changed to PAUSED.
 	// If the Container state is PAUSED, do nothing.


### PR DESCRIPTION
Upon running tests via `make test`, I encountered flaky failures, I'll look into those and see if they have something to do with my host because I noticed the same behavior on `main` too.

Addresses #3343 