### PR TITLE
Code refactor: remove a function scope variable err for psi stats

### DIFF
--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -91,3 +91,11 @@ func statCpu(dirPath string, stats *cgroups.Stats) error {
 	}
 	return nil
 }
+
+func statCpuPressure(dirPath string, stats *cgroups.Stats) error {
+	const file = "cpu.pressure"
+	var err error
+
+	stats.CpuStats.PSI, err = statPSI(dirPath, file)
+	return err
+}

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -115,14 +115,13 @@ func (m *Manager) GetStats() (*cgroups.Stats, error) {
 		errs = append(errs, err)
 	}
 	// PSI (since kernel 4.20).
-	var err error
-	if st.CpuStats.PSI, err = statPSI(m.dirPath, "cpu.pressure"); err != nil {
+	if err := statCpuPressure(m.dirPath, st); err != nil {
 		errs = append(errs, err)
 	}
-	if st.MemoryStats.PSI, err = statPSI(m.dirPath, "memory.pressure"); err != nil {
+	if err := statMemoryPressure(m.dirPath, st); err != nil {
 		errs = append(errs, err)
 	}
-	if st.BlkioStats.PSI, err = statPSI(m.dirPath, "io.pressure"); err != nil {
+	if err := statIoPressure(m.dirPath, st); err != nil {
 		errs = append(errs, err)
 	}
 	// hugetlb (since kernel 5.6)

--- a/libcontainer/cgroups/fs2/io.go
+++ b/libcontainer/cgroups/fs2/io.go
@@ -191,3 +191,11 @@ func statIo(dirPath string, stats *cgroups.Stats) error {
 	stats.BlkioStats = parsedStats
 	return nil
 }
+
+func statIoPressure(dirPath string, stats *cgroups.Stats) error {
+	const file = "io.pressure"
+	var err error
+
+	stats.BlkioStats.PSI, err = statPSI(dirPath, file)
+	return err
+}

--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -219,3 +219,11 @@ func statsFromMeminfo(stats *cgroups.Stats) error {
 
 	return nil
 }
+
+func statMemoryPressure(dirPath string, stats *cgroups.Stats) error {
+	const file = "memory.pressure"
+	var err error
+
+	stats.MemoryStats.PSI, err = statPSI(dirPath, file)
+	return err
+}


### PR DESCRIPTION
Address https://github.com/opencontainers/runc/pull/3900#discussion_r1262794812

I think it's unnecessary to add a function scope variable suddenly. We should keep the code style like other cgroup stats.
