### PR TITLE
ci/gha: remove stable: when installing Go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,6 @@ jobs:
     - name: install go ${{ matrix.go-version }}
       uses: actions/setup-go@v3
       with:
-        stable: '!contains(${{ matrix.go-version }}, "beta") && !contains(${{ matrix.go-version }}, "rc")'
         go-version: ${{ matrix.go-version }}
 
     - name: build


### PR DESCRIPTION
Since the recent bump of actions/setup-go to v3 (commit
9d2268b9dbd5421f0), specifying "stable:" is no longer needed
when we want to try a beta or rc version of Go.

Remove it.

(This is a followup to https://github.com/opencontainers/runc/pull/3454#issuecomment-1095575483)