### PR TITLE
ci/gha: switch to gsactions/commit-message-checker

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -129,18 +129,15 @@ jobs:
     # Only check commits on pull requests.
     if: github.event_name == 'pull_request'
     steps:
-      - name: get pr commits
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: check subject line length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.2
+        uses: gsactions/commit-message-checker@v2
         with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.{0,72}(\n.*)*$'
+          pattern: '^[^#].{72}'
           error: 'Subject too long (max 72)'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
 
   cfmt:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# runc
-
-[![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/runc)](https://goreportcard.com/report/github.com/opencontainers/runc)
+t c[![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/runc)](https://goreportcard.com/report/github.com/opencontainers/runc)
 [![Go Reference](https://pkg.go.dev/badge/github.com/opencontainers/runc.svg)](https://pkg.go.dev/github.com/opencontainers/runc)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/588/badge)](https://bestpractices.coreinfrastructure.org/projects/588)
 [![gha/validate](https://github.com/opencontainers/runc/workflows/validate/badge.svg)](https://github.com/opencontainers/runc/actions?query=workflow%3Avalidate)


### PR DESCRIPTION
We use to check the length of a commit message title, to ensure it's not too long. This is done using a couple of tim-actions which are (1) not very well maintained and (2) result in a CI warning.

Switch to [gsactions/commit-message-checker](https://github.com/GsActions/commit-message-checker).