### PR TITLE
ci/gha: limit jobs permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
       - main
       - release-*
   pull_request:
+permissions:
+  contents: read
 
 env:
   # Don't ignore C warnings. Note that the output of "go env CGO_CFLAGS" by default is "-g -O2", so we keep them.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,10 +9,15 @@ on:
   pull_request:
 env:
   GO_VERSION: 1.18.x
+permissions:
+  contents: read
 
 jobs:
 
   lint:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -140,6 +145,9 @@ jobs:
 
 
   commit:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-20.04
     # Only check commits on pull requests.
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
By default, GHA CI jobs have lots of permissions, which is not good as it can be used by malicious GH actions to e.g. write to the repo.

Most jobs that we have only require to read the repo. Some require to read PRs as well.

Set permissions accordingly.

For details, see
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

Inspired by #3430 

Closes: #3430 