### PR TITLE
.github/ISSUE_TEMPLATE/config.yml: fix contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,8 @@ contact_links:
       please consider asking in GitHub Discussions first.
   - name: Slack (opencontainers.slack.com)
     url: https://communityinviter.com/apps/opencontainers/join-the-oci-community
+    # GitHub requires the `about` property to be set
+    about: Slack
   - name: Mailing list
     url: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
+    about: Mailing list


### PR DESCRIPTION
`contact_links` without `about` properties are not shown in https://github.com/opencontainers/runc/issues/new/choose