### PR TITLE
[1.1] ci: fix for codespell 2.2

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = ./vendor,./.git
-ignore-words-list = clos,creat
+skip = ./vendor,./.git,./go.sum
+ignore-words-list = clos,creat,ro,complies

--- a/tests/integration/cgroup_delegation.bats
+++ b/tests/integration/cgroup_delegation.bats
@@ -35,7 +35,7 @@ function setup() {
 	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
 }
 
-@test "runc exec (cgroup v2, rw cgroupfs, inh cgroupns) does not chown cgroup" {
+@test "runc exec (cgroup v2, rw cgroupfs, inherit cgroupns) does not chown cgroup" {
 	set_cgroup_mount_writable
 
 	# inherit cgroup namespace (remove cgroup from namespaces list)


### PR DESCRIPTION
Backport of #3561 to release-1.1 branch. Original description follows.

----

Recently released codespell 2.2 adds some more false positives,
such as:

	./Makefile:78: ro ==> to, row, rob, rod, roe, rot
	./Makefile:88: ro ==> to, row, rob, rod, roe, rot
	./notify_socket.go:51: ro ==> to, row, rob, rod, roe, rot
	./LICENSE:128: complies ==> compiles
	./go.sum:59: BU ==> BY
	./types/features/features.go:17: ro ==> to, row, rob, rod, roe, rot
	./libcontainer/rootfs_linux.go:52: ro ==> to, row, rob, rod, roe, rot
	./libcontainer/rootfs_linux.go:166: ro ==> to, row, rob, rod, roe, rot
	....
	./tests/integration/cgroup_delegation.bats:38: inh ==> in
	...

To fix:
 - exclude go.sum;
 - add ro and complies to the list of ignored words;
 - s/inh/inherit in cgroup_delegation.bats.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit df9e32bc6abd5dffe469fb294865321ebed3bd17)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>