### PR TITLE
[1.1] libct/cg: add misc controller to v1 drivers

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -28,6 +28,7 @@ var subsystems = []subsystem{
 	&FreezerGroup{},
 	&RdmaGroup{},
 	&NameGroup{GroupName: "name=systemd", Join: true},
+	&NameGroup{GroupName: "misc", Join: true},
 }
 
 var errSubsystemDoesNotExist = errors.New("cgroup: subsystem does not exist")

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -71,6 +71,7 @@ var legacySubsystems = []subsystem{
 	&fs.NetClsGroup{},
 	&fs.NameGroup{GroupName: "name=systemd"},
 	&fs.RdmaGroup{},
+	&fs.NameGroup{GroupName: "misc"},
 }
 
 func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {


### PR DESCRIPTION
This is just so that
- the container can join the misc controller;
- the `Destroy() can actually remove the cgroup.

This should fix the issue reported in https://github.com/kubernetes/kubernetes/issues/112124#issuecomment-1500659886

(cherry picked from commit 611bbacb3bbed377f8427ea398c800de526481f3 / PR #3815.

Proposed changelog entry:
```
- Bare minimal support for cgroup v1 misc controller. (#3823)
```