### PR TITLE
ci: fix delete.bats for GHA

### DIFF
--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -23,7 +23,7 @@ function teardown() {
 
 	testcontainer testbusyboxdelete running
 	# Ensure the find statement used later is correct.
-	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope 2>/dev/null || true)
 	if [ -z "$output" ]; then
 		fail "expected cgroup not found"
 	fi
@@ -38,7 +38,7 @@ function teardown() {
 	runc state testbusyboxdelete
 	[ "$status" -ne 0 ]
 
-	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope)
+	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 
@@ -118,7 +118,7 @@ EOF
 	runc state test_busybox
 	[ "$status" -ne 0 ]
 
-	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d)
+	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 


### PR DESCRIPTION
_TL;DR: this is a forward-port of https://github.com/opencontainers/runc/pull/3538/commits/f46c0dad655e33cf29d38da94b265d982a835f88 (part of #3538) to main branch, fixing a CI flake caused by a GHA CI env peculiarity._

A couple of test cases in delete.bats check that a particular cgroup
exists (or doesn't exist) using find. This is now resulting in errors
like these:

        find: ‘/sys/fs/cgroup/blkio/azsec’: Permission denied
        find: ‘/sys/fs/cgroup/blkio/azsec_clamav’: Permission denied
        find: ‘/sys/fs/cgroup/cpu,cpuacct/azsec’: Permission denied
        find: ‘/sys/fs/cgroup/cpu,cpuacct/azsec_clamav’: Permission denied
        find: ‘/sys/fs/cgroup/memory/azsec’: Permission denied
        find: ‘/sys/fs/cgroup/memory/azsec_clamav’: Permission denied

leading to test case failures.

Apparently, GHA runs something else on a test box, so we get this.

To fix, ignore non-zero exit code from find, and redirect its stderr
to /dev/null.