### PR TITLE
ci: bump golangci-lint to v1.44, golangci-lint-action to v3

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,8 @@ on:
       - master
       - release-*
   pull_request:
+env:
+  GO_VERSION: 1.17.x
 
 jobs:
 
@@ -14,11 +16,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - name: install deps
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.44
 
@@ -30,11 +35,14 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - name: install deps
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
           only-new-issues: true
           args: --config .golangci-extra.yml
@@ -51,7 +59,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.x # Latest stable
+          go-version: "${{ env.GO_VERSION }}"
       - name: compile with no build tags
         run: make BUILDTAGS=""
 
@@ -118,7 +126,7 @@ jobs:
     - name: install go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.x # Latest stable
+        go-version: "${{ env.GO_VERSION }}"
     - name: cache go mod and $GOCACHE
       uses: actions/cache@v2
       with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,8 +20,7 @@ jobs:
           sudo apt -q install libseccomp-dev
       - uses: golangci/golangci-lint-action@v2
         with:
-          # must be specified without patch version
-          version: v1.42
+          version: v1.44
 
   lint-extra:
     # Extra linters, only checking new code from pull requests.
@@ -39,8 +38,7 @@ jobs:
         with:
           only-new-issues: true
           args: --config .golangci-extra.yml
-          # must be specified without patch version
-          version: v1.43
+          version: v1.44
 
 
   compile-buildtags:

--- a/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
+++ b/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
@@ -153,8 +153,7 @@ func TestDeviceFilter_Privileged(t *testing.T) {
 			Allow:       true,
 		},
 	}
-	expected :=
-		`
+	expected := `
 // load parameters into registers
         0: LdXMemW dst: r2 src: r1 off: 0 imm: 0
         1: And32Imm dst: r2 imm: 65535

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -39,13 +39,9 @@ type parentProcess interface {
 
 	// startTime returns the process start time.
 	startTime() (uint64, error)
-
 	signal(os.Signal) error
-
 	externalDescriptors() []string
-
 	setExternalDescriptors(fds []string)
-
 	forwardChildLogs() chan error
 }
 

--- a/update.go
+++ b/update.go
@@ -194,7 +194,6 @@ other options are ignored.
 				opt  string
 				dest *uint64
 			}{
-
 				{"cpu-period", r.CPU.Period},
 				{"cpu-rt-period", r.CPU.RealtimePeriod},
 				{"cpu-share", r.CPU.Shares},
@@ -211,7 +210,6 @@ other options are ignored.
 				opt  string
 				dest *int64
 			}{
-
 				{"cpu-quota", r.CPU.Quota},
 				{"cpu-rt-runtime", r.CPU.RealtimeRuntime},
 			} {


### PR DESCRIPTION
and format sources using gofumpt 0.2.1 (which is uncluded to that golangci-lint version).