### PR TITLE
libcontainer: LockOSThread around Umask calls

### DIFF
--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -3,22 +3,23 @@ package libcontainer
 import (
 	"os"
 
+	"github.com/opencontainers/runc/libcontainer/utils"
 	"golang.org/x/sys/unix"
 )
 
 // mount initializes the console inside the rootfs mounting with the specified mount label
 // and applying the correct ownership of the console.
 func mountConsole(slavePath string) error {
-	oldMask := unix.Umask(0o000)
-	defer unix.Umask(oldMask)
-	f, err := os.Create("/dev/console")
-	if err != nil && !os.IsExist(err) {
-		return err
-	}
-	if f != nil {
-		f.Close()
-	}
-	return mount(slavePath, "/dev/console", "", "bind", unix.MS_BIND, "")
+	return utils.RunWithUmask(0o000, func() error {
+		f, err := os.Create("/dev/console")
+		if err != nil && !os.IsExist(err) {
+			return err
+		}
+		if f != nil {
+			f.Close()
+		}
+		return mount(slavePath, "/dev/console", "", "bind", unix.MS_BIND, "")
+	})
 }
 
 // dupStdio opens the slavePath for the console and dups the fds to the current

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -401,12 +401,11 @@ func (c *Container) createExecFifo() error {
 	if _, err := os.Stat(fifoName); err == nil {
 		return fmt.Errorf("exec fifo %s already exists", fifoName)
 	}
-	oldMask := unix.Umask(0o000)
-	if err := unix.Mkfifo(fifoName, 0o622); err != nil {
-		unix.Umask(oldMask)
+	if err := utils.RunWithUmask(0o000, func() error {
+		return unix.Mkfifo(fifoName, 0o622)
+	}); err != nil {
 		return err
 	}
-	unix.Umask(oldMask)
 	return os.Chown(fifoName, rootuid, rootgid)
 }
 


### PR DESCRIPTION
umask operates on a thread basis, and we risk leaking the umask to other routines
if the go runtime interrupts.

Signed-off-by: Peter Hunt~ <pehunt@redhat.com>