### PR TITLE
Vagrantfile.fedora: fix build wrt new git

### DIFF
--- a/Vagrantfile.fedora
+++ b/Vagrantfile.fedora
@@ -29,6 +29,9 @@ EOF
     done
     dnf clean all
 
+    # Prevent the "fatal: unsafe repository" git complain during build.
+    git config --global --add safe.directory /vagrant
+
     # Install golang.
     # FIXME go back to golang-go rpm once switched to Fedora 36.
     curl -fsSL https://go.dev/dl/go1.18.linux-amd64.tar.gz | tar Cxz /usr/local


### PR DESCRIPTION
Currently Fedora CI is broken on all PRs. This is caused by the updated git,
as a result we can no longer build runc via sudo from Vagrant:

	ssh default 'sudo -i make -C /vagrant localunittest'
	make: Entering directory '/vagrant'
	fatal: unsafe repository ('/vagrant' is owned by someone else)
	To add an exception for this directory, call:

		git config --global --add safe.directory /vagrant
	go build -trimpath "-buildmode=pie"  -tags "seccomp" -ldflags "-X main.gitCommit= -X main.version=1.1.0+dev " -o runc .
	error obtaining VCS status: exit status 128
		Use -buildvcs=false to disable VCS stamping.
	make: Leaving directory '/vagrant'

This commit should fix this.