### PR TITLE
validator: Relax warning for not abs mount dst path

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -38,11 +38,11 @@ func Validate(config *configs.Config) error {
 	}
 	// Relaxed validation rules for backward compatibility
 	warns := []check{
-		mounts, // TODO (runc v1.x.x): make this an error instead of a warning
+		mountsWarn,
 	}
 	for _, c := range warns {
 		if err := c(config); err != nil {
-			logrus.WithError(err).Warn("invalid configuration")
+			logrus.WithError(err).Warn("configuration")
 		}
 	}
 	return nil
@@ -300,10 +300,10 @@ func checkIDMapMounts(config *configs.Config, m *configs.Mount) error {
 	return nil
 }
 
-func mounts(config *configs.Config) error {
+func mountsWarn(config *configs.Config) error {
 	for _, m := range config.Mounts {
 		if !filepath.IsAbs(m.Destination) {
-			return fmt.Errorf("invalid mount %+v: mount destination not absolute", m)
+			return fmt.Errorf("mount %+v: relative destination path is **deprecated**, using it as relative to /", m)
 		}
 	}
 	return nil


### PR DESCRIPTION
The runtime spec now allows relative mount dst paths, so remove the comment saying we will switch this to an error later and change the error messages to reflect that.

This was changed in this runtime-spec PR: https://github.com/opencontainers/runtime-spec/pull/1225

---
I'm not 100% sure this new text is good, but invalid configuration seemed strong now. If you have better suggestions, please share them! :)