### PR TITLE
ci: enable stylecheck linter, fix ST1005 warnings

### DIFF
--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -13,3 +13,9 @@ linters:
   enable:
     - godot
     - revive
+    - stylecheck
+
+linters-settings:
+  stylecheck:
+    # Enable warnings disabled in .golangci.yml.
+    checks: ["ST1003", "ST1016"]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,3 +10,10 @@ linters:
     - errorlint
     - unconvert
     - unparam
+    - stylecheck
+
+linters-settings:
+  stylecheck:
+    # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+    # Default: ["*"]
+    checks: ["all", "-ST1003", "-ST1016"]

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -60,7 +60,7 @@ checkpointed.`,
 			return err
 		}
 		if status == libcontainer.Created || status == libcontainer.Stopped {
-			return fmt.Errorf("Container cannot be checkpointed in %s state", status.String())
+			return fmt.Errorf("container cannot be checkpointed in %s state", status.String())
 		}
 		options, err := criuOptions(context)
 		if err != nil {
@@ -137,11 +137,11 @@ func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
 		address, port, err := net.SplitHostPort(psOpt)
 
 		if err != nil || address == "" || port == "" {
-			return nil, errors.New("Use --page-server ADDRESS:PORT to specify page server")
+			return nil, errors.New("use --page-server ADDRESS:PORT to specify page server")
 		}
 		portInt, err := strconv.Atoi(port)
 		if err != nil {
-			return nil, errors.New("Invalid port number")
+			return nil, errors.New("invalid port number")
 		}
 		opts.PageServer = libcontainer.CriuPageServerInfo{
 			Address: address,
@@ -161,7 +161,7 @@ func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
 	case "ignore":
 		opts.ManageCgroupsMode = criu.CriuCgMode_IGNORE
 	default:
-		return nil, errors.New("Invalid manage-cgroups-mode value")
+		return nil, errors.New("invalid manage-cgroups-mode value")
 	}
 
 	// runc doesn't manage network devices and their configuration.

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -104,7 +104,7 @@ func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {
 	case configs.Undefined:
 		return nil
 	default:
-		return fmt.Errorf("Invalid argument '%s' to freezer.state", string(r.Freezer))
+		return fmt.Errorf("invalid argument %q to freezer.state", string(r.Freezer))
 	}
 }
 

--- a/libcontainer/cgroups/fscommon/rdma.go
+++ b/libcontainer/cgroups/fscommon/rdma.go
@@ -20,7 +20,7 @@ func parseRdmaKV(raw string, entry *cgroups.RdmaEntry) error {
 	parts := strings.SplitN(raw, "=", 3)
 
 	if len(parts) != 2 {
-		return errors.New("Unable to parse RDMA entry")
+		return errors.New("unable to parse RDMA entry")
 	}
 
 	k, v := parts[0], parts[1]

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -290,7 +290,7 @@ func RemovePaths(paths map[string]string) (err error) {
 			return nil
 		}
 	}
-	return fmt.Errorf("Failed to remove paths: %v", paths)
+	return fmt.Errorf("failed to remove paths: %v", paths)
 }
 
 var (

--- a/libcontainer/configs/config_linux.go
+++ b/libcontainer/configs/config_linux.go
@@ -3,10 +3,10 @@ package configs
 import "errors"
 
 var (
-	errNoUIDMap   = errors.New("User namespaces enabled, but no uid mappings found.")
-	errNoUserMap  = errors.New("User namespaces enabled, but no user mapping found.")
-	errNoGIDMap   = errors.New("User namespaces enabled, but no gid mappings found.")
-	errNoGroupMap = errors.New("User namespaces enabled, but no group mapping found.")
+	errNoUIDMap   = errors.New("user namespaces enabled, but no uid mappings found")
+	errNoUserMap  = errors.New("user namespaces enabled, but no user mapping found")
+	errNoGIDMap   = errors.New("user namespaces enabled, but no gid mappings found")
+	errNoGroupMap = errors.New("user namespaces enabled, but no group mapping found")
 )
 
 // HostUID gets the translated uid for the process on host which could be

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -96,7 +96,7 @@ func namespaces(config *configs.Config) error {
 		}
 	} else {
 		if config.UIDMappings != nil || config.GIDMappings != nil {
-			return errors.New("User namespace mappings specified, but USER namespace isn't enabled in the config")
+			return errors.New("user namespace mappings specified, but USER namespace isn't enabled in the config")
 		}
 	}
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1035,7 +1035,7 @@ func (c *Container) handleRestoringNamespaces(rpcOpts *criurpc.CriuOpts, extraFi
 			}
 			if ns.Type == configs.NEWCGROUP {
 				// CRIU has no code to handle NEWCGROUP
-				return fmt.Errorf("Do not know how to handle namespace %v", ns.Type)
+				return fmt.Errorf("do not know how to handle namespace %v", ns.Type)
 			}
 			// CRIU has code to handle NEWTIME, but it does not seem to be defined in runc
 
@@ -1067,7 +1067,7 @@ func (c *Container) handleRestoringExternalNamespaces(rpcOpts *criurpc.CriuOpts,
 	nsFd, err := os.Open(nsPath)
 	if err != nil {
 		logrus.Errorf("If a specific network namespace is defined it must exist: %s", err)
-		return fmt.Errorf("Requested network namespace %v does not exist", nsPath)
+		return fmt.Errorf("requested network namespace %v does not exist", nsPath)
 	}
 	inheritFd := &criurpc.InheritFd{
 		Key: proto.String(criuNsToKey(t)),

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -559,11 +559,11 @@ func setupRoute(config *configs.Config) error {
 		}
 		src := net.ParseIP(config.Source)
 		if src == nil {
-			return fmt.Errorf("Invalid source for route: %s", config.Source)
+			return fmt.Errorf("invalid source for route: %s", config.Source)
 		}
 		gw := net.ParseIP(config.Gateway)
 		if gw == nil {
-			return fmt.Errorf("Invalid gateway for route: %s", config.Gateway)
+			return fmt.Errorf("invalid gateway for route: %s", config.Gateway)
 		}
 		l, err := netlink.LinkByName(config.InterfaceName)
 		if err != nil {

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -189,7 +189,7 @@ var (
 	// For Intel RDT initialization
 	initOnce sync.Once
 
-	errNotFound = errors.New("Intel RDT not available")
+	errNotFound = errors.New("Intel RDT not available") //nolint:stylecheck // Intel is a proper noun.
 )
 
 // Check if Intel RDT sub-features are enabled in featuresInit()

--- a/libcontainer/keys/keyctl.go
+++ b/libcontainer/keys/keyctl.go
@@ -30,7 +30,7 @@ func ModKeyringPerm(ringID KeySerial, mask, setbits uint32) error {
 
 	res := strings.Split(dest, ";")
 	if len(res) < 5 {
-		return errors.New("Destination buffer for key description is too small")
+		return errors.New("destination buffer for key description is too small")
 	}
 
 	// parse permissions

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -445,7 +445,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 			return false
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Unable to find additional groups %v: %w", additionalGroups, err)
+			return nil, fmt.Errorf("unable to find additional groups %v: %w", additionalGroups, err)
 		}
 	}
 
@@ -469,7 +469,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 			gid, err := strconv.ParseInt(ag, 10, 64)
 			if err != nil {
 				// Not a numeric ID either.
-				return nil, fmt.Errorf("Unable to find group %s: %w", ag, ErrNoGroupEntries)
+				return nil, fmt.Errorf("unable to find group %s: %w", ag, ErrNoGroupEntries)
 			}
 			// Ensure gid is inside gid range.
 			if gid < minID || gid > maxID {

--- a/spec.go
+++ b/spec.go
@@ -89,7 +89,7 @@ created by an unprivileged user.
 		checkNoFile := func(name string) error {
 			_, err := os.Stat(name)
 			if err == nil {
-				return fmt.Errorf("File %s exists. Remove it first", name)
+				return fmt.Errorf("file %s exists; remove it first", name)
 			}
 			if !os.IsNotExist(err) {
 				return err

--- a/update.go
+++ b/update.go
@@ -317,10 +317,12 @@ other options are ignored.
 		l3CacheSchema := context.String("l3-cache-schema")
 		memBwSchema := context.String("mem-bw-schema")
 		if l3CacheSchema != "" && !intelrdt.IsCATEnabled() {
+			//nolint:stylecheck // Intel is a proper noun.
 			return errors.New("Intel RDT/CAT: l3 cache schema is not enabled")
 		}
 
 		if memBwSchema != "" && !intelrdt.IsMBAEnabled() {
+			//nolint:stylecheck // Intel is a proper noun.
 			return errors.New("Intel RDT/MBA: memory bandwidth schema is not enabled")
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -114,7 +114,7 @@ func reviseRootDir(context *cli.Context) error {
 		//  - "." (and the CWD is /);
 		//  - "../../.." (enough to get to /);
 		//  - "/" (the actual /).
-		return errors.New("Option --root argument should not be set to /")
+		return errors.New("option --root argument should not be set to /")
 	}
 
 	return context.GlobalSet("root", root)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -315,10 +315,10 @@ func validateProcessSpec(spec *specs.Process) error {
 		return errors.New("process property must not be empty")
 	}
 	if spec.Cwd == "" {
-		return errors.New("Cwd property must not be empty")
+		return errors.New("cwd property must not be empty")
 	}
 	if !filepath.IsAbs(spec.Cwd) {
-		return errors.New("Cwd must be an absolute path")
+		return errors.New("cwd must be an absolute path")
 	}
 	if len(spec.Args) == 0 {
 		return errors.New("args must not be empty")


### PR DESCRIPTION
1. Enable stylecheck linter (with some checks disabled).

2. Enabled checks disabled above in golangci-extra.yml (used for new code).

3. Fix "_ST1005: error strings should not be capitalized (stylecheck)_" warnings.