### PR TITLE
Move the cgroups v2 hybrid check from init()

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -32,14 +32,6 @@ var subsystems = []subsystem{
 
 var errSubsystemDoesNotExist = errors.New("cgroup: subsystem does not exist")
 
-func init() {
-	// If using cgroups-hybrid mode then add a "" controller indicating
-	// it should join the cgroups v2.
-	if cgroups.IsCgroup2HybridMode() {
-		subsystems = append(subsystems, &NameGroup{GroupName: "", Join: true})
-	}
-}
-
 type subsystem interface {
 	// Name returns the name of the subsystem.
 	Name() string
@@ -67,6 +59,12 @@ func NewManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Manager, e
 	}
 	if cg.Resources.Unified != nil {
 		return nil, cgroups.ErrV1NoUnified
+	}
+
+	// If using cgroups-hybrid mode then add a "" controller indicating
+	// it should join the cgroups v2.
+	if cgroups.IsCgroup2HybridMode() {
+		subsystems = append(subsystems, &NameGroup{GroupName: "", Join: true})
 	}
 
 	if paths == nil {

--- a/libcontainer/cgroups/fs/paths.go
+++ b/libcontainer/cgroups/fs/paths.go
@@ -21,7 +21,7 @@ var (
 
 const defaultCgroupRoot = "/sys/fs/cgroup"
 
-func initPaths(cg *configs.Cgroup) (map[string]string, error) {
+func initPaths(cg *configs.Cgroup, subsystems []subsystem) (map[string]string, error) {
 	root, err := rootPath()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Other code that imports the libcontainer cgroups library
may be vulnerable to panic in the function due to insufficient
permissions.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>