### PR TITLE
script/seccomp.sh: check tarball sha256

### DIFF
--- a/script/seccomp.sh
+++ b/script/seccomp.sh
@@ -5,6 +5,11 @@ set -e -u -o pipefail
 # shellcheck source=./script/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# sha256 checksums for seccomp release tarballs.
+declare -A SECCOMP_SHA256=(
+	["2.5.4"]=d82902400405cf0068574ef3dc1fe5f5926207543ba1ae6f8e7a1576351dcbdb
+)
+
 # Due to libseccomp being LGPL we must include its sources,
 # so download, install and build against it.
 # Parameters:
@@ -19,8 +24,10 @@ function build_libseccomp() {
 	local arches=("$@")
 	local tar="libseccomp-${ver}.tar.gz"
 
-	# Download and extract.
+	# Download, check, and extract.
 	wget "https://github.com/seccomp/libseccomp/releases/download/v${ver}/${tar}"{,.asc}
+	sha256sum --strict --check - <<<"${SECCOMP_SHA256[${ver}]} *${tar}"
+
 	local srcdir
 	srcdir="$(mktemp -d)"
 	tar xf "$tar" -C "$srcdir"


### PR DESCRIPTION
Add checking of downloaded tarball checksum.

In case it doesn't match the hardcoded value, the error is like this:

        libseccomp-2.5.4.tar.gz: FAILED
        sha256sum: WARNING: 1 computed checksum did NOT match

In case the checksum for a particular version is not specified in the
script, the error will look like this:

        ./script/seccomp.sh: line 29: SECCOMP_SHA256[${ver}]: unbound variable

In case the the hardcoded value in the file is of wrong format/length,
we'll get:

        sha256sum: 'standard input': no properly formatted SHA256 checksum lines found

In any of these cases, the script aborts (due to set -e).

Addresses https://github.com/opencontainers/runc/pull/3480#pullrequestreview-982570157