### PR TITLE
cgroups: cpuset: fix byte order while parsing cpuset range to bits

### DIFF
--- a/libcontainer/cgroups/systemd/cpuset.go
+++ b/libcontainer/cgroups/systemd/cpuset.go
@@ -51,5 +51,10 @@ func RangeToBits(str string) ([]byte, error) {
 		// do not allow empty values
 		return nil, errors.New("empty value")
 	}
+
+	// fit cpuset parsing order in systemd
+	for l, r := 0, len(ret)-1; l < r; l, r = l+1, r-1 {
+		ret[l], ret[r] = ret[r], ret[l]
+	}
 	return ret, nil
 }

--- a/libcontainer/cgroups/systemd/cpuset_test.go
+++ b/libcontainer/cgroups/systemd/cpuset_test.go
@@ -22,13 +22,13 @@ func TestRangeToBits(t *testing.T) {
 		{in: "4-7", out: []byte{0xf0}},
 		{in: "0-7", out: []byte{0xff}},
 		{in: "0-15", out: []byte{0xff, 0xff}},
-		{in: "16", out: []byte{1, 0, 0}},
-		{in: "0-3,32-33", out: []byte{3, 0, 0, 0, 0x0f}},
+		{in: "16", out: []byte{0, 0, 1}},
+		{in: "0-3,32-33", out: []byte{0x0f, 0, 0, 0, 3}},
 		// extra spaces and tabs are ok
 		{in: "1, 2, 1-2", out: []byte{6}},
 		{in: "    , 1   , 3  ,  5-7,	", out: []byte{0xea}},
 		// somewhat large values
-		{in: "128-130,1", out: []byte{7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}},
+		{in: "128-130,1", out: []byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7}},
 
 		{in: "-", isErr: true},
 		{in: "1-", isErr: true},

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -457,6 +457,13 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		more_than_8_core)
+			local cpus
+			cpus=$(grep -c '^processor' /proc/cpuinfo)
+			if [ "$cpus" -le 8 ]; then
+				skip_me=1
+			fi
+			;;
 		*)
 			fail "BUG: Invalid requires $var."
 			;;


### PR DESCRIPTION
Runc parses cpuset range to bits in the case of cgroup v2 + systemd as cgroup driver. The byte order representation differs from systemd expectation, which will set different cpuset range in systemd transient unit if the length of parsed byte array exceeds one.

	# cat config.json
	...
	"resources": {
		...
		"cpu": {
			"cpus": "10-23"
		}
	},
	...
	# runc --systemd-cgroup run test
	# cat /run/systemd/transient/runc-test.scope.d/50-AllowedCPUs.conf
	# This is a drop-in unit file extension, created via "systemctl set-property"
	# or an equivalent operation. Do not edit.
	[Scope]
	AllowedCPUs=0-7 10-15

The cpuset.cpus in cgroup will also be set to wrong value after reloading systemd manager configuration.

	# systemctl daemon-reload
	# cat /sys/fs/cgroup/system.slice/runc-test.scope/cpuset.cpus
	0-7,10-15

This patch simply reverses the byte order at the end of  RangeToBits().
Please help to verify the patch and any comments and suggestions are welcome!