### PR TITLE
CI: workaround CentOS Stream 9 criu issue

### DIFF
--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -59,6 +60,12 @@ func testCheckpoint(t *testing.T, userns bool) {
 
 	if _, err := exec.LookPath("criu"); err != nil {
 		t.Skipf("criu binary not found: %v", err)
+	}
+
+	// Workaround for https://github.com/opencontainers/runc/issues/3532.
+	out, err := exec.Command("rpm", "-q", "criu").CombinedOutput()
+	if err == nil && regexp.MustCompile(`^criu-3\.17-[123]\.el9`).Match(out) {
+		t.Skip("Test requires criu >= 3.17-4 on CentOS Stream 9.")
 	}
 
 	config := newTemplateConfig(t, &tParam{userns: userns})


### PR DESCRIPTION
Older criu versions fails to work with userns due to changes in glibc's
rseq. Skip a test if an older criu version is found.

Fixes (well, works around): https://github.com/opencontainers/runc/issues/3532