### PR TITLE
[1.1] ci/gha: fix cross-386 job vs go 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,4 +126,4 @@ jobs:
 
     - name: unit test
       # cgo is disabled by default when cross-compiling
-      run: sudo -E PATH="$PATH" -- make GOARCH=386 CGO_ENABLED=1 localunittest
+      run: sudo -E PATH="$PATH" -- make GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS=-fno-stack-protector localunittest


### PR DESCRIPTION
Backport of #3556 to release-1.1 branch, to fix a CI job.

----

When golang 1.19 is used to build unit tests on 386, it fails like this:

```
 sudo -E PATH="$PATH" -- make GOARCH=386 CGO_ENABLED=1 localunittest
 <...>
 go test -timeout 3m -tags "seccomp"  -v ./...
 <...>
 # github.com/opencontainers/runc/libcontainer/capabilities.test
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): unknown symbol __stack_chk_fail_local in pcrel
 runtime/cgo(.text): relocation target __stack_chk_fail_local not defined
 runtime/cgo(.text): relocation target __stack_chk_fail_local not defined
```

The fix is to add CGO_CFLAGS=-fno-stack-protector.

See also:
 - https://github.com/docker-library/golang/pull/426
 - https://go.dev/issue/52919
 - https://go.dev/issue/54313
 - https://go-review.googlesource.com/c/go/+/421935

Cherry picked from commit 589a9d5082a05932d7848f2db1f2253b751ba453.

Conflict in .github/workflows/test.yml due to missing commit dafcacb5225a0668c0.