### PR TITLE
seccomp: set SPEC_ALLOW by default

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -665,6 +665,9 @@ func filterFlags(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (flags 
 }
 
 func sysSeccompSetFilter(flags uint, filter []unix.SockFilter) (fd int, err error) {
+	// This debug output is validated in tests/integration/seccomp.bats
+	// by the SECCOMP_FILTER_FLAG_* test.
+	logrus.Debugf("seccomp filter flags: %d", flags)
 	fprog := unix.SockFprog{
 		Len:    uint16(len(filter)),
 		Filter: &filter[0],

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -105,6 +105,7 @@ func InitSeccomp(config *configs.Seccomp) (int, error) {
 			if err := filter.SetSSB(true); err != nil {
 				return -1, fmt.Errorf("error adding SSB flag to seccomp filter: %w", err)
 			}
+		// NOTE when adding more flags, make sure to also modify filterFlags in patchbpf.
 		default:
 			return -1, fmt.Errorf("seccomp flags %q not yet supported by runc", flag)
 		}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -1020,16 +1020,22 @@ func SetupSeccomp(config *specs.LinuxSeccomp) (*configs.Seccomp, error) {
 	newConfig := new(configs.Seccomp)
 	newConfig.Syscalls = []*configs.Syscall{}
 
-	// The list of flags defined in runtime-spec is a subset of the flags
-	// in the seccomp() syscall
-	for _, flag := range config.Flags {
-		switch flag {
-		case "SECCOMP_FILTER_FLAG_TSYNC":
-			// Tsync can be silently ignored
-		case specs.LinuxSeccompFlagLog, specs.LinuxSeccompFlagSpecAllow:
-			newConfig.Flags = append(newConfig.Flags, flag)
-		default:
-			return nil, fmt.Errorf("seccomp flag %q not yet supported by runc", flag)
+	if config.Flags == nil {
+		// No flags are set explicitly (not even the empty set);
+		// set the default of specs.LinuxSeccompFlagSpecAllow.
+		newConfig.Flags = []specs.LinuxSeccompFlag{specs.LinuxSeccompFlagSpecAllow}
+	} else {
+		// The list of flags defined in runtime-spec is a subset of the flags
+		// in the seccomp() syscall.
+		for _, flag := range config.Flags {
+			switch flag {
+			case "SECCOMP_FILTER_FLAG_TSYNC":
+				// Tsync can be silently ignored
+			case specs.LinuxSeccompFlagLog, specs.LinuxSeccompFlagSpecAllow:
+				newConfig.Flags = append(newConfig.Flags, flag)
+			default:
+				return nil, fmt.Errorf("seccomp flag %q not yet supported by runc", flag)
+			}
 		}
 	}
 

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -70,31 +70,47 @@ function teardown() {
 	# Linux 4.14: SECCOMP_FILTER_FLAG_LOG
 	# Linux 4.17: SECCOMP_FILTER_FLAG_SPEC_ALLOW
 	requires_kernel 4.17
-	SECCOMP_FILTER_FLAGS=(
-		'' # no flag
-		'"SECCOMP_FILTER_FLAG_LOG"'
-		'"SECCOMP_FILTER_FLAG_SPEC_ALLOW"'
-		'"SECCOMP_FILTER_FLAG_TSYNC"'
-		'"SECCOMP_FILTER_FLAG_LOG","SECCOMP_FILTER_FLAG_SPEC_ALLOW"'
-		'"SECCOMP_FILTER_FLAG_LOG","SECCOMP_FILTER_FLAG_TSYNC"'
-		'"SECCOMP_FILTER_FLAG_SPEC_ALLOW","SECCOMP_FILTER_FLAG_TSYNC"'
-		'"SECCOMP_FILTER_FLAG_LOG","SECCOMP_FILTER_FLAG_SPEC_ALLOW","SECCOMP_FILTER_FLAG_TSYNC"'
-	)
-	for flags in "${SECCOMP_FILTER_FLAGS[@]}"; do
-		update_config '   .process.args = ["/bin/sh", "-c", "mkdir /dev/shm/foo"]
-				| .process.noNewPrivileges = false
-				| .linux.seccomp = {
-					"defaultAction":"SCMP_ACT_ALLOW",
-					"architectures":["SCMP_ARCH_X86","SCMP_ARCH_X32","SCMP_ARCH_X86_64","SCMP_ARCH_AARCH64","SCMP_ARCH_ARM"],
-					"flags":['"${flags}"'],
-					"syscalls":[{"names":["mkdir"], "action":"SCMP_ACT_ERRNO"}]
-				}'
 
-		# This test checks that the flags are accepted without errors but does
-		# not check they are effectively applied
-		runc run test_busybox
+	update_config '   .process.args = ["/bin/sh", "-c", "mkdir /dev/shm/foo"]
+			| .process.noNewPrivileges = false
+			| .linux.seccomp = {
+				"defaultAction":"SCMP_ACT_ALLOW",
+				"architectures":["SCMP_ARCH_X86","SCMP_ARCH_X32","SCMP_ARCH_X86_64","SCMP_ARCH_AARCH64","SCMP_ARCH_ARM"],
+				"syscalls":[{"names":["mkdir"], "action":"SCMP_ACT_ERRNO"}]
+			}'
+
+	declare -A FLAGS=(
+		['REMOVE']=0 # No setting, use built-in default.
+		['EMPTY']=0  # Empty set of flags.
+		['"SECCOMP_FILTER_FLAG_LOG"']=2
+		['"SECCOMP_FILTER_FLAG_SPEC_ALLOW"']=4
+		['"SECCOMP_FILTER_FLAG_TSYNC"']=0 # tsync flag is ignored.
+		['"SECCOMP_FILTER_FLAG_LOG","SECCOMP_FILTER_FLAG_SPEC_ALLOW"']=6
+		['"SECCOMP_FILTER_FLAG_LOG","SECCOMP_FILTER_FLAG_TSYNC"']=2
+		['"SECCOMP_FILTER_FLAG_SPEC_ALLOW","SECCOMP_FILTER_FLAG_TSYNC"']=4
+		['"SECCOMP_FILTER_FLAG_LOG","SECCOMP_FILTER_FLAG_SPEC_ALLOW","SECCOMP_FILTER_FLAG_TSYNC"']=6
+	)
+	for key in "${!FLAGS[@]}"; do
+		case "$key" in
+		'REMOVE')
+			update_config ' del(.linux.seccomp.flags)'
+			;;
+		'EMPTY')
+			update_config ' .linux.seccomp.flags = []'
+			;;
+		*)
+			update_config ' .linux.seccomp.flags = [ '"${key}"' ]'
+			;;
+		esac
+
+		runc --debug run test_busybox
 		[ "$status" -ne 0 ]
 		[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Operation not permitted"* ]]
+
+		# Check the numeric flags value, as printed in the debug log, is as expected.
+		exp="\"seccomp filter flags: ${FLAGS[$key]}\""
+		echo "flags $key, expecting $exp"
+		[[ "$output" == *"$exp"* ]]
 	done
 }
 

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -80,7 +80,7 @@ function teardown() {
 			}'
 
 	declare -A FLAGS=(
-		['REMOVE']=0 # No setting, use built-in default.
+		['REMOVE']=4 # No setting, use built-in default.
 		['EMPTY']=0  # Empty set of flags.
 		['"SECCOMP_FILTER_FLAG_LOG"']=2
 		['"SECCOMP_FILTER_FLAG_SPEC_ALLOW"']=4


### PR DESCRIPTION
If no seccomps flags are set in OCI runtime spec (not even the empty
set), set SPEC_ALLOW by default. Otherwise, use the flags set.
    
This mimics the crun behavior, and makes runc seccomp performance on par
with crun.

The test case added in #3580 checks all the cases:
 - no flags (this is when we set SPEC_ALLOW)
 - empty set of flags (this is when we don't set SPEC_ALLOW)
 - specific flags set

_This currently includes #3580, thus a draft pending its merge._