### PR TITLE
libct/dmz: Move comment out of the Makefile rule

### DIFF
--- a/libcontainer/dmz/Makefile
+++ b/libcontainer/dmz/Makefile
@@ -1,7 +1,7 @@
 # Get CC values for cross-compilation.
 include ../../cc_platform.mk
 
+# We use the flags suggested in nolibc/nolibc.h, it makes the binary very small.
 runc-dmz: _dmz.c
-	# We use the flags suggested in nolibc/nolibc.h, it makes the binary very small.
 	$(CC) $(CFLAGS) -fno-asynchronous-unwind-tables -fno-ident -s -Os -nostdlib -lgcc -static -o $@ $^
 	$(STRIP) -gs $@


### PR DESCRIPTION
While addressing [this comment][link], I didn't realize the comment is shown every time we compile. Let's just move it out.

cc @cyphar @AkihiroSuda 

[link]: https://github.com/opencontainers/runc/pull/4024#discussion_r1337157087
---
Otherwise it is shown when compiling, like this:
```
	# We use the flags suggested in nolibc/nolibc.h, it makes the binary very small.
	gcc  -fno-asynchronous-unwind-tables -fno-ident -s -Os -nostdlib -lgcc -static -o runc-dmz _dmz.c
	strip -gs runc-dmz
```
Having it before the target is equally clear and will not be shown while compiling.