### PR TITLE
Remove tun/tap from the default device rules

### DIFF
--- a/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
+++ b/libcontainer/cgroups/ebpf/devicefilter/devicefilter_test.go
@@ -120,21 +120,14 @@ block-8:
         51: Mov32Imm dst: r0 imm: 1
         52: Exit
 block-9:
-// tuntap (c, 10, 200, rwm, allow)
-        53: JNEImm dst: r2 off: -1 imm: 2 <block-10>
-        54: JNEImm dst: r4 off: -1 imm: 10 <block-10>
-        55: JNEImm dst: r5 off: -1 imm: 200 <block-10>
-        56: Mov32Imm dst: r0 imm: 1
-        57: Exit
-block-10:
 // /dev/pts (c, 136, wildcard, rwm, true)
-        58: JNEImm dst: r2 off: -1 imm: 2 <block-11>
-        59: JNEImm dst: r4 off: -1 imm: 136 <block-11>
-        60: Mov32Imm dst: r0 imm: 1
-        61: Exit
-block-11:
-        62: Mov32Imm dst: r0 imm: 0
-        63: Exit
+        53: JNEImm dst: r2 off: -1 imm: 2 <block-10>
+        54: JNEImm dst: r4 off: -1 imm: 136 <block-10>
+        55: Mov32Imm dst: r0 imm: 1
+        56: Exit
+block-10:
+        57: Mov32Imm dst: r0 imm: 0
+        58: Exit
 `
 	var devices []*devices.Rule
 	for _, device := range specconv.AllowedDevices {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -302,16 +302,6 @@ var AllowedDevices = []*devices.Device{
 			Allow:       true,
 		},
 	},
-	// tuntap
-	{
-		Rule: devices.Rule{
-			Type:        devices.CharDevice,
-			Major:       10,
-			Minor:       200,
-			Permissions: "rwm",
-			Allow:       true,
-		},
-	},
 }
 
 type CreateOpts struct {


### PR DESCRIPTION
Looking through git blame, this was added by commit 9fac18329
aka "Initial commit of runc binary", most probably by mistake.

Obviously, a container should not have access to tun/tap device, unless
it is explicitly specified in configuration.

Now, removing this might create a compatibility issue, but I see no
other choice.

Aside from the obvious misconfiguration, this should also fix the
annoying

> Apr 26 03:46:56 foo.bar systemd[1]: Couldn't stat device /dev/char/10:200: No such file or directory

messages from systemd on every container start, when runc uses systemd
cgroup driver, and the system runs an old (< v240) version of systemd
(the message was presumably eliminated by [1]).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1945929

[1] https://github.com/systemd/systemd/pull/10996/commits/d5aecba6e0b7c73657c4cf544ce57289115098e7