### PR TITLE
[CI] increase memory.max in cgroups.bats

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -207,7 +207,7 @@ function setup() {
 				"memory.min":   "131072",
 				"memory.low":   "524288",
 				"memory.high": "5242880",
-				"memory.max": "10485760",
+				"memory.max": "20484096",
 				"memory.swap.max": "20971520",
 				"pids.max": "99",
 				"cpu.max": "10000 100000",
@@ -224,7 +224,7 @@ function setup() {
 	echo "$output" | grep -q '^memory.min:131072$'
 	echo "$output" | grep -q '^memory.low:524288$'
 	echo "$output" | grep -q '^memory.high:5242880$'
-	echo "$output" | grep -q '^memory.max:10485760$'
+	echo "$output" | grep -q '^memory.max:20484096$'
 	echo "$output" | grep -q '^memory.swap.max:20971520$'
 	echo "$output" | grep -q '^pids.max:99$'
 	echo "$output" | grep -q '^cpu.max:10000 100000$'
@@ -232,7 +232,7 @@ function setup() {
 	check_systemd_value "MemoryMin" 131072
 	check_systemd_value "MemoryLow" 524288
 	check_systemd_value "MemoryHigh" 5242880
-	check_systemd_value "MemoryMax" 10485760
+	check_systemd_value "MemoryMax" 20484096
 	check_systemd_value "MemorySwapMax" 20971520
 	check_systemd_value "TasksMax" 99
 	check_cpu_quota 10000 100000 "100ms"
@@ -252,7 +252,7 @@ function setup() {
 			}
 			| .linux.resources.unified |= {
 				"memory.min": "131072",
-				"memory.max": "10485760",
+				"memory.max": "40484864",
 				"pids.max": "42",
 				"cpu.max": "5000 50000",
 				"cpu.weight": "42"
@@ -267,7 +267,7 @@ function setup() {
 
 	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
 	[ "$status" -eq 0 ]
-	[ "$output" = '10485760' ]
+	[ "$output" = '40484864' ]
 
 	runc exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Fix #4019 

As the description in #4019 :
1. "runc run (cgroup v2 resources.unified only)"
change the memory limit from 10MB to 20MB.
2. "runc run (cgroup v2 resources.unified override)"
ensure the memory limit in `unified` is bigger than `.linux.resources.memory.limit`.