### PR TITLE
docs/systemd: fix a broken link

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -124,8 +124,8 @@ The above will set the following properties:
 * `TimeoutStopSec` to 2 minutes and 3 seconds;
 * `CollectMode` to "inactive-or-failed".
 
-The values must be in the gvariant format (for details, see
-[gvariant documentation](https://developer.gnome.org/glib/stable/gvariant-text.html)).
+The values must be in the gvariant text format, as described in
+[gvariant documentation](https://docs.gtk.org/glib/gvariant-text.html).
 
 To find out which type systemd expects for a particular parameter, please
 consult systemd sources.


### PR DESCRIPTION
Apparently, developer.gnome.org/documentation no longer hosts the documentation we used to refer to. Link to docs.gtk.org instead.