### PR TITLE
libct/seccomp/config: add missing KillThread, KillProcess

### DIFF
--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -29,13 +29,15 @@ func KnownOperators() []string {
 }
 
 var actions = map[string]configs.Action{
-	"SCMP_ACT_KILL":   configs.Kill,
-	"SCMP_ACT_ERRNO":  configs.Errno,
-	"SCMP_ACT_TRAP":   configs.Trap,
-	"SCMP_ACT_ALLOW":  configs.Allow,
-	"SCMP_ACT_TRACE":  configs.Trace,
-	"SCMP_ACT_LOG":    configs.Log,
-	"SCMP_ACT_NOTIFY": configs.Notify,
+	"SCMP_ACT_KILL":         configs.Kill,
+	"SCMP_ACT_ERRNO":        configs.Errno,
+	"SCMP_ACT_TRAP":         configs.Trap,
+	"SCMP_ACT_ALLOW":        configs.Allow,
+	"SCMP_ACT_TRACE":        configs.Trace,
+	"SCMP_ACT_LOG":          configs.Log,
+	"SCMP_ACT_NOTIFY":       configs.Notify,
+	"SCMP_ACT_KILL_THREAD":  configs.KillThread,
+	"SCMP_ACT_KILL_PROCESS": configs.KillProcess,
 }
 
 // KnownActions returns the list of the known actions.

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -234,6 +234,14 @@ func TestSetupSeccomp(t *testing.T) {
 				Names:  []string{"mknod"},
 				Action: "SCMP_ACT_NOTIFY",
 			},
+			{
+				Names:  []string{"rmdir"},
+				Action: "SCMP_ACT_KILL_THREAD",
+			},
+			{
+				Names:  []string{"mkdir"},
+				Action: "SCMP_ACT_KILL_PROCESS",
+			},
 		},
 	}
 	seccomp, err := SetupSeccomp(conf)
@@ -263,9 +271,8 @@ func TestSetupSeccomp(t *testing.T) {
 
 	calls := seccomp.Syscalls
 
-	callsLength := len(calls)
-	if callsLength != 8 {
-		t.Errorf("Expected 8 syscalls, got :%d", callsLength)
+	if len(calls) != len(conf.Syscalls) {
+		t.Error("Mismatched number of syscalls")
 	}
 
 	for _, call := range calls {
@@ -315,6 +322,14 @@ func TestSetupSeccomp(t *testing.T) {
 			}
 		case "mknod":
 			if call.Action != configs.Notify {
+				t.Errorf("Wrong conversion for the %s syscall action", call.Name)
+			}
+		case "rmdir":
+			if call.Action != configs.KillThread {
+				t.Errorf("Wrong conversion for the %s syscall action", call.Name)
+			}
+		case "mkdir":
+			if call.Action != configs.KillProcess {
 				t.Errorf("Wrong conversion for the %s syscall action", call.Name)
 			}
 		default:


### PR DESCRIPTION
OCI spec added SCMP_ACT_KILL_THREAD and SCMP_ACT_KILL_PROCESS almost two
years ago ([1], [2]), but runc support was half-finished [3].

Add these actions, and modify the test case to check them.

In addition, "runc features" now lists the new actions.

[1] https://github.com/opencontainers/runtime-spec/pull/1044
[2] https://github.com/opencontainers/runtime-spec/pull/1064
[3] https://github.com/opencontainers/runc/pulls/3204

Fixes: 4a4d4f109b6b257a7189e
