### PR TITLE
runc-kill(8): amend the --all description

### DIFF
--- a/man/runc-kill.8.md
+++ b/man/runc-kill.8.md
@@ -17,7 +17,12 @@ to list available signals.
 
 # OPTIONS
 **--all**|**-a**
-: Send the signal to all processes inside the container.
+: Send the signal to all processes inside the container, rather than
+the container's init only. This option is useful when the container does not
+have its own PID namespace.
+
+: When this option is set, no error is returned if the container is stopped
+or does not exist.
 
 # EXAMPLES
 


### PR DESCRIPTION
Document the aspects of --all.

Reference: https://github.com/opencontainers/runc/pull/3812#issuecomment-1513680512