### PR TITLE
ci/gha: don't skip rootless+systemd on ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,16 @@ jobs:
       run: sudo -E PATH="$PATH" script -e -c 'make local${{ matrix.rootless }}integration'
 
     - name: integration test (systemd driver)
-      # can't use systemd driver with cgroupv1
-      if: matrix.rootless != 'rootless'
-      run: sudo -E PATH="$PATH" script -e -c 'make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'
+      # Skip rootless+systemd for ubuntu 20.04 because of cgroup v1.
+      if: ${{ !(matrix.os == 'ubuntu-20.04' && matrix.rootless == 'rootless') }}
+      run: |
+        # Delegate all cgroup v2 controllers to rootless user via --systemd-cgroup.
+        # The default (since systemd v252) is "pids memory cpu".
+        sudo mkdir -p /etc/systemd/system/user@.service.d
+        printf "[Service]\nDelegate=yes\n" | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
+        sudo systemctl daemon-reload
+        # Run the tests.
+        sudo -E PATH="$PATH" script -e -c 'make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'
 
   # We need to continue support for 32-bit ARM.
   # However, we do not have 32-bit ARM CI, so we use i386 for testing 32bit stuff.


### PR DESCRIPTION
We used to skip testing rootless integration tests for systemd, because in case of cgroup v1 it does not support user delegation.

Since we added ubuntu 22.04 to the testing matrix, we can actually test rootless+systemd there.

Fixes: 953e1cc48547942481ff71f58fff7bb9cb76e5d2 (PR #3820)