### PR TITLE
libcontainer: skip chown of /dev/null caused by fd redirection

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -411,8 +411,9 @@ func fixStdioPermissions(u *user.ExecUser) error {
 			return &os.PathError{Op: "fstat", Path: file.Name(), Err: err}
 		}
 
-		// Skip chown if uid is already the one we want.
-		if int(s.Uid) == u.Uid {
+		// Skip chown if uid is already the one we want or any of the STDIO descriptors
+		// were redirected to /dev/null.
+		if int(s.Uid) == u.Uid || s.Rdev == null.Rdev {
 			continue
 		}
 


### PR DESCRIPTION
In #3355 the check whether the STDIO file descriptors point to /dev/null was removed which can cause /dev/null to change ownership e.g. when using docker exec on a running container:

$ ls -l /dev/null
crw-rw-rw- 1 root root 1, 3 Aug 1 14:12 /dev/null
$ docker exec -u test 0ad6d3064e9d ls
$ ls -l /dev/null
crw-rw-rw- 1 test root 1, 3 Aug 1 14:12 /dev/null

This PR reintroduces that check and fixes the issue for me on runc v1.1.{3,4} (I did not find any information about this change being intentional, if it was feel free to close this PR).

Fixes: #3674