### PR TITLE
ci: bump shfmt to 3.5.1, simplify CI setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# This file is used by shfmt. See https://EditorConfig.org
+
+# This is a top-most EditorConfig file.
+root = true
+
+# Ignore the entire "vendor" directory.
+[vendor/**]
+ignore = true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,22 +67,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - name: vars
-      run: |
-        echo "VERSION=3.3.1" >> $GITHUB_ENV
-        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-    - name: cache go mod and $GOCACHE
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-shfmt-${{ env.VERSION }}
-        restore-keys: ${{ runner.os }}-shfmt-
-    - name: install shfmt
-      run: |
-        command -v shfmt || \
-          (cd ~ && GO111MODULE=on time go get mvdan.cc/sh/v3/cmd/shfmt@v$VERSION)
     - name: shfmt
       run: make shfmt
 

--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,12 @@ shellcheck:
 	# TODO: add shellcheck for more sh files (contrib/completions/bash/runc).
 
 shfmt:
-	shfmt -ln bats -d -w tests/integration/*.bats
-	shfmt -ln bash -d -w man/*.sh script/* \
-		tests/*.sh tests/integration/*.bash tests/fuzzing/*.sh \
-		contrib/completions/bash/runc contrib/cmd/seccompagent/*.sh
+	$(CONTAINER_ENGINE) run $(CONTAINER_ENGINE_RUN_FLAGS) \
+		--rm -v $(CURDIR):/src -w /src \
+		mvdan/shfmt:v3.5.1 -d -w .
+
+localshfmt:
+	shfmt -d -w .
 
 vendor:
 	$(GO) mod tidy
@@ -192,5 +194,5 @@ verify-dependencies: vendor
 	localrelease dbuild lint man runcimage \
 	test localtest unittest localunittest integration localintegration \
 	rootlessintegration localrootlessintegration shell install install-bash \
-	install-man clean cfmt shfmt shellcheck \
+	install-man clean cfmt shfmt localshfmt shellcheck \
 	vendor verify-changelog verify-dependencies


### PR DESCRIPTION
1. Bump shfmt to v3.5.1. Release notes:
    https://github.com/mvdan/sh/releases
    
2. Since shfmt v3.5.0, specifying `-l bash` (or `-l bats`) is no longer
     necessary. Therefore, we can use shfmt to find all the files.
     Add `.editorconfig` to ignore `vendor` subdirectory.
    
3. Use shfmt docker image, so that we don't have to install anything
    explicitly. This greatly simplifies the shfmt CI job. Add
    localshfmt target so developers can still use a local shfmt binary
    when necessary.
