### PR TITLE
ci/gha: run on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
       - release-*
   pull_request:
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
       - release-*
   pull_request:
 env:


### PR DESCRIPTION
Since we have renamed our default branch (https://github.com/opencontainers/runc/issues/3250), GHA CI is no longer testing
it (see https://github.com/opencontainers/runc/actions).

Fix this.