### PR TITLE
[1.1] Update github actions packages in validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,7 +89,7 @@ jobs:
           sha256sum ~/bin/shellcheck | grep -q $SHA256SUM
           # make sure to remove the old version
           sudo rm -f /usr/bin/shellcheck
-      - uses: lumaxis/shellcheck-problem-matchers@v1
+      - uses: lumaxis/shellcheck-problem-matchers@v2
       - name: shellcheck
         run: |
           make shellcheck
@@ -176,7 +176,7 @@ jobs:
     - name: make releaseall
       run: make releaseall
     - name: upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-${{ github.run_id }}
         path: release/*


### PR DESCRIPTION
Resolve nodejs 12 deprecation warnings by updating `lumaxis/shellcheck-problem-matchers` and `actions/upload-artifact`. 

Ref: [https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

Last validation run : https://github.com/opencontainers/runc/actions/runs/5600058896