### PR TITLE
features: graduate from experimental

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,11 +1,8 @@
 # Experimental features
 
-The following features are experimental and subject to change:
-
-- The `runc features` command (since runc v1.1.0)
-
 The following features were experimental in the past:
 
 Feature                                  | Experimental release | Graduation release
 ---------------------------------------- | -------------------- | ------------------
 cgroup v2                                | v1.0.0-rc91          | v1.0.0-rc93
+The `runc features` command              | v1.1.0               | v1.2.0

--- a/features.go
+++ b/features.go
@@ -20,8 +20,7 @@ var featuresCommand = cli.Command{
 	ArgsUsage: "",
 	Description: `Show the enabled features.
    The result is parsable as a JSON.
-   See https://pkg.go.dev/github.com/opencontainers/runc/types/features for the type definition.
-   The types are experimental and subject to change.
+   See https://github.com/opencontainers/runtime-spec/blob/main/features.md for the type definition.
 `,
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 0, exactArgs); err != nil {


### PR DESCRIPTION
The type definition was merged into the OCI Runtime Spec v1.1.0-rc.2: https://github.com/opencontainers/runtime-spec/blob/v1.1.0-rc.2/features.md