### PR TITLE
[1.1] Allow mounting of /proc/sys/kernel/ns_last_pid

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -577,6 +577,7 @@ func checkProcMount(rootfs, dest, source string) error {
 		"/proc/loadavg",
 		"/proc/slabinfo",
 		"/proc/net/dev",
+		"/proc/sys/kernel/ns_last_pid",
 	}
 	for _, valid := range validProcMounts {
 		path, err := filepath.Rel(filepath.Join(rootfs, valid), dest)

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -38,6 +38,14 @@ func TestCheckMountDestFalsePositive(t *testing.T) {
 	}
 }
 
+func TestCheckMountDestNsLastPid(t *testing.T) {
+	dest := "/rootfs/proc/sys/kernel/ns_last_pid"
+	err := checkProcMount("/rootfs", dest, "/proc")
+	if err != nil {
+		t.Fatal("/proc/sys/kernel/ns_last_pid should not return an error")
+	}
+}
+
 func TestNeedsSetupDev(t *testing.T) {
 	config := &configs.Config{
 		Mounts: []*configs.Mount{


### PR DESCRIPTION
Backport of #3451.