### PR TITLE
signals: fix signal name debug print

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -99,8 +99,9 @@ func (h *signalHandler) forward(process *libcontainer.Process, tty *tty, detach 
 				}
 			}
 		default:
-			logrus.Debugf("sending signal to process %s", s)
-			if err := unix.Kill(pid1, s.(unix.Signal)); err != nil {
+			us := s.(unix.Signal)
+			logrus.Debugf("forwarding signal %d (%s) to %d", int(us), unix.SignalName(us), pid1)
+			if err := unix.Kill(pid1, us); err != nil {
 				logrus.Error(err)
 			}
 		}


### PR DESCRIPTION
Here's how it looks now:

```console
$ runc --debug exec ctid sleep 1h
...
DEBU[0000]signals.go:102 main.(*signalHandler).forward() sending signal to process urgent I/O condition
DEBU[0000]signals.go:102 main.(*signalHandler).forward() sending signal to process urgent I/O condition
DEBU[0022]signals.go:102 main.(*signalHandler).forward() sending signal to process terminated
DEBU[0022]signals.go:102 main.(*signalHandler).forward() sending signal to process urgent I/O condition
```
This is obviously not very readable.

Use unix.SignalName, and add PID while we're at it.

With this commit:

```console
DEBU[0000]signals.go:103 main.(*signalHandler).forward() forwarding signal 23 (SIGURG) to 891345
DEBU[0020]signals.go:103 main.(*signalHandler).forward() forwarding signal 45 () to 891345
DEBU[0020]signals.go:103 main.(*signalHandler).forward() forwarding signal 23 (SIGURG) to 891345
DEBU[0020]signals.go:103 main.(*signalHandler).forward() forwarding signal 23 (SIGURG) to 891345
```