### PR TITLE
[1.1] ci/cirrus: enable some rootless tests on cs9

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,6 +111,11 @@ task:
     centos-stream-9)
       dnf config-manager --set-enabled crb # for glibc-static
       dnf -y install epel-release epel-next-release # for fuse-sshfs
+      # Delegate all cgroup v2 controllers to rootless user via --systemd-cgroup.
+      # The default (since systemd v252) is "pids memory cpu".
+      mkdir -p /etc/systemd/system/user@.service.d
+      printf "[Service]\nDelegate=yes\n" > /etc/systemd/system/user@.service.d/delegate.conf
+      systemctl daemon-reload
       ;;
     esac
     # Work around dnf mirror failures by retrying a few times.
@@ -170,13 +175,19 @@ task:
   integration_fs_script: |
     ssh -tt localhost "make -C /home/runc localintegration"
   integration_systemd_rootless_script: |
-    echo "SKIP: integration_systemd_rootless_script requires cgroup v2"
+    case $DISTRO in
+    centos-7|centos-stream-8)
+      echo "SKIP: integration_systemd_rootless_script requires cgroup v2"
+      ;;
+    *)
+      ssh -tt localhost "make -C /home/runc localrootlessintegration RUNC_USE_SYSTEMD=yes"
+    esac
   integration_fs_rootless_script: |
     case $DISTRO in
     centos-7)
       echo "SKIP: FIXME: integration_fs_rootless_script is skipped because of EPERM on writing cgroup.procs"
         ;;
-    centos-stream-8)
+    *)
       ssh -tt localhost "make -C /home/runc localrootlessintegration"
       ;;
     esac

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -49,8 +49,8 @@ function setup() {
 			if [ "$(id -u)" = "0" ]; then
 				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
 			else
-				# Filter out hugetlb and misc as systemd is unable to delegate them.
-				check_cgroup_value "cgroup.controllers" "$(sed -e 's/ hugetlb//' -e 's/ misc//' </sys/fs/cgroup/user.slice/user-"$(id -u)".slice/cgroup.controllers)"
+				# Filter out controllers that systemd is unable to delegate.
+				check_cgroup_value "cgroup.controllers" "$(sed 's/ \(hugetlb\|misc\|rdma\)//g' </sys/fs/cgroup/user.slice/user-"$(id -u)".slice/cgroup.controllers)"
 			fi
 		else
 			check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"


### PR DESCRIPTION
This is a backport of #3553 to release-1.1 branch. Original description follows.

----

We were not running localrootlessintegration test on CentOS Stream 9
because of some failures.

Fix those, and enable rootless integration with both systemd and fs drivers.

Amends: #3427