### PR TITLE
[1.1] libcontainer: skip chown of /dev/null caused by fd redirection

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -411,8 +411,9 @@ func fixStdioPermissions(u *user.ExecUser) error {
 			return &os.PathError{Op: "fstat", Path: file.Name(), Err: err}
 		}
 
-		// Skip chown if uid is already the one we want.
-		if int(s.Uid) == u.Uid {
+		// Skip chown if uid is already the one we want or any of the STDIO descriptors
+		// were redirected to /dev/null.
+		if int(s.Uid) == u.Uid || s.Rdev == null.Rdev {
 			continue
 		}
 


### PR DESCRIPTION
This is a backport of https://github.com/opencontainers/runc/pull/3707 to release-1.1 branch, fixing #3674.

Clean cherry-pick, no issues.