### PR TITLE
Allow mounting of /proc/sys/kernel/ns_last_pid

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -554,6 +554,7 @@ func checkProcMount(rootfs, dest, source string) error {
 		"/proc/loadavg",
 		"/proc/slabinfo",
 		"/proc/net/dev",
+		"/proc/sys/kernel/ns_last_pid",
 	}
 	for _, valid := range validProcMounts {
 		path, err := filepath.Rel(filepath.Join(rootfs, valid), dest)

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -38,6 +38,14 @@ func TestCheckMountDestFalsePositive(t *testing.T) {
 	}
 }
 
+func TestCheckMountDestNsLastPid(t *testing.T) {
+	dest := "/rootfs/proc/sys/kernel/ns_last_pid"
+	err := checkProcMount("/rootfs", dest, "/proc")
+	if err != nil {
+		t.Fatal("/proc/sys/kernel/ns_last_pid should not return an error")
+	}
+}
+
 func TestNeedsSetupDev(t *testing.T) {
 	config := &configs.Config{
 		Mounts: []*configs.Mount{


### PR DESCRIPTION
The `CAP_CHECKPOINT_RESTORE` linux capability provides the ability to update `/proc/sys/kernel/ns_last_pid`. However, because this "file" is under `/proc`, and by default both K8s and CRI-O specify that `/proc/sys` should be mounted as Read-Only, even with the capability specified, a process will not be able to write to `ns_last_pid`.

To get around this, a pod author can specify a volume mount and a host path to bind-mount `/proc/sys/kernel/ns_last_pid`. However, `runc` does not allow specifying mounts under `/proc`.

This PR adds `/proc/sys/kernel/ns_last_pid` to the `validProcMounts` string array to enable a pod author to mount `ns_last_pid` as read-write. The default remains unchanged; unless explicitly requested as a volume mount, `ns_last_pid` will remain read-only regardless of whether or not `CAP_CHECKPOINT_RESTORE` is specified.

