### PR TITLE
vendor: bump urfave/cli, add urfave_cli_no_docs tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
-BUILDTAGS ?= seccomp
+BUILDTAGS ?= seccomp urfave_cli_no_docs
 
 COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION := $(shell cat ./VERSION)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646
 	github.com/sirupsen/logrus v1.8.1
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
-	github.com/urfave/cli v1.22.6
+	github.com/urfave/cli v1.22.9
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
 	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/urfave/cli v1.22.6 h1:fceBvTciht0l37ZXw49pexwy3YcwRzxYqj5NV1vxalI=
-github.com/urfave/cli v1.22.6/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.9 h1:cv3/KhXGBGjEXLC4bH0sLuJ9BewaAbpk5oyMOveu4pw=
+github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -39,6 +39,16 @@ cli is tested against multiple versions of Go on Linux, and against the latest
 released version of Go on OS X and Windows.  For full details, see
 [`./.travis.yml`](./.travis.yml) and [`./appveyor.yml`](./appveyor.yml).
 
+### Build tags
+
+You can use the following build tags:
+
+#### `urfave_cli_no_docs`
+
+When set, this removes `ToMarkdown` and `ToMan` methods, so your application
+won't be able to call those. This reduces the resulting binary size by about
+300-400 KB (measured using Go 1.18.1 on Linux/amd64), due to less dependencies.
+
 ### Using `v1` releases
 
 ```

--- a/vendor/github.com/urfave/cli/docs.go
+++ b/vendor/github.com/urfave/cli/docs.go
@@ -1,3 +1,6 @@
+//go:build !urfave_cli_no_docs
+// +build !urfave_cli_no_docs
+
 package cli
 
 import (

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -338,8 +338,10 @@ func flagFromFileEnv(filePath, envName string) (val string, ok bool) {
 		}
 	}
 	for _, fileVar := range strings.Split(filePath, ",") {
-		if data, err := ioutil.ReadFile(fileVar); err == nil {
-			return string(data), true
+		if fileVar != "" {
+			if data, err := ioutil.ReadFile(fileVar); err == nil {
+				return string(data), true
+			}
 		}
 	}
 	return "", false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/sirupsen/logrus/hooks/test
 # github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 ## explicit
 github.com/syndtr/gocapability/capability
-# github.com/urfave/cli v1.22.6
+# github.com/urfave/cli v1.22.9
 ## explicit; go 1.11
 github.com/urfave/cli
 # github.com/vishvananda/netlink v1.1.0


### PR DESCRIPTION
This removes the runc dependency on cpuguy83/md2man and
russross/blackfriday, which saves more than 400 KB (more than 300 KB
once stripped) from the binary.