### PR TITLE
ensure the path is a sub-cgroup path

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -632,7 +632,11 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, messageSockP
 			// cgroup v1: using the same path for all controllers.
 			// cgroup v2: the only possible way.
 			for k := range proc.cgroupPaths {
-				proc.cgroupPaths[k] = path.Join(proc.cgroupPaths[k], add)
+				subPath := path.Join(proc.cgroupPaths[k], add)
+				if !strings.HasPrefix(subPath, proc.cgroupPaths[k]) {
+					return nil, fmt.Errorf("%s is not a sub cgroup path", add)
+				}
+				proc.cgroupPaths[k] = subPath
 			}
 			// cgroup v2: do not try to join init process's cgroup
 			// as a fallback (see (*setnsProcess).start).
@@ -641,7 +645,11 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, messageSockP
 			// Per-controller paths.
 			for ctrl, add := range p.SubCgroupPaths {
 				if val, ok := proc.cgroupPaths[ctrl]; ok {
-					proc.cgroupPaths[ctrl] = path.Join(val, add)
+					subPath := path.Join(val, add)
+					if !strings.HasPrefix(subPath, val) {
+						return nil, fmt.Errorf("%s is not a sub cgroup path", add)
+					}
+					proc.cgroupPaths[ctrl] = subPath
 				} else {
 					return nil, fmt.Errorf("unknown controller %s in SubCgroupPaths", ctrl)
 				}

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -197,6 +197,11 @@ function check_exec_debug() {
 	__runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 
+	# Check we can't join parent cgroup.
+	runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
+	[ "$status" -ne 0 ]
+	[[ "$output" == *" .. is not a sub cgroup path"* ]]
+
 	# Check we can't join non-existing subcgroup.
 	runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
 	[ "$status" -ne 0 ]
@@ -242,6 +247,11 @@ function check_exec_debug() {
 
 	__runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
+
+	# Check we can't join parent cgroup.
+	runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
+	[ "$status" -ne 0 ]
+	[[ "$output" == *" .. is not a sub cgroup path"* ]]
 
 	# Check we can't join non-existing subcgroup.
 	runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup


### PR DESCRIPTION
As `runc exec --cgroup` means: run the process in an (existing) sub-cgroup(s), so I think we should ensure the given path in the param is a sub-cgroup path.

Signed-off-by: lifubang <lifubang@acmcoder.com>