### PR TITLE
Support idmap mounts for volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/pkg
 contrib/cmd/recvtty/recvtty
 contrib/cmd/sd-helper/sd-helper
 contrib/cmd/seccompagent/seccompagent
+contrib/cmd/fs-idmap/fs-idmap
 man/man8
 release
 Vagrantfile

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ endif
 runc:
 	$(GO_BUILD) -o runc .
 
-all: runc recvtty sd-helper seccompagent
+all: runc recvtty sd-helper seccompagent fs-idmap
 
-recvtty sd-helper seccompagent:
+recvtty sd-helper seccompagent fs-idmap:
 	$(GO_BUILD) -o contrib/cmd/$@/$@ ./contrib/cmd/$@
 
 static:
@@ -151,6 +151,7 @@ clean:
 	rm -f contrib/cmd/recvtty/recvtty
 	rm -f contrib/cmd/sd-helper/sd-helper
 	rm -f contrib/cmd/seccompagent/seccompagent
+	rm -f contrib/cmd/fs-idmap/fs-idmap
 	rm -rf release
 	rm -rf man/man8
 
@@ -191,7 +192,7 @@ verify-dependencies: vendor
 validate-keyring:
 	script/keyring_validate.sh
 
-.PHONY: runc all recvtty sd-helper seccompagent static releaseall release \
+.PHONY: runc all recvtty sd-helper seccompagent fs-idmap static releaseall release \
 	localrelease dbuild lint man runcimage \
 	test localtest unittest localunittest integration localintegration \
 	rootlessintegration localrootlessintegration shell install install-bash \

--- a/contrib/cmd/fs-idmap/fs-idmap.go
+++ b/contrib/cmd/fs-idmap/fs-idmap.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("usage: %s path_to_mount_set_attr", os.Args[0])
+	}
+
+	src := os.Args[1]
+	treeFD, err := unix.OpenTree(-1, src, uint(unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC|unix.AT_EMPTY_PATH|unix.AT_RECURSIVE))
+	if err != nil {
+		log.Fatalf("error calling open_tree %q: %v", src, err)
+	}
+	defer unix.Close(treeFD)
+
+	cmd := exec.Command("/usr/bin/sleep", "5")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags:  syscall.CLONE_NEWUSER,
+		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: 65536, Size: 65536}},
+		GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: 65536, Size: 65536}},
+	}
+	if err := cmd.Start(); err != nil {
+		log.Fatalf("failed to run the helper binary: %v", err)
+	}
+
+	path := fmt.Sprintf("/proc/%d/ns/user", cmd.Process.Pid)
+	var userNsFile *os.File
+	if userNsFile, err = os.Open(path); err != nil {
+		log.Fatalf("unable to get user ns file descriptor: %v", err)
+		return
+	}
+	defer userNsFile.Close()
+
+	attr := unix.MountAttr{
+		Attr_set:  unix.MOUNT_ATTR_IDMAP,
+		Userns_fd: uint64(userNsFile.Fd()),
+	}
+	if err := unix.MountSetattr(treeFD, "", unix.AT_EMPTY_PATH|unix.AT_RECURSIVE, &attr); err != nil {
+		log.Fatalf("error calling mount_setattr: %v", err)
+	}
+}

--- a/libcontainer/configs/mount_linux.go
+++ b/libcontainer/configs/mount_linux.go
@@ -29,8 +29,24 @@ type Mount struct {
 
 	// Extensions are additional flags that are specific to runc.
 	Extensions int `json:"extensions"`
+
+	// UIDMappings is used to changing file user owners w/o calling chown.
+	// Note that, the underlying filesystem should support this feature to be
+	// used.
+	// Every mount point could have its own mapping.
+	UIDMappings []IDMap `json:"uidMappings,omitempty"`
+
+	// GIDMappings is used to changing file group owners w/o calling chown.
+	// Note that, the underlying filesystem should support this feature to be
+	// used.
+	// Every mount point could have its own mapping.
+	GIDMappings []IDMap `json:"gidMappings,omitempty"`
 }
 
 func (m *Mount) IsBind() bool {
 	return m.Flags&unix.MS_BIND != 0
+}
+
+func (m *Mount) IsIDMapped() bool {
+	return len(m.UIDMappings) > 0 || len(m.GIDMappings) > 0
 }

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	selinux "github.com/opencontainers/selinux/go-selinux"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -29,19 +28,11 @@ func Validate(config *configs.Config) error {
 		sysctl,
 		intelrdtCheck,
 		rootlessEUIDCheck,
+		mounts,
 	}
 	for _, c := range checks {
 		if err := c(config); err != nil {
 			return err
-		}
-	}
-	// Relaxed validation rules for backward compatibility
-	warns := []check{
-		mounts, // TODO (runc v1.x.x): make this an error instead of a warning
-	}
-	for _, c := range warns {
-		if err := c(config); err != nil {
-			logrus.WithError(err).Warn("invalid configuration")
 		}
 	}
 	return nil

--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -360,11 +360,10 @@ func TestValidateMounts(t *testing.T) {
 		isErr bool
 		dest  string
 	}{
-		// TODO (runc v1.x.x): make these relative paths an error. See https://github.com/opencontainers/runc/pull/3004
-		{isErr: false, dest: "not/an/abs/path"},
-		{isErr: false, dest: "./rel/path"},
-		{isErr: false, dest: "./rel/path"},
-		{isErr: false, dest: "../../path"},
+		{isErr: true, dest: "not/an/abs/path"},
+		{isErr: true, dest: "./rel/path"},
+		{isErr: true, dest: "./rel/path"},
+		{isErr: true, dest: "../../path"},
 
 		{isErr: false, dest: "/abs/path"},
 		{isErr: false, dest: "/abs/but/../unclean"},

--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -386,3 +386,199 @@ func TestValidateMounts(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateIDMapMounts(t *testing.T) {
+	mapping := []configs.IDMap{
+		{
+			ContainerID: 0,
+			HostID:      10000,
+			Size:        1,
+		},
+	}
+
+	testCases := []struct {
+		name   string
+		isErr  bool
+		config *configs.Config
+	}{
+		{
+			name:  "idmap mount without bind opt specified",
+			isErr: true,
+			config: &configs.Config{
+				UidMappings: mapping,
+				GidMappings: mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/abs/path/",
+						Destination: "/abs/path/",
+						UIDMappings: mapping,
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+		{
+			name:  "rootless idmap mount",
+			isErr: true,
+			config: &configs.Config{
+				RootlessEUID: true,
+				UidMappings:  mapping,
+				GidMappings:  mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/abs/path/",
+						Destination: "/abs/path/",
+						Flags:       unix.MS_BIND,
+						UIDMappings: mapping,
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+		{
+			name:  "idmap mount without userns mappings",
+			isErr: true,
+			config: &configs.Config{
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/abs/path/",
+						Destination: "/abs/path/",
+						Flags:       unix.MS_BIND,
+						UIDMappings: mapping,
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+		{
+			name:  "idmap mounts with different userns and mount mappings",
+			isErr: true,
+			config: &configs.Config{
+				UidMappings: mapping,
+				GidMappings: mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/abs/path/",
+						Destination: "/abs/path/",
+						Flags:       unix.MS_BIND,
+						UIDMappings: []configs.IDMap{
+							{
+								ContainerID: 10,
+								HostID:      10,
+								Size:        1,
+							},
+						},
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+		{
+			name:  "idmap mounts with different userns and mount mappings",
+			isErr: true,
+			config: &configs.Config{
+				UidMappings: mapping,
+				GidMappings: mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/abs/path/",
+						Destination: "/abs/path/",
+						Flags:       unix.MS_BIND,
+						UIDMappings: mapping,
+						GIDMappings: []configs.IDMap{
+							{
+								ContainerID: 10,
+								HostID:      10,
+								Size:        1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "idmap mounts without abs source path",
+			isErr: true,
+			config: &configs.Config{
+				UidMappings: mapping,
+				GidMappings: mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "./rel/path/",
+						Destination: "/abs/path/",
+						Flags:       unix.MS_BIND,
+						UIDMappings: mapping,
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+		{
+			name:  "idmap mounts without abs dest path",
+			isErr: true,
+			config: &configs.Config{
+				UidMappings: mapping,
+				GidMappings: mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/abs/path/",
+						Destination: "./rel/path/",
+						Flags:       unix.MS_BIND,
+						UIDMappings: mapping,
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+
+		{
+			name: "simple idmap mount",
+			config: &configs.Config{
+				UidMappings: mapping,
+				GidMappings: mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/another-abs/path/",
+						Destination: "/abs/path/",
+						Flags:       unix.MS_BIND,
+						UIDMappings: mapping,
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+		{
+			name: "idmap mount with more flags",
+			config: &configs.Config{
+				UidMappings: mapping,
+				GidMappings: mapping,
+				Mounts: []*configs.Mount{
+					{
+						Source:      "/another-abs/path/",
+						Destination: "/abs/path/",
+						Flags:       unix.MS_BIND | unix.MS_RDONLY,
+						UIDMappings: mapping,
+						GIDMappings: mapping,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			config := tc.config
+			config.Rootfs = "/var"
+
+			err := mounts(config)
+			if tc.isErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+
+			if !tc.isErr && err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -541,6 +541,38 @@ func (c *Container) shouldSendMountSources() bool {
 	return false
 }
 
+// shouldSendIdmapSources says whether the child process must setup idmap mounts with
+// the mount_setattr already done in the host user namespace.
+func (c *Container) shouldSendIdmapSources() bool {
+	// nsexec.c mount_setattr() requires CAP_SYS_ADMIN in:
+	// * the user namespace the filesystem was mounted in;
+	// * the user namespace we're trying to idmap the mount to;
+	// * the owning user namespace of the mount namespace you're currently located in.
+	//
+	// See the comment from Christian Brauner:
+	//	https://github.com/opencontainers/runc/pull/3717#discussion_r1103607972
+	//
+	// Let's just rule out rootless, we don't have those permission in the
+	// rootless case.
+	if c.config.RootlessEUID {
+		return false
+	}
+
+	// For the time being we require userns to be in use.
+	if !c.config.Namespaces.Contains(configs.NEWUSER) {
+		return false
+	}
+
+	// We need to send sources if there are idmap bind-mounts.
+	for _, m := range c.config.Mounts {
+		if m.IsBind() && m.IsIDMapped() {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (c *Container) sendMountSources(cmd *exec.Cmd, messageSockPair filePair) error {
 	if !c.shouldSendMountSources() {
 		return nil
@@ -548,6 +580,16 @@ func (c *Container) sendMountSources(cmd *exec.Cmd, messageSockPair filePair) er
 
 	return c.sendFdsSources(cmd, messageSockPair, "_LIBCONTAINER_MOUNT_FDS", func(m *configs.Mount) bool {
 		return m.IsBind() && !m.IsIDMapped()
+	})
+}
+
+func (c *Container) sendIdmapSources(cmd *exec.Cmd, messageSockPair filePair) error {
+	if !c.shouldSendIdmapSources() {
+		return nil
+	}
+
+	return c.sendFdsSources(cmd, messageSockPair, "_LIBCONTAINER_IDMAP_FDS", func(m *configs.Mount) bool {
+		return m.IsBind() && m.IsIDMapped()
 	})
 }
 
@@ -590,6 +632,9 @@ func (c *Container) newInitProcess(p *Process, cmd *exec.Cmd, messageSockPair, l
 		return nil, err
 	}
 	if err := c.sendMountSources(cmd, messageSockPair); err != nil {
+		return nil, err
+	}
+	if err := c.sendIdmapSources(cmd, messageSockPair); err != nil {
 		return nil, err
 	}
 
@@ -2252,6 +2297,29 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 
 		r.AddData(&Bytemsg{
 			Type:  MountSourcesAttr,
+			Value: mounts,
+		})
+	}
+
+	// Idmap mount sources to open.
+	if it == initStandard && c.shouldSendIdmapSources() {
+		var mounts []byte
+		for _, m := range c.config.Mounts {
+			if m.IsBind() && m.IsIDMapped() {
+				// While other parts of the code check this too (like
+				// libcontainer/specconv/spec_linux.go) we do it here also because some libcontainer
+				// users don't use those functions.
+				if strings.IndexByte(m.Source, 0) >= 0 {
+					return nil, fmt.Errorf("mount source string contains null byte: %q", m.Source)
+				}
+
+				mounts = append(mounts, []byte(m.Source)...)
+			}
+			mounts = append(mounts, byte(0))
+		}
+
+		r.AddData(&Bytemsg{
+			Type:  IdmapSourcesAttr,
 			Value: mounts,
 		})
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -531,9 +531,9 @@ func (c *Container) shouldSendMountSources() bool {
 		return false
 	}
 
-	// We need to send sources if there are bind-mounts.
+	// We need to send sources if there are non-idmap bind-mounts.
 	for _, m := range c.config.Mounts {
-		if m.IsBind() {
+		if m.IsBind() && !m.IsIDMapped() {
 			return true
 		}
 	}
@@ -2231,7 +2231,7 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 	if it == initStandard && c.shouldSendMountSources() {
 		var mounts []byte
 		for _, m := range c.config.Mounts {
-			if m.IsBind() {
+			if m.IsBind() && !m.IsIDMapped() {
 				if strings.IndexByte(m.Source, 0) >= 0 {
 					return nil, fmt.Errorf("mount source string contains null byte: %q", m.Source)
 				}

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -215,17 +215,17 @@ func validateID(id string) error {
 	return nil
 }
 
-func parseMountFds() ([]int, error) {
-	fdsJSON := os.Getenv("_LIBCONTAINER_MOUNT_FDS")
+func parseFdsFromEnv(envVar string) ([]int, error) {
+	fdsJSON := os.Getenv(envVar)
 	if fdsJSON == "" {
 		// Always return the nil slice if no fd is present.
 		return nil, nil
 	}
 
-	var mountFds []int
-	if err := json.Unmarshal([]byte(fdsJSON), &mountFds); err != nil {
-		return nil, fmt.Errorf("Error unmarshalling _LIBCONTAINER_MOUNT_FDS: %w", err)
+	var fds []int
+	if err := json.Unmarshal([]byte(fdsJSON), &fds); err != nil {
+		return nil, fmt.Errorf("Error unmarshalling %v: %w", envVar, err)
 	}
 
-	return mountFds, nil
+	return fds, nil
 }

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -22,6 +22,7 @@ const (
 	UidmapPathAttr   uint16 = 27288
 	GidmapPathAttr   uint16 = 27289
 	MountSourcesAttr uint16 = 27290
+	IdmapSourcesAttr uint16 = 27291
 )
 
 type Int32msg struct {

--- a/libcontainer/nsenter/idmap.h
+++ b/libcontainer/nsenter/idmap.h
@@ -1,0 +1,76 @@
+#ifndef IDMAP_H
+#define IDMAP_H
+
+#include <sys/mount.h>
+// Centos-7 doesn't have this file nor the __has_include() directive, so let's
+// just leave this commented out and we can uncomment when it hits EOL (2024-06-30).
+//#include <linux/mount.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+/* mount_setattr() */
+#ifndef MOUNT_ATTR_IDMAP
+#define MOUNT_ATTR_IDMAP 0x00100000
+#endif
+
+#ifndef __NR_mount_setattr
+	#if defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_mount_setattr (442 + 4000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_mount_setattr (442 + 6000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_mount_setattr (442 + 5000)
+		#endif
+	#else
+		#define __NR_mount_setattr 442
+	#endif
+#endif
+#ifndef MOUNT_ATTR_SIZE_VER0
+struct mount_attr {
+	__u64 attr_set;
+	__u64 attr_clr;
+	__u64 propagation;
+	__u64 userns_fd;
+};
+#endif
+
+/* open_tree() */
+#ifndef OPEN_TREE_CLONE
+#define OPEN_TREE_CLONE 1
+#endif
+
+#ifndef OPEN_TREE_CLOEXEC
+#define OPEN_TREE_CLOEXEC O_CLOEXEC
+#endif
+
+#ifndef __NR_open_tree
+	#if defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_open_tree 4428
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_open_tree 6428
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_open_tree 5428
+		#endif
+	#else
+		#define __NR_open_tree 428
+	#endif
+#endif
+
+static inline int sys_mount_setattr(int dfd, const char *path, unsigned int flags, struct mount_attr *attr, size_t size)
+{
+	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
+}
+
+static inline int sys_open_tree(int dfd, const char *filename, unsigned int flags)
+{
+	return syscall(__NR_open_tree, dfd, filename, flags);
+}
+
+
+#endif /* IDMAP_H */

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -33,6 +33,9 @@
 /* Get all of the CLONE_NEW* flags. */
 #include "namespace.h"
 
+/* Get definitions for idmap sources */
+#include "idmap.h"
+
 /* Synchronisation values. */
 enum sync_t {
 	SYNC_USERMAP_PLS = 0x40,	/* Request parent to map our users. */
@@ -43,6 +46,8 @@ enum sync_t {
 	SYNC_CHILD_FINISH = 0x45,	/* The child or grandchild has finished. */
 	SYNC_MOUNTSOURCES_PLS = 0x46,	/* Tell parent to send mount sources by SCM_RIGHTS. */
 	SYNC_MOUNTSOURCES_ACK = 0x47,	/* All mount sources have been sent. */
+	SYNC_MOUNT_IDMAP_PLS = 0x48,	/* Tell parent to mount idmap sources. */
+	SYNC_MOUNT_IDMAP_ACK = 0x49,	/* All idmap mounts have been done. */
 };
 
 #define STAGE_SETUP  -1
@@ -95,6 +100,10 @@ struct nlconfig_t {
 	/* Mount sources opened outside the container userns. */
 	char *mountsources;
 	size_t mountsources_len;
+
+	/* Idmap sources opened outside the container userns which will be id mapped. */
+	char *idmapsources;
+	size_t idmapsources_len;
 };
 
 /*
@@ -112,6 +121,7 @@ struct nlconfig_t {
 #define UIDMAPPATH_ATTR		27288
 #define GIDMAPPATH_ATTR		27289
 #define MOUNT_SOURCES_ATTR	27290
+#define IDMAP_SOURCES_ATTR	27291
 
 /*
  * Use the raw syscall for versions of glibc which don't include a function for
@@ -431,6 +441,10 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 			config->mountsources = current;
 			config->mountsources_len = payload_len;
 			break;
+		case IDMAP_SOURCES_ATTR:
+			config->idmapsources = current;
+			config->idmapsources_len = payload_len;
+			break;
 		default:
 			bail("unknown netlink message type %d", nlattr->nla_type);
 		}
@@ -648,6 +662,83 @@ void try_unshare(int flags, const char *msg)
 			break;
 	}
 	bail("failed to unshare %s", msg);
+}
+
+void send_idmapsources(int sockfd, pid_t pid, char *idmap_src, int idmap_src_len)
+{
+	char proc_user_path[PATH_MAX];
+
+	/* Open the userns fd only once.
+	 * Currently we only support idmap mounts that use the same mapping than
+	 * the userns. This is validated in libcontainer/configs/validate/validator.go,
+	 * so if we reached here, we know the mapping for the idmap is the same
+	 * as the userns. This is why we just open the userns_fd once from the
+	 * PID of the child process that has the userns already applied.
+	 */
+	int ret = snprintf(proc_user_path, sizeof(proc_user_path), "/proc/%d/ns/user", pid);
+	if (ret < 0 || (size_t)ret >= sizeof(proc_user_path)) {
+		sane_kill(pid, SIGKILL);
+		bail("failed to create userns path string");
+	}
+
+	int userns_fd = open(proc_user_path, O_RDONLY | O_CLOEXEC | O_NOCTTY);
+	if (userns_fd < 0) {
+		sane_kill(pid, SIGKILL);
+		bail("failed to get user namespace fd");
+	}
+
+	char *idmap_end = idmap_src + idmap_src_len;
+	while (idmap_src < idmap_end) {
+		if (idmap_src[0] == '\0') {
+			idmap_src++;
+			continue;
+		}
+
+		int fd_tree = sys_open_tree(-EBADF, idmap_src,
+					    OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC |
+					    AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT);
+		if (fd_tree < 0) {
+			sane_kill(pid, SIGKILL);
+			if (errno == EINVAL)
+				bail("failed to use open_tree(2) with path: %s, the kernel doesn't supports ID-mapped mounts", idmap_src);
+			else
+				bail("failed to use open_tree(2) with path: %s", idmap_src);
+		}
+
+		struct mount_attr attr = {
+			.attr_set = MOUNT_ATTR_IDMAP,
+			.userns_fd = userns_fd,
+		};
+
+		ret = sys_mount_setattr(fd_tree, "", AT_EMPTY_PATH, &attr, sizeof(attr));
+		if (ret < 0) {
+			sane_kill(pid, SIGKILL);
+			if (errno == EINVAL)
+				bail("failed to change mount attributes, maybe the filesystem doesn't supports ID-mapped mounts");
+			else
+				bail("failed to change mount attributes");
+		}
+
+		write_log(DEBUG, "~> sending idmap source: %s with mapping from: %s", idmap_src, proc_user_path);
+		send_fd(sockfd, fd_tree);
+
+		if (close(fd_tree) < 0) {
+			sane_kill(pid, SIGKILL);
+			bail("error closing fd_tree");
+		}
+
+		idmap_src += strlen(idmap_src) + 1;
+	}
+
+	if (close(userns_fd) < 0) {
+		sane_kill(pid, SIGKILL);
+		bail("error closing userns fd");
+	}
+}
+
+void receive_idmapsources(int sockfd)
+{
+	receive_fd_sources(sockfd, "_LIBCONTAINER_IDMAP_FDS");
 }
 
 void nsexec(void)
@@ -892,6 +983,17 @@ void nsexec(void)
 						bail("failed to sync with child: write(SYNC_MOUNTSOURCES_ACK)");
 					}
 					break;
+				case SYNC_MOUNT_IDMAP_PLS:
+					write_log(DEBUG, "stage-1 requested to open idmap sources");
+					send_idmapsources(syncfd, stage1_pid, config.idmapsources,
+							  config.idmapsources_len);
+					s = SYNC_MOUNT_IDMAP_ACK;
+					if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
+						sane_kill(stage1_pid, SIGKILL);
+						bail("failed to sync with child: write(SYNC_MOUNT_IDMAP_ACK)");
+					}
+
+					break;
 				case SYNC_CHILD_FINISH:
 					write_log(DEBUG, "stage-1 complete");
 					stage1_complete = true;
@@ -1060,6 +1162,21 @@ void nsexec(void)
 					bail("failed to sync with parent: read(SYNC_MOUNTSOURCES_ACK)");
 				if (s != SYNC_MOUNTSOURCES_ACK)
 					bail("failed to sync with parent: SYNC_MOUNTSOURCES_ACK: got %u", s);
+			}
+
+			if (config.idmapsources) {
+				write_log(DEBUG, "request stage-0 to send idmap sources");
+				s = SYNC_MOUNT_IDMAP_PLS;
+				if (write(syncfd, &s, sizeof(s)) != sizeof(s))
+					bail("failed to sync with parent: write(SYNC_MOUNT_IDMAP_PLS)");
+
+				/* Receive and install all idmap fds. */
+				receive_idmapsources(syncfd);
+
+				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
+					bail("failed to sync with parent: read(SYNC_MOUNT_IDMAP_ACK)");
+				if (s != SYNC_MOUNT_IDMAP_ACK)
+					bail("failed to sync with parent: SYNC_MOUNT_IDMAP_ACK: got %u", s);
 			}
 
 			/*

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -40,7 +40,8 @@ type mountConfig struct {
 // mountEntry contains mount data specific to a mount point.
 type mountEntry struct {
 	*configs.Mount
-	srcFD string
+	srcFD   string
+	idmapFD int
 }
 
 func (m *mountEntry) src() string {
@@ -73,6 +74,10 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds mountFds) (
 		return fmt.Errorf("malformed mountFds slice. Expected size: %v, got: %v", len(config.Mounts), len(mountFds.sourceFds))
 	}
 
+	if mountFds.idmapFds != nil && len(mountFds.idmapFds) != len(config.Mounts) {
+		return fmt.Errorf("malformed idmapFds slice: expected size: %v, got: %v", len(config.Mounts), len(mountFds.idmapFds))
+	}
+
 	mountConfig := &mountConfig{
 		root:            config.Rootfs,
 		label:           config.MountLabel,
@@ -81,11 +86,20 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds mountFds) (
 		cgroupns:        config.Namespaces.Contains(configs.NEWCGROUP),
 	}
 	for i, m := range config.Mounts {
-		entry := mountEntry{Mount: m}
+		entry := mountEntry{Mount: m, idmapFD: -1}
 		// Just before the loop we checked that if not empty, len(mountFds) == len(config.Mounts).
 		// Therefore, we can access mountFds[i] without any concerns.
 		if mountFds.sourceFds != nil && mountFds.sourceFds[i] != -1 {
 			entry.srcFD = "/proc/self/fd/" + strconv.Itoa(mountFds.sourceFds[i])
+		}
+
+		// We validated before we can access idmapFds[i].
+		if mountFds.idmapFds != nil && mountFds.idmapFds[i] != -1 {
+			entry.idmapFD = mountFds.idmapFds[i]
+		}
+
+		if entry.idmapFD != -1 && entry.srcFD != "" {
+			return fmt.Errorf("malformed mountFds and idmapFds slice, entry: %v has fds in both slices", i)
 		}
 
 		if err := mountToRootfs(mountConfig, entry); err != nil {
@@ -466,8 +480,35 @@ func mountToRootfs(c *mountConfig, m mountEntry) error {
 		if err := prepareBindMount(m, rootfs); err != nil {
 			return err
 		}
-		if err := mountPropagate(m, rootfs, mountLabel); err != nil {
-			return err
+
+		if m.IsBind() && m.IsIDMapped() {
+			if m.idmapFD == -1 {
+				return fmt.Errorf("error creating mount %+v: idmapFD is invalid, should point to a valid fd", m)
+			}
+			if err := unix.MoveMount(m.idmapFD, "", -1, dest, unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
+				return fmt.Errorf("error on unix.MoveMount %+v: %w", m, err)
+			}
+
+			// In nsexec.c, we did not set the propagation field of mount_attr struct.
+			// So, let's deal with these flags right now!
+			if err := utils.WithProcfd(rootfs, dest, func(dstFD string) error {
+				for _, pflag := range m.PropagationFlags {
+					// When using mount for setting propagations flags, the source, file
+					// system type and data arguments are ignored:
+					// https://man7.org/linux/man-pages/man2/mount.2.html
+					// We also ignore procfd because we want to act on dest.
+					if err := mountViaFDs("", "", dest, dstFD, "", uintptr(pflag), ""); err != nil {
+						return err
+					}
+				}
+				return nil
+			}); err != nil {
+				return fmt.Errorf("change mount propagation through procfd: %w", err)
+			}
+		} else {
+			if err := mountPropagate(m, rootfs, mountLabel); err != nil {
+				return err
+			}
 		}
 		// bind mount won't change mount options, we need remount to make mount options effective.
 		// first check that we have non-default options required before attempting a remount

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -70,7 +70,7 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds mountFds) (
 	}
 
 	if mountFds.sourceFds != nil && len(mountFds.sourceFds) != len(config.Mounts) {
-		return fmt.Errorf("malformed mountFds slice. Expected size: %v, got: %v. Slice: %v", len(config.Mounts), len(mountFds.sourceFds), mountFds.sourceFds)
+		return fmt.Errorf("malformed mountFds slice. Expected size: %v, got: %v", len(config.Mounts), len(mountFds.sourceFds))
 	}
 
 	mountConfig := &mountConfig{

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -63,14 +63,14 @@ func needsSetupDev(config *configs.Config) bool {
 // prepareRootfs sets up the devices, mount points, and filesystems for use
 // inside a new mount namespace. It doesn't set anything as ro. You must call
 // finalizeRootfs after this function to finish setting up the rootfs.
-func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds []int) (err error) {
+func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds mountFds) (err error) {
 	config := iConfig.Config
 	if err := prepareRoot(config); err != nil {
 		return fmt.Errorf("error preparing rootfs: %w", err)
 	}
 
-	if mountFds != nil && len(mountFds) != len(config.Mounts) {
-		return fmt.Errorf("malformed mountFds slice. Expected size: %v, got: %v. Slice: %v", len(config.Mounts), len(mountFds), mountFds)
+	if mountFds.sourceFds != nil && len(mountFds.sourceFds) != len(config.Mounts) {
+		return fmt.Errorf("malformed mountFds slice. Expected size: %v, got: %v. Slice: %v", len(config.Mounts), len(mountFds.sourceFds), mountFds.sourceFds)
 	}
 
 	mountConfig := &mountConfig{
@@ -84,8 +84,8 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds []int) (err
 		entry := mountEntry{Mount: m}
 		// Just before the loop we checked that if not empty, len(mountFds) == len(config.Mounts).
 		// Therefore, we can access mountFds[i] without any concerns.
-		if mountFds != nil && mountFds[i] != -1 {
-			entry.srcFD = "/proc/self/fd/" + strconv.Itoa(mountFds[i])
+		if mountFds.sourceFds != nil && mountFds.sourceFds[i] != -1 {
+			entry.srcFD = "/proc/self/fd/" + strconv.Itoa(mountFds.sourceFds[i])
 		}
 
 		if err := mountToRootfs(mountConfig, entry); err != nil {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -944,20 +944,9 @@ next:
 }
 
 func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
-	create := func(m specs.LinuxIDMapping) configs.IDMap {
-		return configs.IDMap{
-			HostID:      int(m.HostID),
-			ContainerID: int(m.ContainerID),
-			Size:        int(m.Size),
-		}
-	}
 	if spec.Linux != nil {
-		for _, m := range spec.Linux.UIDMappings {
-			config.UidMappings = append(config.UidMappings, create(m))
-		}
-		for _, m := range spec.Linux.GIDMappings {
-			config.GidMappings = append(config.GidMappings, create(m))
-		}
+		config.UidMappings = toConfigIDMap(spec.Linux.UIDMappings)
+		config.GidMappings = toConfigIDMap(spec.Linux.GIDMappings)
 	}
 	rootUID, err := config.HostRootUID()
 	if err != nil {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -497,6 +497,18 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	return config, nil
 }
 
+func toConfigIDMap(specMaps []specs.LinuxIDMapping) []configs.IDMap {
+	idmaps := make([]configs.IDMap, len(specMaps))
+	for i, id := range specMaps {
+		idmaps[i] = configs.IDMap{
+			ContainerID: int(id.ContainerID),
+			HostID:      int(id.HostID),
+			Size:        int(id.Size),
+		}
+	}
+	return idmaps
+}
+
 func createLibcontainerMount(cwd string, m specs.Mount) (*configs.Mount, error) {
 	if !filepath.IsAbs(m.Destination) {
 		// Relax validation for backward compatibility
@@ -518,6 +530,9 @@ func createLibcontainerMount(cwd string, m specs.Mount) (*configs.Mount, error) 
 			mnt.Source = filepath.Join(cwd, m.Source)
 		}
 	}
+
+	mnt.UIDMappings = toConfigIDMap(m.UIDMappings)
+	mnt.GIDMappings = toConfigIDMap(m.GIDMappings)
 
 	// None of the mount arguments can contain a null byte. Normally such
 	// strings would either cause some other failure or would just be truncated

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -25,7 +25,7 @@ type linuxStandardInit struct {
 	parentPid     int
 	fifoFd        int
 	logFd         int
-	mountFds      []int
+	mountFds      mountFds
 	config        *initConfig
 }
 
@@ -86,15 +86,15 @@ func (l *linuxStandardInit) Init() error {
 	// initialises the labeling system
 	selinux.GetEnabled()
 
-	// We don't need the mountFds after prepareRootfs() nor if it fails.
+	// We don't need the mountFds.SourceFds after prepareRootfs() nor if it fails.
 	err := prepareRootfs(l.pipe, l.config, l.mountFds)
-	for _, m := range l.mountFds {
+	for _, m := range l.mountFds.sourceFds {
 		if m == -1 {
 			continue
 		}
 
 		if err := unix.Close(m); err != nil {
-			return fmt.Errorf("Unable to close mountFds fds: %w", err)
+			return fmt.Errorf("unable to close mount sourceFds: %w", err)
 		}
 	}
 

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -86,15 +86,14 @@ func (l *linuxStandardInit) Init() error {
 	// initialises the labeling system
 	selinux.GetEnabled()
 
-	// We don't need the mountFds.SourceFds after prepareRootfs() nor if it fails.
+	// We don't need the mount nor idmap fds after prepareRootfs() nor if it fails.
 	err := prepareRootfs(l.pipe, l.config, l.mountFds)
-	for _, m := range l.mountFds.sourceFds {
+	for _, m := range append(l.mountFds.sourceFds, l.mountFds.idmapFds...) {
 		if m == -1 {
 			continue
 		}
-
 		if err := unix.Close(m); err != nil {
-			return fmt.Errorf("unable to close mount sourceFds: %w", err)
+			return fmt.Errorf("unable to close mountFds fds: %w", err)
 		}
 	}
 

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -16,6 +16,7 @@ unset IMAGES
 RECVTTY="${INTEGRATION_ROOT}/../../contrib/cmd/recvtty/recvtty"
 SD_HELPER="${INTEGRATION_ROOT}/../../contrib/cmd/sd-helper/sd-helper"
 SECCOMP_AGENT="${INTEGRATION_ROOT}/../../contrib/cmd/seccompagent/seccompagent"
+FS_IDMAP="${INTEGRATION_ROOT}/../../contrib/cmd/fs-idmap/fs-idmap"
 
 # Some variables may not always be set. Set those to empty value,
 # if unset, to avoid "unbound variable" error.
@@ -621,4 +622,43 @@ function requires_kernel() {
 	if [[ "$KERNEL_MAJOR" -lt $major_required || ("$KERNEL_MAJOR" -eq $major_required && "$KERNEL_MINOR" -lt $minor_required) ]]; then
 		skip "requires kernel $1"
 	fi
+}
+
+function requires_idmap_fs() {
+	local fs
+	fs=$1
+
+	# We need to "|| true" it to avoid CI failure as this binary may return with
+	# something different than 0.
+	stderr=$($FS_IDMAP "$fs" 2>&1 >/dev/null || true)
+
+	case $stderr in
+	*invalid\ argument)
+		skip "$fs underlying file system does not support ID map mounts"
+		;;
+	*operation\ not\ permitted)
+		if uname -r | grep -q el9; then
+			# centos kernel 5.14.0-200 does not permit using ID map mounts due to a
+			# specific patch added to their sources:
+			# 	https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/merge_requests/131
+			#
+			# There doesn't seem to be any technical reason behind
+			# it, none was provided in numerous examples, like:
+			# 	https://lore.kernel.org/lkml/20210213130042.828076-1-christian.brauner@ubuntu.com/T/#m3a9df31aa183e8797c70bc193040adfd601399ad
+			#	https://lore.kernel.org/lkml/20210213130042.828076-1-christian.brauner@ubuntu.com/T/#m59cdad9630d5a279aeecd0c1f117115144bc15eb
+			#	https://lore.kernel.org/lkml/m1r1ifzf8x.fsf@fess.ebiederm.org
+			#	https://lore.kernel.org/lkml/20210510125147.tkgeurcindldiwxg@wittgenstein
+			#
+			# So, sadly we just need to skip this on centos.
+			#
+			# TODO Nonetheless, there are ongoing works to revert the patch
+			# deactivating ID map mounts:
+			# https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/merge_requests/2179/diffs?commit_id=06f4fe946394cb94d2cf274aa7f3091d8f8469dc
+			# Once this patch is merge, we should be able to remove the below skip
+			# if the revert is backported or if CI centos kernel is upgraded.
+			skip "sadly, centos kernel 5.14 does not permit using ID map mounts"
+		fi
+		;;
+	esac
+	# If we have another error, the integration test will fail and report it.
 }

--- a/tests/integration/idmap.bats
+++ b/tests/integration/idmap.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	requires root
+	requires_kernel 5.12
+	requires_idmap_fs /tmp
+
+	setup_debian
+
+	# Prepare source folders for bind mount
+	mkdir -p source-{1,2}/
+	touch source-{1,2}/foo.txt
+
+	# Use other owner for source-2
+	chown 1:1 source-2/foo.txt
+
+	mkdir -p rootfs/{proc,sys,tmp}
+	mkdir -p rootfs/tmp/mount-{1,2}
+	mkdir -p rootfs/mnt/bind-mount-{1,2}
+
+	update_config ' .linux.namespaces += [{"type": "user"}]
+		| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65536}]
+		| .linux.gidMappings += [{"hostID": 100000, "containerID": 0, "size": 65536}]
+		| .process.args += ["-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]
+		| .mounts += [
+					{
+						"source": "source-1/",
+						"destination": "/tmp/mount-1",
+						"options": ["bind"],
+						"uidMappings": [ {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						],
+						"gidMappings": [        {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						]
+					}
+				] '
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+@test "simple idmap mount" {
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=0=0="* ]]
+}
+
+@test "write to an idmap mount" {
+	update_config ' .process.args = ["sh", "-c", "touch /tmp/mount-1/bar && stat -c =%u=%g= /tmp/mount-1/bar"]'
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=0=0="* ]]
+}
+
+@test "idmap mount with propagation flag" {
+	update_config ' .process.args = ["sh", "-c", "findmnt -o PROPAGATION /tmp/mount-1"]'
+	# Add the shared option to the idmap mount
+	update_config ' .mounts |= map((select(.source == "source-1/") | .options += ["shared"]) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"shared"* ]]
+}
+
+@test "idmap mount with bind mount" {
+	update_config '   .mounts += [
+					{
+						"source": "source-2/",
+						"destination": "/tmp/mount-2",
+						"options": ["bind"]
+					}
+				] '
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=0=0="* ]]
+}
+
+@test "two idmap mounts with two bind mounts" {
+	update_config '   .process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt /tmp/mount-2/foo.txt"]
+			| .mounts += [
+					{
+						"source": "source-1/",
+						"destination": "/mnt/bind-mount-1",
+						"options": ["bind"]
+					},
+					{
+						"source": "source-2/",
+						"destination": "/mnt/bind-mount-2",
+						"options": ["bind"]
+					},
+					{
+						"source": "source-2/",
+						"destination": "/tmp/mount-2",
+						"options": ["bind"],
+						"uidMappings": [ {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						],
+						"gidMappings": [        {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						]
+					}
+				] '
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=0=0="* ]]
+	# source-2/ is owned by 1:1, so we expect this with the idmap mount too.
+	[[ "$output" == *"=1=1="* ]]
+}
+
+@test "idmap mount without gidMappings fails" {
+	update_config ' .mounts |= map((select(.source == "source-1/") | del(.gidMappings) ) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"invalid mount"* ]]
+}
+
+@test "idmap mount without uidMappings fails" {
+	update_config ' .mounts |= map((select(.source == "source-1/") | del(.uidMappings) ) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"invalid mount"* ]]
+}
+
+@test "idmap mount without bind fails" {
+	update_config ' .mounts |= map((select(.source == "source-1/") | .options = [""]) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"invalid mount"* ]]
+}
+
+@test "idmap mount with different mapping than userns fails" {
+	# Let's modify the containerID to be 1, instead of 0 as it is in the
+	# userns config.
+	update_config ' .mounts |= map((select(.source == "source-1/") | .uidMappings[0]["containerID"] = 1 ) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"invalid mount"* ]]
+}


### PR DESCRIPTION
This PR implements support for this runtime-spec change that added idmap mounts support: https://github.com/opencontainers/runtime-spec/pull/1143

We open the idmap source paths and call mount_setattr() in runc PARENT,
as we need privileges in the init userns for that, and then sends the
fds to the child process. For this fd passing we use the same mechanism
used in other parts of thecode, the `_LIBCONTAINER_` env vars.

The mount is finished (unix.MoveMount) from go code, inside the userns,
so we reuse all the prepareBindMount() security checks and the remount
logic for some flags too.

This PR only supports idmap mounts when userns are used AND the mappings
are the same specified for the userns mapping. This limitation is to
simplify the initial implementation, as all our users so far only need
this, and we can avoid sending over netlink the mappings, creating a
userns with this custom mapping, etc. Future PRs will remove this
limitation.

As the idmap case is quite similar to the existing mount sources case we
open with O_PATH, some simple refactors are done to share more code and
to group the slices of fds in go code. To that end, we created the
mountFds struct, and add all the slices of fds there.

This replaces PR #3429, as that PR tries to mount already when we are inside the user namespace. AFAIK, that will never work and therefore this PR tries a completely different way to do the idmap mounts.

This PR is co-authored-by: `Francis Laniel <flaniel@linux.microsoft.com> `

cc @eiffel-fl

Question
------------
One open question I have is I added most validations in `libcontainer/configs/validate/validator.go` but I couldn't help to notice that other parts of the code do some other validations. All examples that I tried hit the validations, but am I missing adding the validations in some other part, that don't use this maybe when runc is called differently? Or adding them there should be enough?


TODO
--------
- [x] Pass idmap mount sources using bootstrap data (now hardcoded an example path)
- [x] Add integration tests
- [x] Modify the mountToRootfs() function to not move_mount and finish the idmap mount
- [x] Update runtime spec to have the new fields for UID/GID mappings
- [x] Address all TODOs I added in this PR

Changelog entry
----------------------

 * Support idmap mounts as specified in the OCI runtime-spec. Currently the mount mappings need to be identical to the mappings used in the user namespace section.
 * Enforce absolute paths for mounts


Closes: #3429 
Closes: #3020