### PR TITLE
libct/cg/dev: skip flaky test of CentOS 7

### DIFF
--- a/libcontainer/cgroups/devices/systemd_test.go
+++ b/libcontainer/cgroups/devices/systemd_test.go
@@ -122,6 +122,11 @@ func testSkipDevices(t *testing.T, skipDevices bool, expected []string) {
 	if os.Geteuid() != 0 {
 		t.Skip("Test requires root.")
 	}
+	// https://github.com/opencontainers/runc/issues/3743
+	centosVer, _ := exec.Command("rpm", "-q", "--qf", "%{version}", "centos-release").CombinedOutput()
+	if string(centosVer) == "7" {
+		t.Skip("Flaky on CentOS 7")
+	}
 
 	podConfig := &configs.Cgroup{
 		Parent: "system.slice",


### PR DESCRIPTION
There is some kind of a race in CentOS 7 which sometimes result in one of these tests failing like this:

    systemd_test.go:136: mkdir /sys/fs/cgroup/hugetlb/system.slice/system-runc_test_pods.slice: no such file or directory

or

    systemd_test.go:187: open /sys/fs/cgroup/cpuset/system.slice/system-runc_test_pods.slice/cpuset.mems: no such file or directory

As this is only happening on CentOS 7, let's skip this test on this platform.

Fixes: #3743 