### PR TITLE
seccomp: refactor flags support; add flags to features, set SPEC_ALLOW by default

### DIFF
--- a/features.go
+++ b/features.go
@@ -59,10 +59,12 @@ var featuresCommand = cli.Command{
 
 		if seccomp.Enabled {
 			feat.Linux.Seccomp = &features.Seccomp{
-				Enabled:   &tru,
-				Actions:   seccomp.KnownActions(),
-				Operators: seccomp.KnownOperators(),
-				Archs:     seccomp.KnownArchs(),
+				Enabled:        &tru,
+				Actions:        seccomp.KnownActions(),
+				Operators:      seccomp.KnownOperators(),
+				Archs:          seccomp.KnownArchs(),
+				KnownFlags:     seccomp.KnownFlags(),
+				SupportedFlags: seccomp.SupportedFlags(),
 			}
 			major, minor, patch := seccomp.Version()
 			feat.Annotations[features.AnnotationLibseccompVersion] = fmt.Sprintf("%d.%d.%d", major, minor, patch)

--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -5,7 +5,12 @@ import (
 	"sort"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
+
+// flagTsync is recognized but ignored by runc, and it is not defined
+// in the runtime-spec.
+const flagTsync = "SECCOMP_FILTER_FLAG_TSYNC"
 
 var operators = map[string]configs.Operator{
 	"SCMP_CMP_NE":        configs.NotEqualTo,
@@ -110,4 +115,36 @@ func ConvertStringToArch(in string) (string, error) {
 		return arch, nil
 	}
 	return "", fmt.Errorf("string %s is not a valid arch for seccomp", in)
+}
+
+// List of flags known to this version of runc.
+var flags = []string{
+	flagTsync,
+	string(specs.LinuxSeccompFlagSpecAllow),
+	string(specs.LinuxSeccompFlagLog),
+}
+
+// KnownFlags returns the list of the known filter flags.
+// Used by `runc features`.
+func KnownFlags() []string {
+	return flags
+}
+
+// SupportedFlags returns the list of the supported filter flags.
+// This list may be a subset of one returned by KnownFlags due to
+// some flags not supported by the current kernel and/or libseccomp.
+// Used by `runc features`.
+func SupportedFlags() []string {
+	if !Enabled {
+		return nil
+	}
+
+	var res []string
+	for _, flag := range flags {
+		if FlagSupported(specs.LinuxSeccompFlag(flag)) == nil {
+			res = append(res, flag)
+		}
+	}
+
+	return res
 }

--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -643,6 +643,7 @@ func filterFlags(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (flags 
 			flags |= uint(C.C_FILTER_FLAG_SPEC_ALLOW)
 		}
 	}
+	// XXX: add newly supported filter flags above this line.
 
 	for _, call := range config.Syscalls {
 		if call.Action == configs.Notify {

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -163,7 +163,7 @@ func setFlag(filter *libseccomp.ScmpFilter, flag specs.LinuxSeccompFlag) error {
 	}
 	// NOTE when adding more flags above, do not forget to also:
 	// - add new flags to `flags` slice in config.go;
-	// - add new flags to tests/integration/seccomp.bats flags test;
+	// - add new flag values to flags_value() in tests/integration/seccomp.bats;
 	// - modify func filterFlags in patchbpf/ accordingly.
 
 	return &unknownFlagError{flag: flag}

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var ErrSeccompNotEnabled = errors.New("seccomp: config provided but seccomp not supported")
@@ -17,6 +18,11 @@ func InitSeccomp(config *configs.Seccomp) (int, error) {
 		return -1, ErrSeccompNotEnabled
 	}
 	return -1, nil
+}
+
+// FlagSupported tells if a provided seccomp flag is supported.
+func FlagSupported(_ specs.LinuxSeccompFlag) error {
+	return ErrSeccompNotEnabled
 }
 
 // Version returns major, minor, and micro.

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -1026,14 +1026,10 @@ func SetupSeccomp(config *specs.LinuxSeccomp) (*configs.Seccomp, error) {
 	// The list of flags defined in runtime-spec is a subset of the flags
 	// in the seccomp() syscall
 	for _, flag := range config.Flags {
-		switch flag {
-		case "SECCOMP_FILTER_FLAG_TSYNC":
-			// Tsync can be silently ignored
-		case specs.LinuxSeccompFlagLog, specs.LinuxSeccompFlagSpecAllow:
-			newConfig.Flags = append(newConfig.Flags, flag)
-		default:
-			return nil, fmt.Errorf("seccomp flag %q not yet supported by runc", flag)
+		if err := seccomp.FlagSupported(flag); err != nil {
+			return nil, err
 		}
+		newConfig.Flags = append(newConfig.Flags, flag)
 	}
 
 	if len(config.Architectures) > 0 {

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -80,7 +80,7 @@ function teardown() {
 			}'
 
 	declare -A FLAGS=(
-		['REMOVE']=0 # No setting, use built-in default.
+		['REMOVE']=4 # No setting, use built-in default.
 		['EMPTY']=0  # Empty set of flags.
 		['"SECCOMP_FILTER_FLAG_LOG"']=2
 		['"SECCOMP_FILTER_FLAG_SPEC_ALLOW"']=4

--- a/types/features/features.go
+++ b/types/features/features.go
@@ -60,6 +60,16 @@ type Seccomp struct {
 	// Archs is the list of the recognized archs, e.g., "SCMP_ARCH_X86_64".
 	// Nil value means "unknown", not "no support for any arch".
 	Archs []string `json:"archs,omitempty"`
+
+	// KnownFlags is the list of the recognized filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// Nil value means "unknown", not "no flags are recognized".
+	KnownFlags []string `json:"knownFlags,omitempty"`
+
+	// SupportedFlags is the list of the supported filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// This list may be a subset of KnownFlags due to some flags
+	// not supported by the current kernel and/or libseccomp.
+	// Nil value means "unknown", not "no flags are supported".
+	SupportedFlags []string `json:"supportedFlags,omitempty"`
 }
 
 // Apparmor represents the "apparmor" field.

--- a/types/features/features.go
+++ b/types/features/features.go
@@ -53,11 +53,11 @@ type Seccomp struct {
 	// Nil value means "unknown", not "no support for any action".
 	Actions []string `json:"actions,omitempty"`
 
-	// Operators is the list of the recognized actions, e.g., "SCMP_CMP_NE".
+	// Operators is the list of the recognized operators, e.g., "SCMP_CMP_NE".
 	// Nil value means "unknown", not "no support for any operator".
 	Operators []string `json:"operators,omitempty"`
 
-	// Operators is the list of the recognized archs, e.g., "SCMP_ARCH_X86_64".
+	// Archs is the list of the recognized archs, e.g., "SCMP_ARCH_X86_64".
 	// Nil value means "unknown", not "no support for any arch".
 	Archs []string `json:"archs,omitempty"`
 }


### PR DESCRIPTION
~~_Currently a draft pending #3580 merge. When reviewing as a draft, please skip the first 2 commits (they are from #3580)._~~

This PR reworks seccomp flags support:
 - adds new functions `KnownFlags()`, `SupportedFlags()` and `FlagSupported()` to seccomp pkg;
 - adds showing of known and supported seccomp filter flags to `runc features`;
 - consolidates/deduplicates code that handles flags (as much as possible);
 - changes the default (when no flags are set) to have `SPEC_ALLOW`, if supported (crun does that).
 
~~TODO: fix the seccomp flags test to use runc features and not depend on kernel version (maybe in a separate PR).~~