### PR TITLE
[1.1] CHANGELOG: fixes for 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,7 +346,7 @@ implementation (libcontainer) is *not* covered by this policy.
 
 <!-- 1.1.z patch releases -->
 [Unreleased 1.1.z]: https://github.com/opencontainers/runc/compare/v1.1.5...release-1.1
-[1.1.5]: https://github.com/opencontainers/runc/compare/v1.1.3...v1.1.5
+[1.1.5]: https://github.com/opencontainers/runc/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/opencontainers/runc/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/opencontainers/runc/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/opencontainers/runc/compare/v1.1.1...v1.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > 囚われた屈辱は
 > 反撃の嚆矢だ
 
+### Security
+
+The following CVEs were fixed in this release:
+
+* [CVE-2023-25809][] is a vulnerability involving rootless containers where
+  (under specific configurations), the container would have write access to the
+  `/sys/fs/cgroup/user.slice/...` cgroup hierarchy. No other hierarchies on the
+  host were affected. This vulnerability was discovered by Akihiro Suda.
+
+* [CVE-2023-27561][] was a regression in our protections against tricky `/proc`
+  and `/sys` configurations (where the container mountpoint is a symlink)
+  causing us to be tricked into incorrectly configuring the container, which
+  effectively re-introduced [CVE-2019-19921][]. This regression was present
+  from v1.0.0-rc95 to v1.1.4 and was discovered by @Beuc. (#3785)
+
+* [CVE-2023-28642][] is a different attack vector using the same regression
+  as in [CVE-2023-27561][]. This was reported by Lei Wang.
+
+[CVE-2019-19921]: https://github.com/advisories/GHSA-fh74-hm69-rqjw
+[CVE-2023-25809]: https://github.com/opencontainers/runc/security/advisories/GHSA-m8cg-xc2p-r3fc
+[CVE-2023-27561]: https://github.com/advisories/GHSA-vpvm-3wq2-2wvm
+[CVE-2023-28642]: https://github.com/opencontainers/runc/security/advisories/GHSA-g2j6-57v7-gm8c
+
 ### Fixed
 
-* Prohibit container's `/proc` and `/sys` to be symlinks (CVE-2019-19921,
-  CVE-2023-27561, CVE-2023-28642, #3785)
-* rootless: rework /sys/fs/cgroup mounts to avoid exposing the host's cgroup
-  hierarchy into the container. (CVE-2023-25809)
 * Fix the inability to use `/dev/null` when inside a container. (#3620)
 * Fix changing the ownership of host's `/dev/null` caused by fd redirection
   (a regression in 1.1.1). (#3674, #3731)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix the inability to use `/dev/null` when inside a container. (#3620)
 * Fix changing the ownership of host's `/dev/null` caused by fd redirection
   (a regression in 1.1.1). (#3674, #3731)
-* Fix rare runc exec/enter unshare error on older kernels, inlcuding
+* Fix rare runc exec/enter unshare error on older kernels, including
   CentOS < 7.7. (#3776)
 * nsexec: Check for errors in `write_log()`. (#3721)
 * Various CI fixes and updates. (#3618, #3630, #3640, #3729)

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ release: runcimage
 		$(RUNC_IMAGE) make localrelease
 	script/release_sign.sh -S $(GPG_KEYID) -r release/$(VERSION) -v $(VERSION)
 
-localrelease:
+localrelease: verify-changelog
 	script/release_build.sh -r release/$(VERSION) -v $(VERSION) $(RELEASE_ARGS)
 
 dbuild: runcimage

--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,6 @@ vendor:
 	$(GO) mod verify
 
 verify-changelog:
-	# No non-ASCII characters.
-	! LC_ALL=C grep -n -P '[\x80-\xFF]' CHANGELOG.md
 	# No space at EOL.
 	! grep -n '\s$$' CHANGELOG.md
 	# Period before issue/PR references.


### PR DESCRIPTION
### Changelog fixes: 
1. Fix wrong old version in a github compare link.
2. Fix a typo in changelog (found by our CI codespell)
3. Moved 1.1.5 CVEs to a separate "Security" section (by @cyphar, see https://github.com/opencontainers/runc/pull/3796#issuecomment-1489656062)

### CI fix:

1. Removed the changelog check for non-ASCII characters, as it was failing the `release` job:

```console
Run make verify-changelog
# No non-ASCII characters.
>! LC_ALL=C grep -n -P '[\x80-\xFF]' CHANGELOG.md
11:> 囚われた屈辱は
12:> 反撃の嚆矢だ
make: *** [Makefile:150: verify-changelog] Error 1
```

### Improvements
1. Added `verify-changelog` to `localrelease` target, as one more way to catch those errors early.

PS need to forward-port these changes as well as 1.1.4 and 1.1.5 changelogs to main branch.