### PR TITLE
Add support for CRIU's 'ignore' manage-cgroup mode

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -38,7 +38,7 @@ checkpointed.`,
 		cli.StringFlag{Name: "page-server", Value: "", Usage: "ADDRESS:PORT of the page server"},
 		cli.BoolFlag{Name: "file-locks", Usage: "handle file locks, for safety"},
 		cli.BoolFlag{Name: "pre-dump", Usage: "dump container's memory information only, leave the container running after this"},
-		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'"},
+		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'ignore', 'full' and 'strict'"},
 		cli.StringSliceFlag{Name: "empty-ns", Usage: "create a namespace, but don't restore its properties"},
 		cli.BoolFlag{Name: "auto-dedup", Usage: "enable auto deduplication of memory images"},
 	},
@@ -147,6 +147,8 @@ func setManageCgroupsMode(context *cli.Context, options *libcontainer.CriuOpts) 
 			options.ManageCgroupsMode = criu.CriuCgMode_FULL
 		case "strict":
 			options.ManageCgroupsMode = criu.CriuCgMode_STRICT
+		case "ignore":
+			options.ManageCgroupsMode = criu.CriuCgMode_IGNORE
 		default:
 			return errors.New("Invalid manage cgroups mode")
 		}

--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -57,7 +57,7 @@ together with **criu lazy-pages**. See
 : Do a pre-dump, i.e. dump container's memory information only, leaving the
 container running. See [criu iterative migration](https://criu.org/Iterative_migration).
 
-**--manage-cgroups-mode** **soft**|**full**|**strict**.
+**--manage-cgroups-mode** **soft**|**ignore**|**full**|**strict**.
 : Cgroups mode. Default is **soft**. See
 [criu --manage-cgroups option](https://criu.org/CLI/opt/--manage-cgroups).
 

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -37,7 +37,7 @@ image files directory.
 : Allow checkpoint/restore of file locks. See
 [criu --file-locks option](https://criu.org/CLI/opt/--file-locks).
 
-**--manage-cgroups-mode** **soft**|**full**|**strict**.
+**--manage-cgroups-mode** **soft**|**ignore**|**full**|**strict**.
 : Cgroups mode. Default is **soft**. See
 [criu --manage-cgroups option](https://criu.org/CLI/opt/--manage-cgroups).
 

--- a/restore.go
+++ b/restore.go
@@ -53,7 +53,7 @@ using the runc checkpoint command.`,
 		cli.StringFlag{
 			Name:  "manage-cgroups-mode",
 			Value: "",
-			Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'",
+			Usage: "cgroups mode: 'soft' (default), 'ignore', 'full' and 'strict'",
 		},
 		cli.StringFlag{
 			Name:  "bundle, b",
@@ -114,6 +114,9 @@ using the runc checkpoint command.`,
 			return err
 		}
 		if err := setEmptyNsMask(context, options); err != nil {
+			return err
+		}
+		if err := setManageCgroupsMode(context, options); err != nil {
 			return err
 		}
 		status, err := startContainer(context, CT_ACT_RESTORE, options)


### PR DESCRIPTION
This adds an already existing CRIU cgroup mode to be selectable from runc: 'ignore'.

This is a fix for errors seen with Podman containers that have been restored multiple times into new cgroups. CRIU fails to checkpoint a container that has already been restored once in a cgroup named differently than the original container.

CRIU keeps information about the original cgroup and during restore in a differently named cgroup CRIU still tries to restore to original cgroup. This leads to a process with wrong cgroup settings and a second checkpoint of that container fails.

With 'ignore' CRIU will ignore any cgroups and leave the cgroup setting to runc.