### PR TITLE
[Proposal] Use runc-dmz to defeat CVE-2019-5736

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,12 @@ endif
 
 .DEFAULT: runc
 
-runc:
+runc: runc-dmz runc-bin
+
+runc-dmz:
+	$(CC) -o runc-dmz -static contrib/cmd/runc-dmz/runc-dmz.c
+
+runc-bin:
 	$(GO_BUILD) -o runc .
 
 all: runc recvtty sd-helper seccompagent fs-idmap

--- a/contrib/cmd/runc-dmz/runc-dmz.c
+++ b/contrib/cmd/runc-dmz/runc-dmz.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+
+extern char **environ;
+
+int main(int argv, char **args)
+{
+    if (argv > 0) {
+        return execve(args[0], args, environ);
+    }
+    return 0;
+}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -492,6 +492,7 @@ func (c *Container) commandTemplate(p *Process, childInitPipe *os.File, childLog
 	cmd.Env = append(cmd.Env,
 		"_LIBCONTAINER_INITPIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
 		"_LIBCONTAINER_STATEDIR="+c.root,
+		"_LIBCONTAINER_DMZFD=-1",
 	)
 
 	cmd.ExtraFiles = append(cmd.ExtraFiles, childLogPipe)

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -27,6 +27,16 @@ func init() {
 	// Figure out path to get-images.sh. Note it won't work
 	// in case the compiled test binary is moved elsewhere.
 	_, ex, _, _ := runtime.Caller(0)
+	// make and copy runc-dmg
+	rootDir, err := filepath.Abs(filepath.Join(filepath.Dir(ex), "..", ".."))
+	if err != nil {
+		panic(err)
+	}
+	nowPath := getExeDir()
+	dmzMake, err := exec.Command("gcc", "-o", filepath.Join(nowPath, "integration.test-dmz"), "-static", filepath.Join(rootDir, "contrib/cmd/runc-dmz/runc-dmz.c")).CombinedOutput()
+	if err != nil {
+		panic(fmt.Errorf("make runc-dmz error %w (output: %s)", err, dmzMake))
+	}
 	getImages, err := filepath.Abs(filepath.Join(filepath.Dir(ex), "..", "..", "tests", "integration", "get-images.sh"))
 	if err != nil {
 		panic(err)
@@ -46,6 +56,15 @@ func init() {
 	if _, err := os.Stat(busyboxTar); err != nil {
 		panic(err)
 	}
+}
+
+func getExeDir() string {
+	exePath, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	res, _ := filepath.EvalSymlinks(filepath.Dir(exePath))
+	return res
 }
 
 func ptrInt(v int) *int {

--- a/libcontainer/nsenter/cloned_binary.c
+++ b/libcontainer/nsenter/cloned_binary.c
@@ -132,7 +132,7 @@ int memfd_create(const char *name, unsigned int flags)
 #endif
 
 #define CLONED_BINARY_ENV "_LIBCONTAINER_CLONED_BINARY"
-#define RUNC_MEMFD_COMMENT "runc_cloned:/proc/self/exe"
+#define RUNC_MEMFD_COMMENT "runc_cloned:runc-dmz"
 /*
  * There are newer memfd seals (such as F_SEAL_FUTURE_WRITE and F_SEAL_EXEC),
  * which we use opportunistically. However, this set is the original set of
@@ -141,162 +141,6 @@ int memfd_create(const char *name, unsigned int flags)
  */
 #define RUNC_MEMFD_MIN_SEALS \
 	(F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE)
-
-static void *must_realloc(void *ptr, size_t size)
-{
-	void *old = ptr;
-	do {
-		ptr = realloc(old, size);
-	} while (!ptr);
-	return ptr;
-}
-
-/*
- * Verify whether we are currently in a self-cloned program (namely, is
- * /proc/self/exe a memfd). F_GET_SEALS will only succeed for memfds (or rather
- * for shmem files), and we want to be sure it's actually sealed.
- */
-static int is_self_cloned(void)
-{
-	int fd, seals = 0, is_cloned = false;
-	struct stat statbuf = { };
-	struct statfs fsbuf = { };
-
-	fd = open("/proc/self/exe", O_RDONLY | O_CLOEXEC);
-	if (fd < 0) {
-		write_log(ERROR, "cannot open runc binary for reading: open /proc/self/exe: %m");
-		return -ENOTRECOVERABLE;
-	}
-
-	/*
-	 * Is the binary a fully-sealed memfd? We don't need CLONED_BINARY_ENV for
-	 * this, because you cannot write to a sealed memfd no matter what.
-	 */
-	seals = fcntl(fd, F_GET_SEALS);
-	if (seals >= 0) {
-		write_log(DEBUG, "checking /proc/self/exe memfd seals: 0x%x", seals);
-		is_cloned = (seals & RUNC_MEMFD_MIN_SEALS) == RUNC_MEMFD_MIN_SEALS;
-		if (is_cloned)
-			goto out;
-	}
-
-	/*
-	 * All other forms require CLONED_BINARY_ENV, since they are potentially
-	 * writeable (or we can't tell if they're fully safe) and thus we must
-	 * check the environment as an extra layer of defence.
-	 */
-	if (!getenv(CLONED_BINARY_ENV)) {
-		is_cloned = false;
-		goto out;
-	}
-
-	/*
-	 * Is the binary on a read-only filesystem? We can't detect bind-mounts in
-	 * particular (in-kernel they are identical to regular mounts) but we can
-	 * at least be sure that it's read-only. In addition, to make sure that
-	 * it's *our* bind-mount we check CLONED_BINARY_ENV.
-	 */
-	if (fstatfs(fd, &fsbuf) >= 0)
-		is_cloned |= (fsbuf.f_flags & MS_RDONLY);
-
-	/*
-	 * Okay, we're a tmpfile -- or we're currently running on RHEL <=7.6
-	 * which appears to have a borked backport of F_GET_SEALS. Either way,
-	 * having a file which has no hardlinks indicates that we aren't using
-	 * a host-side "runc" binary and this is something that a container
-	 * cannot fake (because unlinking requires being able to resolve the
-	 * path that you want to unlink).
-	 */
-	if (fstat(fd, &statbuf) >= 0)
-		is_cloned |= (statbuf.st_nlink == 0);
-
-out:
-	close(fd);
-	return is_cloned;
-}
-
-/* Read a given file into a new buffer, and providing the length. */
-static char *read_file(char *path, size_t *length)
-{
-	int fd;
-	char buf[4096], *copy = NULL;
-
-	if (!length)
-		return NULL;
-
-	fd = open(path, O_RDONLY | O_CLOEXEC);
-	if (fd < 0)
-		return NULL;
-
-	*length = 0;
-	for (;;) {
-		ssize_t n;
-
-		n = read(fd, buf, sizeof(buf));
-		if (n < 0)
-			goto error;
-		if (!n)
-			break;
-
-		copy = must_realloc(copy, (*length + n) * sizeof(*copy));
-		memcpy(copy + *length, buf, n);
-		*length += n;
-	}
-	close(fd);
-	return copy;
-
-error:
-	close(fd);
-	free(copy);
-	return NULL;
-}
-
-/*
- * A poor-man's version of "xargs -0". Basically parses a given block of
- * NUL-delimited data, within the given length and adds a pointer to each entry
- * to the array of pointers.
- */
-static int parse_xargs(char *data, int data_length, char ***output)
-{
-	int num = 0;
-	char *cur = data;
-
-	if (!data || *output != NULL)
-		return -1;
-
-	while (cur < data + data_length) {
-		num++;
-		*output = must_realloc(*output, (num + 1) * sizeof(**output));
-		(*output)[num - 1] = cur;
-		cur += strlen(cur) + 1;
-	}
-	(*output)[num] = NULL;
-	return num;
-}
-
-/*
- * "Parse" out argv from /proc/self/cmdline.
- * This is necessary because we are running in a context where we don't have a
- * main() that we can just get the arguments from.
- */
-static int fetchve(char ***argv)
-{
-	char *cmdline = NULL;
-	size_t cmdline_size;
-
-	cmdline = read_file("/proc/self/cmdline", &cmdline_size);
-	if (!cmdline)
-		goto error;
-
-	if (parse_xargs(cmdline, cmdline_size, argv) <= 0)
-		goto error;
-
-	return 0;
-
-error:
-	free(cmdline);
-	return -EINVAL;
-}
 
 enum {
 	EFD_NONE = 0,
@@ -499,12 +343,20 @@ static int clone_binary(void)
 	struct stat statbuf = { };
 	size_t sent = 0;
 	int fdtype = EFD_NONE;
+	char runcpath[PATH_MAX] = { 0 };
+	char dmzpath[PATH_MAX] = { 0 };
 
 	execfd = make_execfd(&fdtype);
 	if (execfd < 0 || fdtype == EFD_NONE)
 		return -ENOTRECOVERABLE;
 
-	binfd = open("/proc/self/exe", O_RDONLY | O_CLOEXEC);
+	if (readlink("/proc/self/exe", runcpath, PATH_MAX) < 1)
+		goto error;
+
+	if (snprintf(dmzpath, PATH_MAX, "%s%s", runcpath, "-dmz") < 0)
+		goto error;
+
+	binfd = open(dmzpath, O_RDONLY | O_CLOEXEC);
 	if (binfd < 0)
 		goto error;
 
@@ -543,24 +395,19 @@ extern char **environ;
 int ensure_cloned_binary(void)
 {
 	int execfd;
-	char **argv = NULL;
-
-	/* Check that we're not self-cloned, and if we are then bail. */
-	int cloned = is_self_cloned();
-	if (cloned > 0 || cloned == -ENOTRECOVERABLE)
-		return cloned;
-
-	if (fetchve(&argv) < 0)
-		return -EINVAL;
 
 	execfd = clone_binary();
 	if (execfd < 0)
 		return -EIO;
 
-	if (putenv(CLONED_BINARY_ENV "=1"))
+	char envString[PATH_MAX] = { 0 };
+	if (sprintf(envString, "%d", execfd) < 0)
 		goto error;
 
-	fexecve(execfd, argv, environ);
+	if (setenv("_LIBCONTAINER_DMZFD", envString, 1))
+		goto error;
+
+	return 0;
 error:
 	close(execfd);
 	return -ENOEXEC;

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -24,6 +24,7 @@ type linuxStandardInit struct {
 	consoleSocket *os.File
 	parentPid     int
 	fifoFd        int
+	dmzFd         int
 	logFd         int
 	mountFds      mountFds
 	config        *initConfig
@@ -262,5 +263,10 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	return system.Exec(name, l.config.Args[0:], os.Environ())
+	entryPoint, err := exec.LookPath(l.config.Args[0])
+	if err != nil {
+		return err
+	}
+	dmzArgs := []string{entryPoint}
+	return system.Fexecve(uintptr(l.dmzFd), append(dmzArgs, l.config.Args[1:]...), os.Environ())
 }


### PR DESCRIPTION
Close: #3973 

For CVE-2019-5736, we have to make sure we can't write the original runc binary from a container.
So we use `memfd_create` to load `runc` to the memory and seal it. But the size of `runc` binary file is about 13M, if we concreate lots of containers in a short period, it will eat host's memory.

We want to reduce the size of `runc` binary file, but it's very diffculty.
There is another way, before the container's entrypoint start, if we can't see `runc`, then there is no need to protect runc. So we need to make runc exit before the container task start. The only way is to replace it with an other process, we call it `runc-dmz`, it means a temp zone between `runc` and `container`.

The runc-dmz is very simple:
```c
#include <unistd.h>

extern char **environ;

int main(int argv, char **args) {
    if (argv > 0) {
        return execve(args[0], args, environ);
    }
    return 0;
}
```
We can make it as a static binary, the size is 852kb.
I think 852kb is more smaller than 14mb, so it will save many memory when concreating lots of container at a time.

But I don't know whether it will cause some other problems.