### PR TITLE
[RFC] build: add build tag to disable eBPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ e.g. to disable seccomp:
 make BUILDTAGS=""
 ```
 
-| Build Tag | Feature                            | Enabled by default | Dependency |
-|-----------|------------------------------------|--------------------|------------|
-| seccomp   | Syscall filtering                  | yes                | libseccomp |
+| Build Tag      | Feature                            | Enabled by default | Dependency |
+|----------------|------------------------------------|--------------------|------------|
+| seccomp        | Syscall filtering                  | yes                | libseccomp |
+| runc_no_ebpf   | Disable eBPF support               | no                 |            |
 
 The following build tags were used earlier, but are now obsoleted:
  - **nokmem** (since runc v1.0.0-rc94 kernel memory settings are ignored)

--- a/libcontainer/cgroups/devices/devicefilter.go
+++ b/libcontainer/cgroups/devices/devicefilter.go
@@ -1,3 +1,5 @@
+//go:build !runc_no_ebpf
+
 // Implements creation of eBPF device filter program.
 //
 // Based on https://github.com/containers/crun/blob/0.10.2/src/libcrun/ebpf.c

--- a/libcontainer/cgroups/devices/ebpf_disabled_linux.go
+++ b/libcontainer/cgroups/devices/ebpf_disabled_linux.go
@@ -1,0 +1,13 @@
+//go:build runc_no_ebpf
+
+package devices
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func setV2(dirPath string, r *configs.Resources) error {
+	return fmt.Errorf("eBPF support is disabled")
+}

--- a/libcontainer/cgroups/devices/v2.go
+++ b/libcontainer/cgroups/devices/v2.go
@@ -1,10 +1,6 @@
 package devices
 
 import (
-	"fmt"
-
-	"golang.org/x/sys/unix"
-
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/userns"
@@ -49,25 +45,4 @@ func canSkipEBPFError(r *configs.Resources) bool {
 		}
 	}
 	return true
-}
-
-func setV2(dirPath string, r *configs.Resources) error {
-	if r.SkipDevices {
-		return nil
-	}
-	insts, license, err := deviceFilter(r.Devices)
-	if err != nil {
-		return err
-	}
-	dirFD, err := unix.Open(dirPath, unix.O_DIRECTORY|unix.O_RDONLY, 0o600)
-	if err != nil {
-		return fmt.Errorf("cannot get dir FD for %s", dirPath)
-	}
-	defer unix.Close(dirFD)
-	if _, err := loadAttachCgroupDeviceFilter(insts, license, dirFD); err != nil {
-		if !canSkipEBPFError(r) {
-			return err
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
we are using runc to read the cgroup configuration, if eBPF is enabled it pulls in the cilium/ebpf dependency that increases the binary size by ~1 MB.