### PR TITLE
[1.1 backport] fix typos

### DIFF
--- a/libcontainer/nsenter/cloned_binary.c
+++ b/libcontainer/nsenter/cloned_binary.c
@@ -151,7 +151,7 @@ static int is_self_cloned(void)
 	 * Is the binary a fully-sealed memfd? We don't need CLONED_BINARY_ENV for
 	 * this, because you cannot write to a sealed memfd no matter what (so
 	 * sharing it isn't a bad thing -- and an admin could bind-mount a sealed
-	 * memfd to /usr/bin/runc to allow re-use).
+	 * memfd to /usr/bin/runc to allow reuse).
 	 */
 	ret = fcntl(fd, F_GET_SEALS);
 	if (ret >= 0) {

--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -81,7 +81,7 @@ import "C"
 var retErrnoEnosys = uint32(C.C_ACT_ERRNO_ENOSYS)
 
 // This syscall is used for multiplexing "large" syscalls on s390(x). Unknown
-// syscalls will end up with this syscall number, so we need to explcitly
+// syscalls will end up with this syscall number, so we need to explicitly
 // return -ENOSYS for this syscall on those architectures.
 const s390xMultiplexSyscall libseccomp.ScmpSyscall = 0
 

--- a/man/runc-update.8.md
+++ b/man/runc-update.8.md
@@ -41,7 +41,7 @@ In case **-r** is used, the JSON format is like this:
 
 # OPTIONS
 **--resources**|**-r** _resources.json_
-: Read the new resource limtis from _resources.json_. Use **-** to read from
+: Read the new resource limits from _resources.json_. Use **-** to read from
 stdin. If this option is used, all other options are ignored.
 
 **--blkio-weight** _weight_


### PR DESCRIPTION
This fixes CI for release-1.1 branch

(cherry picked from commit 109dcadd9d1756258ba0ee096871d11c8581002e)

```
Run codespell
  codespell
  shell: /usr/bin/bash -e {0}
  env:
    GO_VERSION: 1.20.x
./man/runc-update.8.md:45: limtis ==> limits
./libcontainer/seccomp/patchbpf/enosys_linux.go:92: explcitly ==> explicitly
Error: Process completed with exit code 65.
```

---
This pr also fix an new typo:
```
Run codespell
  codespell
  shell: /usr/bin/bash -e {0}
  env:
    GO_VERSION: 1.20.x
./libcontainer/nsenter/cloned_binary.c:154: re-use ==> reuse
Error: Process completed with exit code 65.
```