### PR TITLE
Support `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV`

### DIFF
--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -122,6 +122,7 @@ var flags = []string{
 	flagTsync,
 	string(specs.LinuxSeccompFlagSpecAllow),
 	string(specs.LinuxSeccompFlagLog),
+	string(specs.LinuxSeccompFlagWaitKillableRecv),
 }
 
 // KnownFlags returns the list of the known filter flags.

--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -53,6 +53,11 @@ const uintptr_t C_FILTER_FLAG_SPEC_ALLOW = SECCOMP_FILTER_FLAG_SPEC_ALLOW;
 #endif
 const uintptr_t C_FILTER_FLAG_NEW_LISTENER = SECCOMP_FILTER_FLAG_NEW_LISTENER;
 
+#ifndef SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
+#	define SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV (1UL << 5)
+#endif
+const uintptr_t C_FILTER_FLAG_WAIT_KILLABLE_RECV = SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV;
+
 #ifndef AUDIT_ARCH_RISCV64
 #ifndef EM_RISCV
 #define EM_RISCV		243
@@ -643,6 +648,11 @@ func filterFlags(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (flags 
 			flags |= uint(C.C_FILTER_FLAG_SPEC_ALLOW)
 		}
 	}
+	// TODO: Check if the version is the right API level for SECCOMP_FILTER_FLAG_TSYNC
+	// Unfortunately, there is no way to check API levels above 7 in libseccomp-golang.
+	// if apiLevel >= 7 {
+	// }
+
 	// XXX: add newly supported filter flags above this line.
 
 	for _, call := range config.Syscalls {

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -75,6 +75,7 @@ function flags_value() {
 		['"SECCOMP_FILTER_FLAG_TSYNC"']=0 # Supported but ignored by runc, thus 0.
 		['"SECCOMP_FILTER_FLAG_LOG"']=2
 		['"SECCOMP_FILTER_FLAG_SPEC_ALLOW"']=4
+		['"SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"']=7
 		# XXX: add new values above this line.
 	)
 	# Split the flags.


### PR DESCRIPTION
Fix #3860

I didn't find a good way to test `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` 😭 