### PR TITLE
tests/int: increase num retries for oom tests

### DIFF
--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -93,7 +93,7 @@ function test_events() {
 		retry 10 1 grep -q test_busybox events.log
 		# shellcheck disable=SC2016
 		__runc exec -d test_busybox sh -c 'test=$(dd if=/dev/urandom ibs=5120k)'
-		retry 10 1 grep -q oom events.log
+		retry 30 1 grep -q oom events.log
 		__runc delete -f test_busybox
 	) &
 	wait # wait for the above sub shells to finish


### PR DESCRIPTION
This test is occasionally failing on CS9.

The test case always takes about 7 seconds on my laptop (decreasing
memory, using a different memory eater in shell etc. doesn't help).

Increase the number of iterations from 10 to 30 to make sure we don't
see any flakes.

Fixes: #3868 