### PR TITLE
[1.1] init: do not print environment variable value

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -116,17 +116,17 @@ func populateProcessEnvironment(env []string) error {
 	for _, pair := range env {
 		p := strings.SplitN(pair, "=", 2)
 		if len(p) < 2 {
-			return fmt.Errorf("invalid environment variable: %q", pair)
+			return errors.New("invalid environment variable: missing '='")
 		}
 		name, val := p[0], p[1]
 		if name == "" {
-			return fmt.Errorf("environment variable name can't be empty: %q", pair)
+			return errors.New("invalid environment variable: name cannot be empty")
 		}
 		if strings.IndexByte(name, 0) >= 0 {
-			return fmt.Errorf("environment variable name can't contain null(\\x00): %q", pair)
+			return fmt.Errorf("invalid environment variable %q: name contains nul byte (\\x00)", name)
 		}
 		if strings.IndexByte(val, 0) >= 0 {
-			return fmt.Errorf("environment variable value can't contain null(\\x00): %q", pair)
+			return fmt.Errorf("invalid environment variable %q: value contains nul byte (\\x00)", name)
 		}
 		if err := os.Setenv(name, val); err != nil {
 			return err


### PR DESCRIPTION
_This is a backport of #3850 to release-1.1 branch. Original description follows._

When given an environment variable that is invalid, it's not a good idea to output the contents in case they are supposed to be private (though such a container wouldn't start anyway so it seems unlikely there's a real way to use this to exfiltrate environment variables you didn't already know).

Reported-by: Carl Henrik Lunde <chlunde@ifi.uio.no>

(cherry picked from commit 20e38fb2b1201325e7cd275afbb5c7d17ccfde60)