### PR TITLE
Fix directory perms vs umask for tmpcopyup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/moby/sys/user v0.1.0
-	github.com/mrunalp/fileutils v0.5.0
+	github.com/mrunalp/fileutils v0.5.1
 	github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4
 	github.com/opencontainers/selinux v1.11.0
 	github.com/seccomp/libseccomp-golang v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vyg
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=
 github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
-github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
-github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
+github.com/mrunalp/fileutils v0.5.1 h1:F+S7ZlNKnrwHfSwdlgNSkKo67ReVf8o9fel6C3dkm/Q=
+github.com/mrunalp/fileutils v0.5.1/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4 h1:EctkgBjZ1y4q+sibyuuIgiKpa0QSd2elFtSSdNvBVow=
 github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -10,6 +10,24 @@ function teardown() {
 	teardown_bundle
 }
 
+# https://github.com/opencontainers/runc/issues/3991
+@test "runc run [tmpcopyup]" {
+	mkdir -p rootfs/dir1/dir2
+	chmod 777 rootfs/dir1/dir2
+	update_config '	  .mounts += [{
+					source: "tmpfs",
+					destination: "/dir1",
+					type: "tmpfs",
+					options: ["tmpcopyup"]
+				}]
+			| .process.args |= ["ls", "-ld", "/dir1/dir2"]'
+
+	umask 022
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == *'drwxrwxrwx'* ]]
+}
+
 @test "runc run [bind mount]" {
 	update_config '	  .mounts += [{
 					source: ".",

--- a/vendor/github.com/mrunalp/fileutils/fileutils.go
+++ b/vendor/github.com/mrunalp/fileutils/fileutils.go
@@ -125,6 +125,7 @@ func CopyDirectory(source string, dest string) error {
 		if err != nil {
 			return nil
 		}
+		destPath := filepath.Join(dest, relPath)
 
 		if info.IsDir() {
 			// Skip the source directory.
@@ -138,18 +139,20 @@ func CopyDirectory(source string, dest string) error {
 				uid := int(st.Uid)
 				gid := int(st.Gid)
 
-				if err := os.Mkdir(filepath.Join(dest, relPath), info.Mode()); err != nil {
+				if err := os.Mkdir(destPath, info.Mode()); err != nil {
 					return err
 				}
-
-				if err := os.Lchown(filepath.Join(dest, relPath), uid, gid); err != nil {
+				if err := os.Lchown(destPath, uid, gid); err != nil {
+					return err
+				}
+				if err := os.Chmod(destPath, info.Mode()); err != nil {
 					return err
 				}
 			}
 			return nil
 		}
 
-		return CopyFile(path, filepath.Join(dest, relPath))
+		return CopyFile(path, destPath)
 	})
 }
 

--- a/vendor/github.com/mrunalp/fileutils/idtools.go
+++ b/vendor/github.com/mrunalp/fileutils/idtools.go
@@ -49,6 +49,9 @@ func MkdirAllNewAs(path string, mode os.FileMode, ownerUID, ownerGID int) error 
 		if err := os.Chown(pathComponent, ownerUID, ownerGID); err != nil {
 			return err
 		}
+		if err := os.Chmod(pathComponent, mode); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,7 +38,7 @@ github.com/moby/sys/mountinfo
 # github.com/moby/sys/user v0.1.0
 ## explicit; go 1.17
 github.com/moby/sys/user
-# github.com/mrunalp/fileutils v0.5.0
+# github.com/mrunalp/fileutils v0.5.1
 ## explicit; go 1.13
 github.com/mrunalp/fileutils
 # github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4


### PR DESCRIPTION
Bump fileutils to v0.5.1, which fixes permissions of newly created directories to not depend on the value of umask (see mrunalp/fileutils#9).

Add a test case which fails like this before the fix:
    
            mounts.bats
             ✗ runc run [tmpcopyup]
               (in test file tests/integration/mounts.bats, line 28)
                 `[[ "${lines[0]}" == *'drwxrwxrwx'* ]]' failed
               runc spec (status=0):
    
               runc run test_busybox (status=0):
               drwxr-xr-x    2 root     root            40 Oct  4 22:35 /dir1/dir2

Fixes #3991.
