### PR TITLE
ci/cirrus: use Go 1.19.x not 1.19

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,12 +30,12 @@ task:
 
   host_info_script: |
     uname -a
-    echo "-----"
+    # -----
     cat /etc/os-release
-    echo "-----"
-    cat /proc/cpuinfo
-    echo "-----"
+    # -----
     df -T
+    # -----
+    cat /proc/cpuinfo
   install_libvirt_vagrant_script: |
     apt-get update
     apt-get install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt
@@ -149,14 +149,16 @@ task:
     systemctl restart sshd
   host_info_script: |
     uname -a
-    echo "-----"
-    cat /etc/os-release
-    echo "-----"
-    cat /proc/cpuinfo
-    echo "-----"
-    df -T
-    echo "-----"
+    # -----
+    /usr/local/go/bin/go version
+    # -----
     systemctl --version
+    # -----
+    cat /etc/os-release
+    # -----
+    df -T
+    # -----
+    cat /proc/cpuinfo
   check_config_script: |
     /home/runc/script/check-config.sh
   unit_tests_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,7 +118,10 @@ task:
     # Use --whatprovides since some packages are renamed.
     rpm -q --whatprovides $RPMS
     # install Go
-    curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar Cxz /usr/local
+    PREFIX="https://go.dev/dl/"
+    # Find out the latest minor release URL.
+    eval $(curl -fsSL "${PREFIX}?mode=json" | jq -r  --arg Ver "$GO_VERSION" '.[] | select(.version | startswith("go\($Ver)")) | .files[] | select(.os == "linux" and .arch == "amd64" and .kind == "archive") | "filename=\"" + .filename + "\""')
+    curl -fsSL "$PREFIX$filename" | tar Cxz /usr/local
     # install bats
     cd /tmp
     git clone https://github.com/bats-core/bats-core


### PR DESCRIPTION
This variable is used in curl to download a go release, so we are using the initial Go 1.19 release in Cirrus CI, not the latest Go 1.19.x release.

From the CI perspective, it makes more sense to use the latest release, so let's use 1.19.x here.

Add some ~~shell~~ `jq` magic to extract the latest minor release information
from the download page, and use it.
    
This brings Cirrus CI jobs logic in line with all the others (GHA,
Dockerfile), where by 1.20 we actually mean "latest 1.20.x".
  

Previous commits touching this:
* 5ecd40b9b 1.19
* 5211cc3f7 1.18 <-- I blame the author of this one 😄 
* 12a36265c 1.17.3
* 9f656dbb1 1.16.6