### PR TITLE
ci/gha: fix cross-386 job vs go 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,4 +126,5 @@ jobs:
         go-version: 1.x # Latest stable
 
     - name: unit test
-      run: sudo -E PATH="$PATH" -- make GOARCH=386 localunittest
+      # See https://go-review.googlesource.com/c/go/+/421935
+      run: sudo -E PATH="$PATH" -- make GOARCH=386 CGO_CFLAGS=-fno-stack-protector localunittest


### PR DESCRIPTION
When golang 1.19 is used to build unit tests on 386, it fails like this:
```
 sudo -E PATH="$PATH" -- make GOARCH=386 CGO_ENABLED=1 localunittest
 <...>
 go test -timeout 3m -tags "seccomp"  -v ./...
 <...>
 # github.com/opencontainers/runc/libcontainer/capabilities.test
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): relocation target __stack_chk_fail_local not defined
 runtime/cgo(.text): relocation target __stack_chk_fail_local not defined
```
The fix is to add `CGO_CFLAGS=-fno-stack-protector`

See also:
 - https://github.com/docker-library/golang/pull/426
 - https://go.dev/issue/52919
 - https://go.dev/issue/54313
 - https://go-review.googlesource.com/c/go/+/421935