### PR TITLE
Fix a regression when killing and deleting a container with shared(host) pid namespace

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -70,7 +70,9 @@ checkpointed.`,
 		err = container.Checkpoint(options)
 		if err == nil && !(options.LeaveRunning || options.PreDump) {
 			// Destroy the container unless we tell CRIU to keep it.
-			destroy(container)
+			if err := destroy(container); err != nil {
+				logrus.Warn(err)
+			}
 		}
 		return err
 	},

--- a/delete.go
+++ b/delete.go
@@ -18,8 +18,7 @@ func killContainer(container *libcontainer.Container) error {
 	for i := 0; i < 100; i++ {
 		time.Sleep(100 * time.Millisecond)
 		if err := container.Signal(unix.Signal(0)); err != nil {
-			destroy(container)
-			return nil
+			return destroy(container)
 		}
 	}
 	return errors.New("container init still running")
@@ -72,7 +71,7 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 		}
 		switch s {
 		case libcontainer.Stopped:
-			destroy(container)
+			return destroy(container)
 		case libcontainer.Created:
 			return killContainer(container)
 		default:
@@ -81,7 +80,5 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 			}
 			return fmt.Errorf("cannot delete container %s that is not stopped: %s", id, s)
 		}
-
-		return nil
 	},
 }

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -259,7 +259,7 @@ func RemovePath(path string) error {
 // If after all there are not removed cgroups - appropriate error will be
 // returned.
 func RemovePaths(paths map[string]string) (err error) {
-	const retries = 5
+	const retries = 10
 	delay := 10 * time.Millisecond
 	for i := 0; i < retries; i++ {
 		if i != 0 {

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -36,6 +36,9 @@ type containerState interface {
 
 func destroy(c *Container) error {
 	err := c.cgroupManager.Destroy()
+	if err != nil {
+		return err
+	}
 	if c.intelRdtManager != nil {
 		if ierr := c.intelRdtManager.Destroy(); err == nil {
 			err = ierr

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -82,10 +82,8 @@ func newProcess(p specs.Process) (*libcontainer.Process, error) {
 	return lp, nil
 }
 
-func destroy(container *libcontainer.Container) {
-	if err := container.Destroy(); err != nil {
-		logrus.Error(err)
-	}
+func destroy(container *libcontainer.Container) error {
+	return container.Destroy()
 }
 
 // setupIO modifies the given process config according to the options.
@@ -289,7 +287,9 @@ func (r *runner) run(config *specs.Process) (int, error) {
 
 func (r *runner) destroy() {
 	if r.shouldDestroy {
-		destroy(r.container)
+		if err := destroy(r.container); err != nil {
+			logrus.Warn(err)
+		}
 	}
 }
 


### PR DESCRIPTION
If we create a container with a shared or host `PID` namespace, after the init process has dead, the container's state becomes `Stopped`, but after we have merged #3825, we can't send any signal to a stopped container, because we removed the logic to check this condition in https://github.com/opencontainers/runc/commit/f8ad20f500bf75edd86041657ee762bce116f8f5 . We should find them back.

Fix #4047 
This also fixes #4040 .