### PR TITLE
Set temporary single CPU affinity before cgroup cpuset transition.

### DIFF
--- a/docs/isolated-cpu-affinity-transition.md
+++ b/docs/isolated-cpu-affinity-transition.md
@@ -1,0 +1,125 @@
+## Isolated CPU affinity transition
+
+The introduction of the kernel commit 46a87b3851f0d6eb05e6d83d5c5a30df0eca8f76
+in 5.7 has affected a deterministic scheduling behavior by distributing tasks
+across CPU cores within a cgroups cpuset. It means that `runc exec` might be
+impacted under some circumstances, by example when a container has been
+created within a cgroup cpuset entirely composed of isolated CPU cores
+usually sets either with `nohz_full` and/or `isolcpus` kernel boot parameters.
+
+Some containerized real-time applications are relying on this deterministic
+behavior and uses the first CPU core to run a slow thread while other CPU
+cores are fully used by the real-time threads with SCHED_FIFO policy.
+Such applications can prevent runc process from joining a container when the
+runc process is randomly scheduled on a CPU core owned by a real-time thread.
+
+Runc introduces a way to restore this behavior by adding the following
+annotation to the container runtime spec (`config.json`):
+
+`org.opencontainers.runc.exec.isolated-cpu-affinity-transition`
+
+This annotation can take one of those values:
+
+* `temporary` to temporarily set the runc process CPU affinity to the first
+isolated CPU core of the container cgroup cpuset.
+* `definitive`: to definitively set the runc process CPU affinity to the first
+isolated CPU core of the container cgroup cpuset.
+
+For example:
+
+```json
+  "annotations": {
+    "org.opencontainers.runc.exec.isolated-cpu-affinity-transition": "temporary"
+  }
+```
+
+__WARNING:__ `definitive` requires a kernel >= 6.2, also works with RHEL 9 and
+above.
+
+### How it works?
+
+When enabled and during `runc exec`, runc is looking for the `nohz_full` kernel
+boot parameter value and considers the CPUs in the list as isolated, it doesn't
+look for `isolcpus` boot parameter, it just assumes that `isolcpus` value is
+identical to `nohz_full` when specified. If `nohz_full` parameter is not found,
+runc also attempts to read the list from `/sys/devices/system/cpu/nohz_full`.
+
+Once it gets the isolated CPU list, it returns an eligible CPU core within the
+container cgroup cpuset based on those heuristics:
+
+* when there is not cpuset cores: no eligible CPU
+* when there is not isolated cores: no eligible CPU
+* when cpuset cores are not in isolated core list: no eligible CPU
+* when cpuset cores are all isolated cores: return the first CPU of the cpuset
+* when cpuset cores are mixed between housekeeping/isolated cores: return the
+  first housekeeping CPU not in isolated CPUs.
+
+The returned CPU core is then used to set the `runc init` CPU affinity before
+the container cgroup cpuset transition.
+
+#### Transition example
+
+`nohz_full` has the isolated cores `4-7`. A container has been created with
+the cgroup cpuset `4-7` to only run on the isolated CPU cores 4 to 7.
+`runc exec` is called by a process with CPU affinity set to `0-3`
+
+* with `temporary` transition:
+
+  runc exec (affinity 0-3) -> runc init (affinity 4) -> container process (affinity 4-7)
+
+* with `definitive` transition:
+
+  runc exec (affinity 0-3) -> runc init (affinity 4) -> container process (affinity 4)
+
+The difference between `temporary` and `definitive` is the container process
+affinity, `definitive` will constraint the container process to run on the
+first isolated CPU core of the cgroup cpuset, while `temporary` restore the
+CPU affinity to match the container cgroup cpuset.
+
+`definitive` transition might be helpful when `nohz_full` is used without
+`isolcpus` to avoid runc and container process to be a noisy neighbour for
+real-time applications.
+
+### How to use it with Kubernetes?
+
+Kubernetes doesn't manage container directly, instead it uses the Container Runtime
+Interface (CRI) to communicate with a software implementing this interface and responsible
+to manage the lifecycle of containers. There are popular CRI implementations like Containerd
+and CRI-O. Those implementations allows to pass pod annotations to the container runtime
+via the container runtime spec. Currently runc is the runtime used by default for both.
+
+#### Containerd configuration
+
+Containerd CRI uses runc by default but requires an extra step to pass the annotation to runc.
+You have to whitelist `org.opencontainers.runc.exec.isolated-cpu-affinity-transition` as a pod
+annotation allowed to be passed to the container runtime in `/etc/containerd/config.toml`:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name = "runc"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+      runtime_type = "io.containerd.runc.v2"
+      base_runtime_spec = "/etc/containerd/cri-base.json"
+      pod_annotations = ["org.opencontainers.runc.exec.isolated-cpu-affinity-transition"]
+```
+
+#### CRI-O configuration
+
+CRI-O doesn't require any extra step, however some annotations could be excluded by
+configuration.
+
+#### Pod deployment example
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-pod
+  annotations:
+    org.opencontainers.runc.exec.isolated-cpu-affinity-transition: "temporary"
+spec:
+  containers:
+  - name: demo
+    image: registry.com/demo:latest
+```

--- a/features.go
+++ b/features.go
@@ -68,6 +68,7 @@ var featuresCommand = cli.Command{
 				"bundle",
 				"org.systemd.property.", // prefix form
 				"org.criu.config",
+				"org.opencontainers.runc.exec.isolated-cpu-affinity-transition",
 			},
 		}
 

--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -71,4 +71,8 @@ type Manager interface {
 
 	// OOMKillCount reports OOM kill count for the cgroup.
 	OOMKillCount() (uint64, error)
+
+	// GetEffectiveCPUs returns the effective CPUs of the cgroup, an empty
+	// value means that the cgroups cpuset subsystem/controller is not enabled.
+	GetEffectiveCPUs() string
 }

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -262,4 +264,29 @@ func (m *Manager) OOMKillCount() (uint64, error) {
 	}
 
 	return c, err
+}
+
+func (m *Manager) GetEffectiveCPUs() string {
+	return GetEffectiveCPUs(m.Path("cpuset"), m.cgroups)
+}
+
+func GetEffectiveCPUs(cpusetPath string, cgroups *configs.Cgroup) string {
+	// Fast path.
+	if cgroups.CpusetCpus != "" {
+		return cgroups.CpusetCpus
+	} else if !strings.HasPrefix(cpusetPath, defaultCgroupRoot) {
+		return ""
+	}
+
+	// Iterates until it goes to the cgroup root path.
+	// It's required for containers in which cpuset controller
+	// is not enabled, in this case a parent cgroup is used.
+	for path := cpusetPath; path != defaultCgroupRoot; path = filepath.Dir(path) {
+		cpus, err := fscommon.GetCgroupParamString(path, "cpuset.effective_cpus")
+		if err == nil {
+			return cpus
+		}
+	}
+
+	return ""
 }

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 type parseError = fscommon.ParseError
@@ -32,6 +34,9 @@ func NewManager(config *configs.Cgroup, dirPath string) (*Manager, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// Clean path for safety.
+		dirPath = utils.CleanPath(dirPath)
 	}
 
 	m := &Manager{
@@ -315,4 +320,27 @@ func CheckMemoryUsage(dirPath string, r *configs.Resources) error {
 	}
 
 	return nil
+}
+
+func (m *Manager) GetEffectiveCPUs() string {
+	// Fast path.
+	if m.config.CpusetCpus != "" {
+		return m.config.CpusetCpus
+	} else if !strings.HasPrefix(m.dirPath, UnifiedMountpoint) {
+		return ""
+	}
+
+	// Iterates until it goes outside of the cgroup root path.
+	// It's required for containers in which cpuset controller
+	// is not enabled, in this case a parent cgroup is used.
+	outsidePath := filepath.Dir(UnifiedMountpoint)
+
+	for path := m.dirPath; path != outsidePath; path = filepath.Dir(path) {
+		cpus, err := fscommon.GetCgroupParamString(path, "cpuset.cpus.effective")
+		if err == nil {
+			return cpus
+		}
+	}
+
+	return ""
 }

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -411,3 +411,7 @@ func (m *LegacyManager) Exists() bool {
 func (m *LegacyManager) OOMKillCount() (uint64, error) {
 	return fs.OOMKillCount(m.Path("memory"))
 }
+
+func (m *LegacyManager) GetEffectiveCPUs() string {
+	return fs.GetEffectiveCPUs(m.Path("cpuset"), m.cgroups)
+}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -514,3 +514,7 @@ func (m *UnifiedManager) Exists() bool {
 func (m *UnifiedManager) OOMKillCount() (uint64, error) {
 	return m.fsMgr.OOMKillCount()
 }
+
+func (m *UnifiedManager) GetEffectiveCPUs() string {
+	return m.fsMgr.GetEffectiveCPUs()
+}

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -69,6 +69,10 @@ func (m *mockCgroupManager) GetFreezerState() (configs.FreezerState, error) {
 	return configs.Thawed, nil
 }
 
+func (m *mockCgroupManager) GetEffectiveCPUs() string {
+	return ""
+}
+
 type mockProcess struct {
 	_pid    int
 	started uint64

--- a/libcontainer/process_linux_test.go
+++ b/libcontainer/process_linux_test.go
@@ -1,0 +1,232 @@
+package libcontainer
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+)
+
+func TestIsolatedCPUAffinityTransition(t *testing.T) {
+	const isolatedCPUAffinityTransitionAnnotation = "org.opencontainers.runc.exec.isolated-cpu-affinity-transition"
+
+	noAffinity := -1
+	temporaryTransition := "temporary"
+	definitiveTransition := "definitive"
+
+	tests := []struct {
+		name                         string
+		testFS                       fs.FS
+		cpuset                       string
+		expectedErr                  bool
+		expectedAffinityCore         int
+		expectedDefinitiveTransition bool
+		annotations                  map[string]string
+	}{
+		{
+			name:   "no affinity",
+			cpuset: "0-15",
+			testFS: fstest.MapFS{
+				"sys/devices/system/cpu/nohz_full": &fstest.MapFile{Data: []byte("0-4\n")},
+			},
+			expectedAffinityCore:         noAffinity,
+			expectedDefinitiveTransition: false,
+		},
+		{
+			name:   "affinity match with temporary transition",
+			cpuset: "3-4",
+			testFS: fstest.MapFS{
+				"sys/devices/system/cpu/nohz_full": &fstest.MapFile{Data: []byte("0-4\n")},
+			},
+			expectedAffinityCore:         3,
+			expectedDefinitiveTransition: false,
+			annotations: map[string]string{
+				isolatedCPUAffinityTransitionAnnotation: temporaryTransition,
+			},
+		},
+		{
+			name:   "affinity match with temporary transition and nohz_full boot param",
+			cpuset: "3-4",
+			testFS: fstest.MapFS{
+				"proc/cmdline": &fstest.MapFile{Data: []byte("nohz_full=0-4\n")},
+			},
+			expectedAffinityCore:         3,
+			expectedDefinitiveTransition: false,
+			annotations: map[string]string{
+				isolatedCPUAffinityTransitionAnnotation: temporaryTransition,
+			},
+		},
+		{
+			name:   "affinity match with definitive transition",
+			cpuset: "3-4",
+			testFS: fstest.MapFS{
+				"sys/devices/system/cpu/nohz_full": &fstest.MapFile{Data: []byte("0-4\n")},
+			},
+			expectedAffinityCore:         3,
+			expectedDefinitiveTransition: true,
+			annotations: map[string]string{
+				isolatedCPUAffinityTransitionAnnotation: definitiveTransition,
+			},
+		},
+		{
+			name:   "affinity match with definitive transition and nohz_full boot param",
+			cpuset: "3-4",
+			testFS: fstest.MapFS{
+				"proc/cmdline": &fstest.MapFile{Data: []byte("nohz_full=0-4\n")},
+			},
+			expectedAffinityCore:         3,
+			expectedDefinitiveTransition: true,
+			annotations: map[string]string{
+				isolatedCPUAffinityTransitionAnnotation: definitiveTransition,
+			},
+		},
+		{
+			name:   "affinity error with bad isolated set",
+			cpuset: "0-15",
+			testFS: fstest.MapFS{
+				"sys/devices/system/cpu/nohz_full": &fstest.MapFile{Data: []byte("bad_isolated_set\n")},
+			},
+			expectedErr:          true,
+			expectedAffinityCore: noAffinity,
+			annotations: map[string]string{
+				isolatedCPUAffinityTransitionAnnotation: temporaryTransition,
+			},
+		},
+		{
+			name:   "affinity error with bad isolated set for nohz_full boot param",
+			cpuset: "0-15",
+			testFS: fstest.MapFS{
+				"proc/cmdline": &fstest.MapFile{Data: []byte("nohz_full=bad_isolated_set\n")},
+			},
+			expectedErr:          true,
+			expectedAffinityCore: noAffinity,
+			annotations: map[string]string{
+				isolatedCPUAffinityTransitionAnnotation: temporaryTransition,
+			},
+		},
+		{
+			name:   "no affinity with null isolated set value",
+			cpuset: "0-15",
+			testFS: fstest.MapFS{
+				"sys/devices/system/cpu/nohz_full": &fstest.MapFile{Data: []byte("(null)\n")},
+			},
+			expectedAffinityCore:         noAffinity,
+			expectedDefinitiveTransition: false,
+			annotations: map[string]string{
+				isolatedCPUAffinityTransitionAnnotation: temporaryTransition,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			affinityCore, definitive, err := isolatedCPUAffinityTransition(tt.testFS, tt.cpuset, tt.annotations)
+			if err != nil && !tt.expectedErr {
+				t.Fatalf("unexpected error: %s", err)
+			} else if err == nil && tt.expectedErr {
+				t.Fatalf("unexpected success")
+			} else if tt.expectedDefinitiveTransition != definitive {
+				t.Fatalf("expected reset affinity %t: got %t instead", tt.expectedDefinitiveTransition, definitive)
+			} else if tt.expectedAffinityCore != affinityCore {
+				t.Fatalf("expected affinity core %d: got %d instead", tt.expectedAffinityCore, affinityCore)
+			}
+		})
+	}
+}
+
+func TestGetEligibleCPU(t *testing.T) {
+	tests := []struct {
+		name                 string
+		cpuset               string
+		isolset              string
+		expectedErr          bool
+		expectedAffinityCore int
+		expectedEligible     bool
+	}{
+		{
+			name:             "no cpuset",
+			isolset:          "2-15,18-31,34-47",
+			expectedEligible: false,
+		},
+		{
+			name:             "no isolated set",
+			cpuset:           "0-15",
+			expectedEligible: false,
+		},
+		{
+			name:        "bad cpuset format",
+			cpuset:      "core0 to core15",
+			isolset:     "2-15,18-31,34-47",
+			expectedErr: true,
+		},
+		{
+			name:        "bad isolated set format",
+			cpuset:      "0-15",
+			isolset:     "core0 to core15",
+			expectedErr: true,
+		},
+		{
+			name:             "no eligible core",
+			cpuset:           "0-1,16-17,32-33",
+			isolset:          "2-15,18-31,34-47",
+			expectedEligible: false,
+		},
+		{
+			name:             "no eligible core inverted",
+			cpuset:           "2-15,18-31,34-47",
+			isolset:          "0-1,16-17,32-33",
+			expectedEligible: false,
+		},
+		{
+			name:                 "eligible core mixed",
+			cpuset:               "8-31",
+			isolset:              "2-15,18-31,34-47",
+			expectedEligible:     true,
+			expectedAffinityCore: 16,
+		},
+		{
+			name:                 "eligible core #4",
+			cpuset:               "4-7",
+			isolset:              "2-15,18-31,34-47",
+			expectedEligible:     true,
+			expectedAffinityCore: 4,
+		},
+		{
+			name:                 "eligible core #40",
+			cpuset:               "40-47",
+			isolset:              "2-15,18-31,34-47",
+			expectedEligible:     true,
+			expectedAffinityCore: 40,
+		},
+		{
+			name:                 "eligible core #24",
+			cpuset:               "24-31",
+			isolset:              "2-15,18-31,34-47",
+			expectedEligible:     true,
+			expectedAffinityCore: 24,
+		},
+		{
+			name:             "no eligible core small isolated set",
+			cpuset:           "60-63",
+			isolset:          "0-1",
+			expectedEligible: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			affinityCore, err := getEligibleCPU(tt.cpuset, tt.isolset)
+			eligible := affinityCore >= 0
+			if err != nil && !tt.expectedErr {
+				t.Fatalf("unexpected error: %s", err)
+			} else if err == nil && tt.expectedErr {
+				t.Fatalf("unexpected success")
+			} else if tt.expectedEligible && !eligible {
+				t.Fatalf("was expecting eligible core but no eligible core returned")
+			} else if !tt.expectedEligible && eligible {
+				t.Fatalf("was not expecting eligible core but got eligible core")
+			} else if tt.expectedEligible && tt.expectedAffinityCore != affinityCore {
+				t.Fatalf("expected affinity core %d: got %d instead", tt.expectedAffinityCore, affinityCore)
+			}
+		})
+	}
+}

--- a/libcontainer/system/kernelparam/lookup.go
+++ b/libcontainer/system/kernelparam/lookup.go
@@ -1,0 +1,41 @@
+package kernelparam
+
+import (
+	"io/fs"
+	"strings"
+)
+
+func runeFilter(c rune) bool {
+	return c < '!' || c > '~'
+}
+
+// LookupKernelBootParameters returns the selected kernel parameters specified
+// in the kernel command line. The parameters are returned as a map of key-value pairs.
+func LookupKernelBootParameters(rootFS fs.FS, lookupParameters ...string) (map[string]string, error) {
+	cmdline, err := fs.ReadFile(rootFS, "proc/cmdline")
+	if err != nil {
+		return nil, err
+	}
+
+	kernelParameters := make(map[string]string)
+	remaining := len(lookupParameters)
+
+	for _, parameter := range strings.FieldsFunc(string(cmdline), runeFilter) {
+		if remaining == 0 {
+			break
+		}
+		idx := strings.IndexByte(parameter, '=')
+		if idx == -1 {
+			continue
+		}
+		for _, lookupParam := range lookupParameters {
+			if lookupParam == parameter[:idx] {
+				kernelParameters[lookupParam] = parameter[idx+1:]
+				remaining--
+				break
+			}
+		}
+	}
+
+	return kernelParameters, nil
+}

--- a/libcontainer/system/kernelparam/lookup_test.go
+++ b/libcontainer/system/kernelparam/lookup_test.go
@@ -1,0 +1,60 @@
+package kernelparam
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestLookupKernelBootParameters(t *testing.T) {
+	for _, test := range []struct {
+		cmdline                  string
+		lookupParameters         []string
+		expectedKernelParameters map[string]string
+	}{
+		{
+			cmdline:          "root=/dev/sda1 ro console=ttyS0 console=tty0",
+			lookupParameters: []string{"root"},
+			expectedKernelParameters: map[string]string{
+				"root": "/dev/sda1",
+			},
+		},
+		{
+			cmdline:          "ro runc.kernel_parameter=a_value console=ttyS0 console=tty0",
+			lookupParameters: []string{"runc.kernel_parameter"},
+			expectedKernelParameters: map[string]string{
+				"runc.kernel_parameter": "a_value",
+			},
+		},
+		{
+			cmdline: "ro runc.kernel_parameter_a=value_a  runc.kernel_parameter_b=value_a:value_b",
+			lookupParameters: []string{
+				"runc.kernel_parameter_a",
+				"runc.kernel_parameter_b",
+			},
+			expectedKernelParameters: map[string]string{
+				"runc.kernel_parameter_a": "value_a",
+				"runc.kernel_parameter_b": "value_a:value_b",
+			},
+		},
+		{
+			cmdline:                  "root=/dev/sda1 ro console=ttyS0 console=tty0",
+			lookupParameters:         []string{"runc.kernel_parameter_a"},
+			expectedKernelParameters: map[string]string{},
+		},
+	} {
+		params, err := LookupKernelBootParameters(fstest.MapFS{
+			"proc/cmdline": &fstest.MapFile{Data: []byte(test.cmdline + "\n")},
+		}, test.lookupParameters...)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if len(params) != len(test.expectedKernelParameters) {
+			t.Fatalf("expected %d parameters, got %d", len(test.expectedKernelParameters), len(params))
+		}
+		for k, v := range test.expectedKernelParameters {
+			if params[k] != v {
+				t.Fatalf("expected parameter %s to be %s, got %s", k, v, params[k])
+			}
+		}
+	}
+}


### PR DESCRIPTION
This handles a corner case when joining a container having all the processes running exclusively on isolated CPU cores to force the kernel to schedule runc process on the first CPU core within the cgroups cpuset.

The introduction of the kernel commit
46a87b3851f0d6eb05e6d83d5c5a30df0eca8f76 has affected this deterministic scheduling behavior by distributing tasks across CPU cores within the cgroups cpuset. Some intensive real-time application are relying on this deterministic behavior and use the first CPU core to run a slow thread while other CPU cores are fully used by real-time threads with SCHED_FIFO policy. Such applications prevents runc process from joining a container when the runc process is randomly scheduled on a CPU core owned by a real-time thread.

* Fixes #3922 