### PR TITLE
libct/intelrdt: skip reading /proc/cpuinfo

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -479,7 +479,7 @@ func (m *Manager) Destroy() error {
 	// Don't remove resctrl group if closid has been explicitly specified. The
 	// group is likely externally managed, i.e. by some other entity than us.
 	// There are probably other containers/tasks sharing the same group.
-	if m.config.IntelRdt == nil || m.config.IntelRdt.ClosID == "" {
+	if m.config.IntelRdt != nil && m.config.IntelRdt.ClosID == "" {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		if err := os.RemoveAll(m.GetPath()); err != nil {

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -152,9 +152,13 @@ type Manager struct {
 	path   string
 }
 
-// NewManager returns a new instance of Manager, or nil, if the Intel RDT
-// functionality is not available from hardware or not enabled in the kernel.
+// NewManager returns a new instance of Manager, or nil if the Intel RDT
+// functionality is not specified in the config, available from hardware or
+// enabled in the kernel.
 func NewManager(config *configs.Config, id string, path string) *Manager {
+	if config.IntelRdt == nil {
+		return nil
+	}
 	if _, err := Root(); err != nil {
 		// Intel RDT is not available.
 		return nil

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -182,8 +182,6 @@ var (
 	catEnabled bool
 	// The flag to indicate if Intel RDT/MBA is enabled
 	mbaEnabled bool
-	// The flag to indicate if Intel RDT/MBA Software Controller is enabled
-	mbaScEnabled bool
 
 	// For Intel RDT initialization
 	initOnce sync.Once
@@ -216,12 +214,7 @@ func featuresInit() {
 				catEnabled = true
 			}
 		}
-		if mbaScEnabled {
-			// We confirm MBA Software Controller is enabled in step 2,
-			// MBA should be enabled because MBA Software Controller
-			// depends on MBA
-			mbaEnabled = true
-		} else if flagsSet.MBA {
+		if flagsSet.MBA {
 			if _, err := os.Stat(filepath.Join(root, "info", "MB")); err == nil {
 				mbaEnabled = true
 			}
@@ -258,11 +251,6 @@ func findIntelRdtMountpointDir() (string, error) {
 	}
 	if len(mi) < 1 {
 		return "", errNotFound
-	}
-
-	// Check if MBA Software Controller is enabled through mount option "-o mba_MBps"
-	if strings.Contains(","+mi[0].VFSOptions+",", ",mba_MBps,") {
-		mbaScEnabled = true
 	}
 
 	return mi[0].Mountpoint, nil
@@ -491,12 +479,6 @@ func IsCATEnabled() bool {
 func IsMBAEnabled() bool {
 	featuresInit()
 	return mbaEnabled
-}
-
-// Check if Intel RDT/MBA Software Controller is enabled
-func IsMBAScEnabled() bool {
-	featuresInit()
-	return mbaScEnabled
 }
 
 // Get the path of the clos group in "resource control" filesystem that the container belongs to


### PR DESCRIPTION
- Relates to #3181 

Reading `/proc/cpuinfo` is a surprisingly expensive operation. [Since kernel version 4.12][1], opening `/proc/cpuinfo` on an x86 system can block for around 20 milliseconds while the kernel samples the current CPU frequency. There is [a very recent patch][2] which gets rid of the delay, but has yet to make it into the mainline kernel. Regardless, kernels for which opening `/proc/cpuinfo` takes 20ms will continue to be run in production for years to come. libcontainer only opens `/proc/cpuinfo` to read the processor feature flags so all the delays to get an accurate snapshot of the CPU frequency are just wasted time.

If we wanted to, we could interrogate the CPU features directly from userspace using the `CPUID` instruction. However, Intel and AMD CPUs have flags in different positions for their analogous sub-features and there are [CPU quirks][3] which would need to be accounted for. Some Haswell server CPUs support RDT/CAT but are missing the `CPUID` flags advertising their support; [the kernel checks for support on that processor family by probing the the hardware using privileged `RDMSR`/`WRMSR` instructions][4]. This sort of probing could not be implemented in userspace so it would not be possible to check for RDT feature support in userspace without false negatives on some hardware configurations.

It looks like libcontainer reads the CPU feature flags as a kind of optimization so that it can skip checking whether the kernel supports an RDT sub-feature if the hardware support is missing. As the kernel only exposes subtrees in the `resctrl` filesystem for RDT sub-features with hardware and kernel support, checking the CPU feature flags is redundant from a correctness point of view. Remove the `/proc/cpuinfo` check as it is an optimization which actually hurts performance.

<details>
<summary>
Benchmarks: <tt>runc run</tt> is 17 ms faster when <tt>"intelRdt"</tt> is enabled in config.json
</summary>

- Hardware: AWS EC2 c5n.metal
- OS: Ubuntu 20.04 LTS
- `/sys/fs/resctrl` mounted
- OCI config:
  - `"args": ["/bin/true"]`
  - `"linux": {"intelRdt": {"memBwSchema": "MB:0=20;1=70"}}`

<table>

<tr>
  <th></th>
  <th>3f0daac9082e422486fdac35b6445f75dd98eb64</th>
  <th>This PR</th>
</tr>

<tr><th>Run 1</th>
<td>

```
real	0m0.098s
user	0m0.029s
sys	0m0.043s
```

</td><td>

```
real	0m0.092s
user	0m0.023s
sys	0m0.048s
```

</td></tr>

<tr><th>Run 2</th>
<td>

```
real	0m0.110s
user	0m0.019s
sys	0m0.052s
```

</td><td>

```
real	0m0.074s
user	0m0.022s
sys	0m0.047s
```

</td></tr>

<tr><th>Run 3</th>
<td>

```
real	0m0.087s
user	0m0.019s
sys	0m0.051s
```

</td><td>

```
real	0m0.077s
user	0m0.025s
sys	0m0.046s
```

</td></tr></table>

</details>

[1]: https://unix.stackexchange.com/a/526679
[2]: https://lore.kernel.org/all/20220415161206.875029458@linutronix.de/
[3]: https://github.com/torvalds/linux/blob/7cf6a8a17f5b134b7e783c2d45c53298faef82a7/arch/x86/kernel/cpu/resctrl/core.c#L834-L851
[4]: https://github.com/torvalds/linux/blob/a6b450573b912316ad36262bfc70e7c3870c56d1/arch/x86/kernel/cpu/resctrl/core.c#L111-L153