### PR TITLE
[1.1] add centos-stream-9

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,6 +74,7 @@ task:
     matrix:
       DISTRO: centos-7
       DISTRO: centos-stream-8
+      DISTRO: centos-stream-9
 
   name: ci / $DISTRO
 
@@ -94,6 +95,10 @@ task:
       ;;
     centos-stream-8)
       yum config-manager --set-enabled powertools # for glibc-static
+      ;;
+    centos-stream-9)
+      dnf config-manager --set-enabled crb # for glibc-static
+      dnf -y install epel-release epel-next-release # for fuse-sshfs
       ;;
     esac
     # Work around dnf mirror failures by retrying a few times.


### PR DESCRIPTION
_Backport of #3427 to 1.1. Original description follows._

----

Add centos-stream-9 to our CI matrix. It runs natively on Cirrus CI and is therefore faster than Fedora job (4 minutes instead of 13 minutes).

centos-stream-9 currently has:
 - kernel 5.14.0-71.el9
 - criu 3.15
so it is quite similar to Fedora 35 at the moment (and this, I guess, explains why we have no issues).

I was thinking at dropping Fedora but decided to keep it since while it does not make much sense now, with a newer Fedora it definitely will (newer kernels etc.)