### PR TITLE
ci/gha: convert lint-extra from a job to a step

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - uses: actions/setup-go@v3
         with:
           go-version: "${{ env.GO_VERSION }}"
@@ -26,28 +28,11 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45
-
-  lint-extra:
-    # Extra linters, only checking new code from pull requests.
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-      - name: install deps
+      # Extra linters, only checking new code from a pull request.
+      - name: lint-extra
+        if: github.event_name == 'pull_request'
         run: |
-          sudo apt -q update
-          sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v3
-        with:
-          only-new-issues: true
-          args: --config .golangci-extra.yml
-          version: v1.45
-
+          golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1 --out-format=github-actions
 
   compile-buildtags:
     runs-on: ubuntu-20.04

--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -1,5 +1,5 @@
 # This is golangci-lint config file which is used to check new code in
-# github PRs only (see lint-extra job in .github/workflows/validate.yml).
+# github PRs only (see lint-extra in .github/workflows/validate.yml).
 #
 # For the default linter config, see .golangci.yml. This config should
 # only enable additional linters not enabled in the default config.


### PR DESCRIPTION
There is no need to parallelize lint and lint-extra jobs,
and they only differ with the arguments to golangci-lint.
Given that the longest time spent in these jobs is installing
libseccomp-dev, and that the second linter run can probably
benefit a lot from caching, it makes sense to merge them.

Move lint-extra from a separate job to a step in lint job.
