### PR TITLE
libct/cg: support hugetlb rsvd

### DIFF
--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -21,6 +21,11 @@ const (
 	limit    = "hugetlb.%s.limit_in_bytes"
 	maxUsage = "hugetlb.%s.max_usage_in_bytes"
 	failcnt  = "hugetlb.%s.failcnt"
+
+	rsvdUsage    = "hugetlb.%s.rsvd.usage_in_bytes"
+	rsvdLimit    = "hugetlb.%s.rsvd.limit_in_bytes"
+	rsvdMaxUsage = "hugetlb.%s.rsvd.max_usage_in_bytes"
+	rsvdFailcnt  = "hugetlb.%s.rsvd.failcnt"
 )
 
 func TestHugetlbSetHugetlb(t *testing.T) {
@@ -52,13 +57,15 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 	}
 
 	for _, pageSize := range cgroups.HugePageSizes() {
-		limit := fmt.Sprintf(limit, pageSize)
-		value, err := fscommon.GetCgroupParamUint(path, limit)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if value != hugetlbAfter {
-			t.Fatalf("Set hugetlb.limit_in_bytes failed. Expected: %v, Got: %v", hugetlbAfter, value)
+		for _, f := range []string{limit, rsvdLimit} {
+			limit := fmt.Sprintf(f, pageSize)
+			value, err := fscommon.GetCgroupParamUint(path, limit)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value != hugetlbAfter {
+				t.Fatalf("Set %s failed. Expected: %v, Got: %v", limit, hugetlbAfter, value)
+			}
 		}
 	}
 }
@@ -70,6 +77,28 @@ func TestHugetlbStats(t *testing.T) {
 			fmt.Sprintf(usage, pageSize):    hugetlbUsageContents,
 			fmt.Sprintf(maxUsage, pageSize): hugetlbMaxUsageContents,
 			fmt.Sprintf(failcnt, pageSize):  hugetlbFailcnt,
+		})
+	}
+
+	hugetlb := &HugetlbGroup{}
+	actualStats := *cgroups.NewStats()
+	err := hugetlb.GetStats(path, &actualStats)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedStats := cgroups.HugetlbStats{Usage: 128, MaxUsage: 256, Failcnt: 100}
+	for _, pageSize := range cgroups.HugePageSizes() {
+		expectHugetlbStatEquals(t, expectedStats, actualStats.HugetlbStats[pageSize])
+	}
+}
+
+func TestHugetlbRStatsRsvd(t *testing.T) {
+	path := tempDir(t, "hugetlb")
+	for _, pageSize := range cgroups.HugePageSizes() {
+		writeFileContents(t, path, map[string]string{
+			fmt.Sprintf(rsvdUsage, pageSize):    hugetlbUsageContents,
+			fmt.Sprintf(rsvdMaxUsage, pageSize): hugetlbMaxUsageContents,
+			fmt.Sprintf(rsvdFailcnt, pageSize):  hugetlbFailcnt,
 		})
 	}
 

--- a/libcontainer/cgroups/fs2/hugetlb.go
+++ b/libcontainer/cgroups/fs2/hugetlb.go
@@ -1,6 +1,8 @@
 package fs2
 
 import (
+	"errors"
+	"os"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -16,8 +18,22 @@ func setHugeTlb(dirPath string, r *configs.Resources) error {
 	if !isHugeTlbSet(r) {
 		return nil
 	}
+	const suffix = ".max"
+	skipRsvd := false
 	for _, hugetlb := range r.HugetlbLimit {
-		if err := cgroups.WriteFile(dirPath, "hugetlb."+hugetlb.Pagesize+".max", strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
+		prefix := "hugetlb." + hugetlb.Pagesize
+		val := strconv.FormatUint(hugetlb.Limit, 10)
+		if err := cgroups.WriteFile(dirPath, prefix+suffix, val); err != nil {
+			return err
+		}
+		if skipRsvd {
+			continue
+		}
+		if err := cgroups.WriteFile(dirPath, prefix+".rsvd"+suffix, val); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				skipRsvd = true
+				continue
+			}
 			return err
 		}
 	}
@@ -27,15 +43,21 @@ func setHugeTlb(dirPath string, r *configs.Resources) error {
 
 func statHugeTlb(dirPath string, stats *cgroups.Stats) error {
 	hugetlbStats := cgroups.HugetlbStats{}
+	rsvd := ".rsvd"
 	for _, pagesize := range cgroups.HugePageSizes() {
-		value, err := fscommon.GetCgroupParamUint(dirPath, "hugetlb."+pagesize+".current")
+	again:
+		prefix := "hugetlb." + pagesize + rsvd
+		value, err := fscommon.GetCgroupParamUint(dirPath, prefix+".current")
 		if err != nil {
+			if rsvd != "" && errors.Is(err, os.ErrNotExist) {
+				rsvd = ""
+				goto again
+			}
 			return err
 		}
 		hugetlbStats.Usage = value
 
-		fileName := "hugetlb." + pagesize + ".events"
-		value, err = fscommon.GetValueByKey(dirPath, fileName, "max")
+		value, err = fscommon.GetValueByKey(dirPath, prefix+".events", "max")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This adds support for `hugetlb.<pagesize>.rsvd` limiting and accounting.
    
The previous non-rsvd max/limit_in_bytes does not account for reserved
huge page memory, making it possible for a processes to reserve all the
huge page memory, without being able to allocate it (due to cgroup
restrictions).
    
In practice this makes it possible to successfully mmap more huge page
memory than allowed via the cgroup settings, but when using the memory
the process will get a SIGBUS and crash. This is bad for applications
trying to mmap at startup (and it succeeds), but the program crashes
when starting to use the memory. eg. postgres is doing this by default.
    
This also keeps writing to the old max/limit_in_bytes, for backward
compatibility.
    
More info can be found here: https://lkml.org/lkml/2020/2/3/1153
   
(commit message mostly written by @odinuge)

Fixes: #3859.