### PR TITLE
libcontainer/cgroups: return concrete types

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -53,13 +53,13 @@ type subsystem interface {
 	Set(path string, r *configs.Resources) error
 }
 
-type manager struct {
+type Manager struct {
 	mu      sync.Mutex
 	cgroups *configs.Cgroup
 	paths   map[string]string
 }
 
-func NewManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Manager, error) {
+func NewManager(cg *configs.Cgroup, paths map[string]string) (*Manager, error) {
 	// Some v1 controllers (cpu, cpuset, and devices) expect
 	// cgroups.Resources to not be nil in Apply.
 	if cg.Resources == nil {
@@ -77,7 +77,7 @@ func NewManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Manager, e
 		}
 	}
 
-	return &manager{
+	return &Manager{
 		cgroups: cg,
 		paths:   paths,
 	}, nil
@@ -104,7 +104,7 @@ func isIgnorableError(rootless bool, err error) bool {
 	return false
 }
 
-func (m *manager) Apply(pid int) (err error) {
+func (m *Manager) Apply(pid int) (err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -138,19 +138,19 @@ func (m *manager) Apply(pid int) (err error) {
 	return nil
 }
 
-func (m *manager) Destroy() error {
+func (m *Manager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return cgroups.RemovePaths(m.paths)
 }
 
-func (m *manager) Path(subsys string) string {
+func (m *Manager) Path(subsys string) string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.paths[subsys]
 }
 
-func (m *manager) GetStats() (*cgroups.Stats, error) {
+func (m *Manager) GetStats() (*cgroups.Stats, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	stats := cgroups.NewStats()
@@ -166,7 +166,7 @@ func (m *manager) GetStats() (*cgroups.Stats, error) {
 	return stats, nil
 }
 
-func (m *manager) Set(r *configs.Resources) error {
+func (m *Manager) Set(r *configs.Resources) error {
 	if r == nil {
 		return nil
 	}
@@ -201,7 +201,7 @@ func (m *manager) Set(r *configs.Resources) error {
 
 // Freeze toggles the container's freezer cgroup depending on the state
 // provided
-func (m *manager) Freeze(state configs.FreezerState) error {
+func (m *Manager) Freeze(state configs.FreezerState) error {
 	path := m.Path("freezer")
 	if path == "" {
 		return errors.New("cannot toggle freezer: cgroups not configured for container")
@@ -217,25 +217,25 @@ func (m *manager) Freeze(state configs.FreezerState) error {
 	return nil
 }
 
-func (m *manager) GetPids() ([]int, error) {
+func (m *Manager) GetPids() ([]int, error) {
 	return cgroups.GetPids(m.Path("devices"))
 }
 
-func (m *manager) GetAllPids() ([]int, error) {
+func (m *Manager) GetAllPids() ([]int, error) {
 	return cgroups.GetAllPids(m.Path("devices"))
 }
 
-func (m *manager) GetPaths() map[string]string {
+func (m *Manager) GetPaths() map[string]string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.paths
 }
 
-func (m *manager) GetCgroups() (*configs.Cgroup, error) {
+func (m *Manager) GetCgroups() (*configs.Cgroup, error) {
 	return m.cgroups, nil
 }
 
-func (m *manager) GetFreezerState() (configs.FreezerState, error) {
+func (m *Manager) GetFreezerState() (configs.FreezerState, error) {
 	dir := m.Path("freezer")
 	// If the container doesn't have the freezer cgroup, say it's undefined.
 	if dir == "" {
@@ -245,7 +245,7 @@ func (m *manager) GetFreezerState() (configs.FreezerState, error) {
 	return freezer.GetState(dir)
 }
 
-func (m *manager) Exists() bool {
+func (m *Manager) Exists() bool {
 	return cgroups.PathExists(m.Path("devices"))
 }
 
@@ -253,7 +253,7 @@ func OOMKillCount(path string) (uint64, error) {
 	return fscommon.GetValueByKey(path, "memory.oom_control", "oom_kill")
 }
 
-func (m *manager) OOMKillCount() (uint64, error) {
+func (m *Manager) OOMKillCount() (uint64, error) {
 	c, err := OOMKillCount(m.Path("memory"))
 	// Ignore ENOENT when rootless as it couldn't create cgroup.
 	if err != nil && m.cgroups.Rootless && os.IsNotExist(err) {

--- a/libcontainer/cgroups/systemd/devices.go
+++ b/libcontainer/cgroups/systemd/devices.go
@@ -17,7 +17,7 @@ import (
 // (unlike our fs driver, they will happily write deny-all rules to running
 // containers). So we have to freeze the container to avoid the container get
 // an occasional "permission denied" error.
-func (m *legacyManager) freezeBeforeSet(unitName string, r *configs.Resources) (needsFreeze, needsThaw bool, err error) {
+func (m *LegacyManager) freezeBeforeSet(unitName string, r *configs.Resources) (needsFreeze, needsThaw bool, err error) {
 	// Special case for SkipDevices, as used by Kubernetes to create pod
 	// cgroups with allow-all device policy).
 	if r.SkipDevices {

--- a/libcontainer/cgroups/systemd/freeze_test.go
+++ b/libcontainer/cgroups/systemd/freeze_test.go
@@ -139,10 +139,9 @@ func TestFreezeBeforeSet(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer m.Destroy() //nolint:errcheck
-			lm := m.(*legacyManager)
 
 			// Checks for a non-existent unit.
-			freeze, thaw, err := lm.freezeBeforeSet(getUnitName(tc.cg), tc.cg.Resources)
+			freeze, thaw, err := m.freezeBeforeSet(getUnitName(tc.cg), tc.cg.Resources)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -176,7 +175,7 @@ func TestFreezeBeforeSet(t *testing.T) {
 					return // no more checks
 				}
 			}
-			freeze, thaw, err = lm.freezeBeforeSet(getUnitName(tc.cg), tc.cg.Resources)
+			freeze, thaw, err = m.freezeBeforeSet(getUnitName(tc.cg), tc.cg.Resources)
 			if err != nil {
 				t.Error(err)
 				return // no more checks

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -20,7 +20,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-type unifiedManager struct {
+type UnifiedManager struct {
 	mu      sync.Mutex
 	cgroups *configs.Cgroup
 	// path is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope"
@@ -29,8 +29,8 @@ type unifiedManager struct {
 	fsMgr cgroups.Manager
 }
 
-func NewUnifiedManager(config *configs.Cgroup, path string) (cgroups.Manager, error) {
-	m := &unifiedManager{
+func NewUnifiedManager(config *configs.Cgroup, path string) (*UnifiedManager, error) {
+	m := &UnifiedManager{
 		cgroups: config,
 		path:    path,
 		dbus:    newDbusConnManager(config.Rootless),
@@ -237,7 +237,7 @@ func genV2ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]syst
 	return properties, nil
 }
 
-func (m *unifiedManager) Apply(pid int) error {
+func (m *UnifiedManager) Apply(pid int) error {
 	var (
 		c          = m.cgroups
 		unitName   = getUnitName(c)
@@ -340,7 +340,7 @@ func cgroupFilesToChown() ([]string, error) {
 	return filesToChown, nil
 }
 
-func (m *unifiedManager) Destroy() error {
+func (m *UnifiedManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -359,13 +359,13 @@ func (m *unifiedManager) Destroy() error {
 	return nil
 }
 
-func (m *unifiedManager) Path(_ string) string {
+func (m *UnifiedManager) Path(_ string) string {
 	return m.path
 }
 
 // getSliceFull value is used in initPath.
 // The value is incompatible with systemdDbus.PropSlice.
-func (m *unifiedManager) getSliceFull() (string, error) {
+func (m *UnifiedManager) getSliceFull() (string, error) {
 	c := m.cgroups
 	slice := "system.slice"
 	if c.Rootless {
@@ -393,7 +393,7 @@ func (m *unifiedManager) getSliceFull() (string, error) {
 	return slice, nil
 }
 
-func (m *unifiedManager) initPath() error {
+func (m *UnifiedManager) initPath() error {
 	if m.path != "" {
 		return nil
 	}
@@ -417,23 +417,23 @@ func (m *unifiedManager) initPath() error {
 	return nil
 }
 
-func (m *unifiedManager) Freeze(state configs.FreezerState) error {
+func (m *UnifiedManager) Freeze(state configs.FreezerState) error {
 	return m.fsMgr.Freeze(state)
 }
 
-func (m *unifiedManager) GetPids() ([]int, error) {
+func (m *UnifiedManager) GetPids() ([]int, error) {
 	return cgroups.GetPids(m.path)
 }
 
-func (m *unifiedManager) GetAllPids() ([]int, error) {
+func (m *UnifiedManager) GetAllPids() ([]int, error) {
 	return cgroups.GetAllPids(m.path)
 }
 
-func (m *unifiedManager) GetStats() (*cgroups.Stats, error) {
+func (m *UnifiedManager) GetStats() (*cgroups.Stats, error) {
 	return m.fsMgr.GetStats()
 }
 
-func (m *unifiedManager) Set(r *configs.Resources) error {
+func (m *UnifiedManager) Set(r *configs.Resources) error {
 	if r == nil {
 		return nil
 	}
@@ -449,24 +449,24 @@ func (m *unifiedManager) Set(r *configs.Resources) error {
 	return m.fsMgr.Set(r)
 }
 
-func (m *unifiedManager) GetPaths() map[string]string {
+func (m *UnifiedManager) GetPaths() map[string]string {
 	paths := make(map[string]string, 1)
 	paths[""] = m.path
 	return paths
 }
 
-func (m *unifiedManager) GetCgroups() (*configs.Cgroup, error) {
+func (m *UnifiedManager) GetCgroups() (*configs.Cgroup, error) {
 	return m.cgroups, nil
 }
 
-func (m *unifiedManager) GetFreezerState() (configs.FreezerState, error) {
+func (m *UnifiedManager) GetFreezerState() (configs.FreezerState, error) {
 	return m.fsMgr.GetFreezerState()
 }
 
-func (m *unifiedManager) Exists() bool {
+func (m *UnifiedManager) Exists() bool {
 	return cgroups.PathExists(m.path)
 }
 
-func (m *unifiedManager) OOMKillCount() (uint64, error) {
+func (m *UnifiedManager) OOMKillCount() (uint64, error) {
 	return m.fsMgr.OOMKillCount()
 }


### PR DESCRIPTION
It's more idiomatic Go to define interfaces on the receiver, and constructors to return concrete types.

This patch changes various constructors to return a concrete type, with the exceptions of NewWithPaths, which needs the abstraction as it switches between implementations.
