### PR TITLE
ci: shellcheck: update to 0.8.0, fix/suppress new warnings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -96,9 +96,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: vars
         run: |
-          echo 'VERSION=v0.7.2' >> $GITHUB_ENV
+          echo 'VERSION=v0.8.0' >> $GITHUB_ENV
           echo 'BASEURL=https://github.com/koalaman/shellcheck/releases/download' >> $GITHUB_ENV
-          echo 'SHA256SUM=12ee2e0b90a3d1e9cae24ac9b2838be66b48573cb2c8e8f3c566b959df6f050c' >> $GITHUB_ENV
+          echo 'SHA256SUM=f4bce23c11c3919c1b20bcb0f206f6b44c44e26f2bc95f8aa708716095fa0651' >> $GITHUB_ENV
           echo ~/bin >> $GITHUB_PATH
       - name: install shellcheck
         run: |

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -10,6 +10,7 @@ function teardown() {
 	teardown_bundle
 }
 
+# shellcheck disable=SC2030
 @test "events --stats" {
 	# XXX: currently cgroups require root containers.
 	requires root
@@ -38,6 +39,7 @@ function test_events() {
 	fi
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	# shellcheck disable=SC2031
 	[ "$status" -eq 0 ]
 
 	# Spawn two subshels:

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -29,7 +29,7 @@ command -v criu &>/dev/null && HAVE_CRIU=yes
 # Kernel version
 KERNEL_VERSION="$(uname -r)"
 KERNEL_MAJOR="${KERNEL_VERSION%%.*}"
-KERNEL_MINOR="${KERNEL_VERSION#$KERNEL_MAJOR.}"
+KERNEL_MINOR="${KERNEL_VERSION#"$KERNEL_MAJOR".}"
 KERNEL_MINOR="${KERNEL_MINOR%%.*}"
 
 ARCH=$(uname -m)


### PR DESCRIPTION
1. This valid warning is reported by shellcheck v0.8.0:
```
	In tests/integration/helpers.bash line 38:
	KERNEL_MINOR="${KERNEL_VERSION#$KERNEL_MAJOR.}"
				       ^-----------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

	Did you mean:
	KERNEL_MINOR="${KERNEL_VERSION#"$KERNEL_MAJOR".}"
```
Fix this.

2. These (invalid) warnings are also reported by the new version:
```
	In tests/integration/events.bats line 13:
	@test "events --stats" {
	^-- SC2030 (info): Modification of status is local (to subshell caused by @bats test).

	In tests/integration/events.bats line 41:
		[ "$status" -eq 0 ]
		   ^-----^ SC2031 (info): status was modified in a subshell. That change might be lost.
```
Basically, this is happening because shellcheck do not really track
the call tree and/or local variables. This is a known (and reported)
deficiency, and the alternative to disabling these warnings is moving
the code around, which is worse due to more changes in git history.

So we have to silence/disable these.

3. Update shellcheck to 0.8.0.