### PR TITLE
runc checkpoint: destroy only on success

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -67,10 +67,6 @@ checkpointed.`,
 			return err
 		}
 
-		if !(options.LeaveRunning || options.PreDump) {
-			// destroy container unless we tell CRIU to keep it
-			defer destroy(container)
-		}
 		// these are the mandatory criu options for a container
 		if err := setPageServer(context, options); err != nil {
 			return err
@@ -81,7 +77,13 @@ checkpointed.`,
 		if err := setEmptyNsMask(context, options); err != nil {
 			return err
 		}
-		return container.Checkpoint(options)
+
+		err = container.Checkpoint(options)
+		if err == nil && !(options.LeaveRunning || options.PreDump) {
+			// Destroy the container unless we tell CRIU to keep it.
+			destroy(container)
+		}
+		return err
 	},
 }
 


### PR DESCRIPTION
If checkpointing has failed, the container is kept running. We do not want to, and we can't remove it in such case.

Do not try to remove the container if there's an error from checkpointing.

This avoids an unclear error message from destroy() saying "container still running" or "container paused".

While at it, avoid using defer since it does not make a lot of sense here.

Fixes: #3577