### PR TITLE
[release-1.1] libct/cg: IsCgroup2HybridMode: don't panic

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -55,12 +55,12 @@ func IsCgroup2HybridMode() bool {
 		var st unix.Statfs_t
 		err := unix.Statfs(hybridMountpoint, &st)
 		if err != nil {
-			if os.IsNotExist(err) {
-				// ignore the "not found" error
-				isHybrid = false
-				return
+			isHybrid = false
+			if !os.IsNotExist(err) {
+				// Report unexpected errors.
+				logrus.WithError(err).Debugf("statfs(%q) failed", hybridMountpoint)
 			}
-			panic(fmt.Sprintf("cannot statfs cgroup root: %s", err))
+			return
 		}
 		isHybrid = st.Type == unix.CGROUP2_SUPER_MAGIC
 	})


### PR DESCRIPTION
In case statfs("/sys/fs/cgroup/unified") fails with any error other
than ENOENT, current code panics. As IsCgroup2HybridMode is called from
libcontainer/cgroups/fs's init function, this means that any user of
libcontainer may panic during initialization, which is ugly.

Avoid panicking; instead, do not enable hybrid hierarchy support and
report the error (under debug level, not to confuse anyone).

Basically, replace the panic with "turn off hybrid mode support"
(which makes total sense since we were unable to statfs its root).

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>