### PR TITLE
tests/int/seccomp: fix flags test on ARM

### DIFF
--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -76,7 +76,7 @@ function teardown() {
 			| .linux.seccomp = {
 				"defaultAction":"SCMP_ACT_ALLOW",
 				"architectures":["SCMP_ARCH_X86","SCMP_ARCH_X32","SCMP_ARCH_X86_64","SCMP_ARCH_AARCH64","SCMP_ARCH_ARM"],
-				"syscalls":[{"names":["mkdir"], "action":"SCMP_ACT_ERRNO"}]
+				"syscalls":[{"names":["mkdir", "mkdirat"], "action":"SCMP_ACT_ERRNO"}]
 			}'
 
 	declare -A FLAGS=(


### PR DESCRIPTION
On ARM, mkdirat(2) is used instead of mkdir(2), thus the seccomp rules needs to be amended accordingly.

This is a change similar to one in commit e119db7a23c773ca9 (PR #3525), but it evaded the test case added in commit 58ea21dae (PR #3390) as it took a long time to merge, and we don't have ARM CI.

Fixes: 58ea21dae ("seccomp: add support for flags")
Reported-by: Ryan Phillips <rphillips@redhat.com>