### PR TITLE
ci: bump golangci-lint to v1.53, remove fixed exception

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,7 @@ jobs:
           sudo apt -q install libseccomp-dev
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51
+          version: v1.53
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -201,7 +201,7 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 			if err != nil {
 				// We should return no error if EOF is reached
 				// without a match.
-				if err == io.EOF { //nolint:errorlint // comparison with io.EOF is legit, https://github.com/polyfloyd/go-errorlint/pull/12
+				if err == io.EOF {
 					err = nil
 				}
 				return out, err


### PR DESCRIPTION
The exception was fixed by https://github.com/polyfloyd/go-errorlint/pull/12 which eventually made its way into golangci-lint.