### PR TITLE
Support time namespace

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -216,6 +216,9 @@ type Config struct {
 	// Do not try to remount a bind mount again after the first attempt failed on source
 	// filesystems that have nodev, noexec, nosuid, noatime, relatime, strictatime, nodiratime set
 	NoMountFallback bool `json:"no_mount_fallback,omitempty"`
+
+	// TimeOffsets specifies the offset for supporting time namespaces.
+	TimeOffsets map[string]specs.LinuxTimeOffset `json:"time_offsets,omitempty"`
 }
 
 type (

--- a/libcontainer/configs/namespaces_linux.go
+++ b/libcontainer/configs/namespaces_linux.go
@@ -14,6 +14,7 @@ const (
 	NEWIPC    NamespaceType = "NEWIPC"
 	NEWUSER   NamespaceType = "NEWUSER"
 	NEWCGROUP NamespaceType = "NEWCGROUP"
+	NEWTIME   NamespaceType = "NEWTIME"
 )
 
 var (
@@ -38,6 +39,8 @@ func NsName(ns NamespaceType) string {
 		return "uts"
 	case NEWCGROUP:
 		return "cgroup"
+	case NEWTIME:
+		return "time"
 	}
 	return ""
 }
@@ -72,6 +75,7 @@ func NamespaceTypes() []NamespaceType {
 		NEWPID,
 		NEWNS,
 		NEWCGROUP,
+		NEWTIME,
 	}
 }
 

--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -17,6 +17,7 @@ var namespaceInfo = map[NamespaceType]int{
 	NEWUTS:    unix.CLONE_NEWUTS,
 	NEWPID:    unix.CLONE_NEWPID,
 	NEWCGROUP: unix.CLONE_NEWCGROUP,
+	NEWTIME:   unix.CLONE_NEWTIME,
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -106,6 +106,12 @@ func namespaces(config *configs.Config) error {
 		}
 	}
 
+	if config.Namespaces.Contains(configs.NEWTIME) {
+		if _, err := os.Stat("/proc/self/timens_offsets"); os.IsNotExist(err) {
+			return errors.New("time namespaces aren't enabled in the kernel")
+		}
+	}
+
 	return nil
 }
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2321,6 +2321,18 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 		})
 	}
 
+	// write boottime and monotonic time ns offsets.
+	if c.config.Namespaces.Contains(configs.NEWTIME) && c.config.TimeOffsets != nil {
+		var offsetSpec bytes.Buffer
+		for clock, offset := range c.config.TimeOffsets {
+			fmt.Fprintf(&offsetSpec, "%s %d %d\n", clock, offset.Secs, offset.Nanosecs)
+		}
+		r.AddData(&Bytemsg{
+			Type:  TimeOffsetsAttr,
+			Value: offsetSpec.Bytes(),
+		})
+	}
+
 	return bytes.NewReader(r.Serialize()), nil
 }
 

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -23,6 +23,7 @@ const (
 	GidmapPathAttr   uint16 = 27289
 	MountSourcesAttr uint16 = 27290
 	IdmapSourcesAttr uint16 = 27291
+	TimeOffsetsAttr  uint16 = 27292
 )
 
 type Int32msg struct {

--- a/libcontainer/nsenter/namespace.h
+++ b/libcontainer/nsenter/namespace.h
@@ -28,5 +28,8 @@
 #ifndef CLONE_NEWNET
 #	define CLONE_NEWNET 0x40000000 /* New network namespace */
 #endif
+#ifndef CLONE_NEWTIME
+#	define CLONE_NEWTIME 0x00000080	/* New time namespace */
+#endif
 
 #endif /* NSENTER_NAMESPACE_H */

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -49,6 +49,7 @@ func initMaps() {
 			specs.IPCNamespace:     configs.NEWIPC,
 			specs.UTSNamespace:     configs.NEWUTS,
 			specs.CgroupNamespace:  configs.NEWCGROUP,
+			specs.TimeNamespace:    configs.NEWTIME,
 		}
 
 		mountPropagationMapping = map[string]int{
@@ -435,6 +436,9 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				MemBwSchema:   spec.Linux.IntelRdt.MemBwSchema,
 			}
 		}
+
+		// update timens offsets
+		config.TimeOffsets = spec.Linux.TimeOffsets
 	}
 
 	// Set the host UID that should own the container's cgroup.


### PR DESCRIPTION
## Background
- runtime-spec now supports time namespace 
  - https://github.com/opencontainers/runtime-spec/pull/1151 - Merged
- Existing issue in runc - https://github.com/opencontainers/runc/issues/2345

## Support time ns in runc
* [x] This PR supports time ns by updating the monotonic and boottime clock offest in `/proc/self/timens_offsets`
  - Support `BootTimeNsAttr` and `MonotonicNsAttr` netlink message type to send to bootstrap program
  - Update time ns in `STAGE_CHILD` after unsharing all the clone flags (stage-1)
  - validate path `/proc/self/timens_offsets` to validate if time ns enabled
* [ ] Add test cases
  - `nsenter_test.go` only checks for invalid ns path and type for netlink requests. No specific `_test.go` for time ns is required.
  - [ ] Add `timens.bats` integration test? - **TBD**
* :x:  Update documentations - Not required
  - runtime-spec documentations are already updated. No docs required in runc.
  - https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#namespaces
  - https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#offset-for-time-namespace

## Unit test
- Launch container with boottime offsets
```
# jq '.linux.timeOffsets["boottime"]' config.json 
{
  "secs": 999999999,
  "nanosecs": 0
}

# jq '.linux.namespaces[5]' config.json 
{
  "type": "time"
}

# jq '.process.args' config.json 
[
  "uptime",
  "-s"
]

# uptime -s; ./runc run test 
2023-05-22 17:05:57
1991-09-13 09:49:18
```

## Discussion points
- The time offset is updated to `/proc/self/timens_offsets`
  - is it important to set `stage1_pid`/`stage2_pid` like done in `update_uidmap`?
- Is it advisable to set offsets elsewhere apart from `STAGE_CHILD`?
  - Ref: https://man7.org/linux/man-pages/man7/time_namespaces.7.html
  - `but after the first process has  been created in or has entered the namespace, write(2)s on this file fail with the error EACCES.`
  - Therefore, considered to write during `STAGE_CHILD` after unshared ns