### PR TITLE
libct/cg: rm GetInitCgroup[Path]

### DIFF
--- a/libcontainer/cgroups/fs/paths.go
+++ b/libcontainer/cgroups/fs/paths.go
@@ -164,9 +164,8 @@ func subsysPath(root, inner, subsystem string) (string, error) {
 		return filepath.Join(root, filepath.Base(mnt), inner), nil
 	}
 
-	// Use GetOwnCgroupPath instead of GetInitCgroupPath, because the creating
-	// process could in container and shared pid namespace with host, and
-	// /proc/1/cgroup could point to whole other world of cgroups.
+	// Use GetOwnCgroupPath for dind-like cases, when cgroupns is not
+	// available. This is ugly.
 	parentPath, err := cgroups.GetOwnCgroupPath(subsystem)
 	if err != nil {
 		return "", err

--- a/libcontainer/cgroups/v1_utils.go
+++ b/libcontainer/cgroups/v1_utils.go
@@ -236,27 +236,6 @@ func GetOwnCgroupPath(subsystem string) (string, error) {
 	return getCgroupPathHelper(subsystem, cgroup)
 }
 
-func GetInitCgroup(subsystem string) (string, error) {
-	if IsCgroup2UnifiedMode() {
-		return "", errUnified
-	}
-	cgroups, err := ParseCgroupFile("/proc/1/cgroup")
-	if err != nil {
-		return "", err
-	}
-
-	return getControllerPath(subsystem, cgroups)
-}
-
-func GetInitCgroupPath(subsystem string) (string, error) {
-	cgroup, err := GetInitCgroup(subsystem)
-	if err != nil {
-		return "", err
-	}
-
-	return getCgroupPathHelper(subsystem, cgroup)
-}
-
 func getCgroupPathHelper(subsystem, cgroup string) (string, error) {
 	mnt, root, err := FindCgroupMountpointAndRoot("", subsystem)
 	if err != nil {


### PR DESCRIPTION
This is a followup to PR #3784.

These functions were added in ancient times, facilitating the docker-in-docker case when cgroup namespace was not available.

As pointed out in commit 2b28b3c2769 (PR #194), using init 1 cgroup is not correct because it won't work in case of host PID namespace.

The last user of GetInitCgroup was removed by commit 54e20217a86f117037e3f5 (PR #3784). GetInitCgroupPath was never used as far as I can see, nor was I able to find any external users.

Remove both functions. Modify the comment in libct/cg/fs.subsysPath to not refer to GetInitCgroupPath.