### PR TITLE
update state earlier to avoid cgroup leak when process failed

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -416,6 +416,12 @@ func (p *initProcess) start() (retErr error) {
 			return fmt.Errorf("unable to apply Intel RDT configuration: %w", err)
 		}
 	}
+	// update state here, so we can retrieve process resource
+	// even it get killed by accident
+	if _, err := p.container.updateState(p); err != nil {
+		return err
+	}
+
 	if _, err := io.Copy(p.messageSockPair.parent, p.bootstrapData); err != nil {
 		return fmt.Errorf("can't copy bootstrap data to pipe: %w", err)
 	}


### PR DESCRIPTION
update state earlier to avoid cgroup leak when process failed
if process stuck in somewhere. upper caller like containerd may
have a timeout for process launching.

process will be killed after this timeout, and then call `runc
delete` to retrieve its resource like cgroup and perform poststop
hook.

if process got stuck right before updating state, and after cgroup
applied, like prestart-hook. In such case, `runc delete xxx` will
do nothing because state file is missing, runc is not aware of this
container. so process cgroup will stay and never get removed.

Signed-off-by: zhongjiawei <zhongjiawei1@huawei.com>