### PR TITLE
Backport riscv64 support into 1.1.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,5 +124,4 @@ jobs:
         go-version: 1.x # Latest stable
 
     - name: unit test
-      # cgo is disabled by default when cross-compiling
-      run: sudo -E PATH="$PATH" -- make GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS=-fno-stack-protector localunittest
+      run: sudo -E PATH="$PATH" -- make GOARCH=386 localunittest

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
     && apt-get install -y --no-install-recommends \
         build-essential \
         criu \
-        crossbuild-essential-arm64 \
-        crossbuild-essential-armel \
-        crossbuild-essential-armhf \
-        crossbuild-essential-ppc64el \
-        crossbuild-essential-s390x \
+        gcc-aarch64-linux-gnu libc-dev-arm64-cross \
+        gcc-arm-linux-gnueabi libc-dev-armel-cross \
+        gcc-arm-linux-gnueabihf libc-dev-armhf-cross \
+        gcc-powerpc64le-linux-gnu libc-dev-ppc64el-cross \
+        gcc-s390x-linux-gnu libc-dev-s390x-cross \
         curl \
         gawk \
         gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN cd /tmp \
 
 # install libseccomp
 ARG LIBSECCOMP_VERSION
-COPY script/* /tmp/script/
+COPY script/seccomp.sh script/lib.sh /tmp/script/
 RUN mkdir -p /opt/libseccomp \
     && /tmp/script/seccomp.sh "$LIBSECCOMP_VERSION" /opt/libseccomp arm64 armel armhf ppc64le s390x
 ENV LIBSECCOMP_VERSION=$LIBSECCOMP_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
         gcc-arm-linux-gnueabihf libc-dev-armhf-cross \
         gcc-powerpc64le-linux-gnu libc-dev-ppc64el-cross \
         gcc-s390x-linux-gnu libc-dev-s390x-cross \
+        gcc-riscv64-linux-gnu libc-dev-riscv64-cross \
         curl \
         gawk \
         gcc \
@@ -52,7 +53,7 @@ RUN cd /tmp \
 ARG LIBSECCOMP_VERSION
 COPY script/seccomp.sh script/lib.sh /tmp/script/
 RUN mkdir -p /opt/libseccomp \
-    && /tmp/script/seccomp.sh "$LIBSECCOMP_VERSION" /opt/libseccomp arm64 armel armhf ppc64le s390x
+    && /tmp/script/seccomp.sh "$LIBSECCOMP_VERSION" /opt/libseccomp arm64 armel armhf ppc64le riscv64 s390x
 ENV LIBSECCOMP_VERSION=$LIBSECCOMP_VERSION
 ENV LD_LIBRARY_PATH=/opt/libseccomp/lib
 ENV PKG_CONFIG_PATH=/opt/libseccomp/lib/pkgconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ ARG CRIU_REPO=https://download.opensuse.org/repositories/devel:/tools:/criu/Debi
 RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
     wget -nv $CRIU_REPO/Release.key -O- | gpg --dearmor > "$KEYFILE" \
     && echo "deb [signed-by=$KEYFILE] $CRIU_REPO/ /" > /etc/apt/sources.list.d/criu.list \
-    && dpkg --add-architecture armel \
-    && dpkg --add-architecture armhf \
-    && dpkg --add-architecture arm64 \
-    && dpkg --add-architecture ppc64el \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION := $(shell cat ./VERSION)
 LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
 
-ifeq ($(shell $(GO) env GOOS),linux)
-	ifeq (,$(filter $(shell $(GO) env GOARCH),mips mipsle mips64 mips64le ppc64))
-		ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
-			GO_BUILDMODE := "-buildmode=pie"
-		endif
+GO_BUILDMODE :=
+# Enable dynamic PIE executables on supported platforms.
+ifneq (,$(filter $(shell $(GO) env GOARCH),386 amd64 arm arm64 ppc64le riscv64 s390x))
+	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+		GO_BUILDMODE := "-buildmode=pie"
 	endif
 endif
 GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ recvtty sd-helper seccompagent:
 static:
 	$(GO_BUILD_STATIC) -o runc .
 
-releaseall: RELEASE_ARGS := "-a arm64 -a armel -a armhf -a ppc64le -a s390x"
+releaseall: RELEASE_ARGS := "-a arm64 -a armel -a armhf -a ppc64le -a riscv64 -a s390x"
 releaseall: release
 
 release: runcimage

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
 BUILDTAGS ?= seccomp
+
 COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION := $(shell cat ./VERSION)
+LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
 
 ifeq ($(shell $(GO) env GOOS),linux)
 	ifeq (,$(filter $(shell $(GO) env GOARCH),mips mipsle mips64 mips64le ppc64))
@@ -21,9 +23,11 @@ ifeq ($(shell $(GO) env GOOS),linux)
 	endif
 endif
 GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
-	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
+	-ldflags "$(LDFLAGS_COMMON) $(EXTRA_LDFLAGS)"
+
+LDFLAGS_STATIC := -extldflags -static
 GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
-	-ldflags "-extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
+	-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS_STATIC) $(EXTRA_LDFLAGS)"
 
 GPG_KEYID ?= asarai@suse.de
 

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,20 @@ ifneq (,$(filter $(GOARCH),arm64 amd64))
 	endif
 endif
 # Enable static PIE binaries on supported platforms.
-GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(GO_BUILDMODE_STATIC) \
+GO_BUILD_STATIC := $(GO) build -trimpath $(GO_BUILDMODE_STATIC) \
 	$(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
 	-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS_STATIC) $(EXTRA_LDFLAGS)"
 
 GPG_KEYID ?= asarai@suse.de
+
+# Some targets need cgo, which is disabled by default when cross compiling.
+# Enable cgo explicitly for those.
+# Both runc and libcontainer/integration need libcontainer/nsenter.
+runc static localunittest: export CGO_ENABLED=1
+# seccompagent needs libseccomp (when seccomp build tag is set).
+ifneq (,$(filter $(BUILDTAGS),seccomp))
+seccompagent: export CGO_ENABLED=1
+endif
 
 .DEFAULT: runc
 

--- a/libcontainer/seccomp/config.go
+++ b/libcontainer/seccomp/config.go
@@ -66,6 +66,7 @@ var archs = map[string]string{
 	"SCMP_ARCH_PPC":         "ppc",
 	"SCMP_ARCH_PPC64":       "ppc64",
 	"SCMP_ARCH_PPC64LE":     "ppc64le",
+	"SCMP_ARCH_RISCV64":     "riscv64",
 	"SCMP_ARCH_S390":        "s390",
 	"SCMP_ARCH_S390X":       "s390x",
 }

--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -48,6 +48,13 @@ const uintptr_t C_FILTER_FLAG_LOG = SECCOMP_FILTER_FLAG_LOG;
 #endif
 const uintptr_t C_FILTER_FLAG_NEW_LISTENER = SECCOMP_FILTER_FLAG_NEW_LISTENER;
 
+#ifndef AUDIT_ARCH_RISCV64
+#ifndef EM_RISCV
+#define EM_RISCV		243
+#endif
+#define AUDIT_ARCH_RISCV64	(EM_RISCV|__AUDIT_ARCH_64BIT|__AUDIT_ARCH_LE)
+#endif
+
 // We use the AUDIT_ARCH_* values because those are the ones used by the kernel
 // and SCMP_ARCH_* sometimes has fake values (such as SCMP_ARCH_X32). But we
 // use <seccomp.h> so we get libseccomp's fallback definitions of AUDIT_ARCH_*.
@@ -67,6 +74,7 @@ const uint32_t C_AUDIT_ARCH_PPC64        = AUDIT_ARCH_PPC64;
 const uint32_t C_AUDIT_ARCH_PPC64LE      = AUDIT_ARCH_PPC64LE;
 const uint32_t C_AUDIT_ARCH_S390         = AUDIT_ARCH_S390;
 const uint32_t C_AUDIT_ARCH_S390X        = AUDIT_ARCH_S390X;
+const uint32_t C_AUDIT_ARCH_RISCV64      = AUDIT_ARCH_RISCV64;
 */
 import "C"
 
@@ -202,6 +210,8 @@ func archToNative(arch libseccomp.ScmpArch) (nativeArch, error) {
 		return nativeArch(C.C_AUDIT_ARCH_S390), nil
 	case libseccomp.ArchS390X:
 		return nativeArch(C.C_AUDIT_ARCH_S390X), nil
+	case libseccomp.ArchRISCV64:
+		return nativeArch(C.C_AUDIT_ARCH_RISCV64), nil
 	default:
 		return invalidArch, fmt.Errorf("unknown architecture: %v", arch)
 	}

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -23,6 +23,9 @@ function set_cross_vars() {
 	ppc64le)
 		HOST=powerpc64le-linux-gnu
 		;;
+	riscv64)
+		HOST=riscv64-linux-gnu
+		;;
 	s390x)
 		HOST=s390x-linux-gnu
 		;;


### PR DESCRIPTION
This is necessary for [running on RISC-V using K3s](https://github.com/k3s-io/k3s/pull/7778).

Many projects - including K3s - depend on runc 1.1.x, so waiting for a 2.0.x release and then porting to any changes introduced may probably be a much larger effort. This includes all changes done in #3446, which are really minimal but necessary to support the new architecture.

With this patch I have successfully compiled and run K3s on a RISC-V QEMU VM and have verified that I can create Pods.