### PR TITLE
Do not use regexp

### DIFF
--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -35,8 +35,11 @@ func TestSystemdVersion(t *testing.T) {
 		{`"v245.4-1.fc32"`, 245, false},
 		{`"241-1"`, 241, false},
 		{`"v241-1"`, 241, false},
-		{"NaN", 0, true},
-		{"", 0, true},
+		{`333.45"`, 333, false},
+		{`v321-0`, 321, false},
+		{"NaN", -1, true},
+		{"", -1, true},
+		{"v", -1, true},
 	}
 	for _, sdTest := range systemdVersionTests {
 		ver, err := systemdVersionAtoi(sdTest.verStr)


### PR DESCRIPTION
Don't get me wrong, I love regular expressions. But the regexp package is somewhat big and slow, and we can do just fine without.

Remove two last uses of regexp in runc code (modulo tests).

**This saves about 200K (2.3%) from the resulting binary, without losing any of the functionality.**

~~Currently a draft pending~~
 - [x] #3514 
 - [x] #3484 (which has https://github.com/urfave/cli/pull/1383)
 - [x] #3491 (which has https://github.com/cilium/ebpf/pull/642)
 - [x] #3543 (which has https://go-review.googlesource.com/c/protobuf/+/402774)
 - [x] #3585 (which has https://github.com/docker/go-units/pull/40)
