### PR TITLE
go:mod: runtime-spec v1.1.0-rc.1; add docs/spec-conformance.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ WantedBy=multi-user.target
 
 ## More documentation
 
+* [Spec conformance](./docs/spec-conformance.md)
 * [cgroup v2](./docs/cgroup-v2.md)
 * [Checkpoint and restore](./docs/checkpoint-restore.md)
 * [systemd cgroup driver](./docs/systemd.md)

--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -1,0 +1,17 @@
+# Spec conformance
+
+This branch of runc implements the [OCI Runtime Spec v1.1.0-rc.1](https://github.com/opencontainers/runtime-spec/tree/v1.1.0-rc.1)
+for the `linux` platform.
+
+The following features are not implemented yet:
+
+Spec version | Feature                                  | PR
+-------------|------------------------------------------|----------------------------------------------------------
+v1.0.0       | `SCMP_ARCH_PARISC`                       | Unplanned, due to lack of users
+v1.0.0       | `SCMP_ARCH_PARISC64`                     | Unplanned, due to lack of users
+v1.0.2       | `.linux.personality`                     | [#3126](https://github.com/opencontainers/runc/pull/3126)
+v1.1.0-rc.1  | `.linux.resources.cpu.burst`             | [#3205](https://github.com/opencontainers/runc/pull/3205)
+v1.1.0-rc.1  | `.domainname`                            | [#3600](https://github.com/opencontainers/runc/pull/3600)
+v1.1.0-rc.1  | `.[]mounts.uidMappings`                  | [#3717](https://github.com/opencontainers/runc/pull/3717)
+v1.1.0-rc.1  | `.[]mounts.gidMappings`                  | [#3717](https://github.com/opencontainers/runc/pull/3717)
+v1.1.0-rc.1  | `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` | TODO

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/mrunalp/fileutils v0.5.0
-	github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78
+	github.com/opencontainers/runtime-spec v1.1.0-rc.1
 	github.com/opencontainers/selinux v1.11.0
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vyg
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
-github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78 h1:R5M2qXZiK/mWPMT4VldCOiSL9HIAMuxQZWdG0CSM5+4=
-github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.1.0-rc.1 h1:wHa9jroFfKGQqFHj0I1fMRKLl0pfj+ynAqBxo3v6u9w=
+github.com/opencontainers/runtime-spec v1.1.0-rc.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -331,6 +331,9 @@ type LinuxCPU struct {
 	Shares *uint64 `json:"shares,omitempty"`
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
 	Quota *int64 `json:"quota,omitempty"`
+	// CPU hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst in a
+	// given period.
+	Burst *uint64 `json:"burst,omitempty"`
 	// CPU period to be used for hardcapping (in usecs).
 	Period *uint64 `json:"period,omitempty"`
 	// How much time realtime scheduling may use (in usecs).

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 0
+	VersionMinor = 1
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = "-rc.1"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/moby/sys/mountinfo
 # github.com/mrunalp/fileutils v0.5.0
 ## explicit; go 1.13
 github.com/mrunalp/fileutils
-# github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78
+# github.com/opencontainers/runtime-spec v1.1.0-rc.1
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opencontainers/selinux v1.11.0


### PR DESCRIPTION
runc now implements the [OCI Runtime Spec v1.1.0-rc.1](https://github.com/opencontainers/runtime-spec/tree/v1.1.0-rc.1) for the `linux` platform.

The following features are not implemented yet:

Spec version | Feature                                  | PR
-------------|------------------------------------------|----------------------------------------------------------
v1.0.0       | `SCMP_ARCH_PARISC`                       | Unplanned, due to lack of users
v1.0.0       | `SCMP_ARCH_PARISC64`                     | Unplanned, due to lack of users
v1.0.2       | `.linux.personality`                     | [#3126](https://github.com/opencontainers/runc/pull/3126)
v1.1.0-rc.1  | `.linux.resources.cpu.burst`             | [#3205](https://github.com/opencontainers/runc/pull/3205)
v1.1.0-rc.1  | `.domainname`                            | [#3600](https://github.com/opencontainers/runc/pull/3600)
v1.1.0-rc.1  | `.[]mounts.uidMappings`                  | [#3717](https://github.com/opencontainers/runc/pull/3717)
v1.1.0-rc.1  | `.[]mounts.gidMappings`                  | [#3717](https://github.com/opencontainers/runc/pull/3717)
v1.1.0-rc.1  | `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` | TODO
