### PR TITLE
Revert "libct/validator: Error out on non-abs paths"

### DIFF
--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -360,10 +360,11 @@ func TestValidateMounts(t *testing.T) {
 		isErr bool
 		dest  string
 	}{
-		{isErr: true, dest: "not/an/abs/path"},
-		{isErr: true, dest: "./rel/path"},
-		{isErr: true, dest: "./rel/path"},
-		{isErr: true, dest: "../../path"},
+		// TODO (runc v1.x.x): make these relative paths an error. See https://github.com/opencontainers/runc/pull/3004
+		{isErr: false, dest: "not/an/abs/path"},
+		{isErr: false, dest: "./rel/path"},
+		{isErr: false, dest: "./rel/path"},
+		{isErr: false, dest: "../../path"},
 
 		{isErr: false, dest: "/abs/path"},
 		{isErr: false, dest: "/abs/but/../unclean"},
@@ -514,8 +515,7 @@ func TestValidateIDMapMounts(t *testing.T) {
 			},
 		},
 		{
-			name:  "idmap mounts without abs dest path",
-			isErr: true,
+			name: "idmap mounts without abs dest path",
 			config: &configs.Config{
 				UIDMappings: mapping,
 				GIDMappings: mapping,
@@ -530,7 +530,6 @@ func TestValidateIDMapMounts(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "simple idmap mount",
 			config: &configs.Config{
@@ -571,7 +570,7 @@ func TestValidateIDMapMounts(t *testing.T) {
 			config := tc.config
 			config.Rootfs = "/var"
 
-			err := mounts(config)
+			err := mountsStrict(config)
 			if tc.isErr && err == nil {
 				t.Error("expected error, got nil")
 			}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -485,7 +485,7 @@ func mountToRootfs(c *mountConfig, m mountEntry) error {
 			if m.srcFD == nil {
 				return fmt.Errorf("error creating mount %+v: idmapFD is invalid, should point to a valid fd", m)
 			}
-			if err := unix.MoveMount(*m.srcFD, "", -1, dest, unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
+			if err := unix.MoveMount(*m.srcFD, "", unix.AT_FDCWD, dest, unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
 				return fmt.Errorf("error on unix.MoveMount %+v: %w", m, err)
 			}
 

--- a/tests/integration/idmap.bats
+++ b/tests/integration/idmap.bats
@@ -72,6 +72,14 @@ function teardown() {
 	[[ "$output" == *"shared"* ]]
 }
 
+@test "idmap mount with relative path" {
+	update_config ' .mounts |= map((select(.source == "source-1/") | .destination = "tmp/mount-1") // .)'
+
+	runc run test_debian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"=0=0="* ]]
+}
+
 @test "idmap mount with bind mount" {
 	update_config '   .mounts += [
 					{


### PR DESCRIPTION
As [discussed here](https://github.com/opencontainers/runc/issues/3944#issuecomment-1669297461) it seems safer, at least for now, to revert the error and continue to throw a warning.

---

This reverts commit 881e92a3fd5eeef80bac57efbb1c822deed4f895 and adjust the code so the idmap validations are strict.

Fixes: #3944 
Updates: #3020 (There is no way to re-open it automatically, can someone re-open it?)