### PR TITLE
Fix running tests under Docker/Podman and cgroup v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,3 +63,7 @@ ENV PKG_CONFIG_PATH=/opt/libseccomp/lib/pkgconfig
 RUN git config --global --add safe.directory /go/src/github.com/opencontainers/runc
 
 WORKDIR /go/src/github.com/opencontainers/runc
+
+# Fixup for cgroup v2.
+COPY script/prepare-cgroup-v2.sh /
+ENTRYPOINT [ "/prepare-cgroup-v2.sh" ]

--- a/libcontainer/cgroups/file_test.go
+++ b/libcontainer/cgroups/file_test.go
@@ -58,8 +58,6 @@ func TestOpenat2(t *testing.T) {
 		{"/sys/fs/cgroup", "/cgroup.controllers"},
 		{"/sys/fs/cgroup/", "cgroup.controllers"},
 		{"/sys/fs/cgroup/", "/cgroup.controllers"},
-		{"/sys/fs/cgroup/user.slice", "cgroup.controllers"},
-		{"/sys/fs/cgroup/user.slice/", "/cgroup.controllers"},
 		{"/", "/sys/fs/cgroup/cgroup.controllers"},
 		{"/", "sys/fs/cgroup/cgroup.controllers"},
 		{"/sys/fs/cgroup/cgroup.controllers", ""},

--- a/libcontainer/cgroups/manager/manager_test.go
+++ b/libcontainer/cgroups/manager/manager_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -10,35 +11,45 @@ import (
 // config.Resources is nil. While it does not make sense to use a
 // manager with no resources, it should not result in a panic.
 //
-// This tests either v1 or v2 managers (both fs and systemd),
-// depending on what cgroup version is available on the host.
+// This tests either v1 or v2 fs cgroup manager, depending on which
+// cgroup version is available.
 func TestNilResources(t *testing.T) {
-	for _, sd := range []bool{false, true} {
-		cg := &configs.Cgroup{} // .Resources is nil
-		cg.Systemd = sd
-		mgr, err := New(cg)
-		if err != nil {
-			// Some managers require non-nil Resources during
-			// instantiation -- provide and retry. In such case
-			// we're mostly testing Set(nil) below.
-			cg.Resources = &configs.Resources{}
-			mgr, err = New(cg)
-			if err != nil {
-				t.Error(err)
-				continue
-			}
-		}
-		_ = mgr.Apply(-1)
-		_ = mgr.Set(nil)
-		_ = mgr.Freeze(configs.Thawed)
-		_ = mgr.Exists()
-		_, _ = mgr.GetAllPids()
-		_, _ = mgr.GetCgroups()
-		_, _ = mgr.GetFreezerState()
-		_ = mgr.Path("")
-		_ = mgr.GetPaths()
-		_, _ = mgr.GetStats()
-		_, _ = mgr.OOMKillCount()
-		_ = mgr.Destroy()
+	testNilResources(t, false)
+}
+
+// TestNilResourcesSystemd is the same as TestNilResources,
+// only checking the systemd cgroup manager.
+func TestNilResourcesSystemd(t *testing.T) {
+	if !systemd.IsRunningSystemd() {
+		t.Skip("requires systemd")
 	}
+	testNilResources(t, true)
+}
+
+func testNilResources(t *testing.T, systemd bool) {
+	cg := &configs.Cgroup{} // .Resources is nil
+	cg.Systemd = systemd
+	mgr, err := New(cg)
+	if err != nil {
+		// Some managers require non-nil Resources during
+		// instantiation -- provide and retry. In such case
+		// we're mostly testing Set(nil) below.
+		cg.Resources = &configs.Resources{}
+		mgr, err = New(cg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = mgr.Apply(-1)
+	_ = mgr.Set(nil)
+	_ = mgr.Freeze(configs.Thawed)
+	_ = mgr.Exists()
+	_, _ = mgr.GetAllPids()
+	_, _ = mgr.GetCgroups()
+	_, _ = mgr.GetFreezerState()
+	_ = mgr.Path("")
+	_ = mgr.GetPaths()
+	_, _ = mgr.GetStats()
+	_, _ = mgr.OOMKillCount()
+	_ = mgr.Destroy()
 }

--- a/script/prepare-cgroup-v2.sh
+++ b/script/prepare-cgroup-v2.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This script is used from ../Dockerfile as the ENTRYPOINT. It sets up cgroup
+# delegation for cgroup v2 to make sure runc tests can be properly run inside
+# a container.
+
+# Only do this for cgroup v2.
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	set -x
+	# Move the current process to a sub-cgroup.
+	mkdir /sys/fs/cgroup/init
+	echo 0 >/sys/fs/cgroup/init/cgroup.procs
+	# Enable all controllers.
+	sed 's/\b\w/+\0/g' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+fi
+
+exec "$@"

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -854,5 +854,5 @@ EOF
 	# The container will be OOM killed, and runc might either succeed
 	# or fail depending on the timing, so we don't check its exit code.
 	runc update test_update --memory 1024
-	testcontainer test_update stopped
+	wait_for_container 10 1 test_update stopped
 }


### PR DESCRIPTION
For "make integration", the tests are run inside a Docker/Podman container. Problem is, if cgroup v2 is used, the in-container /sys/fs/cgroup/cgroup.subtree_control is empty.

The added script, used as Docker entrypoint, moves the current process into a sub-cgroup, and then adds all controllers in top-level cgroup.subtree_control.

Addresses https://github.com/opencontainers/runc/issues/3955