### PR TITLE
ci/gha: use v3 tag for actions/cache

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,7 +72,7 @@ jobs:
         echo "VERSION=3.3.1" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
     - name: cache go mod and $GOCACHE
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod
@@ -119,7 +119,7 @@ jobs:
       with:
         go-version: "${{ env.GO_VERSION }}"
     - name: cache go mod and $GOCACHE
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod


### PR DESCRIPTION
This tag points to the latest v3 version (currently v3.0.11).

Mainly done to avoid cluttering git history with multiple minor v3 upgrades (see e.g. #3634, #3624, #3621, #3566, #3557, #3528, #3505, #3458).

This (using the x.y.z version format) has happened due to #3444; I guess there was no `v3` tag back then.

NB: do not accept dependabot PRs that switch from `vN` to `vX.Y.Z`