### PR TITLE
Assorted CLI nitpicks

### DIFF
--- a/list.go
+++ b/list.go
@@ -117,7 +117,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 	root := context.GlobalString("root")
 	list, err := os.ReadDir(root)
 	if err != nil {
-		fatal(err)
+		return nil, err
 	}
 
 	var s []containerState
@@ -131,7 +131,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 				// Possible race with runc delete.
 				continue
 			}
-			fatal(err)
+			return nil, err
 		}
 		// This cast is safe on Linux.
 		uid := st.Sys().(*syscall.Stat_t).Uid

--- a/list.go
+++ b/list.go
@@ -110,12 +110,19 @@ To list containers created using a non-default value for "--root":
 }
 
 func getContainers(context *cli.Context) ([]containerState, error) {
-	factory, err := loadFactory(context)
-	if err != nil {
-		return nil, err
-	}
 	root := context.GlobalString("root")
 	list, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && context.IsSet("root") {
+			// Ignore non-existing default root directory
+			// (no containers created yet).
+			return nil, nil
+		}
+		// Report other errors, including non-existent custom --root.
+		return nil, err
+	}
+
+	factory, err := loadFactory(context)
 	if err != nil {
 		return nil, err
 	}

--- a/list.go
+++ b/list.go
@@ -121,8 +121,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 		// Report other errors, including non-existent custom --root.
 		return nil, err
 	}
-
-	factory, err := loadFactory(context)
+	factory, err := libcontainer.New(root)
 	if err != nil {
 		return nil, err
 	}

--- a/list.go
+++ b/list.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -116,11 +115,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 		return nil, err
 	}
 	root := context.GlobalString("root")
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		return nil, err
-	}
-	list, err := os.ReadDir(absRoot)
+	list, err := os.ReadDir(root)
 	if err != nil {
 		fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -71,13 +71,12 @@ func main() {
 	}
 	app.Version = strings.Join(v, "\n")
 
-	xdgRuntimeDir := ""
 	root := "/run/runc"
-	if shouldHonorXDGRuntimeDir() {
-		if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
-			root = runtimeDir + "/runc"
-			xdgRuntimeDir = root
-		}
+	xdgDirUsed := false
+	xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if xdgRuntimeDir != "" && shouldHonorXDGRuntimeDir() {
+		root = xdgRuntimeDir + "/runc"
+		xdgDirUsed = true
 	}
 
 	app.Flags = []cli.Flag{
@@ -135,7 +134,7 @@ func main() {
 		featuresCommand,
 	}
 	app.Before = func(context *cli.Context) error {
-		if !context.IsSet("root") && xdgRuntimeDir != "" {
+		if !context.IsSet("root") && xdgDirUsed {
 			// According to the XDG specification, we need to set anything in
 			// XDG_RUNTIME_DIR to have a sticky bit if we don't want it to get
 			// auto-pruned.

--- a/restore.go
+++ b/restore.go
@@ -109,7 +109,10 @@ using the runc checkpoint command.`,
 			logrus.Warn("runc checkpoint is untested with rootless containers")
 		}
 
-		options := criuOptions(context)
+		options, err := criuOptions(context)
+		if err != nil {
+			return err
+		}
 		if err := setEmptyNsMask(context, options); err != nil {
 			return err
 		}
@@ -124,10 +127,10 @@ using the runc checkpoint command.`,
 	},
 }
 
-func criuOptions(context *cli.Context) *libcontainer.CriuOpts {
+func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
 	imagePath, parentPath, err := prepareImagePaths(context)
 	if err != nil {
-		fatal(err)
+		return nil, err
 	}
 
 	return &libcontainer.CriuOpts{
@@ -145,5 +148,5 @@ func criuOptions(context *cli.Context) *libcontainer.CriuOpts {
 		StatusFd:                context.Int("status-fd"),
 		LsmProfile:              context.String("lsm-profile"),
 		LsmMountContext:         context.String("lsm-mount-context"),
-	}
+	}, nil
 }

--- a/rootless_linux.go
+++ b/rootless_linux.go
@@ -52,9 +52,6 @@ func shouldUseRootlessCgroupManager(context *cli.Context) (bool, error) {
 }
 
 func shouldHonorXDGRuntimeDir() bool {
-	if os.Getenv("XDG_RUNTIME_DIR") == "" {
-		return false
-	}
 	if os.Geteuid() != 0 {
 		return true
 	}

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -23,12 +23,6 @@ import (
 
 var errEmptyID = errors.New("container id cannot be empty")
 
-// loadFactory returns the configured factory instance for execing containers.
-func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
-	root := context.GlobalString("root")
-	return libcontainer.New(root)
-}
-
 // getContainer returns the specified container instance by loading it from state
 // with the default factory.
 func getContainer(context *cli.Context) (libcontainer.Container, error) {
@@ -36,7 +30,8 @@ func getContainer(context *cli.Context) (libcontainer.Container, error) {
 	if id == "" {
 		return nil, errEmptyID
 	}
-	factory, err := loadFactory(context)
+	root := context.GlobalString("root")
+	factory, err := libcontainer.New(root)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +184,8 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcont
 		return nil, err
 	}
 
-	factory, err := loadFactory(context)
+	root := context.GlobalString("root")
+	factory, err := libcontainer.New(root)
 	if err != nil {
 		return nil, err
 	}

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -26,12 +26,7 @@ var errEmptyID = errors.New("container id cannot be empty")
 // loadFactory returns the configured factory instance for execing containers.
 func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 	root := context.GlobalString("root")
-	abs, err := filepath.Abs(root)
-	if err != nil {
-		return nil, err
-	}
-
-	return libcontainer.New(abs)
+	return libcontainer.New(root)
 }
 
 // getContainer returns the specified container instance by loading it from state


### PR DESCRIPTION
This is mostly some minor refactoring, making things cleaner.

The only significant change is `runc --root non-existent-dir list` now reports an error for non-existent root directory. The error is not reported in case a default root is used.

This is a preparation for #3373.