### PR TITLE
cgroups: systemd: skip adding device paths that don't exist

### DIFF
--- a/libcontainer/cgroups/devices/systemd.go
+++ b/libcontainer/cgroups/devices/systemd.go
@@ -129,7 +129,13 @@ func systemdProperties(r *configs.Resources) ([]systemdDbus.Property, error) {
 				entry.Path = fmt.Sprintf("/dev/char/%d:%d", rule.Major, rule.Minor)
 			}
 		}
-		deviceAllowList = append(deviceAllowList, entry)
+		// systemd will issue a warning if the path we give here doesn't exist.
+		// Since all of this logic is best-effort anyway (we manually set these
+		// rules separately to systemd) we can safely skip entries that don't
+		// have a corresponding path.
+		if _, err := os.Stat(entry.Path); err == nil {
+			deviceAllowList = append(deviceAllowList, entry)
+		}
 	}
 
 	properties = append(properties, newProp("DeviceAllow", deviceAllowList))


### PR DESCRIPTION
systemd emits very loud warnings when the path specified doesn't exist
(which can be the case for some of our default rules). We don't need the
ruleset we give systemd to be completely accurate (we discard some kinds
of wildcard rules anyway) so we can safely skip adding these.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>