### PR TITLE
Support Id mapped mounts for shared volumes

### DIFF
--- a/libcontainer/configs/mount.go
+++ b/libcontainer/configs/mount.go
@@ -1,6 +1,9 @@
 package configs
 
-import "golang.org/x/sys/unix"
+import (
+	"github.com/opencontainers/runc/libcontainer/user"
+	"golang.org/x/sys/unix"
+)
 
 const (
 	// EXT_COPYUP is a directive to copy up the contents of a directory when
@@ -35,6 +38,10 @@ type Mount struct {
 
 	// Extensions are additional flags that are specific to runc.
 	Extensions int `json:"extensions"`
+
+	// UID/GID mapping per mount point
+	UIDMaps []user.IDMap `json:"uid_maps"`
+	GIDMaps []user.IDMap `json:"gid_maps"`
 }
 
 func (m *Mount) IsBind() bool {


### PR DESCRIPTION
This pull request adds support for id map mount feature for shared volumes.
For rootfs this is already implemented in https://github.com/containerd/containerd/pull/5890.

Both commit has a code in common, which should be placed on the same place in the future.

There are two possibilities to use mount_setattr syscall with fd returned by open_tree or with fd returned by fsmount syscall. This PR uses open_tree, since this approach was used in examples, as well as in crun.

As a fallback scenario, mount syscall still used for bind mount. Open_tree syscall as well as mount_setattr are quite new syscall, to use it latest kernel version is required. In this patch set, kernel version is checked, but as an alternative approach we could just check syscall existence, any suggestions are welcome.
Also this PR includes specs-go which could be moved to separate PR.