### PR TITLE
Add `.github/ISSUE_TEMPLATE/config.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,54 @@
+# Forked from https://github.com/containerd/nerdctl/blob/v1.2.1/.github/ISSUE_TEMPLATE/bug_report.yaml
+name: Bug report
+description: Create a bug report to help improve runc
+labels: kind/unconfirmed-bug-claim
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If you are reporting a new issue, make sure that we do not have any duplicates
+        already open. You can ensure this by searching the issue list for this
+        repository. If there is a duplicate, please close your issue and add a comment
+        to the existing issue instead.
+
+        When reporting a security issue, do not create an issue or file a pull request on GitHub.
+        See [`opencontainers/.github/SECURITY.md`](https://github.com/opencontainers/.github/blob/master/SECURITY.md).
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        Briefly describe the problem you are having in a few paragraphs.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce the issue
+      value: |
+        1.
+        2.
+        3.
+
+  - type: textarea
+    attributes:
+      label: Describe the results you received and expected
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What version of runc are you using?
+      placeholder: runc --version
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Host OS information
+      placeholder: cat /etc/os-release
+
+  - type: textarea
+    attributes:
+      label: Host kernel information
+      placeholder: uname -a

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Forked from https://github.com/containerd/nerdctl/blob/main/.github/ISSUE_TEMPLATE/config.yml
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question (GitHub Discussions)
+    url: https://github.com/opencontainers/runc/discussions
+    about: |
+      Please do not submit "a bug report" for asking a question.
+      In most cases, GitHub Discussions is the best place to ask a question.
+      If you are not sure whether you are going to report a bug or ask a question,
+      please consider asking in GitHub Discussions first.
+  - name: Slack (opencontainers.slack.com)
+    url: https://communityinviter.com/apps/opencontainers/join-the-oci-community
+  - name: Mailing list
+    url: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,4 @@
 # Security
 
+When reporting a security issue, do not create an issue or file a pull request on GitHub.
 The reporting process and disclosure communications are outlined [here](https://github.com/opencontainers/org/blob/master/SECURITY.md).


### PR DESCRIPTION
After merging this PR, the "Report a security vulnerability" button will appear in "New issue" screen.

Demo: https://github.com/containerd/nerdctl/issues

(nerdctl's button is linked to GitHub Advisory, but I think the button will be just linked to https://github.com/opencontainers/runc/blob/main/SECURITY.md for runc, unless we enable GitHub Advisory for runc)