### PR TITLE
libct/cg: IsCgroup2UnifiedMode: don't panic

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -36,13 +36,13 @@ func IsCgroup2UnifiedMode() bool {
 		var st unix.Statfs_t
 		err := unix.Statfs(unifiedMountpoint, &st)
 		if err != nil {
+			level := logrus.WarnLevel
 			if os.IsNotExist(err) && userns.RunningInUserNS() {
-				// ignore the "not found" error if running in userns
-				logrus.WithError(err).Debugf("%s missing, assuming cgroup v1", unifiedMountpoint)
-				isUnified = false
-				return
+				// For rootless containers, sweep it under the rug.
+				level = logrus.DebugLevel
 			}
-			panic(fmt.Sprintf("cannot statfs cgroup root: %s", err))
+			logrus.StandardLogger().Logf(level,
+				"statfs %s: %v; assuming cgroup v1", unifiedMountpoint, err)
 		}
 		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
 	})


### PR DESCRIPTION
Replace a panic with a warning, unless it's ENOENT and we're running in a user namespace. In the latter case, do the same as before, i.e. report the error but using a Debug logging level.

This prevents software that uses libcontainer from panicking in some exotic setups.

This will also print a warning on some very old systems which does not use /sys/fs/cgroup for cgroup mount point. My bet is such systems no longer exist.

Closes: #3745