### PR TITLE
integration tests: skip criu tests incorrectly

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -350,7 +350,7 @@ function requires() {
 		local skip_me
 		case $var in
 		criu)
-			if [ -n "$HAVE_CRIU" ]; then
+			if [ -z "$HAVE_CRIU" ]; then
 				skip_me=1
 			fi
 			;;


### PR DESCRIPTION
I noticed that all criu tests skipped when doing integration tests.
Because `-n "$var"` means the length of "$var" should be greater than 0, and `-z "$var"` means the length of "$var" should  equal to 0.

I don't know whether skipping all integration tests is your intended thought or not?

Signed-off-by: lifubang <lifubang@acmcoder.com>