### PR TITLE
tests: Fix weird error on centos-9

### DIFF
--- a/libcontainer/cgroups/devices/systemd_test.go
+++ b/libcontainer/cgroups/devices/systemd_test.go
@@ -66,7 +66,7 @@ func TestPodSkipDevicesUpdate(t *testing.T) {
 
 	// Create a "container" within the "pod" cgroup.
 	// This is not a real container, just a process in the cgroup.
-	cmd := exec.Command("bash", "-c", "while true; do echo > /dev/null; done")
+	cmd := exec.Command("sleep", "infinity")
 	cmd.Env = append(os.Environ(), "LANG=C")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr


### PR DESCRIPTION
centos-9 unit test sometimes fails with:
```    
            === RUN   TestPodSkipDevicesUpdate
                systemd_test.go:114: container stderr not empty: basename: missing operand
                    Try 'basename --help' for more information.
            --- FAIL: TestPodSkipDevicesUpdate (0.11s)
```
I'm not sure why the container output is an error in basename. It seems
likely that the bashrc in that distro is kind of broken. Let's just run
a sleep command and forget about bash.

Fixes: #3742 
    
Signed-off-by: Rodrigo Campos <rodrigoca@microsoft.com>
