### PR TITLE
ci/gha: add job timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   test:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +114,7 @@ jobs:
   # We are not interested in providing official support for i386.
   cross-i386:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,7 @@ jobs:
       run: make validate-keyring
 
   lint:
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -159,6 +160,7 @@ jobs:
 
 
   release:
+    timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
     - name: checkout


### PR DESCRIPTION
The default timeout is 360 minutes, which is way long for these jobs. If the CI (or a test) has stuck, we'd better know about it earlier than in 6 hours.

Set the timeouts for some [relatively] long running jobs conservatively:
 - test and release jobs usually take ~10 minutes;
 - lint job takes 1 minute (but can be a few times slower when we switch Go or golangci-lint version);
 - cross-386 job takes about 2 minutes;
 - the rest is seconds (and I am lazy to set timeouts everywhere).
 
 Inspired by #3953/#3982.