### PR TITLE
ci: drop docker layer caching from release job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -186,8 +186,6 @@ jobs:
       # under Docker will emerge, it will be good to have a separate make
       # runcimage job and share its result (the docker image) with whoever
       # needs it.
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
     - name: build docker image
       run: make runcimage
     - name: make releaseall


### PR DESCRIPTION
This job is failing with "No space left on device" lately, and this
helps to fix it.

Besides, it seems that caching does not help to shorten execution times
(validate/release job succeeds in under 8 minutes now; ymmv).

----

This is a forward-port of #3479 to main branch.