### PR TITLE
CI fixes

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -191,7 +191,7 @@ func (m *Manager) Set(r *configs.Resources) error {
 			if path == "" {
 				// We never created a path for this cgroup, so we cannot set
 				// limits for it (though we have already tried at this point).
-				return fmt.Errorf("cannot set %s limit: container could not join or create cgroup, and the error is %w", sys.Name(), err)
+				return fmt.Errorf("cannot set %s limit: container could not join or create cgroup", sys.Name())
 			}
 			return err
 		}

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -243,7 +243,7 @@ convert_hugetlb_size() {
 	[ "$status" -eq 0 ]
 
 	lim="max"
-	[ -v CGROUP_V1 ] && lim=".limit_in_bytes"
+	[ -v CGROUP_V1 ] && lim="limit_in_bytes"
 
 	optional=("")
 	# Add rsvd, if available.

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -288,12 +288,6 @@ EOF
 	runc update test_update --cpu-share 200
 	[ "$status" -eq 0 ]
 	check_cpu_shares 200
-	runc update test_update --cpu-period 900000 --cpu-burst 500000
-	[ "$status" -eq 0 ]
-	check_cpu_burst 500000
-	runc update test_update --cpu-period 900000 --cpu-burst 0
-	[ "$status" -eq 0 ]
-	check_cpu_burst 0
 
 	# Revert to the test initial value via json on stding
 	runc update -r - test_update <<EOF
@@ -336,6 +330,23 @@ EOF
 	[ "$status" -eq 0 ]
 	check_cpu_quota 500000 1000000 "500ms"
 	check_cpu_shares 100
+}
+
+@test "cpu burst" {
+	[ $EUID -ne 0 ] && requires rootless_cgroup
+	requires cgroups_cpu_burst
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
+	[ "$status" -eq 0 ]
+	check_cpu_burst 0
+
+	runc update test_update --cpu-period 900000 --cpu-burst 500000
+	[ "$status" -eq 0 ]
+	check_cpu_burst 500000
+
+	runc update test_update --cpu-period 900000 --cpu-burst 0
+	[ "$status" -eq 0 ]
+	check_cpu_burst 0
 }
 
 @test "set cpu period with no quota" {


### PR DESCRIPTION
## Fixups after PR #3205

### tests/int: fix cgroup tests
    
Commit e1584831b6835d did two modifications to check_cgroup_value():
    
1. It now skips the test if the file is not found.
   
2. If the comparison failed, a second comparison, with value divided by 1000,
    is performed.
    
These modifications were only needed for cpu.burst, but instead were done
in a generic function used from many cgroup tests. As a result, we can
no longer be sure about the test coverage (item 1) and the check being
correct (item 2) anymore. In fact, part of "update cgroup cpu limits"
test is currently skipped on CentOS 7 and 8 because of item 1.
    
To fix:
 - replace item 1 with a new "cgroups_cpu_burst" argument for "requires",
  and move the test to a separate case;
 - replace item 2 with a local change in check_cpu_burst.

### libct/cg/fs.Set: fix error message
    
There is no point in showing the underlying error when `path == ""`,
because it is inevitably `ENOENT`.
    
Revert the change done in commit e1584831b6835d.

## Fixup after PR #4073

### tests/int: fix "runc run (hugetlb limits)"

Recent commit 4a7d3ae had a bug.