### PR TITLE
[1.1] libctr/cgroups: don't take init's cgroup into account

### DIFF
--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -273,14 +273,7 @@ func getSubsystemPath(slice, unit, subsystem string) (string, error) {
 		return "", err
 	}
 
-	initPath, err := cgroups.GetInitCgroup(subsystem)
-	if err != nil {
-		return "", err
-	}
-	// if pid 1 is systemd 226 or later, it will be in init.scope, not the root
-	initPath = strings.TrimSuffix(filepath.Clean(initPath), "init.scope")
-
-	return filepath.Join(mountpoint, initPath, slice, unit), nil
+	return filepath.Join(mountpoint, slice, unit), nil
 }
 
 func (m *legacyManager) Freeze(state configs.FreezerState) error {


### PR DESCRIPTION
Sometimes, the init process is not in the root cgroup. This can be noted by GetInitPath, which already scrubs the path of `init.scope`.

This was encountered when trying to patch the Kubelet to handle systemd being in a separate cpuset from root (to allow load balance disabling for containers). At present, there's no way to have libcontainer or runc manage cgroups in a hierarchy outside of the one init is in (unless the path contains `init.scope`, which is limiting)