### PR TITLE
libct/cg: IsCgroup2UnifiedMode: don't panic

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -36,14 +36,15 @@ func IsCgroup2UnifiedMode() bool {
 		var st unix.Statfs_t
 		err := unix.Statfs(unifiedMountpoint, &st)
 		if err != nil {
-			if os.IsNotExist(err) && userns.RunningInUserNS() {
+			isErrNotExist := errors.Is(err, os.ErrNotExist)
+			if isErrNotExist && userns.RunningInUserNS() {
 				// ignore the "not found" error if running in userns
 				logrus.WithError(err).Debugf("%s missing, assuming cgroup v1", unifiedMountpoint)
 				isUnified = false
 				return
 			}
 			isUnified = false
-			if !os.IsNotExist(err) {
+			if isErrNotExist {
 				// Report unexpected errors.
 				logrus.WithError(err).Debugf("statfs(%q) failed", unifiedMountpoint)
 			}

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -42,7 +42,12 @@ func IsCgroup2UnifiedMode() bool {
 				isUnified = false
 				return
 			}
-			panic(fmt.Sprintf("cannot statfs cgroup root: %s", err))
+			isUnified = false
+			if !os.IsNotExist(err) {
+				// Report unexpected errors.
+				logrus.WithError(err).Debugf("statfs(%q) failed", unifiedMountpoint)
+			}
+			return
 		}
 		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
 	})


### PR DESCRIPTION
This the same as https://github.com/opencontainers/runc/commit/8290c4cf58fbc82b6a940dc1a091a6e2f3cbc919 but for the `IsCgroup2UnifiedMode` function.

Related [bug report](https://github.com/hashicorp/nomad/issues/16179) from real world (Nomad)

plagiarized description below

> In case statfs("/sys/fs/cgroup/unified") fails with any error other than ENOENT, current code panics. As IsCgroup2UnifiedMode is called from libcontainer/cgroups/fs's init function, this means that any user of libcontainer may panic during initialization, which is ugly.
> 
> Avoid panicking; instead, do not enable unified hierarchy support and report the error (under debug level, not to confuse anyone).
> 
> Basically, replace the panic with "turn off unified mode support" (which makes total sense since we were unable to statfs its root).
