### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
 
     - name: install bats
-      uses: mig4/setup-bats@v1
+      uses: mig4/setup-bats@e939fcdb4a143e6ba2afa10d444765659db9e1b5 # v1 https://api.github.com/repos/mig4/setup-bats/git/tags/e939fcdb4a143e6ba2afa10d444765659db9e1b5
       with:
         bats-version: 1.3.0
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,9 @@ env:
 jobs:
 
   lint:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@b517f99ae23d86ecc4c0dec08dcf48d2336abc29 # v3 https://api.github.com/repos/golangci/golangci-lint-action/git/commits/b517f99ae23d86ecc4c0dec08dcf48d2336abc29
         with:
           version: v1.45
 
@@ -42,7 +42,7 @@ jobs:
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@b517f99ae23d86ecc4c0dec08dcf48d2336abc29 # v3 https://api.github.com/repos/golangci/golangci-lint-action/git/commits/b517f99ae23d86ecc4c0dec08dcf48d2336abc29
         with:
           only-new-issues: true
           args: --config .golangci-extra.yml
@@ -114,7 +114,7 @@ jobs:
           sha256sum ~/bin/shellcheck | grep -q $SHA256SUM
           # make sure to remove the old version
           sudo rm -f /usr/bin/shellcheck
-      - uses: lumaxis/shellcheck-problem-matchers@v1
+      - uses: lumaxis/shellcheck-problem-matchers@2766fdd076ee4d2c9b92f0768eb2cb3420b5ad2b # v1 https://api.github.com/repos/lumaxis/shellcheck-problem-matchers/git/tags/2766fdd076ee4d2c9b92f0768eb2cb3420b5ad2b
       - name: shellcheck
         run: |
           make shellcheck
@@ -146,12 +146,12 @@ jobs:
     steps:
       - name: get pr commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.2.0
+        uses: tim-actions/get-pr-commits@c64db31d359214d244884dd68f971a110b29ab83 # v1.2.0 https://api.github.com/repos/tim-actions/get-pr-commits/git/commits/c64db31d359214d244884dd68f971a110b29ab83
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check subject line length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd # v0.3.1 https://api.github.com/repos/tim-actions/commit-message-checker-with-regex/git/commits/d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,72}(\n.*)*$'
@@ -191,7 +191,7 @@ jobs:
       # under Docker will emerge, it will be good to have a separate make
       # runcimage job and share its result (the docker image) with whoever
       # needs it.
-    - uses: satackey/action-docker-layer-caching@v0.0.11
+    - uses: satackey/action-docker-layer-caching@46d2c640b1d8ef50d185452ad6fb324e6bd1d052 # v0.0.11 https://api.github.com/repos/satackey/action-docker-layer-caching/git/commits/46d2c640b1d8ef50d185452ad6fb324e6bd1d052
       continue-on-error: true
     - name: build docker image
       run: make runcimage


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
