### PR TITLE
libct/cg/sd/v1: do not update non-frozen cgroup after frozen failed.

### DIFF
--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -350,6 +350,15 @@ func (m *LegacyManager) Set(r *configs.Resources) error {
 		if err := m.doFreeze(configs.Frozen); err != nil {
 			// If freezer cgroup isn't supported, we just warn about it.
 			logrus.Infof("freeze container before SetUnitProperties failed: %v", err)
+			// skip update the cgroup while frozen failed. #3803
+			if !errors.Is(err, errSubsystemDoesNotExist) {
+				if needsThaw {
+					if thawErr := m.doFreeze(configs.Thawed); thawErr != nil {
+						logrus.Infof("thaw container after doFreeze failed: %v", thawErr)
+					}
+				}
+				return err
+			}
 		}
 	}
 	setErr := setUnitProperties(m.dbus, unitName, properties...)


### PR DESCRIPTION
In code we have frozen the cgroup to avoid the processes get
an occasional "permission denied" error, while the systemd's application of device
rules is done disruptively. When the processes in the container can not
be frozen over 2 seconds (which defined in fs/freezer.go),
we still update the cgroup which resulting the container get an occasional
"permission denied" error in some cases.

This PR make sure to return error directly without updating cgroup, when freeze fails.

Fixes: #3803