### PR TITLE
libct/dmz: Support compiling on all arches

### DIFF
--- a/libcontainer/dmz/Makefile
+++ b/libcontainer/dmz/Makefile
@@ -1,7 +1,19 @@
-# Get CC values for cross-compilation.
+# Get GO, GOARCH and CC values for cross-compilation.
 include ../../cc_platform.mk
 
-# We use the flags suggested in nolibc/nolibc.h, it makes the binary very small.
+# List of GOARCH that nolibc supports, from:
+# 	https://go.dev/doc/install/source#environment (with GOOS=linux)
+#
+# See nolibc supported arches in ./nolibc/arch-*.h
+NOLIBC_GOARCHES := 386 amd64 arm arm64 loong64 ppc64le riscv64 s390x
+
+ifneq (,$(filter $(GOARCH), $(NOLIBC_GOARCHES)))
+	# We use the flags suggested in nolibc/nolibc.h, it makes the binary very small.
+	CFLAGS += -fno-asynchronous-unwind-tables -fno-ident -s -Os -nostdlib -lgcc
+else
+	CFLAGS += -DRUNC_USE_STDLIB
+endif
+
 runc-dmz: _dmz.c
-	$(CC) $(CFLAGS) -fno-asynchronous-unwind-tables -fno-ident -s -Os -nostdlib -lgcc -static -o $@ $^
+	$(CC) $(CFLAGS) -static -o $@ $^
 	$(STRIP) -gs $@

--- a/libcontainer/dmz/README.md
+++ b/libcontainer/dmz/README.md
@@ -13,4 +13,6 @@ The current version in that folder is from Linux 6.6-rc3 tag (556fb7131e03b02836
 
 It also support all the architectures we support in runc.
 
+If the GOARCH we use for compiling doesn't support nolibc, it fallbacks to using the C stdlib.
+
 [nolibc-upstream]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/include/nolibc?h=v6.6-rc3

--- a/libcontainer/dmz/_dmz.c
+++ b/libcontainer/dmz/_dmz.c
@@ -1,5 +1,9 @@
-#include "xstat.h"
-#include "nolibc/nolibc.h"
+#ifdef RUNC_USE_STDLIB
+#  include <unistd.h>
+#else
+#  include "xstat.h"
+#  include "nolibc/nolibc.h"
+#endif
 
 extern char **environ;
 


### PR DESCRIPTION
This should make compilation work on all arches, doesn't matter if nolibc is supported there or not. If it is not supported, we just use the C stdlib.

**Please** review the `NOLIBC_GOARCHES` var, as that should have the GOARCH values that nolibc support. If we have a mistake there (i.e. put an arch that is not supported), compilation will fail on that arch.

I tried to be conservative on the arches to put there, but not just limit to the ones I can test (386 and amd64). **Please** review that part.

Fixes: #4037 

cc @cyphar @AkihiroSuda 

See below the commit msg.

---
When we added nolibc, we started using it unconditionally. But runc is currently being compiled on more arches than supported by nolibc, like MIPS.

Let's compile using stdlib if the arch we are compiling on is not supported by nolibc.

If compilation is broken in some arch, just removing it from the NOLIBC_GOARCHES variable should fix the compilation, as it will fallback to use the C stdlib.