### PR TITLE
specconv: avoid mapping "acl" to MS_POSIXACL

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -66,7 +66,7 @@ func initMaps() {
 			clear bool
 			flag  int
 		}{
-			"acl":           {false, unix.MS_POSIXACL},
+			// "acl" cannot be mapped to MS_POSIXACL: https://github.com/opencontainers/runc/issues/3738
 			"async":         {true, unix.MS_SYNCHRONOUS},
 			"atime":         {true, unix.MS_NOATIME},
 			"bind":          {false, unix.MS_BIND},
@@ -79,7 +79,6 @@ func initMaps() {
 			"lazytime":      {false, unix.MS_LAZYTIME},
 			"loud":          {true, unix.MS_SILENT},
 			"mand":          {false, unix.MS_MANDLOCK},
-			"noacl":         {true, unix.MS_POSIXACL},
 			"noatime":       {false, unix.MS_NOATIME},
 			"nodev":         {false, unix.MS_NODEV},
 			"nodiratime":    {false, unix.MS_NODIRATIME},


### PR DESCRIPTION
From https://github.com/torvalds/linux/commit/caaef1ba8c9ee7a54b53dd8bf4bb7e8658185583 :

> In fact SB_POSIXACL is an internal flag, and accepting MS_POSIXACL on
> the mount(2) interface is possibly a bug.

Fix #3738
