### PR TITLE
Refactor mountFd code

### DIFF
--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -18,7 +18,7 @@ func mountConsole(slavePath string) error {
 	if f != nil {
 		f.Close()
 	}
-	return mount(slavePath, "/dev/console", "", "bind", unix.MS_BIND, "")
+	return mount(slavePath, "/dev/console", "bind", unix.MS_BIND, "")
 }
 
 // dupStdio opens the slavePath for the console and dups the fds to the current

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1357,8 +1357,8 @@ func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
 			// because during initial container creation mounts are
 			// set up in the order they are configured.
 			if m.Device == "bind" {
-				if err := utils.WithProcfd(c.config.Rootfs, m.Destination, func(procfd string) error {
-					if err := mount(m.Source, m.Destination, procfd, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+				if err := utils.WithProcfd(c.config.Rootfs, m.Destination, func(dstFD string) error {
+					if err := mountViaFDs(m.Source, "", m.Destination, dstFD, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
 						return err
 					}
 					return nil
@@ -1411,7 +1411,7 @@ func (c *Container) Restore(process *Process, criuOpts *CriuOpts) error {
 	if err != nil {
 		return err
 	}
-	err = mount(c.config.Rootfs, root, "", "", unix.MS_BIND|unix.MS_REC, "")
+	err = mount(c.config.Rootfs, root, "", unix.MS_BIND|unix.MS_REC, "")
 	if err != nil {
 		return err
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1277,9 +1277,8 @@ func (c *Container) makeCriuRestoreMountpoints(m *configs.Mount) error {
 	case "bind":
 		// The prepareBindMount() function checks if source
 		// exists. So it cannot be used for other filesystem types.
-		// TODO: pass something else than nil? Not sure if criu is
-		// impacted by issue #2484
-		if err := prepareBindMount(m, c.config.Rootfs, nil); err != nil {
+		// TODO: pass srcFD? Not sure if criu is impacted by issue #2484.
+		if err := prepareBindMount(mountEntry{Mount: m}, c.config.Rootfs); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
This is a followup to #3510, doing some refactoring of the code introduced by #2576.

This does the following:

1. Simplify `mount` call by removing the procfd argument, and use the new
   simplified mount where procfd is not used. Now, the mount arguments are
   the same as those of `unix.Mount`.

2. Introduce a new `mountWithFD` function, which is similar to the old
   mount(), except it can take procfd for both source and target.
   The new arguments are called `srcFD` and `dstFD`.

3. Modify the mount error to show both `srcFD` and `dstFD` so it's clear
   which one is used for which purpose. This fixes the issue of having
   a somewhat cryptic errors like this:

   > mount /proc/self/fd/11:/sys/fs/cgroup/systemd (via /proc/self/fd/12), flags: 0x20502f: operation not permitted
 
   (in which fd 11 is actually the source, and fd 12 is the target).

4. Fix the `mountWithFD` callers to use `dstFD` (rather than `procfd`) for the
   variable name.

5. Use `srcFD` where `mountFd` is set.

6. Remove fd field from the `mountConfig` (since it contains data not specific to
   a particular mount, while fd is a per mount entry attribute). Introduce `mountEntry`
   structure, which embeds `configs.Mount` and adds `srcFd` to replace the
   removed `mountConfig.fd`.