### PR TITLE
[feature request] *: introduce pidfd-socket flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vendor/pkg
 /contrib/cmd/seccompagent/seccompagent
 /contrib/cmd/fs-idmap/fs-idmap
 /contrib/cmd/memfd-bind/memfd-bind
+/contrib/cmd/pidfd-kill/pidfd-kill
 man/man8
 release
 Vagrantfile

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ runc-bin: runc-dmz
 	$(GO_BUILD) -o runc .
 
 .PHONY: all
-all: runc recvtty sd-helper seccompagent fs-idmap memfd-bind
+all: runc recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill
 
-.PHONY: recvtty sd-helper seccompagent fs-idmap memfd-bind
-recvtty sd-helper seccompagent fs-idmap memfd-bind:
+.PHONY: recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill
+recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill:
 	$(GO_BUILD) -o contrib/cmd/$@/$@ ./contrib/cmd/$@
 
 .PHONY: static
@@ -194,6 +194,7 @@ clean:
 	rm -f contrib/cmd/sd-helper/sd-helper
 	rm -f contrib/cmd/seccompagent/seccompagent
 	rm -f contrib/cmd/memfd-bind/memfd-bind
+	rm -f contrib/cmd/pidfd-kill/pidfd-kill
 	sudo rm -rf release
 	rm -rf man/man8
 

--- a/contrib/cmd/pidfd-kill/pidfd-kill.go
+++ b/contrib/cmd/pidfd-kill/pidfd-kill.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+
+	"github.com/urfave/cli"
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/runc/libcontainer/utils"
+)
+
+const (
+	usage = `Open Container Initiative contrib/cmd/pidfd-kill
+
+pidfd-kill is an implementation of a consumer of runC's --pidfd-socket API.
+After received SIGTERM, pidfd-kill sends the given signal to init process by
+pidfd received from --pidfd-socket.
+
+To use pidfd-kill, just specify a socket path at which you want to receive
+pidfd:
+
+    $ pidfd-kill [--signal KILL] socket.sock
+`
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "pidfd-kill"
+	app.Usage = usage
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "signal",
+			Value: "SIGKILL",
+			Usage: "Signal to send to the init process",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Value: "",
+			Usage: "Path to write the pidfd-kill process ID to",
+		},
+	}
+
+	app.Action = func(ctx *cli.Context) error {
+		args := ctx.Args()
+		if len(args) != 1 {
+			return errors.New("required a single socket path")
+		}
+
+		socketFile := ctx.Args()[0]
+
+		pidFile := ctx.String("pid-file")
+		if pidFile != "" {
+			pid := fmt.Sprintf("%d\n", os.Getpid())
+			if err := os.WriteFile(pidFile, []byte(pid), 0o644); err != nil {
+				return err
+			}
+			defer os.Remove(pidFile)
+		}
+
+		sigStr := ctx.String("signal")
+		if sigStr == "" {
+			sigStr = "SIGKILL"
+		}
+		sig := unix.SignalNum(sigStr)
+
+		pidfdFile, err := recvPidfd(socketFile)
+		if err != nil {
+			return err
+		}
+		defer pidfdFile.Close()
+
+		signalCh := make(chan os.Signal, 16)
+		signal.Notify(signalCh, unix.SIGTERM)
+		<-signalCh
+
+		return unix.PidfdSendSignal(int(pidfdFile.Fd()), sig, nil, 0)
+	}
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "fatal error:", err)
+		os.Exit(1)
+	}
+}
+
+func recvPidfd(socketFile string) (*os.File, error) {
+	ln, err := net.Listen("unix", socketFile)
+	if err != nil {
+		return nil, err
+	}
+	defer ln.Close()
+
+	conn, err := ln.Accept()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	unixconn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, errors.New("failed to cast to unixconn")
+	}
+
+	socket, err := unixconn.File()
+	if err != nil {
+		return nil, err
+	}
+	defer socket.Close()
+
+	return utils.RecvFile(socket)
+}

--- a/create.go
+++ b/create.go
@@ -35,6 +35,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
 		},
 		cli.StringFlag{
+			Name:  "pidfd-socket",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the init process",
+		},
+		cli.StringFlag{
 			Name:  "pid-file",
 			Value: "",
 			Usage: "specify the file to write the process id to",

--- a/exec.go
+++ b/exec.go
@@ -34,6 +34,10 @@ following will output a list of processes running in the container:
 			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
 		},
 		cli.StringFlag{
+			Name:  "pidfd-socket",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the exec process",
+		},
+		cli.StringFlag{
 			Name:  "cwd",
 			Usage: "current working directory in the container",
 		},
@@ -181,6 +185,7 @@ func execProcess(context *cli.Context) (int, error) {
 		shouldDestroy:   false,
 		container:       container,
 		consoleSocket:   context.String("console-socket"),
+		pidfdSocket:     context.String("pidfd-socket"),
 		detach:          context.Bool("detach"),
 		pidFile:         context.String("pid-file"),
 		action:          CT_ACT_RUN,

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -586,6 +586,13 @@ func (c *Container) newParentProcess(p *Process) (parentProcess, error) {
 		cmd.Env = append(cmd.Env, "_LIBCONTAINER_LOGLEVEL="+p.LogLevel)
 	}
 
+	if p.PidfdSocket != nil {
+		cmd.ExtraFiles = append(cmd.ExtraFiles, p.PidfdSocket)
+		cmd.Env = append(cmd.Env,
+			"_LIBCONTAINER_PIDFD_SOCK="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
+		)
+	}
+
 	if safeExe != nil {
 		// Due to a Go stdlib bug, we need to add safeExe to the set of
 		// ExtraFiles otherwise it is possible for the stdlib to clobber the fd

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -179,6 +179,16 @@ func startInitialization() (retErr error) {
 		defer consoleSocket.Close()
 	}
 
+	var pidfdSocket *os.File
+	if envSockFd := os.Getenv("_LIBCONTAINER_PIDFD_SOCK"); envSockFd != "" {
+		sockFd, err := strconv.Atoi(envSockFd)
+		if err != nil {
+			return fmt.Errorf("unable to convert _LIBCONTAINER_PIDFD_SOCK: %w", err)
+		}
+		pidfdSocket = os.NewFile(uintptr(sockFd), "pidfd-socket")
+		defer pidfdSocket.Close()
+	}
+
 	// Get mount files (O_PATH).
 	mountSrcFds, err := parseFdsFromEnv("_LIBCONTAINER_MOUNT_FDS")
 	if err != nil {
@@ -222,10 +232,10 @@ func startInitialization() (retErr error) {
 	}
 
 	// If init succeeds, it will not return, hence none of the defers will be called.
-	return containerInit(it, &config, syncPipe, consoleSocket, fifofd, logFD, dmzExe, mountFds{sourceFds: mountSrcFds, idmapFds: idmapFds})
+	return containerInit(it, &config, syncPipe, consoleSocket, pidfdSocket, fifofd, logFD, dmzExe, mountFds{sourceFds: mountSrcFds, idmapFds: idmapFds})
 }
 
-func containerInit(t initType, config *initConfig, pipe *syncSocket, consoleSocket *os.File, fifoFd, logFd int, dmzExe *os.File, mountFds mountFds) error {
+func containerInit(t initType, config *initConfig, pipe *syncSocket, consoleSocket, pidfdSocket *os.File, fifoFd, logFd int, dmzExe *os.File, mountFds mountFds) error {
 	if err := populateProcessEnvironment(config.Env); err != nil {
 		return err
 	}
@@ -240,6 +250,7 @@ func containerInit(t initType, config *initConfig, pipe *syncSocket, consoleSock
 		i := &linuxSetnsInit{
 			pipe:          pipe,
 			consoleSocket: consoleSocket,
+			pidfdSocket:   pidfdSocket,
 			config:        config,
 			logFd:         logFd,
 			dmzExe:        dmzExe,
@@ -249,6 +260,7 @@ func containerInit(t initType, config *initConfig, pipe *syncSocket, consoleSock
 		i := &linuxStandardInit{
 			pipe:          pipe,
 			consoleSocket: consoleSocket,
+			pidfdSocket:   pidfdSocket,
 			parentPid:     unix.Getppid(),
 			config:        config,
 			fifoFd:        fifoFd,
@@ -689,4 +701,21 @@ func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
 	}
 
 	return nil
+}
+
+// setupPidfd opens a process file descriptor of init process, and sends the
+// file descriptor back to the socket.
+func setupPidfd(socket *os.File, initType string) error {
+	defer socket.Close()
+
+	pidFd, err := unix.PidfdOpen(os.Getpid(), 0)
+	if err != nil {
+		return fmt.Errorf("failed to pidfd_open: %w", err)
+	}
+
+	if err := utils.SendRawFd(socket, initType, uintptr(pidFd)); err != nil {
+		unix.Close(pidFd)
+		return fmt.Errorf("failed to send pidfd on socket: %w", err)
+	}
+	return unix.Close(pidFd)
 }

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -77,6 +77,9 @@ type Process struct {
 	// ConsoleSocket provides the masterfd console.
 	ConsoleSocket *os.File
 
+	// PidfdSocket provides process file descriptor of it own.
+	PidfdSocket *os.File
+
 	// Init specifies whether the process is the first process in the container.
 	Init bool
 

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -22,6 +22,7 @@ import (
 type linuxSetnsInit struct {
 	pipe          *syncSocket
 	consoleSocket *os.File
+	pidfdSocket   *os.File
 	config        *initConfig
 	logFd         int
 	dmzExe        *os.File
@@ -54,6 +55,11 @@ func (l *linuxSetnsInit) Init() error {
 		}
 		if err := system.Setctty(); err != nil {
 			return err
+		}
+	}
+	if l.pidfdSocket != nil {
+		if err := setupPidfd(l.pidfdSocket, "setns"); err != nil {
+			return fmt.Errorf("failed to setup pidfd: %w", err)
 		}
 	}
 	if l.config.NoNewPrivileges {

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -22,6 +22,7 @@ import (
 type linuxStandardInit struct {
 	pipe          *syncSocket
 	consoleSocket *os.File
+	pidfdSocket   *os.File
 	parentPid     int
 	fifoFd        int
 	logFd         int
@@ -111,6 +112,12 @@ func (l *linuxStandardInit) Init() error {
 		}
 		if err := system.Setctty(); err != nil {
 			return &os.SyscallError{Syscall: "ioctl(setctty)", Err: err}
+		}
+	}
+
+	if l.pidfdSocket != nil {
+		if err := setupPidfd(l.pidfdSocket, "standard"); err != nil {
+			return fmt.Errorf("failed to setup pidfd: %w", err)
 		}
 	}
 

--- a/run.go
+++ b/run.go
@@ -35,6 +35,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			Value: "",
 			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
 		},
+		cli.StringFlag{
+			Name:  "pidfd-socket",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the init process",
+		},
 		cli.BoolFlag{
 			Name:  "detach, d",
 			Usage: "detach from the container's process",

--- a/tests/integration/pidfd-socket.bats
+++ b/tests/integration/pidfd-socket.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	requires root
+	requires_kernel 5.3
+	setup_busybox
+	update_config '.process.args = ["/bin/sleep", "1d"]'
+}
+
+function teardown() {
+	teardown_pidfd_kill
+	teardown_bundle
+}
+
+@test "runc create [ --pidfd-socket ] " {
+	setup_pidfd_kill "SIGTERM"
+
+	runc create --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
+	[ "$status" -eq 0 ]
+	testcontainer test_pidfd created
+
+	pidfd_kill
+	wait_for_container 10 1 test_pidfd stopped
+}
+
+@test "runc run [ --pidfd-socket ] " {
+	setup_pidfd_kill "SIGKILL"
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
+	[ "$status" -eq 0 ]
+	testcontainer test_pidfd running
+
+	pidfd_kill
+	wait_for_container 10 1 test_pidfd stopped
+}
+
+@test "runc exec [ --pidfd-socket ] [cgroups_v1] " {
+	requires cgroups_v1
+
+	set_cgroups_path
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
+	[ "$status" -eq 0 ]
+	testcontainer test_pidfd running
+
+	# Use sub-cgroup to ensure that exec process has been killed
+	test_pidfd_cgroup_path=$(get_cgroup_path "pids")
+	mkdir "${test_pidfd_cgroup_path}/exec_pidfd"
+	[ "$status" -eq 0 ]
+
+	setup_pidfd_kill "SIGKILL"
+
+	__runc exec -d --cgroup "pids:exec_pidfd" --pid-file "exec_pid.txt" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd sleep 1d
+	[ "$status" -eq 0 ]
+
+	exec_pid=$(cat exec_pid.txt)
+	exec_pid_in_cgroup=$(cat "${test_pidfd_cgroup_path}/exec_pidfd/cgroup.procs")
+	[ "${exec_pid}" -eq "${exec_pid_in_cgroup}" ]
+
+	pidfd_kill
+
+	# ensure exec process has been reaped
+	retry 10 1 rmdir "${test_pidfd_cgroup_path}/exec_pidfd"
+
+	testcontainer test_pidfd running
+}
+
+@test "runc exec [ --pidfd-socket ] [cgroups_v2] " {
+	requires cgroups_v2
+
+	set_cgroups_path
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
+	[ "$status" -eq 0 ]
+	testcontainer test_pidfd running
+
+	# Use sub-cgroup to ensure that exec process has been killed
+	test_pidfd_cgroup_path=$(get_cgroup_path "pids")
+	mkdir "${test_pidfd_cgroup_path}/exec_pidfd"
+	[ "$status" -eq 0 ]
+
+	setup_pidfd_kill "SIGKILL"
+
+	__runc exec -d --cgroup "exec_pidfd" --pid-file "exec_pid.txt" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd sleep 1d
+	[ "$status" -eq 0 ]
+
+	exec_pid=$(cat exec_pid.txt)
+	exec_pid_in_cgroup=$(cat "${test_pidfd_cgroup_path}/exec_pidfd/cgroup.procs")
+	[ "${exec_pid}" -eq "${exec_pid_in_cgroup}" ]
+
+	pidfd_kill
+
+	# ensure exec process has been reaped
+	retry 10 1 rmdir "${test_pidfd_cgroup_path}/exec_pidfd"
+
+	testcontainer test_pidfd running
+}


### PR DESCRIPTION
The container manager like containerd-shim can't use cgroup.kill feature or freeze all the processes in cgroup to terminate the exec init process. It's unsafe to call kill(2) since the pid can be recycled. It's good to provide the pidfd of init process through the pidfd-socket. It's similar to the console-socket. With the pidfd, the container manager like containerd-shim can send the signal to target process safely.

And for the standard init process, we can have polling support to get exit event instead of blocking on wait4.

---------------------

Let me explain why the containerd-shim needs this feature for containerd init process.

Without pidfd, containerd-shim can't tell which process exits. It has to use reap all the zombies.
However, it requires all the fork/exec operations needs to use the [reap-event-framework][2] in containerd.
For example, the `mount` go-package needs to fork child process which unshares to get brand-new userns. If the child process has been killed and reaped by containerd-shim, the child process's pid can be reused. In order to know the exit event, the `mount` go-package needs to use [reap-event-framework][2], which doesn't make senses.

With pidfd support, we can use polling support to know which process exits instead of calling `wait4` syscall.

And one more detail is that the containerd-shim only cares the container init process and exec init processes.

Currently, containerd-shim uses `PR_SET_CHILD_SUBREAPER`, and watch the signal `SIGCHLD` to reap all the zombie processes, including container init process and exec init processes. Before [v4.11 kernel-exit: fix the setns() && PR_SET_CHILD_SUBREAPER interaction][1], the process X double-forked by the exec init process will be reparented to containerd-shim so that containerd-shim can cleanup the zombie.

```
# docker exec
root@50c69c07310e:/go# uname -r
4.4.0-210-generic
root@50c69c07310e:/go# go install github.com/fuweid/cmdrun-go@v0.1.0
root@50c69c07310e:/go#
root@50c69c07310e:/go# cmdrun-go sleep 30
root@50c69c07310e:/go#
root@50c69c07310e:/go# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 04:57 ?        00:00:00 sleep 1d
root         7     0  0 04:58 pts/0    00:00:00 bash
root       262     0  0 05:11 pts/0    00:00:00 sleep 30
root       264     7  0 05:11 pts/0    00:00:00 ps -ef
root@50c69c07310e:/go#
```

Right now (>= v4.11 kernel), the containerd-shim only receives the SIGCHLD from init processes because the double-forked processes will be reparent to pid-1 in the pid namespace. So, containerd-shim doesn't need to care any double-forked processes. The pidfd can help containerd-shim to focus on the correct processes.

```
# docker exec
root@d46705a1963c:/go# uname -r
6.4.0-4-amd64
root@d46705a1963c:/go#
root@d46705a1963c:/go# go install github.com/fuweid/cmdrun-go@v0.1.0
root@d46705a1963c:/go#
root@d46705a1963c:/go# cmdrun-go sleep 5
root@d46705a1963c:/go#
root@d46705a1963c:/go# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 05:15 ?        00:00:00 /bin/sleep 1d
root           7       0  0 05:15 pts/0    00:00:00 /bin/bash
root         103       1  0 05:16 pts/0    00:00:00 sleep 5
root         104       7  0 05:16 pts/0    00:00:00 ps -ef
root@d46705a1963c:/go#
root@d46705a1963c:/go# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 05:15 ?        00:00:00 /bin/sleep 1d
root           7       0  0 05:15 pts/0    00:00:00 /bin/bash
root         103       1  0 05:16 pts/0    00:00:00 [sleep] <defunct>
root         105       7  0 05:16 pts/0    00:00:00 ps -ef
root@d46705a1963c:/go#
```

[1]: <https://github.com/torvalds/linux/commit/c6c70f4455d1eda91065e93cc4f7eddf4499b105>
[2]: <https://github.com/containerd/containerd/blob/1f0caa11c7f0de481948f26b153462862cfdf450/sys/reaper/reaper_unix.go#L95>

REF: https://github.com/containerd/containerd/pull/9175

