### PR TITLE
Support for ID map mounts without userns

### DIFF
--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -436,8 +436,7 @@ func TestValidateIDMapMounts(t *testing.T) {
 			},
 		},
 		{
-			name:  "idmap mount without userns mappings",
-			isErr: true,
+			name: "idmap mount without userns mappings",
 			config: &configs.Config{
 				Mounts: []*configs.Mount{
 					{
@@ -451,8 +450,7 @@ func TestValidateIDMapMounts(t *testing.T) {
 			},
 		},
 		{
-			name:  "idmap mounts with different userns and mount mappings",
-			isErr: true,
+			name: "idmap mounts with different userns and mount mappings",
 			config: &configs.Config{
 				UIDMappings: mapping,
 				GIDMappings: mapping,
@@ -474,8 +472,7 @@ func TestValidateIDMapMounts(t *testing.T) {
 			},
 		},
 		{
-			name:  "idmap mounts with different userns and mount mappings",
-			isErr: true,
+			name: "idmap mounts with different userns and mount mappings",
 			config: &configs.Config{
 				UIDMappings: mapping,
 				GIDMappings: mapping,

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -23,6 +23,8 @@ const (
 	GidmapPathAttr   uint16 = 27289
 	MountSourcesAttr uint16 = 27290
 	IdmapSourcesAttr uint16 = 27291
+	IdmapUidmapAttr  uint16 = 27292
+	IdmapGidmapAttr  uint16 = 27293
 )
 
 type Int32msg struct {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -415,6 +415,10 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				return nil, err
 			}
 		}
+
+		config.UIDMappings = toConfigIDMap(spec.Linux.UIDMappings)
+		config.GIDMappings = toConfigIDMap(spec.Linux.GIDMappings)
+
 		config.MaskPaths = spec.Linux.MaskedPaths
 		config.ReadonlyPaths = spec.Linux.ReadonlyPaths
 		config.MountLabel = spec.Linux.MountLabel

--- a/tests/integration/idmap-with-userns.bats
+++ b/tests/integration/idmap-with-userns.bats
@@ -149,12 +149,12 @@ function teardown() {
 	[[ "${output}" == *"invalid mount"* ]]
 }
 
-@test "idmap mount with different mapping than userns fails" {
-	# Let's modify the containerID to be 1, instead of 0 as it is in the
-	# userns config.
-	update_config ' .mounts |= map((select(.source == "source-1/") | .uidMappings[0]["containerID"] = 1 ) // .)'
+@test "idmap mount with different mapping than userns" {
+	update_config ' .linux.uidMappings[0].hostID = 99999'
 
 	runc run test_debian
-	[ "$status" -eq 1 ]
-	[[ "${output}" == *"invalid mount"* ]]
+	[ "$status" -eq 0 ]
+	# We have 1 as UID as user ns first UID is 99999 and id map mount is 10000.
+	# We still have 0 as GID was did not modify it.
+	[[ "${output}" == *"=1=0="* ]]
 }

--- a/tests/integration/idmap.bats
+++ b/tests/integration/idmap.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	requires root
+	requires_kernel 5.12
+	requires_idmap_fs /tmp
+
+	setup_debian
+
+	# Prepare source folders for bind mount
+	mkdir -p source-{1,2}/
+	touch source-{1,2}/foo.txt
+
+	# Use other owner for source-2
+	chown 1:1 source-2/foo.txt
+
+	mkdir -p rootfs/{proc,sys,tmp}
+	mkdir -p rootfs/tmp/mount-{1,2}
+	mkdir -p rootfs/mnt/bind-mount-{1,2}
+
+	update_config ' .process.args += ["-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]
+		| .mounts += [
+					{
+						"source": "source-1/",
+						"destination": "/tmp/mount-1",
+						"options": ["bind"],
+						"uidMappings": [ {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						],
+						"gidMappings": [        {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						]
+					}
+				] '
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+@test "simple idmap mount" {
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=100000=100000="* ]]
+}
+
+@test "write to an idmap mount" {
+	# We need to change the config to permit UID 0 to write the mount id map.
+	update_config ' .process.args = ["sh", "-c", "touch /tmp/mount-1/bar && stat -c =%u=%g= /tmp/mount-1/bar"]
+		| .mounts |= map((select(.source == "source-1/") | .uidMappings[0].hostID = 0 | .gidMappings[0].hostID = 0) // .)'
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=0=0="* ]]
+}
+
+@test "idmap mount with propagation flag" {
+	update_config ' .process.args = ["sh", "-c", "findmnt -o PROPAGATION /tmp/mount-1"]'
+	# Add the shared option to the idmap mount
+	update_config ' .mounts |= map((select(.source == "source-1/") | .options += ["shared"]) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"shared"* ]]
+}
+
+@test "idmap mount with bind mount" {
+	update_config '   .mounts += [
+					{
+						"source": "source-2/",
+						"destination": "/tmp/mount-2",
+						"options": ["bind"]
+					}
+				] '
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=100000=100000="* ]]
+}
+
+@test "two idmap mounts with two bind mounts" {
+	update_config '   .process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt /tmp/mount-2/foo.txt"]
+			| .mounts += [
+					{
+						"source": "source-1/",
+						"destination": "/mnt/bind-mount-1",
+						"options": ["bind"]
+					},
+					{
+						"source": "source-2/",
+						"destination": "/mnt/bind-mount-2",
+						"options": ["bind"]
+					},
+					{
+						"source": "source-2/",
+						"destination": "/tmp/mount-2",
+						"options": ["bind"],
+						"uidMappings": [ {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						],
+						"gidMappings": [        {
+						                  "containerID": 0,
+						                  "hostID": 100000,
+						                  "size": 65536
+						                }
+						]
+					}
+				] '
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=100000=100000="* ]]
+	# source-2/ is owned by 1:1, so we expect this with the idmap mount too.
+	[[ "$output" == *"=100001=100001="* ]]
+}
+
+@test "idmap mount without gidMappings fails" {
+	update_config ' .mounts |= map((select(.source == "source-1/") | del(.gidMappings) ) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"invalid mount"* ]]
+}
+
+@test "idmap mount without uidMappings fails" {
+	update_config ' .mounts |= map((select(.source == "source-1/") | del(.uidMappings) ) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"invalid mount"* ]]
+}
+
+@test "idmap mount without bind fails" {
+	update_config ' .mounts |= map((select(.source == "source-1/") | .options = [""]) // .)'
+
+	runc run test_debian
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"invalid mount"* ]]
+}


### PR DESCRIPTION
Hi.


This PR improves the initial support for ID map mounts which was merged in #3717.
Now, it is possible to use ID map mounts without the need of having a user namespace.

Regarding the design, I added two new attribute to send the UID and GID mappings corresponding to the mount sources.
I would like to have your opinion on this.


Best regards and thank you in advance.