### PR TITLE
contrib/fs-idmap: Minor cleanups

### DIFF
--- a/contrib/cmd/fs-idmap/fs-idmap.go
+++ b/contrib/cmd/fs-idmap/fs-idmap.go
@@ -16,7 +16,7 @@ func main() {
 	}
 
 	src := os.Args[1]
-	treeFD, err := unix.OpenTree(-1, src, uint(unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC|unix.AT_EMPTY_PATH|unix.AT_RECURSIVE))
+	treeFD, err := unix.OpenTree(unix.AT_FDCWD, src, uint(unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC|unix.AT_EMPTY_PATH))
 	if err != nil {
 		log.Fatalf("error calling open_tree %q: %v", src, err)
 	}
@@ -48,7 +48,7 @@ func main() {
 		Attr_set:  unix.MOUNT_ATTR_IDMAP,
 		Userns_fd: uint64(userNsFile.Fd()),
 	}
-	if err := unix.MountSetattr(treeFD, "", unix.AT_EMPTY_PATH|unix.AT_RECURSIVE, &attr); err != nil {
+	if err := unix.MountSetattr(treeFD, "", unix.AT_EMPTY_PATH, &attr); err != nil {
 		log.Fatalf("error calling mount_setattr: %v", err)
 	}
 }

--- a/contrib/cmd/fs-idmap/fs-idmap.go
+++ b/contrib/cmd/fs-idmap/fs-idmap.go
@@ -22,7 +22,7 @@ func main() {
 	}
 	defer unix.Close(treeFD)
 
-	cmd := exec.Command("/usr/bin/sleep", "5")
+	cmd := exec.Command("sleep", "5")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags:  syscall.CLONE_NEWUSER,
 		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: 65536, Size: 65536}},

--- a/contrib/cmd/fs-idmap/fs-idmap.go
+++ b/contrib/cmd/fs-idmap/fs-idmap.go
@@ -31,6 +31,10 @@ func main() {
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("failed to run the helper binary: %v", err)
 	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
 
 	path := fmt.Sprintf("/proc/%d/ns/user", cmd.Process.Pid)
 	var userNsFile *os.File

--- a/contrib/cmd/fs-idmap/fs-idmap.go
+++ b/contrib/cmd/fs-idmap/fs-idmap.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) != 2 {
 		log.Fatalf("usage: %s path_to_mount_set_attr", os.Args[0])
 	}
 


### PR DESCRIPTION
Here are some cleanups to the fs-idmap binary that we use in integration test to detect if a fs supports idmap mounts or not.

These are just minor cleanups, I'm not fixing any real bug we hit nor anything (I'm not aware of any).

cc @eiffel-fl