### PR TITLE
[1.1] ci/gha: fix downloading Release.key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         REPO: https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_20.04
       run: |
         # criu repo
-        curl -fSsl $REPO/Release.key | sudo apt-key add -
+        curl -fSsLl $REPO/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_tools_criu.gpg > /dev/null
         echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
         sudo apt install libseccomp-dev criu sshfs


### PR DESCRIPTION
_This is a backport of #4079 to release-1.1 branch._

Since today, the URL from download.opensuse.org started returning a HTTP 302 redirect, so -L option for curl is needed to follow it.

While at it, remove apt-key as per its man page recommendation:

> Note: Instead of using this command a keyring should be placed
> directly in the /etc/apt/trusted.gpg.d/ directory with a descriptive
> name and either "gpg" or "asc" as file extension.