### PR TITLE
Use `fmt.Sprintf` less

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2100,7 +2100,10 @@ func (c *Container) orderNamespacePaths(namespaces map[configs.NamespaceType]str
 func encodeIDMapping(idMap []configs.IDMap) ([]byte, error) {
 	data := bytes.NewBuffer(nil)
 	for _, im := range idMap {
-		line := fmt.Sprintf("%d %d %d\n", im.ContainerID, im.HostID, im.Size)
+		line := strconv.Itoa(im.ContainerID) + " " +
+			strconv.Itoa(im.HostID) + " " +
+			strconv.Itoa(im.Size) + "\n"
+
 		if _, err := data.WriteString(line); err != nil {
 			return nil, err
 		}

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -286,3 +286,33 @@ func TestGetContainerStateAfterUpdate(t *testing.T) {
 		t.Fatalf("expected Memory to be 2048 but received %q", state.Config.Cgroups.Memory)
 	}
 }
+
+func benchmarkEncodeIDMapping(b *testing.B, m []configs.IDMap) {
+	var (
+		res []byte
+		err error
+	)
+	for i := 0; i < b.N; i++ {
+		res, err = encodeIDMapping(m)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	if len(res) == 0 {
+		b.Fatal("no data")
+	}
+}
+
+func BenchmarkEncodeIDMapping1(b *testing.B) {
+	benchmarkEncodeIDMapping(b, []configs.IDMap{
+		{HostID: 10000, ContainerID: 0, Size: 1000},
+	})
+}
+
+func BenchmarkEncodeIDMapping3(b *testing.B) {
+	benchmarkEncodeIDMapping(b, []configs.IDMap{
+		{HostID: 10000, ContainerID: 0, Size: 1000},
+		{HostID: 20000, ContainerID: 5000, Size: 1000},
+		{HostID: 34567, ContainerID: 9999, Size: 1000},
+	})
+}

--- a/libcontainer/devices/device.go
+++ b/libcontainer/devices/device.go
@@ -1,7 +1,6 @@
 package devices
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 )
@@ -156,17 +155,21 @@ type Rule struct {
 }
 
 func (d *Rule) CgroupString() string {
-	var (
-		major = strconv.FormatInt(d.Major, 10)
-		minor = strconv.FormatInt(d.Minor, 10)
-	)
+	var major, minor string
+
 	if d.Major == Wildcard {
 		major = "*"
+	} else {
+		major = strconv.FormatInt(d.Major, 10)
 	}
+
 	if d.Minor == Wildcard {
 		minor = "*"
+	} else {
+		minor = strconv.FormatInt(d.Minor, 10)
 	}
-	return fmt.Sprintf("%c %s:%s %s", d.Type, major, minor, d.Permissions)
+
+	return string(d.Type) + " " + major + ":" + minor + " " + string(d.Permissions)
 }
 
 func (d *Rule) Mkdev() (uint64, error) {

--- a/libcontainer/devices/device_unix_test.go
+++ b/libcontainer/devices/device_unix_test.go
@@ -95,3 +95,16 @@ func TestHostDevicesAllValid(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkCgroupString(b *testing.B) {
+	devs, err := HostDevices()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, d := range devs {
+			_ = d.CgroupString()
+		}
+	}
+}


### PR DESCRIPTION
Two more cases where removing `fmt.Sprintf` makes things faster.

See individual commits for details.