### PR TITLE
libct/specconv: checkPropertyName speedup

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -538,8 +538,10 @@ func checkPropertyName(s string) error {
 	if len(s) < 3 {
 		return errors.New("too short")
 	}
-	// Check ASCII characters rather than Unicode runes.
-	for _, ch := range s {
+	// Check ASCII characters rather than Unicode runes,
+	// so we have to use indexes rather than range.
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
 		if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
 			continue
 		}

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -762,7 +762,7 @@ func TestInitSystemdProps(t *testing.T) {
 	}
 }
 
-func TestIsValidName(t *testing.T) {
+func TestCheckPropertyName(t *testing.T) {
 	testCases := []struct {
 		in    string
 		valid bool
@@ -787,7 +787,7 @@ func TestIsValidName(t *testing.T) {
 	}
 }
 
-func BenchmarkIsValidName(b *testing.B) {
+func BenchmarkCheckPropertyName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, s := range []string{"", "xx", "xxx", "someValidName", "A name", "Кир", "მადლობა", "合い言葉"} {
 			_ = checkPropertyName(s)


### PR DESCRIPTION
See commits for details.

Mostly done because the comment was misleading, not in line with what the code did.

Fix the code, so now the comment is fine.