### PR TITLE
tests/int: nits and cleanups

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -87,7 +87,7 @@ function setup() {
 
 	runc exec test_cgroups_group cat /proc/self/cgroup
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == "0::/" ]]
+	[[ ${lines[0]} = "0::/" ]]
 
 	runc exec test_cgroups_group mkdir /sys/fs/cgroup/foo
 	[ "$status" -eq 0 ]
@@ -99,7 +99,7 @@ function setup() {
 	# because we haven't enabled any domain controller.
 	runc exec test_cgroups_group cat /proc/self/cgroup
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == "0::/" ]]
+	[[ ${lines[0]} = "0::/" ]]
 
 	# turn on a domain controller (memory)
 	runc exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
@@ -109,7 +109,7 @@ function setup() {
 	# falls back to "/foo".
 	runc exec test_cgroups_group cat /proc/self/cgroup
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == "0::/foo" ]]
+	[[ ${lines[0]} = "0::/foo" ]]
 
 	# teardown: remove "/foo"
 	# shellcheck disable=SC2016
@@ -301,7 +301,7 @@ function setup() {
 	[[ $exec_cgroup == *"runc-cgroups-integration-test"* ]]
 
 	# check that the cgroups v2 path is the same for both processes
-	[[ "$run_cgroup" == "$exec_cgroup" ]]
+	[ "$run_cgroup" = "$exec_cgroup" ]
 }
 
 @test "runc exec should refuse a paused container" {

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -44,7 +44,7 @@ function setup() {
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[ "$status" -eq 0 ]
-	if [ "$CGROUP_UNIFIED" != "no" ]; then
+	if [ -v CGROUP_V2 ]; then
 		if [ -v RUNC_USE_SYSTEMD ]; then
 			if [ "$(id -u)" = "0" ]; then
 				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
@@ -177,7 +177,7 @@ function setup() {
 	# The loop device itself is no longer needed.
 	losetup -d "$dev"
 
-	if [ "$CGROUP_UNIFIED" = "yes" ]; then
+	if [ -v CGROUP_V2 ]; then
 		file="io.bfq.weight"
 	else
 		file="blkio.bfq.weight_device"
@@ -377,18 +377,15 @@ function setup() {
 
 	set_cgroups_path
 
-	case $CGROUP_UNIFIED in
-	no)
+	if [ -v CGROUP_V1 ]; then
 		FREEZER_DIR="${CGROUP_FREEZER_BASE_PATH}/${REL_CGROUPS_PATH}"
 		FREEZER="${FREEZER_DIR}/freezer.state"
 		STATE="FROZEN"
-		;;
-	yes)
+	else
 		FREEZER_DIR="${CGROUP_PATH}"
 		FREEZER="${FREEZER_DIR}/cgroup.freeze"
 		STATE="1"
-		;;
-	esac
+	fi
 
 	# Create and freeze the cgroup.
 	mkdir -p "$FREEZER_DIR"

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -37,7 +37,7 @@ function setup() {
 }
 
 @test "runc create (limits + cgrouppath + permission on the cgroup dir) succeeds" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 	set_resources_limit
@@ -46,11 +46,11 @@ function setup() {
 	[ "$status" -eq 0 ]
 	if [ -v CGROUP_V2 ]; then
 		if [ -v RUNC_USE_SYSTEMD ]; then
-			if [ "$(id -u)" = "0" ]; then
+			if [ $EUID -eq 0 ]; then
 				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
 			else
 				# Filter out hugetlb and misc as systemd is unable to delegate them.
-				check_cgroup_value "cgroup.controllers" "$(sed -e 's/ hugetlb//' -e 's/ misc//' </sys/fs/cgroup/user.slice/user-"$(id -u)".slice/cgroup.controllers)"
+				check_cgroup_value "cgroup.controllers" "$(sed -e 's/ hugetlb//' -e 's/ misc//' </sys/fs/cgroup/user.slice/user-${EUID}.slice/cgroup.controllers)"
 			fi
 		else
 			check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"
@@ -59,7 +59,7 @@ function setup() {
 }
 
 @test "runc exec (limits + cgrouppath + permission on the cgroup dir) succeeds" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 	set_resources_limit
@@ -133,7 +133,7 @@ function setup() {
 
 @test "runc run (blkio weight)" {
 	requires cgroups_v2
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 	update_config '.linux.resources.blockIO |= {"weight": 750}'
@@ -270,7 +270,7 @@ function setup() {
 
 @test "runc run (cgroupv2 mount inside container)" {
 	requires cgroups_v2
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 
@@ -305,10 +305,8 @@ function setup() {
 }
 
 @test "runc exec should refuse a paused container" {
-	if [[ "$ROOTLESS" -ne 0 ]]; then
-		requires rootless_cgroup
-	fi
 	requires cgroups_freezer
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 
@@ -324,10 +322,8 @@ function setup() {
 }
 
 @test "runc exec --ignore-paused" {
-	if [[ "$ROOTLESS" -ne 0 ]]; then
-		requires rootless_cgroup
-	fi
 	requires cgroups_freezer
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 
@@ -349,9 +345,7 @@ function setup() {
 }
 
 @test "runc run/create should warn about a non-empty cgroup" {
-	if [[ "$ROOTLESS" -ne 0 ]]; then
-		requires rootless_cgroup
-	fi
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 
@@ -371,9 +365,7 @@ function setup() {
 
 @test "runc run/create should refuse pre-existing frozen cgroup" {
 	requires cgroups_freezer
-	if [[ "$ROOTLESS" -ne 0 ]]; then
-		requires rootless_cgroup
-	fi
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -98,7 +98,7 @@ function runc_restore_with_pipes() {
 
 	runc exec --cwd /bin "$name" echo ok
 	[ "$status" -eq 0 ]
-	[[ ${output} == "ok" ]]
+	[ "$output" = "ok" ]
 }
 
 function simple_cr() {

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -50,7 +50,7 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	[[ $(cat pid.txt) == $(__runc state test_busybox | jq '.pid') ]]
+	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
 
 	# start the command
 	runc start test_busybox
@@ -73,7 +73,7 @@ function teardown() {
 	# check pid.txt was generated
 	[ -e pid.txt ]
 
-	[[ $(cat pid.txt) == $(__runc state test_busybox | jq '.pid') ]]
+	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
 
 	# start the command
 	runc start test_busybox

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -15,7 +15,7 @@ function teardown() {
 	# XXX(@kolyshkin): currently this test does not handle rootless when
 	# fs cgroup driver is used, because in this case cgroup (with a
 	# predefined name) is created by tests/rootless.sh, not by runc.
-	[[ "$ROOTLESS" -ne 0 ]] && requires systemd
+	[ $EUID -ne 0 ] && requires systemd
 	set_resources_limit
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -17,7 +17,7 @@ function teardown() {
 	runc run test_dev
 	[ "$status" -eq 0 ]
 
-	if [[ "$ROOTLESS" -ne 0 ]]; then
+	if [ $EUID -ne 0 ]; then
 		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"65534".+"65534".+"5,".+"0".+"/dev/tty" ]]
 	else
 		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"0".+"0".+"5,".+"0".+"/dev/tty" ]]

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -117,7 +117,7 @@ function teardown() {
 
 @test "runc exec --user" {
 	# --user can't work in rootless containers that don't have idmap.
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
 
 	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -140,8 +140,7 @@ function teardown() {
 
 	runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
 	[ "$status" -eq 0 ]
-
-	[[ ${output} == "1000 100 65534" ]]
+	[ "$output" = "1000 100 65534" ]
 }
 
 @test "runc exec --preserve-fds" {
@@ -154,7 +153,7 @@ function teardown() {
 	exec 4<preserve-fds.test
 	runc exec --preserve-fds=2 test_busybox cat /proc/self/fd/4
 	[ "$status" -eq 0 ]
-	[[ "${output}" == "hello" ]]
+	[ "${output}" = "hello" ]
 }
 
 function check_exec_debug() {

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -152,7 +152,7 @@ function create_parent() {
 		"$SD_HELPER" --parent machine.slice start "$SD_PARENT_NAME"
 	else
 		[ ! -v REL_PARENT_PATH ] && return
-		if [ "$CGROUP_UNIFIED" == "yes" ]; then
+		if [ "$CGROUP_UNIFIED" = "yes" ]; then
 			mkdir "/sys/fs/cgroup$REL_PARENT_PATH"
 		else
 			local subsys
@@ -172,7 +172,7 @@ function remove_parent() {
 		"$SD_HELPER" --parent machine.slice stop "$SD_PARENT_NAME"
 	else
 		[ ! -v REL_PARENT_PATH ] && return
-		if [ "$CGROUP_UNIFIED" == "yes" ]; then
+		if [ "$CGROUP_UNIFIED" = "yes" ]; then
 			rmdir "/sys/fs/cgroup/$REL_PARENT_PATH"
 		else
 			local subsys
@@ -229,7 +229,7 @@ function set_cgroups_path() {
 	fi
 
 	# Absolute path to container's cgroup v2.
-	if [ "$CGROUP_UNIFIED" == "yes" ]; then
+	if [ "$CGROUP_UNIFIED" = "yes" ]; then
 		CGROUP_PATH=${CGROUP_BASE_PATH}${REL_CGROUPS_PATH}
 	fi
 
@@ -498,7 +498,7 @@ function wait_for_container() {
 function testcontainer() {
 	# test state of container
 	runc state "$1"
-	if [ "$2" == "checkpointed" ]; then
+	if [ "$2" = "checkpointed" ]; then
 		[ "$status" -eq 1 ]
 		return
 	fi

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -35,9 +35,9 @@ function teardown() {
 
 	ROOT=$ALT_ROOT runc list -q
 	[ "$status" -eq 0 ]
-	[[ "${lines[0]}" == "test_box1" ]]
-	[[ "${lines[1]}" == "test_box2" ]]
-	[[ "${lines[2]}" == "test_box3" ]]
+	[ "${lines[0]}" = "test_box1" ]
+	[ "${lines[1]}" = "test_box2" ]
+	[ "${lines[2]}" = "test_box3" ]
 
 	ROOT=$ALT_ROOT runc list --format table
 	[ "$status" -eq 0 ]

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -24,7 +24,7 @@ function teardown() {
 
 	runc exec test_busybox cat /testfile
 	[ "$status" -eq 0 ]
-	[[ "${output}" == "" ]]
+	[ -z "$output" ]
 
 	runc exec test_busybox rm -f /testfile
 	[ "$status" -eq 1 ]
@@ -42,7 +42,7 @@ function teardown() {
 
 	runc exec test_busybox ls /testdir
 	[ "$status" -eq 0 ]
-	[[ "${output}" == "" ]]
+	[ -z "$output" ]
 
 	runc exec test_busybox touch /testdir/foo
 	[ "$status" -eq 1 ]

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -11,11 +11,11 @@ function teardown() {
 }
 
 @test "runc pause and resume" {
-	if [[ "$ROOTLESS" -ne 0 ]]; then
+	requires cgroups_freezer
+	if [ $EUID -ne 0 ]; then
 		requires rootless_cgroup
 		set_cgroups_path
 	fi
-	requires cgroups_freezer
 
 	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
@@ -39,11 +39,11 @@ function teardown() {
 }
 
 @test "runc pause and resume with nonexist container" {
-	if [[ "$ROOTLESS" -ne 0 ]]; then
+	requires cgroups_freezer
+	if [ $EUID -ne 0 ]; then
 		requires rootless_cgroup
 		set_cgroups_path
 	fi
-	requires cgroups_freezer
 
 	# run test_busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -62,7 +62,7 @@ function teardown() {
 
 @test "ps after the container stopped" {
 	# ps requires cgroups
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 	set_cgroups_path
 
 	# start busybox detached

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -36,8 +36,7 @@ function teardown() {
 @test "runc run --keep (check cgroup exists)" {
 	# for systemd driver, the unit's cgroup path will be auto removed if container's all processes exited
 	requires no_systemd
-
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path
 

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -21,7 +21,7 @@ function teardown() {
 
 @test "runc run detached ({u,g}id != 0)" {
 	# cannot start containers as another user in rootless setup without idmap
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -21,7 +21,7 @@ function teardown() {
 
 @test "runc run ({u,g}id != 0)" {
 	# cannot start containers as another user in rootless setup without idmap
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -34,7 +34,7 @@ function teardown() {
 @test "runc run [tty owner]" {
 	# tty chmod is not doable in rootless containers without idmap.
 	# TODO: this can be made as a change to the gid test.
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
 
 	# Replace sh script with stat.
 	# shellcheck disable=SC2016
@@ -50,7 +50,7 @@ function teardown() {
 
 @test "runc run [tty owner] ({u,g}id != 0)" {
 	# tty chmod is not doable in rootless containers without idmap.
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
@@ -100,7 +100,7 @@ function teardown() {
 @test "runc exec [tty owner]" {
 	# tty chmod is not doable in rootless containers without idmap.
 	# TODO: this can be made as a change to the gid test.
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
 
 	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
@@ -119,7 +119,7 @@ function teardown() {
 
 @test "runc exec [tty owner] ({u,g}id != 0)" {
 	# tty chmod is not doable in rootless containers without idmap.
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -21,7 +21,7 @@ function setup() {
 # Tests whatever limits are (more or less) common between cgroup
 # v1 and v2: memory/swap, pids, and cpuset.
 @test "update cgroup v1/v2 common limits" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires cgroups_memory cgroups_pids cgroups_cpuset
 	init_cgroup_paths
 
@@ -259,7 +259,7 @@ EOF
 }
 
 @test "update cgroup cpu limits" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	# run a few busyboxes detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
@@ -333,7 +333,7 @@ EOF
 }
 
 @test "set cpu period with no quota" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	update_config '.linux.resources.cpu |= { "period": 1000000 }'
 
@@ -344,7 +344,7 @@ EOF
 }
 
 @test "set cpu period with no quota (invalid period)" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	update_config '.linux.resources.cpu |= { "period": 100 }'
 
@@ -353,7 +353,7 @@ EOF
 }
 
 @test "set cpu quota with no period" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	update_config '.linux.resources.cpu |= { "quota": 5000 }'
 
@@ -363,7 +363,7 @@ EOF
 }
 
 @test "update cpu period with no previous period/quota set" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	update_config '.linux.resources.cpu |= {}'
 
@@ -377,7 +377,7 @@ EOF
 }
 
 @test "update cpu quota with no previous period/quota set" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	update_config '.linux.resources.cpu |= {}'
 
@@ -392,7 +392,7 @@ EOF
 
 @test "update cpu period in a pod cgroup with pod limit set" {
 	requires cgroups_v1
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path "pod_${RANDOM}"
 
@@ -426,7 +426,7 @@ EOF
 }
 
 @test "update cgroup v2 resources via unified map" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires cgroups_v2
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
@@ -455,7 +455,7 @@ EOF
 }
 
 @test "update cpuset parameters via resources.CPU" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires smp cgroups_cpuset
 
 	local AllowedCPUs='AllowedCPUs' AllowedMemoryNodes='AllowedMemoryNodes'
@@ -511,7 +511,7 @@ EOF
 
 @test "update cpuset parameters via v2 unified map" {
 	# This test assumes systemd >= v244
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires cgroups_v2 smp cgroups_cpuset
 
 	update_config ' .linux.resources.unified |= {
@@ -558,7 +558,7 @@ EOF
 }
 
 @test "update rt period and runtime" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires cgroups_v1 cgroups_rt no_systemd
 
 	local cgroup_cpu="${CGROUP_CPU_BASE_PATH}/${REL_CGROUPS_PATH}"
@@ -678,8 +678,8 @@ EOF
 }
 
 @test "update paused container" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
 	requires cgroups_freezer
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	# Run the container in the background.
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -627,8 +627,6 @@ EOF
 }
 
 @test "update devices [minimal transition rules]" {
-	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
-
 	requires root
 
 	# Run a basic shell script that tries to read from /dev/kmsg, but

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -30,8 +30,7 @@ function setup() {
 	[ "$status" -eq 0 ]
 
 	# Set a few variables to make the code below work for both v1 and v2
-	case $CGROUP_UNIFIED in
-	no)
+	if [ -v CGROUP_V1 ]; then
 		MEM_LIMIT="memory.limit_in_bytes"
 		SD_MEM_LIMIT="MemoryLimit"
 		MEM_RESERVE="memory.soft_limit_in_bytes"
@@ -43,8 +42,7 @@ function setup() {
 		if [ -f "${CGROUP_MEMORY_BASE_PATH}/${MEM_SWAP}" ]; then
 			HAVE_SWAP="yes"
 		fi
-		;;
-	yes)
+	else
 		MEM_LIMIT="memory.max"
 		SD_MEM_LIMIT="MemoryMax"
 		MEM_RESERVE="memory.low"
@@ -53,8 +51,8 @@ function setup() {
 		SD_MEM_SWAP="MemorySwapMax"
 		SYSTEM_MEM="max"
 		HAVE_SWAP="yes"
-		;;
-	esac
+	fi
+
 	SD_UNLIMITED="infinity"
 	SD_VERSION=$(systemctl --version | awk '{print $2; exit}')
 	if [ "$SD_VERSION" -lt 227 ]; then
@@ -105,7 +103,7 @@ function setup() {
 		check_systemd_value "$SD_MEM_SWAP" $SD_UNLIMITED
 
 		# update memory swap
-		if [ "$CGROUP_UNIFIED" = "yes" ]; then
+		if [ -v CGROUP_V2 ]; then
 			# for cgroupv2, memory and swap can only be set together
 			runc update test_update --memory 52428800 --memory-swap 96468992
 			[ "$status" -eq 0 ]
@@ -233,7 +231,7 @@ EOF
 		check_cgroup_value $MEM_LIMIT $((30 * 1024 * 1024))
 		check_systemd_value $SD_MEM_LIMIT $((30 * 1024 * 1024))
 
-		if [ "$CGROUP_UNIFIED" = "yes" ]; then
+		if [ -v CGROUP_V2 ]; then
 			# for cgroupv2, swap does not include mem
 			check_cgroup_value "$MEM_SWAP" $((20 * 1024 * 1024))
 			check_systemd_value "$SD_MEM_SWAP" $((20 * 1024 * 1024))
@@ -249,7 +247,7 @@ EOF
 		check_cgroup_value $MEM_LIMIT $((60 * 1024 * 1024))
 		check_systemd_value $SD_MEM_LIMIT $((60 * 1024 * 1024))
 
-		if [ "$CGROUP_UNIFIED" = "yes" ]; then
+		if [ -v CGROUP_V2 ]; then
 			# for cgroupv2, swap does not include mem
 			check_cgroup_value "$MEM_SWAP" $((20 * 1024 * 1024))
 			check_systemd_value "$SD_MEM_SWAP" $((20 * 1024 * 1024))

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -15,7 +15,7 @@ function setup() {
 	mkdir -p rootfs/{proc,sys,tmp}
 	mkdir -p rootfs/tmp/mount-{1,2}
 
-	if [ "$ROOTLESS" -eq 0 ]; then
+	if [ $EUID -eq 0 ]; then
 		update_config ' .linux.namespaces += [{"type": "user"}]
 			| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}]
 			| .linux.gidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}] '

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -112,9 +112,9 @@ function enable_cgroup() {
 		# for runc to set up the hierarchy. XXX: This really shouldn't be
 		# necessary, and might actually be a bug in our impl of cgroup
 		# handling.
-		[[ "$cg" == "cpuset" ]] && chown rootless:rootless "$CGROUP_MOUNT/$cg$CGROUP_PATH/cpuset."{cpus,mems}
+		[ "$cg" = "cpuset" ] && chown rootless:rootless "$CGROUP_MOUNT/$cg$CGROUP_PATH/cpuset."{cpus,mems}
 		# The following is required by "update rt period and runtime".
-		if [[ "$cg" == "cpu" ]]; then
+		if [ "$cg" = "cpu" ]; then
 			if [[ -e "$CGROUP_MOUNT/$cg$CGROUP_PATH/cpu.rt_period_us" ]]; then
 				chown rootless:rootless "$CGROUP_MOUNT/$cg$CGROUP_PATH/cpu.rt_period_us"
 			fi


### PR DESCRIPTION
~~_Based on and currently includes #3367 ~~and #3371~~. Draft until those are merged._~~

This is a set of bash code cleanups for integration tests, mostly done for correctness, uniformity, and readability.

Please review commit by commit, and see individual commit messages for details.