### PR TITLE
enable stack protection with CGO crosscompile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,11 @@ GPG_KEYID ?= asarai@suse.de
 # Some targets need cgo, which is disabled by default when cross compiling.
 # Enable cgo explicitly for those.
 # Both runc and libcontainer/integration need libcontainer/nsenter.
-runc static localunittest: export CGO_ENABLED=1
+#enable stack protection with CGO compile.
+runc static localunittest: export CGO_ENABLED=1 && CGO_CFLAGS='-fstack-protector-strong'
 # seccompagent needs libseccomp (when seccomp build tag is set).
 ifneq (,$(filter $(BUILDTAGS),seccomp))
-seccompagent: export CGO_ENABLED=1
+seccompagent: export CGO_ENABLED=1 && export CGO_CFLAGS='-fstack-protector-strong'
 endif
 
 .DEFAULT: runc


### PR DESCRIPTION
https://github.com/moby/moby/issues/45045
It appears that docker-tools binaries which import c code are built without Stack Protection.

Some local vulnerability scanners attempt to detect binaries that are compiled without stack cookies (e.g. -fstack-protector vs. -fno-stack-protector with GCC), and flag that as a vulnerability. such as checksec http://www.trapkit.de/tools/checksec.html
What should Go's stance be for this sort of thing?
Do docker-tools will also add stack protection?