### PR TITLE
runc run/exec: ignore SIGURG

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -98,6 +98,11 @@ func (h *signalHandler) forward(process *libcontainer.Process, tty *tty, detach 
 					return e.status, nil
 				}
 			}
+		case unix.SIGURG:
+			// SIGURG is used by go runtime for async preemptive
+			// scheduling, so runc receives it from time to time,
+			// and it should not be forwarded to the container.
+			// Do nothing.
 		default:
 			us := s.(unix.Signal)
 			logrus.Debugf("forwarding signal %d (%s) to %d", int(us), unix.SignalName(us), pid1)


### PR DESCRIPTION
Foreground runc exec and runc run forwards all the signals (that it can)
to the process being run.

Since Go 1.14, go runtime uses SIGURG for async preemptive scheduling.
This means that runc regularly receives SIGURG and, in case of
foreground runc run/exec, it gets forwarded to the container process.

For example:

[kir@kir-rhat runc]$ sudo ./runc --debug exec xx67 sleep 1m
...
DEBU[0000] child process in init()
DEBU[0000] setns_init: about to exec
DEBU[0000]signals.go:102 main.(*signalHandler).forward() sending signal to process urgent I/O condition
DEBU[0000]signals.go:102 main.(*signalHandler).forward() sending signal to process urgent I/O condition
DEBU[0000]signals.go:102 main.(*signalHandler).forward() sending signal to process urgent I/O condition
...

Or, with slightly better debug messages from commit 58c1ff39a549636621d:

DEBU[0000]signals.go:102 main.(*signalHandler).forward() forwarding SIGURG to 819784
DEBU[0000]signals.go:102 main.(*signalHandler).forward() forwarding SIGURG to 819784

Obviously, this signal is an internal implementation detail of Go
runtime, and should not be forwarded to the container process.

Fixes: #3364 