### PR TITLE
libct: fix mounting via wrong proc fd

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -73,6 +73,8 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds []int) (err
 		// Therefore, we can access mountFds[i] without any concerns.
 		if mountFds != nil && mountFds[i] != -1 {
 			mountConfig.fd = &mountFds[i]
+		} else {
+			mountConfig.fd = nil
 		}
 
 		if err := mountToRootfs(m, mountConfig); err != nil {

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -64,3 +64,22 @@ function teardown() {
 	runc exec test_busybox stat /tmp/mount-1/foo.txt /tmp/mount-2/foo.txt
 	[ "$status" -eq 0 ]
 }
+
+# Issue fixed by https://github.com/opencontainers/runc/pull/3510.
+@test "userns with bind mount before a cgroupfs mount" {
+	# This can only be reproduced on cgroup v1 (and no cgroupns) due to the
+	# way it is mounted in such case (a bunch of of bind mounts).
+	requires cgroups_v1
+
+	# Add a bind mount right before the /sys/fs/cgroup mount,
+	# and make sure cgroupns is not enabled.
+	update_config '	  .mounts |= map(if .destination == "/sys/fs/cgroup" then ({"source": "source-accessible/dir", "destination": "/tmp/mount-1", "options": ["bind"]}, .) else . end)
+			| .linux.namespaces -= [{"type": "cgroup"}]'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	# Make sure this is real cgroupfs.
+	runc exec test_busybox cat /sys/fs/cgroup/{pids,memory}/tasks
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Due to a bug in commit 9c444070ec7, mountFd is not cleared and
its value might be used for the subsequent mounts.

As mountFd is ignored for all but bind mounts, and bind mounts have
their own mountFd, this is a non-issue, except when the following very
specific set of conditions is met:

 - userns (and mountns) are used
 - cgroupns is not used
 - cgroup v1 is used
 - the mount for /sys/fs/cgroup is after the bind mount in spec

The bug manifests because cgroup v1 `/sys/fs/cgroup` mount
is internally transformed into a bunch of bind mounts (and those
bind mounts are using stale mountFd).

The bug manifests itself in either one of these two ways
(randomly, not entirely sure why):

1. One of /sys/fs/cgroup sub-mounts fails to mount.
2. The cgroup bind mounts succeed, but use the mountFd from the previous bind mount.

A reproducer with podman 4.1:
```console
$ podman version
Client:       Podman Engine
Version:      4.2.0-dev
API Version:  4.2.0-dev
Go Version:   go1.17.6
Git Commit:   b078aeb87c4ef0fdc17a69992d33404efb0ccc40
Built:        Fri Jun 10 15:11:15 2022
OS/Arch:      linux/amd64

$ sudo podman run --runtime /path/to/runc --uidmap 0:100:10000 quay.io/libpod/testimage:20210610 cat /sys/fs/cgroup/pids/tasks
Error: /home/kir/git/runc/runc: runc create failed: unable to start container process: error during container init: error mounting "cgroup" to rootfs at "/sys/fs/cgroup": mount /proc/self/fd/11:/sys/fs/cgroup/systemd (via /proc/self/fd/12), flags: 0x20502f: operation not permitted: OCI permission denied
```

or (same command as above, different error):

```console
cat: can't open '/sys/fs/cgroup/pids/tasks': No such file or directory
```

This PR is a minimal fix for the issue, suitable for backporting.
A test case is added reproducing the issue without using podman.

A followup to this to refactor and clean up this code is being worked on in https://github.com/opencontainers/runc/pull/3512

Fixes: 9c444070ec7 ("Open bind mount sources from the host userns")