### PR TITLE
[1.1] CI fixes

### DIFF
--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -59,6 +60,12 @@ func testCheckpoint(t *testing.T, userns bool) {
 
 	if _, err := exec.LookPath("criu"); err != nil {
 		t.Skipf("criu binary not found: %v", err)
+	}
+
+	// Workaround for https://github.com/opencontainers/runc/issues/3532.
+	out, err := exec.Command("rpm", "-q", "criu").CombinedOutput()
+	if err == nil && regexp.MustCompile(`^criu-3\.17-[123]\.el9`).Match(out) {
+		t.Skip("Test requires criu >= 3.17-4 on CentOS Stream 9.")
 	}
 
 	config := newTemplateConfig(t, &tParam{userns: userns})

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -23,7 +23,7 @@ function teardown() {
 
 	testcontainer testbusyboxdelete running
 	# Ensure the find statement used later is correct.
-	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope 2>/dev/null || true)
 	if [ -z "$output" ]; then
 		fail "expected cgroup not found"
 	fi
@@ -38,7 +38,7 @@ function teardown() {
 	runc state testbusyboxdelete
 	[ "$status" -ne 0 ]
 
-	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 
@@ -118,7 +118,7 @@ EOF
 	runc state test_busybox
 	[ "$status" -ne 0 ]
 
-	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d)
+	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -11,10 +11,22 @@ function teardown() {
 }
 
 @test "runc delete" {
+	# Need a permission to create a cgroup.
+	# XXX(@kolyshkin): currently this test does not handle rootless when
+	# fs cgroup driver is used, because in this case cgroup (with a
+	# predefined name) is created by tests/rootless.sh, not by runc.
+	[[ "$ROOTLESS" -ne 0 ]] && requires systemd
+	set_resources_limit
+
 	runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
 	[ "$status" -eq 0 ]
 
 	testcontainer testbusyboxdelete running
+	# Ensure the find statement used later is correct.
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
+	if [ -z "$output" ]; then
+		fail "expected cgroup not found"
+	fi
 
 	runc kill testbusyboxdelete KILL
 	[ "$status" -eq 0 ]
@@ -26,7 +38,7 @@ function teardown() {
 	runc state testbusyboxdelete
 	[ "$status" -ne 0 ]
 
-	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d)
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -23,8 +23,8 @@ SECCOMP_AGENT="${INTEGRATION_ROOT}/../../contrib/cmd/seccompagent/seccompagent"
 # shellcheck disable=SC2034
 TESTDATA="${INTEGRATION_ROOT}/testdata"
 
-# CRIU PATH
-CRIU="$(which criu 2>/dev/null || true)"
+# Whether we have criu binary.
+command -v criu &>/dev/null && HAVE_CRIU=yes
 
 # Kernel version
 KERNEL_VERSION="$(uname -r)"
@@ -350,7 +350,7 @@ function requires() {
 		local skip_me
 		case $var in
 		criu)
-			if [ ! -e "$CRIU" ]; then
+			if [ -n "$HAVE_CRIU" ]; then
 				skip_me=1
 			fi
 			;;

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -23,9 +23,6 @@ SECCOMP_AGENT="${INTEGRATION_ROOT}/../../contrib/cmd/seccompagent/seccompagent"
 # shellcheck disable=SC2034
 TESTDATA="${INTEGRATION_ROOT}/testdata"
 
-# Whether we have criu binary.
-command -v criu &>/dev/null && HAVE_CRIU=yes
-
 # Kernel version
 KERNEL_VERSION="$(uname -r)"
 KERNEL_MAJOR="${KERNEL_VERSION%%.*}"
@@ -343,6 +340,16 @@ function rootless_cgroup() {
 	[[ "$ROOTLESS_FEATURES" == *"cgroup"* || -n "$RUNC_USE_SYSTEMD" ]]
 }
 
+# Check if criu is available and working.
+function have_criu() {
+	command -v criu &>/dev/null || return 1
+
+	# Workaround for https://github.com/opencontainers/runc/issues/3532.
+	local ver
+	ver=$(rpm -q criu 2>/dev/null || true)
+	! grep -q '^criu-3\.17-[123]\.el9' <<<"$ver"
+}
+
 # Allows a test to specify what things it requires. If the environment can't
 # support it, the test is skipped with a message.
 function requires() {
@@ -350,7 +357,7 @@ function requires() {
 		local skip_me
 		case $var in
 		criu)
-			if [ -n "$HAVE_CRIU" ]; then
+			if ! have_criu; then
 				skip_me=1
 			fi
 			;;


### PR DESCRIPTION
1. Backport #3392 aka 728571c16fc05d2b823fdef59aba2bf69be409cf
2. Fix CI failure due to some GHA changes related to cgroups.
3. Partial backport of 6e1d476aaddc (tests/int changes only).
4. Backport #3539.

See individual commits for details.