### PR TITLE
ci/cirrus: enable some rootless tests on cs9

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,6 +111,11 @@ task:
     centos-stream-9)
       dnf config-manager --set-enabled crb # for glibc-static
       dnf -y install epel-release epel-next-release # for fuse-sshfs
+      # Delegate all cgroup v2 controllers to rootless user via --systemd-cgroup.
+      # The default (since systemd v252) is "pids memory cpu".
+      mkdir -p /etc/systemd/system/user@.service.d
+      printf "[Service]\nDelegate=yes\n" > /etc/systemd/system/user@.service.d/delegate.conf
+      systemctl daemon-reload
       ;;
     esac
     # Work around dnf mirror failures by retrying a few times.
@@ -175,13 +180,19 @@ task:
   integration_fs_script: |
     ssh -tt localhost "make -C /home/runc localintegration"
   integration_systemd_rootless_script: |
-    echo "SKIP: integration_systemd_rootless_script requires cgroup v2"
+    case $DISTRO in
+    centos-7|centos-stream-8)
+      echo "SKIP: integration_systemd_rootless_script requires cgroup v2"
+      ;;
+    *)
+      ssh -tt localhost "make -C /home/runc localrootlessintegration RUNC_USE_SYSTEMD=yes"
+    esac
   integration_fs_rootless_script: |
     case $DISTRO in
     centos-7)
       echo "SKIP: FIXME: integration_fs_rootless_script is skipped because of EPERM on writing cgroup.procs"
         ;;
-    centos-stream-8)
+    *)
       ssh -tt localhost "make -C /home/runc localrootlessintegration"
       ;;
     esac

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -386,7 +386,7 @@ function setup() {
 		FREEZER="${FREEZER_DIR}/freezer.state"
 		STATE="FROZEN"
 	else
-		FREEZER_DIR="${CGROUP_PATH}"
+		FREEZER_DIR="${CGROUP_V2_PATH}"
 		FREEZER="${FREEZER_DIR}/cgroup.freeze"
 		STATE="1"
 	fi

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -49,8 +49,8 @@ function setup() {
 			if [ $EUID -eq 0 ]; then
 				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
 			else
-				# Filter out hugetlb and misc as systemd is unable to delegate them.
-				check_cgroup_value "cgroup.controllers" "$(sed -e 's/ hugetlb//' -e 's/ misc//' </sys/fs/cgroup/user.slice/user-${EUID}.slice/cgroup.controllers)"
+				# Filter out controllers that systemd is unable to delegate.
+				check_cgroup_value "cgroup.controllers" "$(sed 's/ \(hugetlb\|misc\|rdma\)//g' </sys/fs/cgroup/user.slice/user-${EUID}.slice/cgroup.controllers)"
 			fi
 		else
 			check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -157,7 +157,7 @@ EOF
 	[[ "$output" =~ [0-9]+ ]]
 
 	# check create subcgroups success
-	[ -d "$CGROUP_PATH"/foo ]
+	[ -d "$CGROUP_V2_PATH"/foo ]
 
 	# force delete test_busybox
 	runc delete --force test_busybox
@@ -166,5 +166,5 @@ EOF
 	[ "$status" -ne 0 ]
 
 	# check delete subcgroups success
-	[ ! -d "$CGROUP_PATH"/foo ]
+	[ ! -d "$CGROUP_V2_PATH"/foo ]
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -220,7 +220,7 @@ function set_cgroups_path() {
 
 	# Absolute path to container's cgroup v2.
 	if [ -v CGROUP_V2 ]; then
-		CGROUP_PATH=${CGROUP_BASE_PATH}${REL_CGROUPS_PATH}
+		CGROUP_V2_PATH=${CGROUP_BASE_PATH}${REL_CGROUPS_PATH}
 	fi
 
 	[ -v pod ] && create_parent
@@ -233,7 +233,7 @@ function set_cgroups_path() {
 #  $1: controller name (like "pids") or a file name (like "pids.max").
 function get_cgroup_path() {
 	if [ -v CGROUP_V2 ]; then
-		echo "$CGROUP_PATH"
+		echo "$CGROUP_V2_PATH"
 		return
 	fi
 


### PR DESCRIPTION
We were not running localrootlessintegration test on CentOS Stream 9
because of some failures.

Fix those, and enable rootless integration with both systemd and fs drivers.

Amends: #3427