### PR TITLE
ci/gha: re-enable go caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,6 @@ jobs:
     - name: install go ${{ matrix.go-version }}
       uses: actions/setup-go@v4
       with:
-        cache: false # https://github.com/actions/setup-go/issues/368
         go-version: ${{ matrix.go-version }}
 
     - name: build


### PR DESCRIPTION
Since https://github.com/actions/setup-go/issues/368 is now fixed (in https://github.com/actions/setup-go/releases/tag/v4.1.0), there is no need to disable caching when using different distros.