### PR TITLE
libct: Don't use stale mount fds

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -60,15 +60,16 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds []int) (err
 		return fmt.Errorf("malformed mountFds slice. Expected size: %v, got: %v. Slice: %v", len(config.Mounts), len(mountFds), mountFds)
 	}
 
-	mountConfig := &mountConfig{
-		root:            config.Rootfs,
-		label:           config.MountLabel,
-		cgroup2Path:     iConfig.Cgroup2Path,
-		rootlessCgroups: iConfig.RootlessCgroups,
-		cgroupns:        config.Namespaces.Contains(configs.NEWCGROUP),
-	}
 	setupDev := needsSetupDev(config)
 	for i, m := range config.Mounts {
+		mountConfig := &mountConfig{
+			root:            config.Rootfs,
+			label:           config.MountLabel,
+			cgroup2Path:     iConfig.Cgroup2Path,
+			rootlessCgroups: iConfig.RootlessCgroups,
+			cgroupns:        config.Namespaces.Contains(configs.NEWCGROUP),
+		}
+
 		// Just before the loop we checked that if not empty, len(mountFds) == len(config.Mounts).
 		// Therefore, we can access mountFds[i] without any concerns.
 		if mountFds != nil && mountFds[i] != -1 {


### PR DESCRIPTION
This is an alternative fix for the same bug that PR https://github.com/opencontainers/runc/pull/3510 is tackling. Both PRs should have the same effect (the .fd field is nil when it should).

I'm just opening this PR so people can chose the PR they prefer. Both are correct and easy to backport.

What I like about this is that similar bugs should not happen, as the mountConfig is cleared on every iteration, and should be very simple to backport too.

Please keep me in the loop in the future too, so I can help to fix the bugs that come around :)