### PR TITLE
Fix centos 7 ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,6 +72,7 @@ task:
     CIRRUS_WORKING_DIR: /home/runc
     GO_VERSION: "1.18"
     BATS_VERSION: "v1.3.0"
+    RPMS: gcc git iptables jq glibc-static libseccomp-devel make criu fuse-sshfs
     # yamllint disable rule:key-duplicates
     matrix:
       DISTRO: centos-7
@@ -91,6 +92,8 @@ task:
     case $DISTRO in
     centos-7)
       (cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/adrian/criu-el7/repo/epel-7/adrian-criu-el7-epel-7.repo)
+      # EPEL is needed for jq and fuse-sshfs.
+      rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
       # sysctl
       echo "user.max_user_namespaces=15076" > /etc/sysctl.d/userns.conf
       sysctl --system
@@ -106,9 +109,14 @@ task:
     # Work around dnf mirror failures by retrying a few times.
     for i in $(seq 0 2); do
       sleep $i
-      yum install -y -q gcc git iptables jq glibc-static libseccomp-devel make criu fuse-sshfs && break
+      yum install -y $RPMS && break
     done
     [ $? -eq 0 ] # fail if yum failed
+
+    # Double check that all rpms were installed (yum from CentOS 7
+    # does not exit with an error if some packages were not found).
+    # Use --whatprovides since some packages are renamed.
+    rpm -q --whatprovides $RPMS
     # install Go
     curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar Cxz /usr/local
     # install bats

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -126,7 +126,7 @@ function init_cgroup_paths() {
 			CGROUP_SUBSYSTEMS+=" freezer"
 		fi
 	else
-		if stat -f -c %t /sys/fs/cgroup/unified | grep -qFw 63677270; then
+		if stat -f -c %t /sys/fs/cgroup/unified 2>/dev/null | grep -qFw 63677270; then
 			CGROUP_HYBRID=yes
 		fi
 		CGROUP_V1=yes

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -133,7 +133,7 @@ function init_cgroup_paths() {
 		CGROUP_SUBSYSTEMS=$(awk '!/^#/ {print $1}' /proc/cgroups)
 		local g base_path
 		for g in ${CGROUP_SUBSYSTEMS}; do
-			base_path=$(gawk '$(NF-2) == "cgroup" && $NF ~ /\<'"${g}"'\>/ { print $5; exit }' /proc/self/mountinfo)
+			base_path=$(awk '$(NF-2) == "cgroup" && $NF ~ /\<'"${g}"'\>/ { print $5; exit }' /proc/self/mountinfo)
 			test -z "$base_path" && continue
 			eval CGROUP_"${g^^}"_BASE_PATH="${base_path}"
 		done


### PR DESCRIPTION
Turns out, CentOS 7 image used in Cirrus CI had EPEL repo configured, and now it's not. This, together with a "feature" of older yum NOT returning an error when some of the packages requested are not found, resulted in failures in tests that use `jq` and `fuse-sshfs`.

The fix is to add/enable EPEL repo.

1.1 backport: https://github.com/opencontainers/runc/pull/3618