### PR TITLE
ci/gha: disable double caching

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -108,14 +108,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: "${{ env.GO_VERSION }}"
-    - name: cache go mod and $GOCACHE
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go.sum-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go.sum-
     - name: verify deps
       run: make verify-dependencies
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: false # golangci-lint-action does its own caching
       - name: install deps
         run: |
           sudo apt -q update


### PR DESCRIPTION
Since commit e3cf217cf1fa9248d153 (#3771) actions/setup-go@v4 uses caching implicitly.

Fix two cases of double caching.