### PR TITLE
[1.1] Fix some file mode bits missing when doing mount syscall

### DIFF
--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -1,6 +1,7 @@
 package libcontainer
 
 import (
+	"io/fs"
 	"strconv"
 
 	"golang.org/x/sys/unix"
@@ -80,4 +81,21 @@ func unmount(target string, flags int) error {
 		}
 	}
 	return nil
+}
+
+// syscallMode returns the syscall-specific mode bits from Go's portable mode bits.
+// Copy from https://cs.opensource.google/go/go/+/refs/tags/go1.20.7:src/os/file_posix.go;l=61-75
+func syscallMode(i fs.FileMode) (o uint32) {
+	o |= uint32(i.Perm())
+	if i&fs.ModeSetuid != 0 {
+		o |= unix.S_ISUID
+	}
+	if i&fs.ModeSetgid != 0 {
+		o |= unix.S_ISGID
+	}
+	if i&fs.ModeSticky != 0 {
+		o |= unix.S_ISVTX
+	}
+	// No mapping for Go's ModeTemporary (plan9 only).
+	return
 }

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -464,7 +464,7 @@ func mountToRootfs(m *configs.Mount, c *mountConfig) error {
 				return err
 			}
 		} else {
-			dt := fmt.Sprintf("mode=%04o", stat.Mode())
+			dt := fmt.Sprintf("mode=%04o", syscallMode(stat.Mode()))
 			if m.Data != "" {
 				dt = dt + "," + m.Data
 			}


### PR DESCRIPTION
This the backport of #3956 to `release-1.1`, the original description is:

---
Fix #3952

When we call `unix.Mount`, if we use file mode bits from the bits with the type `fs.FileMode` directly, it will cause some bits missing.

Please refer: https://github.com/golang/go/blob/master/src/os/file.go#L258-L265 

---
More details: https://www.gnu.org/software/coreutils/manual/html_node/Mode-Structure.html