### PR TITLE
Fix Vagrant caching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,8 +47,8 @@ task:
     apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
     vagrant plugin install vagrant-libvirt
   vagrant_cache:
-    fingerprint_script: uname -s ; cat Vagrantfile.$DISTRO
-    folder: /root/.vagrant.d
+    fingerprint_script: cat Vagrantfile.$DISTRO
+    folder: /root/.vagrant.d/boxes
   vagrant_up_script: |
     ln -sf Vagrantfile.$DISTRO Vagrantfile
     # Retry if it fails (download.fedoraproject.org returns 404 sometimes)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,8 @@
 ---
-# We use Cirrus for Vagrant tests and native CentOS 7 and 8, because macOS
-# instances of GHA are too slow and flaky, and Linux instances of GHA do not
-# support KVM.
+# We use Cirrus for CentOS (native) and Fedora (in Vagrant), because neither
+# CentOS nor Fedora is available on GHA natively, so the only option is VM.
+# In GHA, nested virtualization is only supported on macOS instances, which
+# are slow and flaky.
 
 # NOTE Cirrus execution environments lack a terminal, needed for
 # some integration tests. So we use `ssh -tt` command to fake a terminal.
@@ -24,9 +25,9 @@ task:
     platform: linux
     nested_virtualization: true
     # CPU limit: `16 / NTASK`: see https://cirrus-ci.org/faq/#are-there-any-limits
-    cpu: 8
+    cpu: 4
     # Memory limit: `4GB * NCPU`
-    memory: 32G
+    memory: 16G
 
   host_info_script: |
     uname -a


### PR DESCRIPTION
As of today, vagrant stopped working, my best guess is due to bad caching. Here's an excerpt from logs (https://cirrus-ci.com/task/6211443486359552?logs=vagrant#L59):

<blockquote>
...

vagrant plugin install vagrant-libvirt
Installing the 'vagrant-libvirt' plugin. This can take a few minutes... Building native extensions. This could take a while... Installed the plugin 'vagrant-libvirt (0.12.1)'!

...

uname -s ; cat Vagrantfile.$DISTRO
Linux

...

Downloaded 481Mb in 4.096201s.
Cache hit for vagrant-8be35383dc00f23d080ff00b2a724c938d650254861f26b67624c28e3fe5e6ae! ...
Vagrant failed to initialize at a very early stage: The plugins failed to initialize correctly. This may be due to manual modifications made within the Vagrant home directory. ...
Error message given during initialization: Unable to resolve dependency: user requested 'vagrant-libvirt (= 0.12.0)'

...
</blockquote>

Note the vargrant-libvirt version difference (0.12.1 installed, 0.12.0 shown in `vagrant up` error). I think the installed version gets overwritten by an older one from the cache.

To fix, let's only cache `~/.vagrant.d/boxes` (to save traffic downloading fedora image).