### PR TITLE
Makefile: fix typo in LDFLAGS_STATIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LDFLAGS_STATIC := -extldflags -static
 ifneq (,$(filter $(GOARCH),arm64 amd64))
 	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
 		GO_BUILDMODE_STATIC := -buildmode=pie
-		LDFLAGS_STATIC := -linkmode external -extldflags --static-pie
+		LDFLAGS_STATIC := -linkmode external -extldflags -static-pie
 	endif
 endif
 # Enable static PIE binaries on supported platforms.


### PR DESCRIPTION
clang is pretty strict while gcc ignores this error:

```
#34 0.279 go build -trimpath -buildmode=pie  -tags "seccomp urfave_cli_no_docs netgo osusergo" -ldflags "-X main.gitCommit=v1.1.0-402-gb199fb2e -X main.version=1.1.0+dev -linkmode external -extldflags --static-pie " -o runc .
#34 5.352 # github.com/opencontainers/runc
#34 5.352 /usr/local/go/pkg/tool/linux_amd64/link: running x86_64-linux-gnu-clang failed: exit status 1
#34 5.352 clang: error: unsupported option '--static-pie'; did you mean '-static-pie'?
#34 5.352
#34 5.384 make: *** [Makefile:69: static] Error 2
```