### PR TITLE
rootfs: prohibit symlinks that conflicts with `readonlyPaths` and/or `maskedPaths` to prevent CVE-2023-27561

### DIFF
--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -6,11 +6,12 @@ function setup() {
 	setup_busybox
 
 	# Create fake rootfs.
-	mkdir rootfs/testdir
+	mkdir rootfs/testdir rootfs/testdir2
 	echo "Forbidden information!" >rootfs/testfile
+	echo "Forbidden information! (in a nested dir)" >rootfs/testdir2/file2
 
 	# add extra masked paths
-	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir", "/testfile"]'
+	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir", "/testfile", "/testdir2/testfile2"]'
 }
 
 function teardown() {
@@ -55,4 +56,42 @@ function teardown() {
 	runc exec test_busybox umount /testdir
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"Operation not permitted"* ]]
+}
+
+@test "mask paths [prohibit symlink /proc]" {
+	ln -s /symlink rootfs/proc
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"must not be a symlink"* ]]
+}
+
+@test "mask paths [prohibit symlink /sys]" {
+	ln -s /symlink rootfs/sys
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"must not be a symlink"* ]]
+}
+
+@test "mask paths [prohibit symlink /testdir]" {
+	rmdir rootfs/testdir
+	ln -s /symlink rootfs/testdir
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"must not be a symlink"* ]]
+}
+
+@test "mask paths [prohibit symlink /testfile]" {
+	rm -f rootfs/testfile
+	ln -s /symlink rootfs/testfile
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"must not be a symlink"* ]]
+}
+
+@test "mask paths [prohibit symlink /testdir2 (parent of /testdir2/testfile2)]" {
+	rm -rf rootfs/testdir2
+	ln -s /symlink rootfs/testdir2
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"must not be a symlink"* ]]
 }


### PR DESCRIPTION
"/proc" and "/sys" in the container rootfs can no longer be symlinks, as they could be tricked to obtain the host root.

Fix #3751 ("CVE-2019-19921 re-introduction/regression")
Fix CVE-2023-27561

The CVE has been already public, so I'm just going to open this PR publicly.