### PR TITLE
Remove duplicated fuzz driver fuzzUIPMap

### DIFF
--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -8,6 +8,5 @@
 # OSS-fuzz environment.
 # More info about compile_go_fuzzer() can be found here:
 #     https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
-compile_go_fuzzer github.com/opencontainers/runc/libcontainer/userns FuzzUIDMap id_map_fuzzer linux,gofuzz
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/user FuzzUser user_fuzzer
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/configs FuzzUnmarshalJSON configs_fuzzer


### PR DESCRIPTION
Remove duplicated fuzz driver `fuzzUIPMap` as CNCF fuzzing has contained this [fuzz driver](https://github.com/cncf/cncf-fuzzing/blob/3ea83bf3cf346b2de075949927d836512de89fa1/projects/runc/build.sh#L20C1-L20C73)