### PR TITLE
bump golangci-lint; remove nolint annotations for unix errno comparisons

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt -q install libseccomp-dev
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53
+          version: v1.54
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/libcontainer/cgroups/file.go
+++ b/libcontainer/cgroups/file.go
@@ -89,7 +89,7 @@ func prepareOpenat2() error {
 		})
 		if err != nil {
 			prepErr = &os.PathError{Op: "openat2", Path: cgroupfsDir, Err: err}
-			if err != unix.ENOSYS { //nolint:errorlint // unix errors are bare
+			if err != unix.ENOSYS {
 				logrus.Warnf("falling back to securejoin: %s", prepErr)
 			} else {
 				logrus.Debug("openat2 not available, falling back to securejoin")

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -195,7 +195,7 @@ func cpusetEnsureParent(current string) error {
 	}
 	// Treat non-existing directory as cgroupfs as it will be created,
 	// and the root cpuset directory obviously exists.
-	if err != nil && err != unix.ENOENT { //nolint:errorlint // unix errors are bare
+	if err != nil && err != unix.ENOENT {
 		return &os.PathError{Op: "statfs", Path: parent, Err: err}
 	}
 

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -219,7 +219,7 @@ func PathExists(path string) bool {
 
 func rmdir(path string) error {
 	err := unix.Rmdir(path)
-	if err == nil || err == unix.ENOENT { //nolint:errorlint // unix errors are bare
+	if err == nil || err == unix.ENOENT {
 		return nil
 	}
 	return &os.PathError{Op: "rmdir", Path: path, Err: err}

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -593,7 +593,7 @@ func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
 		for _, u := range umounts {
 			_ = utils.WithProcfd(c.config.Rootfs, u, func(procfd string) error {
 				if e := unix.Unmount(procfd, unix.MNT_DETACH); e != nil {
-					if e != unix.EINVAL { //nolint:errorlint // unix errors are bare
+					if e != unix.EINVAL {
 						// Ignore EINVAL as it means 'target is not a mount point.'
 						// It probably has already been unmounted.
 						logrus.Warnf("Error during cleanup unmounting of %s (%s): %v", procfd, u, e)

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -642,7 +642,7 @@ func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
 	}
 	for _, pid := range pids {
 		err := unix.Kill(pid, s)
-		if err != nil && err != unix.ESRCH { //nolint:errorlint // unix errors are bare
+		if err != nil && err != unix.ESRCH {
 			logrus.Warnf("kill %d: %v", pid, err)
 		}
 	}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -322,7 +322,6 @@ type CreateOpts struct {
 func getwd() (wd string, err error) {
 	for {
 		wd, err = unix.Getwd()
-		//nolint:errorlint // unix errors are bare
 		if err != unix.EINTR {
 			break
 		}

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -43,7 +43,7 @@ func Execv(cmd string, args []string, env []string) error {
 func Exec(cmd string, args []string, env []string) error {
 	for {
 		err := unix.Exec(cmd, args, env)
-		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+		if err != unix.EINTR {
 			return &os.PathError{Op: "exec", Path: cmd, Err: err}
 		}
 	}

--- a/notify_socket.go
+++ b/notify_socket.go
@@ -215,7 +215,7 @@ func sdNotifyBarrier(client *net.UnixConn) error {
 		// Probably the other end doesn't support the sd_notify_barrier protocol.
 		logrus.Warn("Timeout after waiting 30s for barrier. Ignored.")
 		return nil
-	} else if err == io.EOF { //nolint:errorlint // comparison with io.EOF is legit.
+	} else if err == io.EOF { //nolint:errorlint // https://github.com/polyfloyd/go-errorlint/issues/49
 		return nil
 	} else {
 		return err

--- a/signals.go
+++ b/signals.go
@@ -124,7 +124,7 @@ func (h *signalHandler) reap() (exits []exit, err error) {
 	for {
 		pid, err := unix.Wait4(-1, &ws, unix.WNOHANG, &rus)
 		if err != nil {
-			if err == unix.ECHILD { //nolint:errorlint // unix errors are bare
+			if err == unix.ECHILD {
 				return exits, nil
 			}
 			return nil, err


### PR DESCRIPTION
golangci-lint v1.54.2 comes with errorlint v1.4.4, which contains
the fix (https://github.com/polyfloyd/go-errorlint/pull/47) whitelisting all errno comparisons for errors coming from
x/sys/unix.
    
Thus, these annotations are no longer necessary. Hooray!
