### PR TITLE
tests/int: runc delete: fix flake, enable for rootless

### DIFF
--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -11,10 +11,22 @@ function teardown() {
 }
 
 @test "runc delete" {
+	# Need a permission to create a cgroup.
+	# XXX(@kolyshkin): currently this test does not handle rootless when
+	# fs cgroup driver is used, because in this case cgroup (with a
+	# predefined name) is created by tests/rootless.sh, not by runc.
+	[[ "$ROOTLESS" -ne 0 ]] && requires systemd
+	set_resources_limit
+
 	runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
 	[ "$status" -eq 0 ]
 
 	testcontainer testbusyboxdelete running
+	# Ensure the find statement used later is correct.
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
+	if [ -z "$output" ]; then
+		fail "expected cgroup not found"
+	fi
 
 	runc kill testbusyboxdelete KILL
 	[ "$status" -eq 0 ]
@@ -26,7 +38,7 @@ function teardown() {
 	runc state testbusyboxdelete
 	[ "$status" -ne 0 ]
 
-	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d)
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 


### PR DESCRIPTION
The following failure was observed in CI (on centos-stream-8 in
integration-cgroup suite):

	not ok 42 runc delete
	 (from function `fail' in file tests/integration/helpers.bash, line 338,
	  in test file tests/integration/delete.bats, line 30)
	   `[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"' failed
	....
	cgroup not cleaned up correctly: /sys/fs/cgroup/pids/system.slice/tmp-bats\x2drun\x2d68012-runc.IPOypI-state-testbusyboxdelete-runc.zriC8C.mount
	/sys/fs/cgroup/cpu,cpuacct/system.slice/tmp-bats\x2drun\x2d68012-runc.IPOypI-state-testbusyboxdelete-runc.zriC8C.mount
	...

Apparently, this is a cgroup systemd creates for a mount unit which
appears then runc does internal /proc/self/exe bind-mount. The test
case should not take it into account.

Fix the find arguments to look for a specific cgroup name, and add
a check that these arguments are correct (i.e. the cgroup is found
when the container is running).

This added correctness check reveals another problem -- for rootless,
the test is not able to create a cgroup, so the test case is not checking anything.
The obvious fix would be to add `requires rootless_cgroups`. It is not the right
fix, because for rootless + fs cgroup driver runc does not actually create a cgroup
(it is done by tests/rootless.sh). So, require systemd (which allows to create
user cgroups), and do not test the fs driver.

Fixes: https://github.com/opencontainers/runc/issues/3391