### PR TITLE
docs: clarify the supported architectures (No MIPS)

### DIFF
--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -7,8 +7,6 @@ The following features are not implemented yet:
 
 Spec version | Feature                                  | PR
 -------------|------------------------------------------|----------------------------------------------------------
-v1.0.0       | `SCMP_ARCH_PARISC`                       | Unplanned, due to lack of users
-v1.0.0       | `SCMP_ARCH_PARISC64`                     | Unplanned, due to lack of users
 v1.0.2       | `.linux.personality`                     | [#3126](https://github.com/opencontainers/runc/pull/3126)
 v1.1.0       | `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` | [#3862](https://github.com/opencontainers/runc/pull/3862)
 v1.1.0       | time namespaces                          | [#3876](https://github.com/opencontainers/runc/pull/3876)
@@ -22,3 +20,20 @@ Spec version | Feature                                  | Limitation
 -------------|------------------------------------------|----------------------------------------------------------
 v1.1.0       | `.[]mounts.uidMappings`                  | Requires using UserNS with identical uidMappings
 v1.1.0       | `.[]mounts.gidMappings`                  | Requires using UserNS with identical gidMappings
+
+## Architectures
+
+The following architectures are supported:
+
+runc binary  | seccomp
+-------------|-------------------------------------------------------
+`amd64`      | `SCMP_ARCH_X86`, `SCMP_ARCH_X86_64`, `SCMP_ARCH_X32`
+`arm64`      | `SCMP_ARCH_ARM`, `SCMP_ARCH_AARCH64`
+`armel`      | `SCMP_ARCH_ARM`
+`armhf`      | `SCMP_ARCH_ARM`
+`ppc64le`    | `SCMP_ARCH_PPC64LE`
+`riscv64`    | `SCMP_ARCH_RISCV64`
+`s390x`      | `SCMP_ARCH_S390`, `SCMP_ARCH_S390X`
+
+The runc binary might be compilable for i386, big-endian PPC64,
+and several MIPS variants too, but these architectures are not officially supported.


### PR DESCRIPTION
In reviewing PR #4024 ("libct/dmz: Reduce the binary size using nolibc"), we noticed that we do not intend to actively support MIPS.

We do not intend to support i386 either.

This might be a breaking change for Debian, which has been officially providing runc packages for `i386`, `mips64el` and `mipsel`: https://packages.debian.org/bookworm/runc