### PR TITLE
Skip TestWriteCgroupFileHandlesInterrupt on CentOS 7

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"os/exec"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+var (
+	centosVer     string
+	centosVerOnce sync.Once
+)
+
+func centosVersion() string {
+	centosVerOnce.Do(func() {
+		ver, _ := exec.Command("rpm", "-q", "--qf", "%{version}", "centos-release").CombinedOutput()
+		centosVer = string(ver)
+	})
+	return centosVer
+}
+
+func SkipOnCentOS(t *testing.T, reason string, versions ...int) {
+	t.Helper()
+	for _, v := range versions {
+		if vstr := strconv.Itoa(v); centosVersion() == vstr {
+			t.Skip(reason + " on CentOS " + vstr)
+		}
+	}
+}

--- a/libcontainer/cgroups/devices/systemd_test.go
+++ b/libcontainer/cgroups/devices/systemd_test.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 	"testing"
 
+	"github.com/opencontainers/runc/internal/testutil"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -27,7 +27,8 @@ func TestPodSkipDevicesUpdate(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("Test requires root.")
 	}
-	skipOnCentOS7(t)
+	// https://github.com/opencontainers/runc/issues/3743.
+	testutil.SkipOnCentOS(t, "Flaky (#3743)", 7)
 
 	podName := "system-runc_test_pod" + t.Name() + ".slice"
 	podConfig := &configs.Cgroup{
@@ -118,27 +119,6 @@ func TestPodSkipDevicesUpdate(t *testing.T) {
 	}
 }
 
-var (
-	centosVer     string
-	centosVerOnce sync.Once
-)
-
-func centosVersion() string {
-	centosVerOnce.Do(func() {
-		ver, _ := exec.Command("rpm", "-q", "--qf", "%{version}", "centos-release").CombinedOutput()
-		centosVer = string(ver)
-	})
-	return centosVer
-}
-
-func skipOnCentOS7(t *testing.T) {
-	t.Helper()
-	// https://github.com/opencontainers/runc/issues/3743
-	if centosVersion() == "7" {
-		t.Skip("Flaky on CentOS 7")
-	}
-}
-
 func testSkipDevices(t *testing.T, skipDevices bool, expected []string) {
 	if !systemd.IsRunningSystemd() {
 		t.Skip("Test requires systemd.")
@@ -146,7 +126,8 @@ func testSkipDevices(t *testing.T, skipDevices bool, expected []string) {
 	if os.Geteuid() != 0 {
 		t.Skip("Test requires root.")
 	}
-	skipOnCentOS7(t)
+	// https://github.com/opencontainers/runc/issues/3743.
+	testutil.SkipOnCentOS(t, "Flaky (#3743)", 7)
 
 	podConfig := &configs.Cgroup{
 		Parent: "system.slice",

--- a/libcontainer/cgroups/file_test.go
+++ b/libcontainer/cgroups/file_test.go
@@ -8,9 +8,13 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/opencontainers/runc/internal/testutil"
 )
 
 func TestWriteCgroupFileHandlesInterrupt(t *testing.T) {
+	testutil.SkipOnCentOS(t, "Flaky (see #3418)", 7)
+
 	const (
 		memoryCgroupMount = "/sys/fs/cgroup/memory"
 		memoryLimit       = "memory.limit_in_bytes"


### PR DESCRIPTION
It's flaky and we can do nothing about it.

Also, this is a chance to finally introduce our first `internal` package (even if for tests only), discussed in https://github.com/opencontainers/runc/issues/3028.

Fixes #3418.