### PR TITLE
mountToRootfs: minor refactor

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -469,6 +469,7 @@ func mountToRootfs(m *configs.Mount, c *mountConfig) error {
 				return err
 			}
 		}
+		return setRecAttr(m, rootfs)
 	case "cgroup":
 		if cgroups.IsCgroup2UnifiedMode() {
 			return mountCgroupV2(m, c)
@@ -483,10 +484,6 @@ func mountToRootfs(m *configs.Mount, c *mountConfig) error {
 		}
 		return mountPropagate(m, rootfs, mountLabel, mountFd)
 	}
-	if err := setRecAttr(m, rootfs); err != nil {
-		return err
-	}
-	return nil
 }
 
 func getCgroupMounts(m *configs.Mount) ([]*configs.Mount, error) {


### PR DESCRIPTION
The setRecAttr is only called for "bind" case, as cases end with a return statement. Indeed, recursive mount attributes only make sense for bind mounts.

Move the code to under case "bind" to improve readability. No change in logic.

Fixes: 382eba4354d764aaff
Reported-by: Sebastiaan van Stijn <github@gone.nl>