### PR TITLE
libct: use chmod instead of umask

### DIFF
--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -9,13 +9,15 @@ import (
 // mount initializes the console inside the rootfs mounting with the specified mount label
 // and applying the correct ownership of the console.
 func mountConsole(slavePath string) error {
-	oldMask := unix.Umask(0o000)
-	defer unix.Umask(oldMask)
 	f, err := os.Create("/dev/console")
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
 	if f != nil {
+		// Ensure permission bits (can be different because of umask).
+		if err := f.Chmod(0o666); err != nil {
+			return err
+		}
 		f.Close()
 	}
 	return mount(slavePath, "/dev/console", "bind", unix.MS_BIND, "")

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -413,12 +413,13 @@ func (c *Container) createExecFifo() error {
 	if _, err := os.Stat(fifoName); err == nil {
 		return fmt.Errorf("exec fifo %s already exists", fifoName)
 	}
-	oldMask := unix.Umask(0o000)
 	if err := unix.Mkfifo(fifoName, 0o622); err != nil {
-		unix.Umask(oldMask)
+		return &os.PathError{Op: "mkfifo", Path: fifoName, Err: err}
+	}
+	// Ensure permission bits (can be different because of umask).
+	if err := os.Chmod(fifoName, 0o622); err != nil {
 		return err
 	}
-	unix.Umask(oldMask)
 	return os.Chown(fifoName, rootuid, rootgid)
 }
 


### PR DESCRIPTION
_(this is an alternative to #3563, implementing @cyphar [suggestion](https://github.com/opencontainers/runc/pull/3563#pullrequestreview-1138343099))_

Umask is problematic for Go programs as it affects other goroutines (see [1] for more details).

Instead of using it, let's just prop up with Chmod.

Note this patch misses the MkdirAll call in createDeviceNode. Since the runtime spec does not say anything about creating intermediary directories for device nodes, let's assume that doing it via mkdir with the current umask set is sufficient (if not, we have to reimplement MkdirAll from scratch, with added call to os.Chmod).

[1] https://github.com/opencontainers/runc/pull/3563#discussion_r990293788