### PR TITLE
fix two typos

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -89,7 +89,7 @@ var retErrnoEnosys = uint32(C.C_ACT_ERRNO_ENOSYS)
 const bpfSizeofInt = 4
 
 // This syscall is used for multiplexing "large" syscalls on s390(x). Unknown
-// syscalls will end up with this syscall number, so we need to explcitly
+// syscalls will end up with this syscall number, so we need to explicitly
 // return -ENOSYS for this syscall on those architectures.
 const s390xMultiplexSyscall libseccomp.ScmpSyscall = 0
 

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -42,7 +42,7 @@ In case **-r** is used, the JSON format is like this:
 
 # OPTIONS
 **--resources**|**-r** _resources.json_
-: Read the new resource limtis from _resources.json_. Use **-** to read from
+: Read the new resource limits from _resources.json_. Use **-** to read from
 stdin. If this option is used, all other options are ignored.
 
 **--blkio-weight** _weight_


### PR DESCRIPTION
Run codespell
  codespell
  shell: /usr/bin/bash -e {0}
  env:
    GO_VERSION: 1.20.x
./man/runc-update.8.md:45: limtis ==> limits
./libcontainer/seccomp/patchbpf/enosys_linux.go:92: explcitly ==> explicitly
Error: Process completed with exit code 65.