### PR TITLE
[1.1] libcontainer: relax getenv_int sanity check

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -416,11 +416,9 @@ static int getenv_int(const char *name)
 	if (val == endptr || *endptr != '\0')
 		bail("unable to parse %s=%s", name, val);
 	/*
-	 * Sanity check: this must be a small non-negative number.
-	 * Practically, we pass two fds (3 and 4) and a log level,
-	 * for which the maximum is 6 (TRACE).
-	 * */
-	if (ret < 0 || ret > TRACE)
+	 * Sanity check: this must be a non-negative number.
+	 */
+	if (ret < 0)
 		bail("bad value for %s=%s (%d)", name, val, ret);
 
 	return ret;


### PR DESCRIPTION
 This is a backport of #3489 to release-1.1 branch.

Remove upper bound in integer sanity check
to not restrict the number of socket-activated
sockets passed in.
