### PR TITLE
Rename root to stateDir in struct Container

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -563,7 +563,6 @@ func (c *Container) newParentProcess(p *Process) (parentProcess, error) {
 			"_LIBCONTAINER_CONSOLE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
 		)
 	}
-	cmd.Env = append(cmd.Env, "_LIBCONTAINER_STATEDIR="+c.root)
 
 	cmd.ExtraFiles = append(cmd.ExtraFiles, comm.initSockChild)
 	cmd.Env = append(cmd.Env,

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -36,7 +36,7 @@ const stdioFdCount = 3
 // Container is a libcontainer container object.
 type Container struct {
 	id                   string
-	root                 string
+	stateDir             string
 	config               *configs.Config
 	cgroupManager        cgroups.Manager
 	intelRdtManager      *intelrdt.Manager
@@ -242,7 +242,7 @@ func (c *Container) Exec() error {
 }
 
 func (c *Container) exec() error {
-	path := filepath.Join(c.root, execFifoFilename)
+	path := filepath.Join(c.stateDir, execFifoFilename)
 	pid := c.initProcess.pid()
 	blockingFifoOpenCh := awaitFifoOpen(path)
 	for {
@@ -409,7 +409,7 @@ func (c *Container) createExecFifo() error {
 		return err
 	}
 
-	fifoName := filepath.Join(c.root, execFifoFilename)
+	fifoName := filepath.Join(c.stateDir, execFifoFilename)
 	if _, err := os.Stat(fifoName); err == nil {
 		return fmt.Errorf("exec fifo %s already exists", fifoName)
 	}
@@ -424,7 +424,7 @@ func (c *Container) createExecFifo() error {
 }
 
 func (c *Container) deleteExecFifo() {
-	fifoName := filepath.Join(c.root, execFifoFilename)
+	fifoName := filepath.Join(c.stateDir, execFifoFilename)
 	os.Remove(fifoName)
 }
 
@@ -433,7 +433,7 @@ func (c *Container) deleteExecFifo() {
 // un-opened). It then adds the FifoFd to the given exec.Cmd as an inherited
 // fd, with _LIBCONTAINER_FIFOFD set to its fd number.
 func (c *Container) includeExecFifo(cmd *exec.Cmd) error {
-	fifoName := filepath.Join(c.root, execFifoFilename)
+	fifoName := filepath.Join(c.stateDir, execFifoFilename)
 	fifo, err := os.OpenFile(fifoName, unix.O_PATH|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return err
@@ -512,7 +512,7 @@ func (c *Container) newParentProcess(p *Process) (parentProcess, error) {
 	} else {
 		var err error
 		if isDmzBinarySafe(c.config) {
-			dmzExe, err = dmz.Binary(c.root)
+			dmzExe, err = dmz.Binary(c.stateDir)
 			if err == nil {
 				// We can use our own executable without cloning if we are using
 				// runc-dmz.
@@ -531,7 +531,7 @@ func (c *Container) newParentProcess(p *Process) (parentProcess, error) {
 			err = dmz.ErrNoDmzBinary
 		}
 		if errors.Is(err, dmz.ErrNoDmzBinary) {
-			safeExe, err = dmz.CloneSelfExe(c.root)
+			safeExe, err = dmz.CloneSelfExe(c.stateDir)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create safe /proc/self/exe clone for runc init: %w", err)
 			}
@@ -951,7 +951,7 @@ func (c *Container) updateState(process parentProcess) (*State, error) {
 }
 
 func (c *Container) saveState(s *State) (retErr error) {
-	tmpFile, err := os.CreateTemp(c.root, "state-")
+	tmpFile, err := os.CreateTemp(c.stateDir, "state-")
 	if err != nil {
 		return err
 	}
@@ -972,7 +972,7 @@ func (c *Container) saveState(s *State) (retErr error) {
 		return err
 	}
 
-	stateFilePath := filepath.Join(c.root, stateFilename)
+	stateFilePath := filepath.Join(c.stateDir, stateFilename)
 	return os.Rename(tmpFile.Name(), stateFilePath)
 }
 
@@ -1019,7 +1019,7 @@ func (c *Container) runType() Status {
 	}
 	// We'll create exec fifo and blocking on it after container is created,
 	// and delete it after start container.
-	if _, err := os.Stat(filepath.Join(c.root, execFifoFilename)); err == nil {
+	if _, err := os.Stat(filepath.Join(c.stateDir, execFifoFilename)); err == nil {
 		return Created
 	}
 	return Running

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -233,8 +233,8 @@ func TestGetContainerStateAfterUpdate(t *testing.T) {
 	}
 
 	container := &Container{
-		root: t.TempDir(),
-		id:   "myid",
+		stateDir: t.TempDir(),
+		id:       "myid",
 		config: &configs.Config{
 			Namespaces: []configs.Namespace{
 				{Type: configs.NEWPID},

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -662,7 +662,7 @@ func (c *Container) Restore(process *Process, criuOpts *CriuOpts) error {
 	// * its parent must not be overmounted
 	// c.config.Rootfs is bind-mounted to a temporary directory
 	// to satisfy these requirements.
-	root := filepath.Join(c.root, "criu-root")
+	root := filepath.Join(c.stateDir, "criu-root")
 	if err := os.Mkdir(root, 0o755); err != nil {
 		return err
 	}
@@ -1113,7 +1113,7 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 	logrus.Debugf("notify: %s\n", script)
 	switch script {
 	case "post-dump":
-		f, err := os.Create(filepath.Join(c.root, "checkpoint"))
+		f, err := os.Create(filepath.Join(c.stateDir, "checkpoint"))
 		if err != nil {
 			return err
 		}
@@ -1166,7 +1166,7 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 		if _, err := c.updateState(r); err != nil {
 			return err
 		}
-		if err := os.Remove(filepath.Join(c.root, "checkpoint")); err != nil {
+		if err := os.Remove(filepath.Join(c.stateDir, "checkpoint")); err != nil {
 			if !os.IsNotExist(err) {
 				logrus.Error(err)
 			}

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -46,11 +46,11 @@ func Create(root, id string, config *configs.Config) (*Container, error) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
-	containerRoot, err := securejoin.SecureJoin(root, id)
+	stateDir, err := securejoin.SecureJoin(root, id)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := os.Stat(containerRoot); err == nil {
+	if _, err := os.Stat(stateDir); err == nil {
 		return nil, ErrExist
 	} else if !os.IsNotExist(err) {
 		return nil, err
@@ -89,12 +89,12 @@ func Create(root, id string, config *configs.Config) (*Container, error) {
 	}
 
 	// Parent directory is already created above, so Mkdir is enough.
-	if err := os.Mkdir(containerRoot, 0o711); err != nil {
+	if err := os.Mkdir(stateDir, 0o711); err != nil {
 		return nil, err
 	}
 	c := &Container{
 		id:              id,
-		root:            containerRoot,
+		stateDir:        stateDir,
 		config:          config,
 		cgroupManager:   cm,
 		intelRdtManager: intelrdt.NewManager(config, id, ""),
@@ -114,11 +114,11 @@ func Load(root, id string) (*Container, error) {
 	if err := validateID(id); err != nil {
 		return nil, err
 	}
-	containerRoot, err := securejoin.SecureJoin(root, id)
+	stateDir, err := securejoin.SecureJoin(root, id)
 	if err != nil {
 		return nil, err
 	}
-	state, err := loadState(containerRoot)
+	state, err := loadState(stateDir)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func Load(root, id string) (*Container, error) {
 		config:               &state.Config,
 		cgroupManager:        cm,
 		intelRdtManager:      intelrdt.NewManager(&state.Config, id, state.IntelRdtPath),
-		root:                 containerRoot,
+		stateDir:             stateDir,
 		created:              state.Created,
 	}
 	c.state = &loadedState{c: c}

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -41,7 +41,7 @@ func destroy(c *Container) error {
 			err = ierr
 		}
 	}
-	if rerr := os.RemoveAll(c.root); err == nil {
+	if rerr := os.RemoveAll(c.stateDir); err == nil {
 		err = rerr
 	}
 	c.initProcess = nil
@@ -200,7 +200,7 @@ func (r *restoredState) transition(s containerState) error {
 }
 
 func (r *restoredState) destroy() error {
-	if _, err := os.Stat(filepath.Join(r.c.root, "checkpoint")); err != nil {
+	if _, err := os.Stat(filepath.Join(r.c.stateDir, "checkpoint")); err != nil {
 		if !os.IsNotExist(err) {
 			return err
 		}


### PR DESCRIPTION
The name `root` (or `containerRoot`) is confusing; one might think it is
the root of container's file system (the directory runc chroots into).
    
Rename to `stateDir` for clarity.
    
