### PR TITLE
[1.1] .codespellrc: update for 2.2.5

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = ./vendor,./.git,./go.sum
-ignore-words-list = clos,creat,ro,complies
+ignore-words-list = clos,mis


### PR DESCRIPTION
Backport of #3907 to release-1.1 branch.

----

Remove some old exceptions (no longer needed), add a new one (codespell 2.2.5 flags "(mis)features" in docs/terminal.md).
