### PR TITLE
[1.1] man/runc: fixes

### DIFF
--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -40,19 +40,15 @@ value for _bundle_ is the current directory.
 : Create a container. See **runc-create**(8).
 
 **delete**
-: Delete any resources held by the container often used with detached
+: Delete any resources held by the container; often used with detached
 containers. See **runc-delete**(8).
 
 **events**
-: Display container events such as OOM notifications, cpu, memory, IO and
-network stats. See **runc-events**(8).
+: Display container events, such as OOM notifications, CPU, memory, I/O and
+network statistics. See **runc-events**(8).
 
 **exec**
 : Execute a new process inside the container. See **runc-exec**(8).
-
-**init**
-: Initialize the namespaces and launch the container init process. This command
-is not supposed to be used directly.
 
 **kill**
 : Send a specified signal to the container's init process. See


### PR DESCRIPTION
This is a backport of #3887 to release-1.1 branch.

----

1. Fix some missing punctuation, use proper case.

2. Remove "runc init" (previously removed from "runc --help" by commit 7a0302f0d79e32766).


(cherry picked from commit 511c76143bba15712d4b5159aeef2f4903005809)