### PR TITLE
Fix some file mode bits missing when doing mount syscall

### DIFF
--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -1,6 +1,7 @@
 package libcontainer
 
 import (
+	"io/fs"
 	"strconv"
 
 	"golang.org/x/sys/unix"
@@ -102,4 +103,21 @@ func unmount(target string, flags int) error {
 		}
 	}
 	return nil
+}
+
+// syscallMode returns the syscall-specific mode bits from Go's portable mode bits.
+// Copy from https://cs.opensource.google/go/go/+/refs/tags/go1.20.7:src/os/file_posix.go;l=61-75
+func syscallMode(i fs.FileMode) (o uint32) {
+	o |= uint32(i.Perm())
+	if i&fs.ModeSetuid != 0 {
+		o |= unix.S_ISUID
+	}
+	if i&fs.ModeSetgid != 0 {
+		o |= unix.S_ISGID
+	}
+	if i&fs.ModeSticky != 0 {
+		o |= unix.S_ISVTX
+	}
+	// No mapping for Go's ModeTemporary (plan9 only).
+	return
 }

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -462,7 +462,7 @@ func mountToRootfs(c *mountConfig, m mountEntry) error {
 				return err
 			}
 		} else {
-			dt := fmt.Sprintf("mode=%04o", stat.Mode())
+			dt := fmt.Sprintf("mode=%04o", syscallMode(stat.Mode()))
 			if m.Data != "" {
 				dt = dt + "," + m.Data
 			}

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -77,6 +77,22 @@ function teardown() {
 	[[ "${lines[0]}" == *'mydomainname'* ]]
 }
 
+# https://github.com/opencontainers/runc/issues/3952
+@test "runc run with tmpfs" {
+	requires root
+
+	chmod 'a=rwx,ug+s,+t' rootfs/tmp # set all bits
+	mode=$(stat -c %A rootfs/tmp)
+
+	# shellcheck disable=SC2016
+	update_config '.process.args = ["sh", "-c", "stat -c %A /tmp"]'
+	update_config '.mounts += [{"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options":["noexec","nosuid","nodev","rprivate"]}]'
+
+	runc run test_tmpfs
+	[ "$status" -eq 0 ]
+	[ "$output" = "$mode" ]
+}
+
 @test "runc run with tmpfs perms" {
 	# shellcheck disable=SC2016
 	update_config '.process.args = ["sh", "-c", "stat -c %a /tmp/test"]'


### PR DESCRIPTION
Fix #3952

When we call `unix.Mount`, if we use file mode bits from the bits with the type `fs.FileMode` directly, it will cause some bits missing.

Please refer: https://github.com/golang/go/blob/master/src/os/file.go#L258-L265 