### PR TITLE
timens: minor cleanups

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -120,6 +120,10 @@ func namespaces(config *configs.Config) error {
 		if _, err := os.Stat("/proc/self/timens_offsets"); os.IsNotExist(err) {
 			return errors.New("time namespaces aren't enabled in the kernel")
 		}
+	} else {
+		if config.TimeOffsets != nil {
+			return errors.New("time namespace offsets specified, but time namespace isn't enabled in the config")
+		}
 	}
 
 	return nil

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1192,7 +1192,7 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 	}
 
 	// write boottime and monotonic time ns offsets.
-	if c.config.Namespaces.Contains(configs.NEWTIME) && c.config.TimeOffsets != nil {
+	if c.config.TimeOffsets != nil {
 		var offsetSpec bytes.Buffer
 		for clock, offset := range c.config.TimeOffsets {
 			fmt.Fprintf(&offsetSpec, "%s %d %d\n", clock, offset.Secs, offset.Nanosecs)

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -422,6 +422,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		config.ReadonlyPaths = spec.Linux.ReadonlyPaths
 		config.MountLabel = spec.Linux.MountLabel
 		config.Sysctl = spec.Linux.Sysctl
+		config.TimeOffsets = spec.Linux.TimeOffsets
 		if spec.Linux.Seccomp != nil {
 			seccomp, err := SetupSeccomp(spec.Linux.Seccomp)
 			if err != nil {
@@ -436,9 +437,6 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				MemBwSchema:   spec.Linux.IntelRdt.MemBwSchema,
 			}
 		}
-
-		// update timens offsets
-		config.TimeOffsets = spec.Linux.TimeOffsets
 	}
 
 	// Set the host UID that should own the container's cgroup.

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -429,6 +429,11 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		timens)
+			if [ ! -e "/proc/self/ns/time" ]; then
+				skip_me=1
+			fi
+			;;
 		cgroups_v1)
 			init_cgroup_paths
 			if [ ! -v CGROUP_V1 ]; then

--- a/tests/integration/timens.bats
+++ b/tests/integration/timens.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_busybox
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+@test "runc run [timens offsets with no timens]" {
+	requires timens
+
+	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
+	update_config '.linux.namespaces = .linux.namespace | map(select(.type != "time"))'
+	update_config '.linux.timeOffsets = {
+			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
+			"boottime": { "secs": 1337, "nanosecs": 3141519 }
+		}'
+
+	runc run test_busybox
+	[ "$status" -ne 0 ]
+}
+
+@test "runc run [timens with no offsets]" {
+	requires timens
+
+	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
+	update_config '.linux.namespaces += [{"type": "time"}]
+		| .linux.timeOffsets = null'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	# Default offsets are 0.
+	grep -E '^monotonic\s+0\s+0$' <<<"$output"
+	grep -E '^boottime\s+0\s+0$' <<<"$output"
+}
+
+@test "runc run [simple timens]" {
+	requires timens
+
+	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
+	update_config '.linux.namespaces += [{"type": "time"}]
+		| .linux.timeOffsets = {
+			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
+			"boottime": { "secs": 1337, "nanosecs": 3141519 }
+		}'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
+	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
+}


### PR DESCRIPTION
Fix up a few things that were flagged in the review of [the original timens PR](https://github.com/opencontainers/runc/pull/3876), namely around error handling and validation. In addition, add some basic smoke tests for timens.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>