### PR TITLE
reduce the chance of parsing /etc/passwd & /etc/group

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -395,7 +395,7 @@ func TestAdditionalGroups(t *testing.T) {
 		Env:              standardEnvironment,
 		Stdin:            nil,
 		Stdout:           &stdout,
-		AdditionalGroups: []string{"plugdev", "audio"},
+		AdditionalGroups: []string{"1", "2"},
 		Init:             true,
 	}
 	err = container.Run(&pconfig)
@@ -407,12 +407,12 @@ func TestAdditionalGroups(t *testing.T) {
 	outputGroups := stdout.String()
 
 	// Check that the groups output has the groups that we specified
-	if !strings.Contains(outputGroups, "audio") {
-		t.Fatalf("Listed groups do not contain the audio group as expected: %v", outputGroups)
+	if !strings.Contains(outputGroups, "1") {
+		t.Fatalf("Listed groups do not contain the group as expected: %v", outputGroups)
 	}
 
-	if !strings.Contains(outputGroups, "plugdev") {
-		t.Fatalf("Listed groups do not contain the plugdev group as expected: %v", outputGroups)
+	if !strings.Contains(outputGroups, "2") {
+		t.Fatalf("Listed groups do not contain the group as expected: %v", outputGroups)
 	}
 }
 

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -162,7 +162,7 @@ func TestExecInAdditionalGroups(t *testing.T) {
 		Env:              standardEnvironment,
 		Stdin:            nil,
 		Stdout:           &stdout,
-		AdditionalGroups: []string{"plugdev", "audio"},
+		AdditionalGroups: []string{"1", "2"},
 	}
 	err = container.Run(&pconfig)
 	ok(t, err)
@@ -176,12 +176,12 @@ func TestExecInAdditionalGroups(t *testing.T) {
 	outputGroups := stdout.String()
 
 	// Check that the groups output has the groups that we specified
-	if !strings.Contains(outputGroups, "audio") {
-		t.Fatalf("Listed groups do not contain the audio group as expected: %v", outputGroups)
+	if !strings.Contains(outputGroups, "1") {
+		t.Fatalf("Listed groups do not contain the group as expected: %v", outputGroups)
 	}
 
-	if !strings.Contains(outputGroups, "plugdev") {
-		t.Fatalf("Listed groups do not contain the plugdev group as expected: %v", outputGroups)
+	if !strings.Contains(outputGroups, "2") {
+		t.Fatalf("Listed groups do not contain the group as expected: %v", outputGroups)
 	}
 }
 


### PR DESCRIPTION
According to https://github.com/opencontainers/runc/issues/3998#issuecomment-1702005233, we can do the third step to reduce the chance of parsing /etc/passwd & /etc/group when start or exec to a container.

Because in `runtime-spec`(https://github.com/opencontainers/runtime-spec/blob/v1.0.2/config.md#posix-platform-user), `uid`, `gid`, and `additionalGids` are all defined as a numeric field/array. It is no need to parse a numeric id from `/etc/passwd` or `/etc/group`, except `$HOME` is empty or gid is not provided(But `runtime-spec` said gid is required).