### PR TITLE
checkpoint/restore: implement --manage-cgroups-mode ignore

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -38,7 +38,7 @@ checkpointed.`,
 		cli.StringFlag{Name: "page-server", Value: "", Usage: "ADDRESS:PORT of the page server"},
 		cli.BoolFlag{Name: "file-locks", Usage: "handle file locks, for safety"},
 		cli.BoolFlag{Name: "pre-dump", Usage: "dump container's memory information only, leave the container running after this"},
-		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'"},
+		cli.StringFlag{Name: "manage-cgroups-mode", Value: "", Usage: "cgroups mode: soft|full|strict|ignore (default: soft)"},
 		cli.StringSliceFlag{Name: "empty-ns", Usage: "create a namespace, but don't restore its properties"},
 		cli.BoolFlag{Name: "auto-dedup", Usage: "enable auto deduplication of memory images"},
 	},
@@ -149,17 +149,19 @@ func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
 		}
 	}
 
-	if cgOpt := context.String("manage-cgroups-mode"); cgOpt != "" {
-		switch cgOpt {
-		case "soft":
-			opts.ManageCgroupsMode = criu.CriuCgMode_SOFT
-		case "full":
-			opts.ManageCgroupsMode = criu.CriuCgMode_FULL
-		case "strict":
-			opts.ManageCgroupsMode = criu.CriuCgMode_STRICT
-		default:
-			return nil, errors.New("Invalid manage cgroups mode")
-		}
+	switch context.String("manage-cgroups-mode") {
+	case "":
+		// do nothing
+	case "soft":
+		opts.ManageCgroupsMode = criu.CriuCgMode_SOFT
+	case "full":
+		opts.ManageCgroupsMode = criu.CriuCgMode_FULL
+	case "strict":
+		opts.ManageCgroupsMode = criu.CriuCgMode_STRICT
+	case "ignore":
+		opts.ManageCgroupsMode = criu.CriuCgMode_IGNORE
+	default:
+		return nil, errors.New("Invalid manage-cgroups-mode value")
 	}
 
 	// runc doesn't manage network devices and their configuration.

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -67,17 +67,6 @@ checkpointed.`,
 			return err
 		}
 
-		// these are the mandatory criu options for a container
-		if err := setPageServer(context, options); err != nil {
-			return err
-		}
-		if err := setManageCgroupsMode(context, options); err != nil {
-			return err
-		}
-		if err := setEmptyNsMask(context, options); err != nil {
-			return err
-		}
-
 		err = container.Checkpoint(options)
 		if err == nil && !(options.LeaveRunning || options.PreDump) {
 			// Destroy the container unless we tell CRIU to keep it.
@@ -119,59 +108,78 @@ func prepareImagePaths(context *cli.Context) (string, string, error) {
 	return imagePath, parentPath, nil
 }
 
-func setPageServer(context *cli.Context, options *libcontainer.CriuOpts) error {
-	// xxx following criu opts are optional
-	// The dump image can be sent to a criu page server
+func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
+	imagePath, parentPath, err := prepareImagePaths(context)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &libcontainer.CriuOpts{
+		ImagesDirectory:         imagePath,
+		WorkDirectory:           context.String("work-path"),
+		ParentImage:             parentPath,
+		LeaveRunning:            context.Bool("leave-running"),
+		TcpEstablished:          context.Bool("tcp-established"),
+		ExternalUnixConnections: context.Bool("ext-unix-sk"),
+		ShellJob:                context.Bool("shell-job"),
+		FileLocks:               context.Bool("file-locks"),
+		PreDump:                 context.Bool("pre-dump"),
+		AutoDedup:               context.Bool("auto-dedup"),
+		LazyPages:               context.Bool("lazy-pages"),
+		StatusFd:                context.Int("status-fd"),
+		LsmProfile:              context.String("lsm-profile"),
+		LsmMountContext:         context.String("lsm-mount-context"),
+	}
+
+	// CRIU options below may or may not be set.
+
 	if psOpt := context.String("page-server"); psOpt != "" {
 		address, port, err := net.SplitHostPort(psOpt)
 
 		if err != nil || address == "" || port == "" {
-			return errors.New("Use --page-server ADDRESS:PORT to specify page server")
+			return nil, errors.New("Use --page-server ADDRESS:PORT to specify page server")
 		}
 		portInt, err := strconv.Atoi(port)
 		if err != nil {
-			return errors.New("Invalid port number")
+			return nil, errors.New("Invalid port number")
 		}
-		options.PageServer = libcontainer.CriuPageServerInfo{
+		opts.PageServer = libcontainer.CriuPageServerInfo{
 			Address: address,
 			Port:    int32(portInt),
 		}
 	}
-	return nil
-}
 
-func setManageCgroupsMode(context *cli.Context, options *libcontainer.CriuOpts) error {
 	if cgOpt := context.String("manage-cgroups-mode"); cgOpt != "" {
 		switch cgOpt {
 		case "soft":
-			options.ManageCgroupsMode = criu.CriuCgMode_SOFT
+			opts.ManageCgroupsMode = criu.CriuCgMode_SOFT
 		case "full":
-			options.ManageCgroupsMode = criu.CriuCgMode_FULL
+			opts.ManageCgroupsMode = criu.CriuCgMode_FULL
 		case "strict":
-			options.ManageCgroupsMode = criu.CriuCgMode_STRICT
+			opts.ManageCgroupsMode = criu.CriuCgMode_STRICT
 		default:
-			return errors.New("Invalid manage cgroups mode")
+			return nil, errors.New("Invalid manage cgroups mode")
 		}
 	}
-	return nil
-}
 
-var namespaceMapping = map[specs.LinuxNamespaceType]int{
-	specs.NetworkNamespace: unix.CLONE_NEWNET,
-}
-
-func setEmptyNsMask(context *cli.Context, options *libcontainer.CriuOpts) error {
-	/* Runc doesn't manage network devices and their configuration */
+	// runc doesn't manage network devices and their configuration.
 	nsmask := unix.CLONE_NEWNET
 
-	for _, ns := range context.StringSlice("empty-ns") {
-		f, exists := namespaceMapping[specs.LinuxNamespaceType(ns)]
-		if !exists {
-			return fmt.Errorf("namespace %q is not supported", ns)
+	if context.IsSet("empty-ns") {
+		namespaceMapping := map[specs.LinuxNamespaceType]int{
+			specs.NetworkNamespace: unix.CLONE_NEWNET,
 		}
-		nsmask |= f
+
+		for _, ns := range context.StringSlice("empty-ns") {
+			f, exists := namespaceMapping[specs.LinuxNamespaceType(ns)]
+			if !exists {
+				return nil, fmt.Errorf("namespace %q is not supported", ns)
+			}
+			nsmask |= f
+		}
 	}
 
-	options.EmptyNs = uint32(nsmask)
-	return nil
+	opts.EmptyNs = uint32(nsmask)
+
+	return opts, nil
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1560,11 +1560,6 @@ func (c *Container) criuApplyCgroups(pid int, req *criurpc.CriuReq) error {
 		return err
 	}
 
-	if cgroups.IsCgroup2UnifiedMode() {
-		return nil
-	}
-	// the stuff below is cgroupv1-specific
-
 	path := fmt.Sprintf("/proc/%d/cgroup", pid)
 	cgroupsPaths, err := cgroups.ParseCgroupFile(path)
 	if err != nil {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1560,6 +1560,8 @@ func (c *Container) criuApplyCgroups(pid int, req *criurpc.CriuReq) error {
 		return err
 	}
 
+	// TODO(@kolyshkin): should we use c.cgroupManager.GetPaths()
+	// instead of reading /proc/pid/cgroup?
 	path := fmt.Sprintf("/proc/%d/cgroup", pid)
 	cgroupsPaths, err := cgroups.ParseCgroupFile(path)
 	if err != nil {

--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -57,7 +57,7 @@ together with **criu lazy-pages**. See
 : Do a pre-dump, i.e. dump container's memory information only, leaving the
 container running. See [criu iterative migration](https://criu.org/Iterative_migration).
 
-**--manage-cgroups-mode** **soft**|**full**|**strict**.
+**--manage-cgroups-mode** **soft**|**full**|**strict**|**ignore**.
 : Cgroups mode. Default is **soft**. See
 [criu --manage-cgroups option](https://criu.org/CLI/opt/--manage-cgroups).
 

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -41,6 +41,11 @@ image files directory.
 : Cgroups mode. Default is **soft**. See
 [criu --manage-cgroups option](https://criu.org/CLI/opt/--manage-cgroups).
 
+: In particular, to restore the container into a different cgroup,
+**--manage-cgroups-mode ignore** must be used during both
+**checkpoint** and **restore**, and the _container_id_ (or
+**cgroupsPath** property in OCI config, if set) must be changed.
+
 **--bundle**|**-b** _path_
 : Path to the root of the bundle directory. Default is current directory.
 

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -37,7 +37,7 @@ image files directory.
 : Allow checkpoint/restore of file locks. See
 [criu --file-locks option](https://criu.org/CLI/opt/--file-locks).
 
-**--manage-cgroups-mode** **soft**|**full**|**strict**.
+**--manage-cgroups-mode** **soft**|**full**|**strict**|**ignore**.
 : Cgroups mode. Default is **soft**. See
 [criu --manage-cgroups option](https://criu.org/CLI/opt/--manage-cgroups).
 

--- a/restore.go
+++ b/restore.go
@@ -52,7 +52,7 @@ using the runc checkpoint command.`,
 		cli.StringFlag{
 			Name:  "manage-cgroups-mode",
 			Value: "",
-			Usage: "cgroups mode: 'soft' (default), 'full' and 'strict'",
+			Usage: "cgroups mode: soft|full|strict|ignore (default: soft)",
 		},
 		cli.StringFlag{
 			Name:  "bundle, b",

--- a/restore.go
+++ b/restore.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 
-	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/userns"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -113,9 +112,6 @@ using the runc checkpoint command.`,
 		if err != nil {
 			return err
 		}
-		if err := setEmptyNsMask(context, options); err != nil {
-			return err
-		}
 		status, err := startContainer(context, CT_ACT_RESTORE, options)
 		if err != nil {
 			return err
@@ -125,28 +121,4 @@ using the runc checkpoint command.`,
 		os.Exit(status)
 		return nil
 	},
-}
-
-func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
-	imagePath, parentPath, err := prepareImagePaths(context)
-	if err != nil {
-		return nil, err
-	}
-
-	return &libcontainer.CriuOpts{
-		ImagesDirectory:         imagePath,
-		WorkDirectory:           context.String("work-path"),
-		ParentImage:             parentPath,
-		LeaveRunning:            context.Bool("leave-running"),
-		TcpEstablished:          context.Bool("tcp-established"),
-		ExternalUnixConnections: context.Bool("ext-unix-sk"),
-		ShellJob:                context.Bool("shell-job"),
-		FileLocks:               context.Bool("file-locks"),
-		PreDump:                 context.Bool("pre-dump"),
-		AutoDedup:               context.Bool("auto-dedup"),
-		LazyPages:               context.Bool("lazy-pages"),
-		StatusFd:                context.Int("status-fd"),
-		LsmProfile:              context.String("lsm-profile"),
-		LsmMountContext:         context.String("lsm-mount-context"),
-	}, nil
 }


### PR DESCRIPTION
This patchset fixes a few issues and adds support for `--manage-cgroups-mode ignore`. This option allows to restore a container into a different cgroup than the original one. A test case is added to check that it works as expected.

See individual commits for details.

Loosely based on https://github.com/opencontainers/runc/pull/3447 and my earlier work from 2021.

Closes: https://github.com/opencontainers/runc/pull/3447

Also, this uses the new mode in lazy checkpoint/restore test, hopefully fixing this test flakiness.

Fixes: https://github.com/opencontainers/runc/issues/2760
Fixes: https://github.com/opencontainers/runc/issues/2924
Fixes: https://github.com/opencontainers/runc/issues/2475

PS I am thinking whether this (`--manage-cgroups-mode ignore` should become a default in 1.2.0, because otherwise changing the `cgroupsPath` in container's `config.json` before restore doesn't have any effect)