### PR TITLE
Fix runc crushes when parsing invalid JSON specification file

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -125,6 +126,9 @@ func loadSpec(cPath string) (spec *specs.Spec, err error) {
 
 	if err = json.NewDecoder(cf).Decode(&spec); err != nil {
 		return nil, err
+	}
+	if spec == nil {
+		return nil, errors.New("config cannot be null")
 	}
 	return spec, validateProcessSpec(spec.Process)
 }


### PR DESCRIPTION
Fixes [#3727](https://github.com/opencontainers/runc/issues/3727#issue-1573797885)