### PR TITLE
init simplification

### DIFF
--- a/init.go
+++ b/init.go
@@ -3,11 +3,9 @@ package main
 import (
 	"os"
 	"runtime"
-	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer"
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -16,21 +14,6 @@ func init() {
 		// before main() but after libcontainer/nsenter's nsexec().
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
-
-		level, err := strconv.Atoi(os.Getenv("_LIBCONTAINER_LOGLEVEL"))
-		if err != nil {
-			panic(err)
-		}
-
-		logPipeFd, err := strconv.Atoi(os.Getenv("_LIBCONTAINER_LOGPIPE"))
-		if err != nil {
-			panic(err)
-		}
-
-		logrus.SetLevel(logrus.Level(level))
-		logrus.SetOutput(os.NewFile(uintptr(logPipeFd), "logpipe"))
-		logrus.SetFormatter(new(logrus.JSONFormatter))
-		logrus.Debug("child process in init()")
 
 		if err := libcontainer.StartInitialization(); err != nil {
 			// as the error is sent back to the parent there is no need to log

--- a/init.go
+++ b/init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/opencontainers/runc/libcontainer"
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"
@@ -12,14 +11,6 @@ func init() {
 	if len(os.Args) > 1 && os.Args[1] == "init" {
 		// This is the golang entry point for runc init, executed
 		// before main() but after libcontainer/nsenter's nsexec().
-		runtime.GOMAXPROCS(1)
-		runtime.LockOSThread()
-
-		if err := libcontainer.StartInitialization(); err != nil {
-			// as the error is sent back to the parent there is no need to log
-			// or write it to stderr because the parent process will handle this
-			os.Exit(1)
-		}
-		panic("libcontainer: container init failed to exec")
+		libcontainer.Init()
 	}
 }

--- a/libcontainer/README.md
+++ b/libcontainer/README.md
@@ -23,22 +23,9 @@ function as the entry of "bootstrap".
 In addition to the go init function the early stage bootstrap is handled by importing
 [nsenter](https://github.com/opencontainers/runc/blob/master/libcontainer/nsenter/README.md).
 
-```go
-import (
-	_ "github.com/opencontainers/runc/libcontainer/nsenter"
-)
-
-func init() {
-	if len(os.Args) > 1 && os.Args[1] == "init" {
-		runtime.GOMAXPROCS(1)
-		runtime.LockOSThread()
-		if err := libcontainer.StartInitialization(); err != nil {
-			logrus.Fatal(err)
-		}
-		panic("--this line should have never been executed, congratulations--")
-	}
-}
-```
+For details on how runc implements such "init", see
+[init.go](https://github.com/opencontainers/runc/blob/master/init.go)
+and [libcontainer/init_linux.go](https://github.com/opencontainers/runc/blob/master/libcontainer/init_linux.go).
 
 Then to create a container you first have to create a configuration
 struct describing how the container is to be created. A sample would look similar to this:

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -501,9 +501,10 @@ func (c *Container) commandTemplate(p *Process, childInitPipe *os.File, childLog
 
 	cmd.ExtraFiles = append(cmd.ExtraFiles, childLogPipe)
 	cmd.Env = append(cmd.Env,
-		"_LIBCONTAINER_LOGPIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
-		"_LIBCONTAINER_LOGLEVEL="+p.LogLevel,
-	)
+		"_LIBCONTAINER_LOGPIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1))
+	if p.LogLevel != "" {
+		cmd.Env = append(cmd.Env, "_LIBCONTAINER_LOGLEVEL="+p.LogLevel)
+	}
 
 	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
 	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason

--- a/libcontainer/integration/init_test.go
+++ b/libcontainer/integration/init_test.go
@@ -1,9 +1,7 @@
 package integration
 
 import (
-	"fmt"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer"
@@ -14,20 +12,9 @@ import (
 
 // Same as ../../init.go but for libcontainer/integration.
 func init() {
-	if len(os.Args) < 2 || os.Args[1] != "init" {
-		return
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		libcontainer.Init()
 	}
-	// This is the golang entry point for runc init, executed
-	// before TestMain() but after libcontainer/nsenter's nsexec().
-	runtime.GOMAXPROCS(1)
-	runtime.LockOSThread()
-	if err := libcontainer.StartInitialization(); err != nil {
-		// logrus is not initialized
-		fmt.Fprintln(os.Stderr, err)
-	}
-	// Normally, StartInitialization() never returns, meaning
-	// if we are here, it had failed.
-	os.Exit(1)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
~~_Based on and currently includes #3375. Draft until that one is merged._~~
~~_Based on and currently includes #3854. Draft until that one is merged._~~

This  moves logging setup out of `func init()` and into `StartInitialization()` (where it should belong);

This concludes the spring cleaning started in #3354 (promise). Loosely based on parts of #3316.