### PR TITLE
tests: Improve seccomp-notify test names and description

### DIFF
--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -92,7 +92,8 @@ function scmp_act_notify_template() {
 	[ "$status" -eq 0 ]
 }
 
-@test "runc run [seccomp] (empty listener path)" {
+# Ignore listenerPath if the profile doesn't use seccomp notify actions.
+@test "runc run [seccomp] (ignore listener path if no notify act)" {
 	update_config '   .process.args = ["/bin/sh", "-c", "mkdir /dev/shm/foo && stat /dev/shm/foo"]
 			| .linux.seccomp = {
 				"defaultAction":"SCMP_ACT_ALLOW",

--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -42,6 +42,7 @@ function scmp_act_notify_template() {
 # noNewPrivileges, for this reason many of the following cases are tested with
 # both values.
 
+# Test basic actions handled by the agent work fine. noNewPrivileges FALSE.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY noNewPrivileges false)" {
 	scmp_act_notify_template "mkdir /dev/shm/foo && stat /dev/shm/foo-bar" false '"mkdir"'
 
@@ -49,6 +50,7 @@ function scmp_act_notify_template() {
 	[ "$status" -eq 0 ]
 }
 
+# Test basic actions handled by the agent work fine. noNewPrivileges TRUE.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY noNewPrivileges true)" {
 	scmp_act_notify_template "mkdir /dev/shm/foo && stat /dev/shm/foo-bar" true '"mkdir"'
 
@@ -56,6 +58,7 @@ function scmp_act_notify_template() {
 	[ "$status" -eq 0 ]
 }
 
+# Test actions not-handled by the agent work fine. noNewPrivileges FALSE.
 @test "runc exec [seccomp] (SCMP_ACT_NOTIFY noNewPrivileges false)" {
 	requires root
 
@@ -68,6 +71,7 @@ function scmp_act_notify_template() {
 	[ "$status" -eq 0 ]
 }
 
+# Test actions not-handled by the agent work fine. noNewPrivileges TRUE.
 @test "runc exec [seccomp] (SCMP_ACT_NOTIFY noNewPrivileges true)" {
 	requires root
 
@@ -78,6 +82,7 @@ function scmp_act_notify_template() {
 	[ "$status" -eq 0 ]
 }
 
+# Test important syscalls (some might be executed by runc) work fine when handled by the agent. noNewPrivileges FALSE.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY important syscalls noNewPrivileges false)" {
 	scmp_act_notify_template "/bin/true" false '"execve","openat","open","read","close"'
 
@@ -85,6 +90,7 @@ function scmp_act_notify_template() {
 	[ "$status" -eq 0 ]
 }
 
+# Test important syscalls (some might be executed by runc) work fine when handled by the agent. noNewPrivileges TRUE.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY important syscalls noNewPrivileges true)" {
 	scmp_act_notify_template "/bin/true" true '"execve","openat","open","read","close"'
 
@@ -105,7 +111,8 @@ function scmp_act_notify_template() {
 	[ "$status" -eq 0 ]
 }
 
-@test "runc run [seccomp] (SCMP_ACT_NOTIFY empty listener path)" {
+# Ensure listenerPath is present if the profile uses seccomp notify actions.
+@test "runc run [seccomp] (SCMP_ACT_NOTIFY empty listener path and notify act)" {
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 	update_config '.linux.seccomp.listenerPath = ""'
 
@@ -113,6 +120,7 @@ function scmp_act_notify_template() {
 	[ "$status" -ne 0 ]
 }
 
+# Test using an invalid socket (none listening) as listenerPath fails.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY wrong listener path)" {
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 	update_config '.linux.seccomp.listenerPath = "/some-non-existing-listener-path.sock"'
@@ -121,7 +129,8 @@ function scmp_act_notify_template() {
 	[ "$status" -ne 0 ]
 }
 
-@test "runc run [seccomp] (SCMP_ACT_NOTIFY abstract listener path)" {
+# Test using an invalid abstract socket as listenerPath fails.
+@test "runc run [seccomp] (SCMP_ACT_NOTIFY wrong abstract listener path)" {
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 	update_config '.linux.seccomp.listenerPath = "@mysocketishere"'
 


### PR DESCRIPTION
This PR fixes a typo in the name of a test (reported in #3415) and, while I was there, I also looked at all the tests in that file and made sure the name was correct. While doing so, I added a 1 line sentence to clarify the intent, as other tests in that file already do.

Fixes: #3415 

cc @mauriciovasquezbernal @alban 