### PR TITLE
ci: reset failed systemd unit on OOM test

### DIFF
--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -99,4 +99,6 @@ function test_events() {
 	wait # wait for the above sub shells to finish
 
 	grep -q '{"type":"oom","id":"test_busybox"}' events.log
+
+	systemd_reset_failed
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -620,3 +620,8 @@ function requires_kernel() {
 		skip "requires kernel $1"
 	fi
 }
+
+function systemd_reset_failed() {
+	[ ! -v RUNC_USE_SYSTEMD ] && return
+	systemctl reset-failed
+}


### PR DESCRIPTION
On centos stream9, when running the `events oom` test, systemd goes into a `degraded` state causing subsequent tests to fail, resetting the failed unit after the test fixes this. Not sure if this is the right fix but hopefully it's a step in the right direction to getting CI back to green. 

```
$ RUNC_USE_SYSTEMD=true bats -t tests/integration/events.bats
$ [root@localhost runc]# systemctl --failed
  UNIT                                      LOAD   ACTIVE SUB    DESCRIPTION
● runc-cgroups-integration-test-29550.scope loaded failed failed libcontainer container integration-test-29550
```

several tests then start failing:

```
$ RUNC_USE_SYSTEMD=true bats -t tests/integration/ps.bats
# (in test file tests/integration/ps.bats, line 60)
#   `[[ "${lines[1]}" =~ [0-9]+ ]]' failed
# runc spec (status=0):
#
# runc run -d --console-socket /tmp/bats-run-85oCGW/runc.mWta7t/tty/sock test_busybox (status=0):
#
# runc state test_busybox (status=0):
# {
#   "ociVersion": "1.1.0-rc.1",
#   "id": "test_busybox",
#   "pid": 26325,
#   "status": "running",
#   "bundle": "/tmp/bats-run-85oCGW/runc.mWta7t/bundle",
#   "rootfs": "/tmp/bats-run-85oCGW/runc.mWta7t/bundle/rootfs",
#   "created": "2023-04-02T22:19:42.912423842Z",
#   "owner": ""
# }
# runc ps test_busybox -e -x (status=0):
#     PID TTY      STAT   TIME COMMAND
# /root/runc/tests/integration/ps.bats: line 60: lines[1]: unbound variable
ok 4 ps after the container stopped
```

`systemctl reset-failed`