### PR TITLE
ci: add go 1.21, rm go 1.19, fix cirrus jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ task:
   env:
     HOME: /root
     CIRRUS_WORKING_DIR: /home/runc
-    GO_VERSION: "1.19"
+    GO_VERSION: "1.20"
     BATS_VERSION: "v1.9.0"
     RPMS: gcc git iptables jq glibc-static libseccomp-devel make criu fuse-sshfs
     # yamllint disable rule:key-duplicates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
         criu: ["", "criu-dev"]
@@ -31,7 +31,7 @@ jobs:
           - criu: criu-dev
             rootless: rootless
           - criu: criu-dev
-            go-version: 1.19.x
+            go-version: 1.20.x
           - criu: criu-dev
             race: -race
     runs-on: ${{ matrix.os }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/runc
 
-go 1.19
+go 1.20
 
 require (
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0


### PR DESCRIPTION
Go 1.21 is out, and go 1.19 is no longer supported.
    
This also fixes cirrus-ci failures seen recently (and happening because go 1.19 is no longer listed).