### PR TITLE
Disable clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+---
+# We use GNU indent from the Makefile to format C code in this project. Alas,
+# there is no way to map indent options to clang-format style options in a way
+# to achieve identical results for both formatters.
+#
+# Therefore, let's disable clang-format entirely.
+DisableFormat: true
+...


### PR DESCRIPTION
For the sake of developers who have LSP configured to auto-format the code upon save (that would me with my new nvim setup), let's not auto-format the C code when using clangd.

Initially I tried to write a set of rules for clang-format which is identical to what we use (indent with a handful of options invoked from cfmt target in Makefile), but it appears to be impossible.