### PR TITLE
export blockIODevice

### DIFF
--- a/libcontainer/configs/blkio_device.go
+++ b/libcontainer/configs/blkio_device.go
@@ -2,8 +2,8 @@ package configs
 
 import "fmt"
 
-// blockIODevice holds major:minor format supported in blkio cgroup
-type blockIODevice struct {
+// BlockIODevice holds major:minor format supported in blkio cgroup.
+type BlockIODevice struct {
 	// Major is the device's major number
 	Major int64 `json:"major"`
 	// Minor is the device's minor number
@@ -12,7 +12,7 @@ type blockIODevice struct {
 
 // WeightDevice struct holds a `major:minor weight`|`major:minor leaf_weight` pair
 type WeightDevice struct {
-	blockIODevice
+	BlockIODevice
 	// Weight is the bandwidth rate for the device, range is from 10 to 1000
 	Weight uint16 `json:"weight"`
 	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only
@@ -41,7 +41,7 @@ func (wd *WeightDevice) LeafWeightString() string {
 
 // ThrottleDevice struct holds a `major:minor rate_per_second` pair
 type ThrottleDevice struct {
-	blockIODevice
+	BlockIODevice
 	// Rate is the IO rate limit per cgroup per device
 	Rate uint64 `json:"rate"`
 }


### PR DESCRIPTION
the struct blockIODevice is used in an exported struct but it is not itself exported rendering that type inaccessible to
outside projects

Signed-off-by: cdoern <cdoern@redhat.com>