### PR TITLE
use the length of UIDMappings/GIDMappings to check whether empty or not

### DIFF
--- a/libcontainer/configs/config_linux.go
+++ b/libcontainer/configs/config_linux.go
@@ -13,7 +13,7 @@ var (
 // different when user namespaces are enabled.
 func (c Config) HostUID(containerId int) (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
-		if c.UIDMappings == nil {
+		if len(c.UIDMappings) == 0 {
 			return -1, errNoUIDMap
 		}
 		id, found := c.hostIDFromMapping(containerId, c.UIDMappings)
@@ -36,7 +36,7 @@ func (c Config) HostRootUID() (int, error) {
 // different when user namespaces are enabled.
 func (c Config) HostGID(containerId int) (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
-		if c.GIDMappings == nil {
+		if len(c.GIDMappings) == 0 {
 			return -1, errNoGIDMap
 		}
 		id, found := c.hostIDFromMapping(containerId, c.GIDMappings)


### PR DESCRIPTION
This is the follow-up to #3939 , Please see https://github.com/opencontainers/runc/pull/3939#discussion_r1269023899

As @thaJeztah and @fuweid indicated that `a nil slice has length 0`, so we can use the length of UIDMappings/GIDMappings to check whether it is an empty array or not.