### PR TITLE
ci/gha: fix downloading Release.key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         # criu repo
         REPO=${PREFIX}_$(echo ${{ matrix.os }} | sed 's/.*-//')
-        curl -fSsl $REPO/Release.key | sudo apt-key add -
+        curl -fSsLl $REPO/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_tools_criu.gpg > /dev/null
         echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
         sudo apt install libseccomp-dev criu sshfs


### PR DESCRIPTION
For some reason, since today

	curl -fSsl https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_20.04/Release.key

does not produce any error, but there's no output either.

~~Switch to wget.~~ Add -L to follow 3xx redirects.

While at it, ditch apt-key as it's not supposed to be used that way.

Fixes: #4078