### PR TITLE
libct: document process.LogLevel field

### DIFF
--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -79,6 +79,9 @@ type Process struct {
 
 	ops processOperations
 
+	// LogLevel is a string containing a numeric representation of the current
+	// log level (i.e. "4", but never "info"). It is passed on to runc init as
+	// _LIBCONTAINER_LOGLEVEL environment variable.
 	LogLevel string
 
 	// SubCgroupPaths specifies sub-cgroups to run the process in.


### PR DESCRIPTION
This field used to hold a string representation of log level (like "debug" or "info"). Since commit 6c4a3b13d132aa4 this is now a string holding a numeric representation of log level (e.g. "4"). This was done in preparation to commit f1b703fc45dd6142, and simplifies things in a few places.

Let's document it.

Fixes: 6c4a3b13d132aa4

Reference: https://github.com/opencontainers/runc/pull/3385#discussion_r1175151837