### PR TITLE
ci/gha: cross-i386: fix build, rm kludges

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,9 +120,6 @@ jobs:
         sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to.
 
-        # Due to a bug in apt, we have to update it first
-        # (see https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268)
-        sudo apt -q install apt
         sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib criu
 
     - name: install go
@@ -131,5 +128,4 @@ jobs:
         go-version: 1.x # Latest stable
 
     - name: unit test
-      # See https://go-review.googlesource.com/c/go/+/421935
-      run: sudo -E PATH="$PATH" -- make GOARCH=386 CGO_CFLAGS=-fno-stack-protector localunittest
+      run: sudo -E PATH="$PATH" -- make GOARCH=386 localunittest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to.
 
-        sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib criu
+        sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib libgcc-s1:i386 criu
 
     - name: install go
       uses: actions/setup-go@v4


### PR DESCRIPTION
1. Fix cross-i386 job failure due to issues with Ubuntu repo (see e.g. https://github.com/pwndbg/pwndbg/issues/1714)
2. Remove old kludges that are no longer needed.