### PR TITLE
tests/int: fix a bad typo

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -405,7 +405,7 @@ function requires() {
 			;;
 		cgroups_v1)
 			init_cgroup_paths
-			if [ ! -v GROUP_V1 ]; then
+			if [ ! -v CGROUP_V1 ]; then
 				skip_me=1
 			fi
 			;;


### PR DESCRIPTION
As a result, cgroup v1 only tests are being skipped 🤦🏻 

Fixes: a2123baf63fd