### PR TITLE
tests/int/ps: enable for rootless

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -184,7 +184,12 @@ function set_parent_systemd_properties() {
 }
 
 # Randomize cgroup path(s), and update cgroupsPath in config.json.
-# This function sets a few cgroup-related variables.
+# This function also sets a few cgroup-related variables that are used
+# by other cgroup-related functions.
+#
+# If this function is not called (and cgroupsPath is not set in config),
+# runc uses default container's cgroup path derived from the container's name
+# (except for rootless containers, that have no default cgroup path).
 #
 # Optional parameter $1 is a pod/parent name. If set, a parent/pod cgroup is
 # created, and variables $REL_PARENT_PATH and $SD_PARENT_NAME can be used to

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -3,7 +3,17 @@
 load helpers
 
 function setup() {
+	# ps requires cgroups
+	[ $EUID -ne 0 ] && requires rootless_cgroup
+
 	setup_busybox
+
+	# Rootless does not have default cgroup path.
+	[ $EUID -ne 0 ] && set_cgroups_path
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+	testcontainer test_busybox running
 }
 
 function teardown() {
@@ -11,67 +21,26 @@ function teardown() {
 }
 
 @test "ps" {
-	# ps is not supported, it requires cgroups
-	requires root
-
-	# start busybox detached
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-
-	# check state
-	testcontainer test_busybox running
-
 	runc ps test_busybox
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
-	[[ "${lines[1]}" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
+	[[ "$output" =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
+	[[ "$output" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
 }
 
 @test "ps -f json" {
-	# ps is not supported, it requires cgroups
-	requires root
-
-	# start busybox detached
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-
-	# check state
-	testcontainer test_busybox running
-
 	runc ps -f json test_busybox
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ [0-9]+ ]]
+	[[ "$output" =~ [0-9]+ ]]
 }
 
 @test "ps -e -x" {
-	# ps is not supported, it requires cgroups
-	requires root
-
-	# start busybox detached
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-
-	# check state
-	testcontainer test_busybox running
-
 	runc ps test_busybox -e -x
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
-	[[ "${lines[1]}" =~ [0-9]+ ]]
+	[[ "$output" =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
+	[[ "$output" =~ [0-9]+ ]]
 }
 
 @test "ps after the container stopped" {
-	# ps requires cgroups
-	[ $EUID -ne 0 ] && requires rootless_cgroup
-	set_cgroups_path
-
-	# start busybox detached
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-
-	# check state
-	testcontainer test_busybox running
-
 	runc ps test_busybox
 	[ "$status" -eq 0 ]
 


### PR DESCRIPTION
runc ps requires cgroup, but all the tests but one required root.

Add rootless cgroup requirement to setup to avoid repetition.

While at it, remove set_cgroups_path as it is not required (default cgroup path, derived from the container name, is used).