### PR TITLE
Handle kmem.limit_in_bytes removal

### DIFF
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -234,6 +234,12 @@ func getMemoryData(path, name string) (cgroups.MemoryData, error) {
 	memoryData.Failcnt = value
 	value, err = fscommon.GetCgroupParamUint(path, limit)
 	if err != nil {
+		if name == "kmem" && os.IsNotExist(err) {
+			// Ignore ENOENT as kmem.limit_in_bytes has
+			// been removed in newer kernels.
+			return memoryData, nil
+		}
+
 		return cgroups.MemoryData{}, err
 	}
 	memoryData.Limit = value


### PR DESCRIPTION
kmem.limit_in_bytes has been removed in upstream linux and this patch is queued to be backported to linux 6.1 stable:

- https://lore.kernel.org/linux-mm/20230705134434.GA156754@cmpxchg.org/T/
- https://www.spinics.net/lists/stable-commits/msg316619.html

Without this change to libcontainerd, GetStats() will return an error on the latest kernel(s). A downstream effect is that Kubernetes's kubelet does not start up. This fix was tested by ensuring that it unblocks kubelet startup when running on the latest kernel.