### PR TITLE
libct/cg: remove retry on EINTR in

### DIFF
--- a/libcontainer/cgroups/file.go
+++ b/libcontainer/cgroups/file.go
@@ -49,22 +49,11 @@ func WriteFile(dir, file, data string) error {
 		return err
 	}
 	defer fd.Close()
-	if err := retryingWriteFile(fd, data); err != nil {
+	if _, err := fd.WriteString(data); err != nil {
 		// Having data in the error message helps in debugging.
 		return fmt.Errorf("failed to write %q: %w", data, err)
 	}
 	return nil
-}
-
-func retryingWriteFile(fd *os.File, data string) error {
-	for {
-		_, err := fd.Write([]byte(data))
-		if errors.Is(err, unix.EINTR) {
-			logrus.Infof("interrupted while writing %s to %s", data, fd.Name())
-			continue
-		}
-		return err
-	}
 }
 
 const (


### PR DESCRIPTION
Commit f34eb2c00 introduced a workaround to retry on EINTR due to changes in Go 1.14. It was fixed in Go 1.15 [1], meaning a custom retry loop is no longer necessary.

Keep the test case to avoid future regressions.

[1] https://github.com/golang/go/issues/38033