### PR TITLE
script/lib.sh: set GOARM=5 for armel, GOARM=6 for armhf

### DIFF
--- a/script/lib.sh
+++ b/script/lib.sh
@@ -45,12 +45,21 @@ function set_cross_vars() {
 	armel)
 		HOST=arm-${PLATFORM}eabi
 		GOARCH=arm
-		GOARM=6
+		GOARM=5
 		;;
 	armhf)
 		HOST=arm-${PLATFORM}eabihf
 		GOARCH=arm
-		GOARM=7
+		# "armhf" means ARMv7 for Debian, ARMv6 for Raspbian.
+		# ARMv6 is chosen here for compatibility.
+		#
+		# https://wiki.debian.org/RaspberryPi
+		#
+		# > Raspberry Pi OS builds a single image for all of the Raspberry families,
+		# > so you will get an armhf 32-bit, hard floating-point system, but built
+		# > for the ARMv6 ISA (with VFP2), unlike Debian's ARMv7 ISA (with VFP3)
+		# > port.
+		GOARM=6
 		;;
 	ppc64le)
 		HOST=powerpc64le-${PLATFORM}


### PR DESCRIPTION
https://github.com/golang/go/wiki/GoArm#supported-operating-systems

> ARM on Linux. You must run an EABI kernel.
> These are generally known as armel for softfloat (compatible with ARMv5)
> or armhf for hardware floating point (ARMv6 and above).

Prior to this commit, the script was setting GOARM=6 for armel, GOARM=7 for armhf.

Fix #4033