### PR TITLE
libct/seccomp/patchbpf: rm duplicated code

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -240,16 +240,6 @@ func findLastSyscalls(config *configs.Seccomp) (lastSyscallMap, error) {
 			return nil, fmt.Errorf("unable to validate seccomp architecture: %w", err)
 		}
 
-		// Map native architecture to a real architecture value to avoid
-		// doubling-up the lastSyscall mapping.
-		if arch == libseccomp.ArchNative {
-			nativeArch, err := libseccomp.GetNativeArch()
-			if err != nil {
-				return nil, fmt.Errorf("unable to get native architecture: %w", err)
-			}
-			arch = nativeArch
-		}
-
 		// Figure out native architecture representation of the architecture.
 		nativeArch, err := archToNative(arch)
 		if err != nil {


### PR DESCRIPTION
In findLastSyscalls, we convert libseccomp.ArchNative to the real libseccomp architecture, but archToNative already does that, so this code is redundant.

Remove the redundant code, and move its comment to archToNative.

Fixes: 7a8d7162f