### PR TITLE
Dockerfile: fix build wrt new git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,7 @@ ENV LIBSECCOMP_VERSION=$LIBSECCOMP_VERSION
 ENV LD_LIBRARY_PATH=/opt/libseccomp/lib
 ENV PKG_CONFIG_PATH=/opt/libseccomp/lib/pkgconfig
 
+# Prevent the "fatal: detected dubious ownership in repository" git complain during build.
+RUN git config --global --add safe.directory /go/src/github.com/opencontainers/runc
+
 WORKDIR /go/src/github.com/opencontainers/runc


### PR DESCRIPTION
After #3718 merge, updated git in golang:1.19-bullseye image results in failure to build a release:

	make -C /go/src/github.com/opencontainers/runc PKG_CONFIG_PATH=/opt/libseccomp/lib/pkgconfig COMMIT_NO= EXTRA_FLAGS=-a 'EXTRA_LDFLAGS=-w -s -buildid=' static
	make[1]: Entering directory '/go/src/github.com/opencontainers/runc'
	fatal: detected dubious ownership in repository at '/go/src/github.com/opencontainers/runc'
	To add an exception for this directory, call:
		git config --global --add safe.directory /go/src/github.com/opencontainers/runc
	go build -trimpath -buildmode=pie -a -tags "seccomp urfave_cli_no_docs netgo osusergo" -ldflags "-X main.gitCommit= -X main.version=1.1.0+dev -linkmode external -extldflags --static-pie -w -s -buildid=" -o runc .
	error obtaining VCS status: exit status 128
		Use -buildvcs=false to disable VCS stamping.
		
(see e.g. here: https://github.com/opencontainers/runc/actions/runs/4130222410/jobs/7136690396)

This PR should fix it (similar to #3471).