### PR TITLE
runc kill: add support for cgroup.kill

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -14,10 +14,10 @@ import (
 )
 
 func killContainer(container *libcontainer.Container) error {
-	_ = container.Signal(unix.SIGKILL, false)
+	_ = container.Signal(unix.SIGKILL)
 	for i := 0; i < 100; i++ {
 		time.Sleep(100 * time.Millisecond)
-		if err := container.Signal(unix.Signal(0), false); err != nil {
+		if err := container.Signal(unix.Signal(0)); err != nil {
 			destroy(container)
 			return nil
 		}

--- a/kill.go
+++ b/kill.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/opencontainers/runc/libcontainer"
 	"github.com/urfave/cli"
 	"golang.org/x/sys/unix"
 )
@@ -24,8 +26,9 @@ signal to the init process of the "ubuntu01" container:
        # runc kill ubuntu01 KILL`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
-			Name:  "all, a",
-			Usage: "send the specified signal to all processes inside the container",
+			Name:   "all, a",
+			Usage:  "(obsoleted, do not use)",
+			Hidden: true,
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -49,7 +52,11 @@ signal to the init process of the "ubuntu01" container:
 		if err != nil {
 			return err
 		}
-		return container.Signal(signal, context.Bool("all"))
+		err = container.Signal(signal)
+		if errors.Is(err, libcontainer.ErrNotRunning) && context.Bool("all") {
+			err = nil
+		}
+		return err
 	},
 }
 

--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -31,3 +31,15 @@ func (n *Namespaces) CloneFlags() uintptr {
 	}
 	return uintptr(flag)
 }
+
+// IsPrivate tells whether the namespace of type t is configured as private
+// (i.e. it exists and is not shared).
+func (n Namespaces) IsPrivate(t NamespaceType) bool {
+	for _, v := range n {
+		if v.Type == t {
+			return v.Path == ""
+		}
+	}
+	// Not found, so implicitly sharing a parent namespace.
+	return false
+}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -549,7 +549,6 @@ func (c *Container) newInitProcess(p *Process, cmd *exec.Cmd, messageSockPair, l
 			nsMaps[ns.Type] = ns.Path
 		}
 	}
-	_, sharePidns := nsMaps[configs.NEWPID]
 	data, err := c.bootstrapData(c.config.Namespaces.CloneFlags(), nsMaps, initStandard)
 	if err != nil {
 		return nil, err
@@ -594,7 +593,7 @@ func (c *Container) newInitProcess(p *Process, cmd *exec.Cmd, messageSockPair, l
 		container:       c,
 		process:         p,
 		bootstrapData:   data,
-		sharePidns:      sharePidns,
+		sharePidns:      !c.config.Namespaces.IsPrivate(configs.NEWPID),
 	}
 	c.initProcess = init
 	return init, nil

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -11,7 +11,6 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	"github.com/containerd/console"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -575,39 +574,9 @@ func setupRlimits(limits []configs.Rlimit, pid int) error {
 	return nil
 }
 
-const _P_PID = 1
-
-//nolint:structcheck,unused
-type siginfo struct {
-	si_signo int32
-	si_errno int32
-	si_code  int32
-	// below here is a union; si_pid is the only field we use
-	si_pid int32
-	// Pad to 128 bytes as detailed in blockUntilWaitable
-	pad [96]byte
-}
-
-// isWaitable returns true if the process has exited false otherwise.
-// Its based off blockUntilWaitable in src/os/wait_waitid.go
-func isWaitable(pid int) (bool, error) {
-	si := &siginfo{}
-	_, _, e := unix.Syscall6(unix.SYS_WAITID, _P_PID, uintptr(pid), uintptr(unsafe.Pointer(si)), unix.WEXITED|unix.WNOWAIT|unix.WNOHANG, 0, 0)
-	if e != 0 {
-		return false, &os.SyscallError{Syscall: "waitid", Err: e}
-	}
-
-	return si.si_pid != 0, nil
-}
-
 // signalAllProcesses freezes then iterates over all the processes inside the
 // manager's cgroups sending the signal s to them.
-// If s is SIGKILL and subreaper is not enabled then it will wait for each
-// process to exit.
-// For all other signals it will check if the process is ready to report its
-// exit status and only if it is will a wait be performed.
-func signalAllProcesses(m cgroups.Manager, s os.Signal) error {
-	var procs []*os.Process
+func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
 	if err := m.Freeze(configs.Frozen); err != nil {
 		logrus.Warn(err)
 	}
@@ -619,55 +588,14 @@ func signalAllProcesses(m cgroups.Manager, s os.Signal) error {
 		return err
 	}
 	for _, pid := range pids {
-		p, err := os.FindProcess(pid)
-		if err != nil {
-			logrus.Warn(err)
-			continue
-		}
-		procs = append(procs, p)
-		if err := p.Signal(s); err != nil {
-			logrus.Warn(err)
+		err := unix.Kill(pid, s)
+		if err != nil && err != unix.ESRCH { //nolint:errorlint // unix errors are bare
+			logrus.Warnf("kill %d: %v", pid, err)
 		}
 	}
 	if err := m.Freeze(configs.Thawed); err != nil {
 		logrus.Warn(err)
 	}
 
-	subreaper, err := system.GetSubreaper()
-	if err != nil {
-		// The error here means that PR_GET_CHILD_SUBREAPER is not
-		// supported because this code might run on a kernel older
-		// than 3.4. We don't want to throw an error in that case,
-		// and we simplify things, considering there is no subreaper
-		// set.
-		subreaper = 0
-	}
-
-	for _, p := range procs {
-		if s != unix.SIGKILL {
-			if ok, err := isWaitable(p.Pid); err != nil {
-				if !errors.Is(err, unix.ECHILD) {
-					logrus.Warn("signalAllProcesses: ", p.Pid, err)
-				}
-				continue
-			} else if !ok {
-				// Not ready to report so don't wait
-				continue
-			}
-		}
-
-		// In case a subreaper has been setup, this code must not
-		// wait for the process. Otherwise, we cannot be sure the
-		// current process will be reaped by the subreaper, while
-		// the subreaper might be waiting for this process in order
-		// to retrieve its exit code.
-		if subreaper == 0 {
-			if _, err := p.Wait(); err != nil {
-				if !errors.Is(err, unix.ECHILD) {
-					logrus.Warn("wait: ", err)
-				}
-			}
-		}
-	}
 	return nil
 }

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1399,8 +1399,8 @@ func testPidnsInitKill(t *testing.T, config *configs.Config) {
 	err = container.Run(process2)
 	ok(t, err)
 
-	// Kill the init process and Wait for it.
-	err = process1.Signal(syscall.SIGKILL)
+	// Kill the container.
+	err = container.Signal(syscall.SIGKILL, false)
 	ok(t, err)
 	_, err = process1.Wait()
 	if err == nil {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1400,7 +1400,7 @@ func testPidnsInitKill(t *testing.T, config *configs.Config) {
 	ok(t, err)
 
 	// Kill the container.
-	err = container.Signal(syscall.SIGKILL, false)
+	err = container.Signal(syscall.SIGKILL)
 	ok(t, err)
 	_, err = process1.Wait()
 	if err == nil {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1355,16 +1355,26 @@ func TestPIDHost(t *testing.T) {
 	}
 }
 
-func TestPIDHostInitProcessWait(t *testing.T) {
+func TestHostPidnsInitKill(t *testing.T) {
+	config := newTemplateConfig(t, nil)
+	// Implicitly use host pid ns.
+	config.Namespaces.Remove(configs.NEWPID)
+	testPidnsInitKill(t, config)
+}
+
+func TestSharedPidnsInitKill(t *testing.T) {
+	config := newTemplateConfig(t, nil)
+	// Explicitly use host pid ns.
+	config.Namespaces.Add(configs.NEWPID, "/proc/1/ns/pid")
+	testPidnsInitKill(t, config)
+}
+
+func testPidnsInitKill(t *testing.T, config *configs.Config) {
 	if testing.Short() {
 		return
 	}
 
-	pidns := "/proc/1/ns/pid"
-
 	// Run a container with two long-running processes.
-	config := newTemplateConfig(t, nil)
-	config.Namespaces.Add(configs.NEWPID, pidns)
 	container, err := newContainer(t, config)
 	ok(t, err)
 	defer func() {

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1373,7 +1373,7 @@ func TestPIDHostInitProcessWait(t *testing.T) {
 
 	process1 := &libcontainer.Process{
 		Cwd:  "/",
-		Args: []string{"sleep", "100"},
+		Args: []string{"sleep", "1h"},
 		Env:  standardEnvironment,
 		Init: true,
 	}
@@ -1382,7 +1382,7 @@ func TestPIDHostInitProcessWait(t *testing.T) {
 
 	process2 := &libcontainer.Process{
 		Cwd:  "/",
-		Args: []string{"sleep", "100"},
+		Args: []string{"sleep", "1h"},
 		Env:  standardEnvironment,
 		Init: false,
 	}
@@ -1397,10 +1397,11 @@ func TestPIDHostInitProcessWait(t *testing.T) {
 		t.Fatal("expected Wait to indicate failure")
 	}
 
-	// The non-init process must've been killed.
-	err = process2.Signal(syscall.Signal(0))
-	if err == nil || err.Error() != "no such process" {
-		t.Fatalf("expected process to have been killed: %v", err)
+	// The non-init process must've also been killed. If not,
+	// the test will time out.
+	_, err = process2.Wait()
+	if err == nil {
+		t.Fatal("expected Wait to indicate failure")
 	}
 }
 

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -304,7 +304,6 @@ type initProcess struct {
 	fds             []string
 	process         *Process
 	bootstrapData   io.Reader
-	sharePidns      bool
 }
 
 func (p *initProcess) pid() int {
@@ -616,10 +615,6 @@ func (p *initProcess) start() (retErr error) {
 
 func (p *initProcess) wait() (*os.ProcessState, error) {
 	err := p.cmd.Wait()
-	// we should kill all processes in cgroup when init is died if we use host PID namespace
-	if p.sharePidns {
-		_ = signalAllProcesses(p.manager, unix.SIGKILL)
-	}
 	return p.cmd.ProcessState, err
 }
 

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -36,12 +35,6 @@ type containerState interface {
 }
 
 func destroy(c *Container) error {
-	if !c.config.Namespaces.Contains(configs.NEWPID) ||
-		c.config.Namespaces.PathOf(configs.NEWPID) != "" {
-		if err := signalAllProcesses(c.cgroupManager, unix.SIGKILL); err != nil {
-			logrus.Warn(err)
-		}
-	}
 	err := c.cgroupManager.Destroy()
 	if c.intelRdtManager != nil {
 		if ierr := c.intelRdtManager.Destroy(); err == nil {

--- a/man/runc-kill.8.md
+++ b/man/runc-kill.8.md
@@ -4,7 +4,7 @@
 **runc-kill** - send a specified signal to container
 
 # SYNOPSIS
-**runc kill** [**--all**|**-a**] _container-id_ [_signal_]
+**runc kill** _container-id_ [_signal_]
 
 # DESCRIPTION
 
@@ -14,15 +14,6 @@ only.
 A different signal can be specified either by its name (with or without the
 **SIG** prefix), or its numeric value. Use **kill**(1) with **-l** option
 to list available signals.
-
-# OPTIONS
-**--all**|**-a**
-: Send the signal to all processes inside the container, rather than
-the container's init only. This option is implied when the _signal_ is **KILL**
-and the container does not have its own PID namespace.
-
-: When this option is set, no error is returned if the container is stopped
-or does not exist.
 
 # EXAMPLES
 

--- a/man/runc-kill.8.md
+++ b/man/runc-kill.8.md
@@ -18,8 +18,8 @@ to list available signals.
 # OPTIONS
 **--all**|**-a**
 : Send the signal to all processes inside the container, rather than
-the container's init only. This option is useful when the container does not
-have its own PID namespace.
+the container's init only. This option is implied when the _signal_ is **KILL**
+and the container does not have its own PID namespace.
 
 : When this option is set, no error is returned if the container is stopped
 or does not exist.

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -29,3 +29,51 @@ function teardown() {
 	runc delete test_busybox
 	[ "$status" -eq 0 ]
 }
+
+# This is roughly the same as TestPIDHostInitProcessWait in libcontainer/integration.
+@test "kill --all KILL [host pidns]" {
+	# kill -a currently requires cgroup freezer.
+	requires cgroups_freezer
+
+	update_config '	  .linux.namespaces -= [{"type": "pid"}]'
+	set_cgroups_path
+	if [ $EUID -ne 0 ]; then
+		# kill --all requires working cgroups.
+		requires rootless_cgroup
+		update_config '	  .mounts |= map((select(.type == "proc")
+					| .type = "none"
+					| .source = "/proc"
+					| .options = ["rbind", "nosuid", "nodev", "noexec"]
+				  ) // .)'
+	fi
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	# Start a few more processes.
+	for _ in 1 2 3 4 5; do
+		__runc exec -d test_busybox sleep 1h
+		[ "$status" -eq 0 ]
+	done
+
+	# Get the list of all container processes.
+	path=$(get_cgroup_path "pids")
+	pids=$(cat "$path"/cgroup.procs)
+	echo "pids: $pids"
+	# Sanity check -- make sure all processes exist.
+	for p in $pids; do
+		kill -0 "$p"
+	done
+
+	runc kill -a test_busybox KILL
+	[ "$status" -eq 0 ]
+	wait_for_container 10 1 test_busybox stopped
+
+	# Make sure all processes are gone.
+	pids=$(cat "$path"/cgroup.procs) || true # OK if cgroup is gone
+	echo "pids: $pids"
+	for p in $pids; do
+		run ! kill -0 "$p"
+		[[ "$output" = *"No such process" ]]
+	done
+}

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -22,7 +22,12 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	wait_for_container 10 1 test_busybox stopped
 
-	# we should ensure kill work after the container stopped
+	# Check that kill errors on a stopped container.
+	runc kill test_busybox 0
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"container not running"* ]]
+
+	# Check that -a (now obsoleted) makes kill return no error for a stopped container.
 	runc kill -a test_busybox 0
 	[ "$status" -eq 0 ]
 
@@ -31,7 +36,7 @@ function teardown() {
 }
 
 # This is roughly the same as TestPIDHostInitProcessWait in libcontainer/integration.
-@test "kill --all KILL [host pidns]" {
+@test "kill KILL [host pidns]" {
 	# kill -a currently requires cgroup freezer.
 	requires cgroups_freezer
 
@@ -65,7 +70,7 @@ function teardown() {
 		kill -0 "$p"
 	done
 
-	runc kill -a test_busybox KILL
+	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
 	wait_for_container 10 1 test_busybox stopped
 

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 # Copyright (C) 2017 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The `cgroup.kill` API was added to Linux kernel 5.14 (see [1], [2]). This PR adds its support to runc, and changes quite a few things around killing containers.

[1] https://lwn.net/Articles/855049/
[2] https://lwn.net/Articles/855924/

Fixes: #3135
Fixes: #3866
Fixes: #3864
Closes: #3199

This also removes child reaper from libcontainer. It is useless for runc itself, and any libcontainer users who start a container  need to take care of reaping their own children. See "libct: signalAllProcesses: remove child reaping" commit for more details.

### Release note

```markdown
### Deprecated

- `runc kill` option `-a` is now deprecated. Previously, it had to be specified
  to kill a container (with SIGKILL) which does not have its own private PID
  namespace (so that runc would send SIGKILL to all processes). Now, this is
  done automatically. (#3864, #3825)

### Fixed

- libcontainer: fix private PID namespace detection when killing the container
  (#3866, #3825)

### Changed

- libcontainer users that create and kill containers from a daemon process
  (so that the container init is a child of that process) must now implement
  a proper child reaper in case a container does not have its own private PID
  namespace, as documented in `container.Signal`. (#3825)
- libcontainer: `container.Signal` no longer have the second `all bool`
  argument; a need to kill all processes is now determined automatically.
  (#3885)

### Added

- Support for `cgroup.kill` to kill all processes inside a container. (#3135,
  #3825)
```