### PR TITLE
Fix compilation for GOLANG=(mipsle|mips64le)

### DIFF
--- a/cc_platform.mk
+++ b/cc_platform.mk
@@ -48,6 +48,10 @@ else ifeq ($(GOARCH),riscv64)
 	HOST := riscv64-$(PLATFORM)-
 else ifeq ($(GOARCH),s390x)
 	HOST := s390x-$(PLATFORM)-
+else ifeq ($(GOARCH),mipsle)
+	HOST := mipsel-$(PLATFORM)-
+else ifeq ($(GOARCH),mips64le)
+	HOST := mips64el-$(PLATFORM)abi64-
 else
 $(error Unsupported GOARCH $(GOARCH))
 endif

--- a/libcontainer/dmz/dmz_linux.go
+++ b/libcontainer/dmz/dmz_linux.go
@@ -1,4 +1,5 @@
-//go:build !runc_nodmz
+//go:build (386 || amd64 || arm || arm64 || loong64 || ppc64le || riscv64 || s390x) && !runc_nodmz
+// +build 386 amd64 arm arm64 loong64 ppc64le riscv64 s390x
 // +build !runc_nodmz
 
 package dmz

--- a/libcontainer/dmz/dmz_unsupported.go
+++ b/libcontainer/dmz/dmz_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux || runc_nodmz
-// +build !linux runc_nodmz
+//go:build !linux || (!386 && !amd64 && !arm && !arm64 && !loong64 && !ppc64le && !riscv64 && !s390x) || runc_nodmz
+// +build !linux !386,!amd64,!arm,!arm64,!loong64,!ppc64le,!riscv64,!s390x runc_nodmz
 
 package dmz
 

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -61,6 +61,12 @@ function set_cross_vars() {
 	s390x)
 		HOST=s390x-${PLATFORM}
 		;;
+	mipsle)
+		HOST=mipsel-${PLATFORM}
+		;;
+	mips64le)
+		HOST=mips64el-${PLATFORM}abi64
+		;;
 	*)
 		echo "set_cross_vars: unsupported architecture: $1" >&2
 		exit 1


### PR DESCRIPTION
`libcontainer/dmz_linux.go` is not compiled in for MIPS, as libcontainer/dmz/nolibc/arch.h isn't compatible.

Fixes #4037 


- - -

Note: MIPS is no longer officially supported by runc maintainers, but still supported by Debian: 
- https://github.com/opencontainers/runc/pull/4031
