### PR TITLE
Fix invalid handling of pids.limit=0 from runtime spec

### DIFF
--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -90,7 +90,7 @@ type Resources struct {
 	// cgroup SCHED_IDLE
 	CPUIdle *int64 `json:"cpu_idle,omitempty"`
 
-	// Process limit; set <= `0' to disable limit.
+	// Maximum number of tasks; 0 for unset, -1 for max/unlimited.
 	PidsLimit int64 `json:"pids_limit"`
 
 	// Specifies per cgroup weight, range is from 10 to 1000.

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -775,8 +775,14 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
 				c.Resources.CpusetMems = r.CPU.Mems
 				c.Resources.CPUIdle = r.CPU.Idle
 			}
+			// Convert pids limit from the runtime-spec value (where any value <= 0 means "unlimited")
+			// to internal runc value (where -1 is "unlimited", and 0 is "unset").
 			if r.Pids != nil {
-				c.Resources.PidsLimit = r.Pids.Limit
+				if r.Pids.Limit > 0 {
+					c.Resources.PidsLimit = r.Pids.Limit
+				} else {
+					c.Resources.PidsLimit = -1
+				}
 			}
 			if r.BlockIO != nil {
 				if r.BlockIO.Weight != nil {

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -85,7 +85,7 @@ stdin. If this option is used, all other options are ignored.
 (i.e. use unlimited swap).
 
 **--pids-limit** _num_
-: Set the maximum number of processes allowed in the container.
+: Set the maximum number of tasks. Use **-1** for unlimited.
 
 **--l3-cache-schema** _value_
 : Set the value for Intel RDT/CAT L3 cache schema.

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -309,6 +309,7 @@ convert_hugetlb_size() {
 	set_cgroups_path
 	# CPU shares of 3333 corresponds to CPU weight of 128.
 	update_config '   .linux.resources.memory |= {"limit": 33554432}
+			| .linux.resources.pids.limit |= 100
 			| .linux.resources.cpu |= {
 				"shares": 3333,
 				"quota": 40000,

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -54,8 +54,7 @@ function setup() {
 	fi
 
 	SD_UNLIMITED="infinity"
-	SD_VERSION=$(systemctl --version | awk '{print $2; exit}')
-	if [ "$SD_VERSION" -lt 227 ]; then
+	if [ "$(systemd_version)" -lt 227 ]; then
 		SD_UNLIMITED="18446744073709551615"
 	fi
 

--- a/update.go
+++ b/update.go
@@ -122,11 +122,11 @@ other options are ignored.
 		},
 		cli.StringFlag{
 			Name:  "memory-swap",
-			Usage: "Total memory usage (memory + swap); set '-1' to enable unlimited swap",
+			Usage: "Total memory usage (memory + swap); use '-1' to enable unlimited swap",
 		},
 		cli.IntFlag{
 			Name:  "pids-limit",
-			Usage: "Maximum number of pids allowed in the container",
+			Usage: "Maximum number of tasks; use '-1' for unlimited",
 		},
 		cli.StringFlag{
 			Name:  "l3-cache-schema",


### PR DESCRIPTION
_This is an alternative to #4015 (smaller set of code changes, no libct API breakage)._

It has been pointed out in #4014 that runc incorrectly ignores pids.limit=0 set
in the runtime spec. This happens because runtime-spec says "default is
unlimited" and also allows for Pids to not be set at all, thus
distinguishing unset (Resources.Pids == nil) from unlimited
(Resources.Pids.Limit <= 0).

Internally, runc also distinguishes unset from unlimited, but since we
do not use a pointer, we treat 0 as unset and -1 as unlimited.

Add a conversion code to libcontainer/specconv.

Add a test case to check that starting a container with pids.limit=0
results in no pids limit (the test fails before the fix when systemd
cgroup manager is used, as systemd apparently uses parent's TasksMax;
see #4022 for CI runs).

NOTE that runc update still treats 0 as "unset".

Finally, fix/update the documentation here and there.

Fixes: #4014.
