### PR TITLE
cirrus: lower limits to avoid exhausting monthly limits

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,10 +24,10 @@ task:
     image: family/docker-kvm
     platform: linux
     nested_virtualization: true
-    # CPU limit: `16 / NTASK`: see https://cirrus-ci.org/faq/#are-there-any-limits
-    cpu: 4
-    # Memory limit: `4GB * NCPU`
-    memory: 16G
+    # We need to limit this as much as possible to avoid going over the new monthly limits.
+    # <https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/>
+    cpu: 1
+    memory: 2G
 
   host_info_script: |
     uname -a


### PR DESCRIPTION
We might move away from cirrus to avoid hitting these limits, but for now we can easily limit the amount of resources we use. Looking at the graphs of past runs, it seems we usually use ~1 CPU and <2GB of RAM.

> Starting September 1st 2023, there will be an upper monthly limit on free usage equal to 50 compute credits (which is equal to a little over 16,000 CPU-minutes for Linux tasks).

Ref: https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>