### PR TITLE
Fix ossfuzz building script

### DIFF
--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -8,6 +8,25 @@
 # OSS-fuzz environment.
 # More info about compile_go_fuzzer() can be found here:
 #     https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
+set -o nounset
+set -o pipefail
+set -o errexit
+set -x
+
+# specifiy go version
+apt-get update && apt-get install -y wget
+cd $SRC
+
+wget --quiet https://go.dev/dl/go1.21.0.linux-amd64.tar.gz
+mkdir tmp-go
+rm -rf /root/.go/*
+tar -C tmp-go/ -xzf go1.21.0.linux-amd64.tar.gz
+mv tmp-go/go/* /root/.go/
+
+# supporting cncf-fuzzing
+cd $SRC/runc
+go mod tidy
+
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/userns FuzzUIDMap id_map_fuzzer linux,gofuzz
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/user FuzzUser user_fuzzer
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/configs FuzzUnmarshalJSON configs_fuzzer

--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -13,7 +13,7 @@ set -o pipefail
 set -o errexit
 set -x
 
-# specifiy go version
+# specify go version
 apt-get update && apt-get install -y wget
 cd $SRC
 
@@ -27,6 +27,5 @@ mv tmp-go/go/* /root/.go/
 cd $SRC/runc
 go mod tidy
 
-compile_go_fuzzer github.com/opencontainers/runc/libcontainer/userns FuzzUIDMap id_map_fuzzer linux,gofuzz
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/user FuzzUser user_fuzzer
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/configs FuzzUnmarshalJSON configs_fuzzer


### PR DESCRIPTION
1. The current ossfuzz build process ends with incomplete drivers due to improper go version (1.19). So add code for specifying go version.
```bash
go: go.mod file indicates go 1.20, but maximum version supported by tidy is 1.19
```
2. Remove duplicated driver `FuzzUIDMap` which has been included in cncf-fuzzing project.

[oss-fuzz build.sh](https://github.com/google/oss-fuzz/blob/master/projects/runc/build.sh)
[cncf-fuzzing build.sh](https://github.com/cncf/cncf-fuzzing/blob/main/projects/runc/build.sh)