### PR TITLE
libct/nsenter: namespace the bindfd shuffle

### DIFF
--- a/libcontainer/nsenter/getenv.c
+++ b/libcontainer/nsenter/getenv.c
@@ -1,0 +1,27 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdlib.h>
+#include "getenv.h"
+#include "log.h"
+
+int getenv_int(const char *name)
+{
+	char *val, *endptr;
+	int ret;
+
+	val = getenv(name);
+	/* Treat empty value as unset variable. */
+	if (val == NULL || *val == '\0')
+		return -ENOENT;
+
+	ret = strtol(val, &endptr, 10);
+	if (val == endptr || *endptr != '\0')
+		bail("unable to parse %s=%s", name, val);
+	/*
+	 * Sanity check: this must be a non-negative number.
+	 */
+	if (ret < 0)
+		bail("bad value for %s=%s (%d)", name, val, ret);
+
+	return ret;
+}

--- a/libcontainer/nsenter/getenv.h
+++ b/libcontainer/nsenter/getenv.h
@@ -1,0 +1,13 @@
+#ifndef NSENTER_GETENV_H
+#define NSENTER_GETENV_H
+
+/*
+ * Returns an environment variable value as a non-negative integer, or -ENOENT
+ * if the variable was not found or has an empty value.
+ *
+ * If the value can not be converted to an integer, or the result is out of
+ * range, the function bails out.
+ */
+int getenv_int(const char *name);
+
+#endif /* NSENTER_GETENV_H */

--- a/libcontainer/nsenter/ipc.c
+++ b/libcontainer/nsenter/ipc.c
@@ -30,7 +30,7 @@ int receive_fd(int sockfd)
 
 	memset(msg.msg_control, 0, msg.msg_controllen);
 
-	bytes_read = recvmsg(sockfd, &msg, 0);
+	bytes_read = recvmsg(sockfd, &msg, MSG_CMSG_CLOEXEC);
 	if (bytes_read != 1)
 		bail("failed to receive fd from unix socket %d", sockfd);
 	if (msg.msg_flags & MSG_CTRUNC)

--- a/libcontainer/nsenter/ipc.c
+++ b/libcontainer/nsenter/ipc.c
@@ -1,0 +1,103 @@
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include "ipc.h"
+#include "log.h"
+
+void receive_fd(int sockfd, int new_fd)
+{
+	int bytes_read;
+	struct msghdr msg = { };
+	struct cmsghdr *cmsg;
+	struct iovec iov = { };
+	char null_byte = '\0';
+	int ret;
+	int fd_count;
+	int *fd_payload;
+
+	iov.iov_base = &null_byte;
+	iov.iov_len = 1;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	msg.msg_controllen = CMSG_SPACE(sizeof(int));
+	msg.msg_control = malloc(msg.msg_controllen);
+	if (msg.msg_control == NULL) {
+		bail("Can't allocate memory to receive fd.");
+	}
+
+	memset(msg.msg_control, 0, msg.msg_controllen);
+
+	bytes_read = recvmsg(sockfd, &msg, 0);
+	if (bytes_read != 1)
+		bail("failed to receive fd from unix socket %d", sockfd);
+	if (msg.msg_flags & MSG_CTRUNC)
+		bail("received truncated control message from unix socket %d", sockfd);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	if (!cmsg)
+		bail("received message from unix socket %d without control message", sockfd);
+
+	if (cmsg->cmsg_level != SOL_SOCKET)
+		bail("received unknown control message from unix socket %d: cmsg_level=%d", sockfd, cmsg->cmsg_level);
+
+	if (cmsg->cmsg_type != SCM_RIGHTS)
+		bail("received unknown control message from unix socket %d: cmsg_type=%d", sockfd, cmsg->cmsg_type);
+
+	fd_count = (cmsg->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+	if (fd_count != 1)
+		bail("received control message from unix socket %d with too many fds: %d", sockfd, fd_count);
+
+	fd_payload = (int *)CMSG_DATA(cmsg);
+	ret = dup3(*fd_payload, new_fd, O_CLOEXEC);
+	if (ret < 0)
+		bail("cannot dup3 fd %d to %d", *fd_payload, new_fd);
+
+	free(msg.msg_control);
+
+	ret = close(*fd_payload);
+	if (ret < 0)
+		bail("cannot close fd %d", *fd_payload);
+}
+
+void send_fd(int sockfd, int fd)
+{
+	int bytes_written;
+	struct msghdr msg = { };
+	struct cmsghdr *cmsg;
+	struct iovec iov[1] = { };
+	char null_byte = '\0';
+
+	iov[0].iov_base = &null_byte;
+	iov[0].iov_len = 1;
+
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 1;
+
+	/* We send only one fd as specified by cmsg->cmsg_len below, even
+	 * though msg.msg_controllen might have more space due to alignment. */
+	msg.msg_controllen = CMSG_SPACE(sizeof(int));
+	msg.msg_control = malloc(msg.msg_controllen);
+	if (msg.msg_control == NULL) {
+		bail("Can't allocate memory to send fd.");
+	}
+
+	memset(msg.msg_control, 0, msg.msg_controllen);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+
+	bytes_written = sendmsg(sockfd, &msg, 0);
+
+	free(msg.msg_control);
+
+	if (bytes_written != 1)
+		bail("failed to send fd %d via unix socket %d", fd, sockfd);
+}

--- a/libcontainer/nsenter/ipc.h
+++ b/libcontainer/nsenter/ipc.h
@@ -1,7 +1,12 @@
 #ifndef NSENTER_IPC_H
 #define NSENTER_IPC_H
 
-void receive_fd(int sockfd, int new_fd);
-void send_fd(int sockfd, int fd);
+int receive_fd(int sockfd);
+
+/*
+ * send_fd passes the open file descriptor fd to another process via the UNIX
+ * domain socket sockfd. The return value of the sendmsg(2) call is returned.
+ */
+int send_fd(int sockfd, int fd);
 
 #endif /* NSENTER_IPC_H */

--- a/libcontainer/nsenter/ipc.h
+++ b/libcontainer/nsenter/ipc.h
@@ -1,0 +1,7 @@
+#ifndef NSENTER_IPC_H
+#define NSENTER_IPC_H
+
+void receive_fd(int sockfd, int new_fd);
+void send_fd(int sockfd, int fd);
+
+#endif /* NSENTER_IPC_H */

--- a/libcontainer/nsenter/log.c
+++ b/libcontainer/nsenter/log.c
@@ -1,0 +1,83 @@
+#define _GNU_SOURCE
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "log.h"
+#include "getenv.h"
+
+static const char *level_str[] = { "panic", "fatal", "error", "warning", "info", "debug", "trace" };
+
+int logfd = -1;
+static int loglevel = DEBUG;
+
+extern char *escape_json_string(char *str);
+void setup_logpipe(void)
+{
+	int i;
+
+	i = getenv_int("_LIBCONTAINER_LOGPIPE");
+	if (i < 0) {
+		/* We are not runc init, or log pipe was not provided. */
+		return;
+	}
+	logfd = i;
+
+	i = getenv_int("_LIBCONTAINER_LOGLEVEL");
+	if (i < 0)
+		return;
+	loglevel = i;
+}
+
+/* Defined in nsexec.c */
+extern int current_stage;
+
+void write_log(int level, const char *format, ...)
+{
+	char *message = NULL, *stage = NULL, *json = NULL;
+	va_list args;
+	int ret;
+
+	if (logfd < 0 || level > loglevel)
+		goto out;
+
+	va_start(args, format);
+	ret = vasprintf(&message, format, args);
+	va_end(args);
+	if (ret < 0) {
+		message = NULL;
+		goto out;
+	}
+
+	message = escape_json_string(message);
+
+	if (current_stage < 0) {
+		stage = strdup("nsexec");
+		if (stage == NULL)
+			goto out;
+	} else {
+		ret = asprintf(&stage, "nsexec-%d", current_stage);
+		if (ret < 0) {
+			stage = NULL;
+			goto out;
+		}
+	}
+	ret = asprintf(&json, "{\"level\":\"%s\", \"msg\": \"%s[%d]: %s\"}\n",
+		       level_str[level], stage, getpid(), message);
+	if (ret < 0) {
+		json = NULL;
+		goto out;
+	}
+
+	/* This logging is on a best-effort basis. In case of a short or failed
+	 * write there is nothing we can do, so just ignore write() errors.
+	 */
+	ssize_t __attribute__((unused)) __res = write(logfd, json, ret);
+
+out:
+	free(message);
+	free(stage);
+	free(json);
+}

--- a/libcontainer/nsenter/log.h
+++ b/libcontainer/nsenter/log.h
@@ -1,0 +1,37 @@
+#ifndef NSENTER_LOG_H
+#define NSENTER_LOG_H
+
+#include <stdio.h>
+
+/*
+ * Log levels are the same as in logrus.
+ */
+#define PANIC   0
+#define FATAL   1
+#define ERROR   2
+#define WARNING 3
+#define INFO    4
+#define DEBUG   5
+#define TRACE   6
+
+/*
+ * Sets up logging by getting log fd and log level from the environment,
+ * if available.
+ */
+void setup_logpipe(void);
+
+void write_log(int level, const char *format, ...);
+
+extern int logfd;
+#define bail(fmt, ...)                                               \
+	do {                                                         \
+		if (logfd < 0)                                       \
+			fprintf(stderr, "FATAL: " fmt ": %m\n",      \
+				##__VA_ARGS__);                      \
+		else                                                 \
+			write_log(FATAL, fmt ": %m", ##__VA_ARGS__); \
+		exit(1);                                             \
+	} while(0)
+
+
+#endif /* NSENTER_LOG_H */

--- a/libcontainer/nsenter/log.h
+++ b/libcontainer/nsenter/log.h
@@ -20,7 +20,7 @@
  */
 void setup_logpipe(void);
 
-void write_log(int level, const char *format, ...);
+void write_log(int level, const char *format, ...) __attribute__((format(printf, 2, 3)));
 
 extern int logfd;
 #define bail(fmt, ...)                                               \


### PR DESCRIPTION
* closes https://github.com/opencontainers/runc/issues/2532
* relates to https://github.com/systemd/systemd/issues/8703

Processes can watch `/proc/self/mounts` or `/mountinfo`, and the kernel will notify them whenever the namespace's mount table is modified. The notified process still needs to read and parse the mountinfo to determine what changed once notified. Many such processes, including `udisksd` and systemd < v248, make no attempt to rate-limit their mountinfo notifications. This tends to not be a problem on many systems, where mount tables are small and mounting and unmounting is uncommon. Every runC exec which successfully uses the `try_bindfd` container-escape mitigation performs two `mount()`s and one `umount()` in the host's mount namespace, causing any mount-watching processes to wake up and parse the mountinfo file three times in a row. Consequently, using 'exec' health checks on containers has a larger-than-expected impact on system load when such mount-watching daemons are running. Furthermore, the size of the mount table in the host's mount namespace tends to be proportional to the number of OCI containers as a unique mount is required for the rootfs of each container. Therefore, on systems with mount-watching processes, the system load increases *quadratically* with the number of running containers which use health checks!

Prevent runC from incidentally modifying the host's mount namespace for container-escape mitigations by setting up the mitigation in a private mount namespace.
