### PR TITLE
Fix for host mount ns containers

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -514,36 +514,6 @@ func (p *initProcess) start() (retErr error) {
 			if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
 				return fmt.Errorf("error setting rlimits for ready process: %w", err)
 			}
-			// call prestart and CreateRuntime hooks
-			if !p.config.Config.Namespaces.Contains(configs.NEWNS) {
-				// Setup cgroup before the hook, so that the prestart and CreateRuntime hook could apply cgroup permissions.
-				if err := p.manager.Set(p.config.Config.Cgroups.Resources); err != nil {
-					return fmt.Errorf("error setting cgroup config for ready process: %w", err)
-				}
-				if p.intelRdtManager != nil {
-					if err := p.intelRdtManager.Set(p.config.Config); err != nil {
-						return fmt.Errorf("error setting Intel RDT config for ready process: %w", err)
-					}
-				}
-
-				if len(p.config.Config.Hooks) != 0 {
-					s, err := p.container.currentOCIState()
-					if err != nil {
-						return err
-					}
-					// initProcessStartTime hasn't been set yet.
-					s.Pid = p.cmd.Process.Pid
-					s.Status = specs.StateCreating
-					hooks := p.config.Config.Hooks
-
-					if err := hooks.Run(configs.Prestart, s); err != nil {
-						return err
-					}
-					if err := hooks.Run(configs.CreateRuntime, s); err != nil {
-						return err
-					}
-				}
-			}
 
 			// generate a timestamp indicating when the container was started
 			p.container.created = time.Now().UTC()

--- a/tests/integration/host-mntns.bats
+++ b/tests/integration/host-mntns.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	requires root
+	setup_busybox
+}
+
+function teardown() {
+	[ ! -v ROOT ] && return 0 # nothing to teardown
+
+	# XXX runc does not unmount a container which
+	# shares mount namespace with the host.
+	umount -R --lazy "$ROOT"/bundle/rootfs
+
+	teardown_bundle
+}
+
+@test "runc run [host mount ns + hooks]" {
+	update_config '	  .process.args = ["/bin/echo", "Hello World"]
+			| .hooks |= . + {"createRuntime": [{"path": "/bin/sh", "args": ["/bin/sh", "-c", "touch createRuntimeHook.$$"]}]}
+			| .linux.namespaces -= [{"type": "mount"}]
+			| .linux.maskedPaths = []
+			| .linux.readonlyPaths = []'
+	runc run test_host_mntns
+	[ "$status" -eq 0 ]
+	runc delete -f test_host_mntns
+
+	# There should be one such file.
+	run -0 ls createRuntimeHook.*
+	[ "$(echo "$output" | wc -w)" -eq 1 ]
+}


### PR DESCRIPTION
If the container does not have own mount namespace configured (i.e. it shares the mount namespace with the host), its "prestart" (obsoleted) and "createRuntime" hooks are called twice, and its cgroups and Intel RDT settings are also applied twice.

The code being removed was originally added by commit 2f2764984 ("Move pre-start hooks after container mounts", Feb 17 2016). At that time, the syncParentHooks() was called from setupRootfs(), which was only used when the container config has mount namespace (NEWNS) enabled.

Later, commit 244c9fc426a ("*: console rewrite", Jun 4 2016) spli the relevant part of setupRootfs() into prepareRootfs(). It was still called conditionally (only if mount namespace was enabled).

Finally, commit 91ca331474b6b ("chroot when no mount namespaces is provided", Jan 25 2018) removed the above condition, meaning prepareRootfs(), and thus syncParentHooks(), is now called for any container.

Meaning, the special case for when mount namespace is not enabled is no longer needed.

Remove it.

Add a test case.