### PR TITLE
CHANGELOG.md: forward-port 1.1.x changes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -151,7 +151,6 @@ jobs:
           pattern: '^.{0,72}(\n.*)*$'
           error: 'Subject too long (max 72)'
 
-
   cfmt:
     runs-on: ubuntu-20.04
     steps:
@@ -176,6 +175,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
+    - name: check CHANGELOG.md
+      run: make verify-changelog
+
       # We have to run this under Docker as Ubuntu (host) does not support all
       # the architectures we want to compile test against, and Dockerfile uses
       # Debian (which does).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog/
+# Changelog
 This file documents all notable changes made to this project since runc 1.0.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -27,6 +27,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    support would return `-EPERM` despite the existence of the `-ENOSYS` stub
    code (this was due to how s390x does syscall multiplexing). (#3474)
 
+
+## [1.1.3] - 2022-06-09
+
+> In the beginning there was nothing, which exploded.
+
+### Fixed
+ * Our seccomp `-ENOSYS` stub now correctly handles multiplexed syscalls on
+   s390 and s390x. This solves the issue where syscalls the host kernel did not
+   support would return `-EPERM` despite the existence of the `-ENOSYS` stub
+   code (this was due to how s390x does syscall multiplexing). (#3478)
+ * Retry on dbus disconnect logic in libcontainer/cgroups/systemd now works as
+   intended; this fix does not affect runc binary itself but is important for
+   libcontainer users such as Kubernetes. (#3476)
+ * Inability to compile with recent clang due to an issue with duplicate
+   constants in libseccomp-golang. (#3477)
+ * When using systemd cgroup driver, skip adding device paths that don't exist,
+   to stop systemd from emitting warnings about those paths. (#3504)
+ * Socket activation was failing when more than 3 sockets were used. (#3494)
+ * Various CI fixes. (#3472, #3479)
+
+### Added
+ * Allow to bind mount /proc/sys/kernel/ns_last_pid to inside container. (#3493)
+
+### Changed
+ * runc static binaries are now linked against libseccomp v2.5.4. (#3481)
+
+
+## [1.1.2] - 2022-05-11
+
+> I should think I'm going to be a perpetual student.
+
+### Security
+ * A bug was found in runc where runc exec --cap executed processes with
+   non-empty inheritable Linux process capabilities, creating an atypical Linux
+   environment. For more information, see [GHSA-f3fp-gc8g-vw66][] and
+   CVE-2022-29162.
+
+### Changed
+ * `runc spec` no longer sets any inheritable capabilities in the created
+   example OCI spec (`config.json`) file.
+
+[GHSA-f3fp-gc8g-vw66]: https://github.com/opencontainers/runc/security/advisories/GHSA-f3fp-gc8g-vw66
+
+
+## [1.1.1] - 2022-03-28
+
+> Violence is the last refuge of the incompetent.
+
+### Added
+ * CI is now also run on centos-stream-9. (#3436)
+
+### Fixed
+ * `runc run/start` can now run a container with read-only `/dev` in OCI spec,
+   rather than error out. (#3355)
+ * `runc exec` now ensures that `--cgroup` argument is a sub-cgroup. (#3403)
+ * libcontainer systemd v2 manager no longer errors out if one of the files
+   listed in `/sys/kernel/cgroup/delegate` do not exist in container's cgroup.
+   (#3387, #3404)
+ * Loose OCI spec validation to avoid bogus "Intel RDT is not supported" error.
+   (#3406)
+ * libcontainer/cgroups no longer panics in cgroup v1 managers if `stat`
+   of `/sys/fs/cgroup/unified` returns an error other than ENOENT. (#3435)
+
+
 ## [1.1.0] - 2022-01-14
 
 > A plan depends as much upon execution as it does upon concept.
@@ -36,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    correctly compiled (specifically this requires CGO to be enabled). This
    should avoid folks accidentally creating broken runc binaries (and
    incorrectly importing our internal libraries into their projects). (#3331)
+
 
 ## [1.1.0-rc.1] - 2021-12-14
 
@@ -62,7 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    binary etc.) and failures of the command being executed. (#3073)
  * runc run: new `--keep` option to skip removal exited containers artefacts.
    This might be useful to check the state (e.g. of cgroup controllers) after
-   the container has￼exited. (#2817, #2825)
+   the container has exited. (#2817, #2825)
  * seccomp: add support for `SCMP_ACT_KILL_PROCESS` and `SCMP_ACT_KILL_THREAD`
    (the latter is just an alias for `SCMP_ACT_KILL`). (#3204)
  * seccomp: add support for `SCMP_ACT_NOTIFY` (seccomp actions). This allows
@@ -151,13 +216,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  * Fixed inability to start a container with read-write bind mount of a
    read-only fuse host mount. (#3283, #3292)
- * Fixed inability to start when read-only /dev in set in spec (#3276, #3277)
+ * Fixed inability to start when read-only /dev in set in spec. (#3276, #3277)
  * Fixed not removing sub-cgroups upon container delete, when rootless cgroup v2
    is used with older systemd. (#3226, #3297)
  * Fixed returning error from GetStats when hugetlb is unsupported (which causes
    excessive logging for Kubernetes). (#3233, #3295)
  * Improved an error message when dbus-user-session is not installed and
-   rootless + cgroup2 + systemd are used (#3212)
+   rootless + cgroup2 + systemd are used. (#3212)
 
 [GHSA-v95c-p5hm-xq8f]: https://github.com/opencontainers/runc/security/advisories/GHSA-v95c-p5hm-xq8f
 
@@ -237,7 +302,7 @@ implementation (libcontainer) is *not* covered by this policy.
    code, optimize the method for checking whether a cgroup is frozen. (#2955)
  * cgroups/systemd: fixed "retry on dbus disconnect" logic introduced in rc94
  * cgroups/systemd: fixed returning "unit already exists" error from a systemd
-   cgroup manager (regression in rc94) (#2997, #2996)
+   cgroup manager (regression in rc94). (#2997, #2996)
 
 ### Added
  * cgroupv2: support SkipDevices with systemd driver. (#2958, #3019)
@@ -246,7 +311,7 @@ implementation (libcontainer) is *not* covered by this policy.
    (#3022)
 
 ### Changed
- * cgroup/systemd: return, not ignore, stop unit error from Destroy (#2946)
+ * cgroup/systemd: return, not ignore, stop unit error from Destroy. (#2946)
  * Fix all golangci-lint failures. (#2781, #2962)
  * Make `runc --version` output sane even when built with `go get` or
    otherwise outside of our build scripts. (#2962)
@@ -254,7 +319,7 @@ implementation (libcontainer) is *not* covered by this policy.
    cgroups at all during `runc update`). (#2994)
 
 <!-- minor releases -->
-[Unreleased]: https://github.com/opencontainers/runc/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/opencontainers/runc/compare/v1.1.3...HEAD
 [1.1.0]: https://github.com/opencontainers/runc/compare/v1.1.0-rc.1...v1.1.0
 [1.0.0]: https://github.com/opencontainers/runc/releases/tag/v1.0.0
 
@@ -265,5 +330,8 @@ implementation (libcontainer) is *not* covered by this policy.
 [1.0.1]: https://github.com/opencontainers/runc/compare/v1.0.0...v1.0.1
 
 <!-- 1.1.z patch releases -->
-[Unreleased 1.1.z]: https://github.com/opencontainers/runc/compare/v1.1.0...release-1.1
+[Unreleased 1.1.z]: https://github.com/opencontainers/runc/compare/v1.1.3...release-1.1
+[1.1.3]: https://github.com/opencontainers/runc/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/opencontainers/runc/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/opencontainers/runc/compare/v1.1.0...v1.1.1
 [1.1.0-rc.1]: https://github.com/opencontainers/runc/compare/v1.0.0...v1.1.0-rc.1

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,14 @@ vendor:
 	$(GO) mod vendor
 	$(GO) mod verify
 
+verify-changelog:
+	# No non-ASCII characters.
+	! LC_ALL=C grep -n -P '[\x80-\xFF]' CHANGELOG.md
+	# No space at EOL.
+	! grep -n '\s$$' CHANGELOG.md
+	# Period before issue/PR references.
+	! grep -n '[0-9a-zA-Z][^.] (#[1-9][0-9, #]*)$$' CHANGELOG.md
+
 verify-dependencies: vendor
 	@test -z "$$(git status --porcelain -- go.mod go.sum vendor/)" \
 		|| (echo -e "git status:\n $$(git status -- go.mod go.sum vendor/)\nerror: vendor/, go.mod and/or go.sum not up to date. Run \"make vendor\" to update"; exit 1) \
@@ -185,4 +193,4 @@ verify-dependencies: vendor
 	test localtest unittest localunittest integration localintegration \
 	rootlessintegration localrootlessintegration shell install install-bash \
 	install-man clean cfmt shfmt shellcheck \
-	vendor verify-dependencies
+	vendor verify-changelog verify-dependencies


### PR DESCRIPTION
This is a forward-port of commit 91fa032da406 ("ci: add basic checks for
CHANGELOG.md"), plus whatever changes were made in release-1.1 branch
(up to v1.1.3).