### PR TITLE
Fix checkpoints integration tests failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
         sshfs \
         sudo \
         uidmap \
+        iproute2 \
     && apt-get clean \
     && rm -rf /var/cache/apt /var/lib/apt/lists/* /etc/apt/sources.list.d/*.list
 


### PR DESCRIPTION
Checkpoint integration test failed when running the tests inside the docker container instead of local environment:  `make integration TESTPATH="/checkpoint.bats`. The error are shown below:
```
# /go/src/github.com/opencontainers/runc/tests/integration/checkpoint.bats: line 288: ip: command not found
```
Fixed by adding the missing package iproute into the Dockerfile.