### PR TITLE
Fix `runc kill` and `runc delete` for containers with no init and no private PID namespace

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -70,7 +70,9 @@ checkpointed.`,
 		err = container.Checkpoint(options)
 		if err == nil && !(options.LeaveRunning || options.PreDump) {
 			// Destroy the container unless we tell CRIU to keep it.
-			destroy(container)
+			if err := container.Destroy(); err != nil {
+				logrus.Warn(err)
+			}
 		}
 		return err
 	},

--- a/delete.go
+++ b/delete.go
@@ -18,8 +18,7 @@ func killContainer(container *libcontainer.Container) error {
 	for i := 0; i < 100; i++ {
 		time.Sleep(100 * time.Millisecond)
 		if err := container.Signal(unix.Signal(0)); err != nil {
-			destroy(container)
-			return nil
+			return container.Destroy()
 		}
 	}
 	return errors.New("container init still running")
@@ -80,13 +79,11 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 		}
 		switch s {
 		case libcontainer.Stopped:
-			destroy(container)
+			return container.Destroy()
 		case libcontainer.Created:
 			return killContainer(container)
 		default:
 			return fmt.Errorf("cannot delete container %s that is not stopped: %s", id, s)
 		}
-
-		return nil
 	},
 }

--- a/delete.go
+++ b/delete.go
@@ -66,6 +66,14 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 			}
 			return err
 		}
+		// When --force is given, we kill all container processes and
+		// then destroy the container. This is done even for a stopped
+		// container, because (in case it does not have its own PID
+		// namespace) there may be some leftover processes in the
+		// container's cgroup.
+		if force {
+			return killContainer(container)
+		}
 		s, err := container.Status()
 		if err != nil {
 			return err
@@ -76,9 +84,6 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 		case libcontainer.Created:
 			return killContainer(container)
 		default:
-			if force {
-				return killContainer(container)
-			}
 			return fmt.Errorf("cannot delete container %s that is not stopped: %s", id, s)
 		}
 

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -217,10 +217,26 @@ func PathExists(path string) bool {
 	return true
 }
 
-func rmdir(path string) error {
+// rmdir tries to remove a directory, optionally retrying on EBUSY.
+func rmdir(path string, retry bool) error {
+	delay := time.Millisecond
+	tries := 10
+
+again:
 	err := unix.Rmdir(path)
-	if err == nil || err == unix.ENOENT {
+	switch err { // nolint:errorlint // unix errors are bare
+	case nil, unix.ENOENT:
 		return nil
+	case unix.EINTR:
+		goto again
+	case unix.EBUSY:
+		if retry && tries > 0 {
+			time.Sleep(delay)
+			delay *= 2
+			tries--
+			goto again
+
+		}
 	}
 	return &os.PathError{Op: "rmdir", Path: path, Err: err}
 }
@@ -228,67 +244,41 @@ func rmdir(path string) error {
 // RemovePath aims to remove cgroup path. It does so recursively,
 // by removing any subdirectories (sub-cgroups) first.
 func RemovePath(path string) error {
-	// try the fast path first
-	if err := rmdir(path); err == nil {
+	// Try the fast path first.
+	if err := rmdir(path, false); err == nil {
 		return nil
 	}
 
 	infos, err := os.ReadDir(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			err = nil
-		}
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	for _, info := range infos {
 		if info.IsDir() {
-			// We should remove subcgroups dir first
+			// We should remove subcgroup first.
 			if err = RemovePath(filepath.Join(path, info.Name())); err != nil {
 				break
 			}
 		}
 	}
 	if err == nil {
-		err = rmdir(path)
+		err = rmdir(path, true)
 	}
 	return err
 }
 
 // RemovePaths iterates over the provided paths removing them.
-// We trying to remove all paths five times with increasing delay between tries.
-// If after all there are not removed cgroups - appropriate error will be
-// returned.
 func RemovePaths(paths map[string]string) (err error) {
-	const retries = 5
-	delay := 10 * time.Millisecond
-	for i := 0; i < retries; i++ {
-		if i != 0 {
-			time.Sleep(delay)
-			delay *= 2
+	for s, p := range paths {
+		if err := RemovePath(p); err == nil {
+			delete(paths, s)
 		}
-		for s, p := range paths {
-			if err := RemovePath(p); err != nil {
-				// do not log intermediate iterations
-				switch i {
-				case 0:
-					logrus.WithError(err).Warnf("Failed to remove cgroup (will retry)")
-				case retries - 1:
-					logrus.WithError(err).Error("Failed to remove cgroup")
-				}
-			}
-			_, err := os.Stat(p)
-			// We need this strange way of checking cgroups existence because
-			// RemoveAll almost always returns error, even on already removed
-			// cgroups
-			if os.IsNotExist(err) {
-				delete(paths, s)
-			}
-		}
-		if len(paths) == 0 {
-			//nolint:ineffassign,staticcheck // done to help garbage collecting: opencontainers/runc#2506
-			paths = make(map[string]string)
-			return nil
-		}
+	}
+	if len(paths) == 0 {
+		//nolint:ineffassign,staticcheck // done to help garbage collecting: opencontainers/runc#2506
+		// TODO: switch to clear once Go < 1.21 is not supported.
+		paths = make(map[string]string)
+		return nil
 	}
 	return fmt.Errorf("Failed to remove paths: %v", paths)
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -874,7 +874,10 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 func (c *Container) Destroy() error {
 	c.m.Lock()
 	defer c.m.Unlock()
-	return c.state.destroy()
+	if err := c.state.destroy(); err != nil {
+		return fmt.Errorf("unable to destroy container: %w", err)
+	}
+	return nil
 }
 
 // Pause pauses the container, if its state is RUNNING or CREATED, changing

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -673,6 +673,9 @@ func setupPersonality(config *configs.Config) error {
 // signalAllProcesses freezes then iterates over all the processes inside the
 // manager's cgroups sending the signal s to them.
 func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
+	if !m.Exists() {
+		return ErrNotRunning
+	}
 	// Use cgroup.kill, if available.
 	if s == unix.SIGKILL {
 		if p := m.Path(""); p != "" { // Either cgroup v2 or hybrid.

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -62,6 +62,69 @@ function teardown() {
 	[ "$status" -eq 0 ]
 }
 
+# Issue 4047, case "runc delete -f".
+# See also: "kill KILL [host pidns + init gone]" test in kill.bats.
+@test "runc delete --force [host pidns + init gone]" {
+	requires cgroups_freezer
+
+	update_config '	  .linux.namespaces -= [{"type": "pid"}]'
+	set_cgroups_path
+	if [ $EUID -ne 0 ]; then
+		requires rootless_cgroup
+		# Apparently, for rootless test, when using systemd cgroup manager,
+		# newer versions of systemd clean up the container as soon as its init
+		# process is gone. This is all fine and dandy, except it prevents us to
+		# test this case, thus we skip the test.
+		#
+		# It is not entirely clear which systemd version got this feature:
+		# v245 works fine, and v249 does not.
+		if [ -v RUNC_USE_SYSTEMD ] && [ "$(systemd_version)" -gt 245 ]; then
+			skip "rootless+systemd conflicts with systemd > 245"
+		fi
+		# Can't mount real /proc when rootless + no pidns,
+		# so change it to a bind-mounted one from the host.
+		update_config '	  .mounts |= map((select(.type == "proc")
+					| .type = "none"
+					| .source = "/proc"
+					| .options = ["rbind", "nosuid", "nodev", "noexec"]
+				  ) // .)'
+	fi
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+	cgpath=$(get_cgroup_path "pids")
+	init_pid=$(cat "$cgpath"/cgroup.procs)
+
+	# Start a few more processes.
+	for _ in 1 2 3 4 5; do
+		__runc exec -d test_busybox sleep 1h
+	done
+
+	# Now kill the container's init process. Since the container do
+	# not have own PID ns, its init is no special and the container
+	# will still be up and running.
+	kill -9 "$init_pid"
+
+	# Get the list of all container processes.
+	pids=$(cat "$cgpath"/cgroup.procs)
+	echo "pids: $pids"
+	# Sanity check -- make sure all processes exist.
+	for p in $pids; do
+		kill -0 "$p"
+	done
+
+	runc delete -f test_busybox
+	[ "$status" -eq 0 ]
+
+	runc state test_busybox
+	[ "$status" -ne 0 ] # "Container does not exist"
+
+	# Make sure all processes are gone.
+	pids=$(cat "$cgpath"/cgroup.procs) || true # OK if cgroup is gone
+	echo "pids: $pids"
+	[ -z "$pids" ]
+}
+
 @test "runc delete --force [paused container]" {
 	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 	[ "$status" -eq 0 ]

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -10,6 +10,7 @@ function teardown() {
 	teardown_bundle
 }
 
+# shellcheck disable=SC2030
 @test "kill detached busybox" {
 	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
@@ -35,16 +36,15 @@ function teardown() {
 	[ "$status" -eq 0 ]
 }
 
-# This is roughly the same as TestPIDHostInitProcessWait in libcontainer/integration.
-@test "kill KILL [host pidns]" {
-	# kill -a currently requires cgroup freezer.
+test_host_pidns_kill() {
 	requires cgroups_freezer
 
 	update_config '	  .linux.namespaces -= [{"type": "pid"}]'
 	set_cgroups_path
 	if [ $EUID -ne 0 ]; then
-		# kill --all requires working cgroups.
 		requires rootless_cgroup
+		# Can't mount real /proc when rootless + no pidns,
+		# so change it to a bind-mounted one from the host.
 		update_config '	  .mounts |= map((select(.type == "proc")
 					| .type = "none"
 					| .source = "/proc"
@@ -53,17 +53,28 @@ function teardown() {
 	fi
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	# shellcheck disable=SC2031
 	[ "$status" -eq 0 ]
+	cgpath=$(get_cgroup_path "pids")
+	init_pid=$(cat "$cgpath"/cgroup.procs)
 
 	# Start a few more processes.
 	for _ in 1 2 3 4 5; do
 		__runc exec -d test_busybox sleep 1h
-		[ "$status" -eq 0 ]
 	done
 
+	if [ -v KILL_INIT ]; then
+		# Now kill the container's init process. Since the container do
+		# not have own PID ns, its init is no special and the container
+		# will still be up and running (except for rootless container
+		# AND systemd cgroup driver AND systemd > v245, when systemd
+		# kills the container; see "kill KILL [host pidns + init gone]"
+		# below).
+		kill -9 "$init_pid"
+	fi
+
 	# Get the list of all container processes.
-	path=$(get_cgroup_path "pids")
-	pids=$(cat "$path"/cgroup.procs)
+	pids=$(cat "$cgpath"/cgroup.procs)
 	echo "pids: $pids"
 	# Sanity check -- make sure all processes exist.
 	for p in $pids; do
@@ -71,14 +82,45 @@ function teardown() {
 	done
 
 	runc kill test_busybox KILL
+	# shellcheck disable=SC2031
 	[ "$status" -eq 0 ]
 	wait_for_container 10 1 test_busybox stopped
 
 	# Make sure all processes are gone.
-	pids=$(cat "$path"/cgroup.procs) || true # OK if cgroup is gone
+	pids=$(cat "$cgpath"/cgroup.procs) || true # OK if cgroup is gone
 	echo "pids: $pids"
-	for p in $pids; do
-		run ! kill -0 "$p"
-		[[ "$output" = *"No such process" ]]
-	done
+	[ -z "$pids" ]
+}
+
+# This is roughly the same as TestPIDHostInitProcessWait in libcontainer/integration.
+# The differences are:
+#
+# 1. Here we use separate processes to create and to kill a container, so the
+#    processes inside a container are not children of "runc kill".
+#
+# 2. We hit different codepaths (nonChildProcess.signal rather than initProcess.signal).
+@test "kill KILL [host pidns]" {
+	unset KILL_INIT
+	test_host_pidns_kill
+}
+
+# Same as above plus:
+#
+# 3. Test runc kill on a container whose init process is gone.
+#
+# Issue 4047, case "runc kill".
+@test "kill KILL [host pidns + init gone]" {
+	# Apparently, for rootless test, when using systemd cgroup manager,
+	# newer versions of systemd clean up the container as soon as its init
+	# process is gone. This is all fine and dandy, except it prevents us to
+	# test this case, thus we skip the test.
+	#
+	# It is not entirely clear which systemd version got this feature:
+	# v245 works fine, and v249 does not.
+	if [ $EUID -ne 0 ] && [ -v RUNC_USE_SYSTEMD ] && [ "$(systemd_version)" -gt 245 ]; then
+		skip "rootless+systemd conflicts with systemd > 245"
+	fi
+	KILL_INIT=1
+	test_host_pidns_kill
+	unset KILL_INIT
 }

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -109,6 +109,7 @@ test_host_pidns_kill() {
 # 3. Test runc kill on a container whose init process is gone.
 #
 # Issue 4047, case "runc kill".
+# See also: "runc delete --force [host pidns + init gone]" test in delete.bats.
 @test "kill KILL [host pidns + init gone]" {
 	# Apparently, for rootless test, when using systemd cgroup manager,
 	# newer versions of systemd clean up the container as soon as its init

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -88,12 +88,6 @@ func newProcess(p specs.Process) (*libcontainer.Process, error) {
 	return lp, nil
 }
 
-func destroy(container *libcontainer.Container) {
-	if err := container.Destroy(); err != nil {
-		logrus.Error(err)
-	}
-}
-
 // setupIO modifies the given process config according to the options.
 func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, detach bool, sockpath string) (*tty, error) {
 	if createTTY {
@@ -303,7 +297,9 @@ func (r *runner) run(config *specs.Process) (int, error) {
 
 func (r *runner) destroy() {
 	if r.shouldDestroy {
-		destroy(r.container)
+		if err := r.container.Destroy(); err != nil {
+			logrus.Warn(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes a couple of regressions introduced in #3825, most related to
killing and destroying containers without own private PID namespace,
and with initial container process gone. In this scenario, container is
considered stopped, but there might be some leftover processes in
the container cgroup.

1. Commit f8ad20f made it impossible to kill those leftover processes.
Fix this by moving the check if container init exists to after the
special case of handling the container without own PID namespace.

2. `runc delete -f` is not killing leftover processes either, ignoring those.

3. `runc delete` in runc 1.1 and earier used to kill leftover processes.
I think this is a bug, as `delete` (without `-f`) is not supposed to kill
anything. With this PR, such error is reported.

4. Fix the minor issue introduced by commit 9583b3d:
if signalAllProcesses is used, there is no need to thaw the
container (as freeze/thaw is either done in signalAllProcesses already,
or not needed at all).

Also, a few non-regressions:

5. make signalAllProcesses return an error early if the container
cgroup does not exist (as it relies on it to do its job). This way, the
error message returned is more generic and easier to understand
("container not running" instead of "can't open file").

6. Make `runc delete` return with non-zero exit code if the container
is not removed.

7. `runc delete`: do not remove container state if container's cgroup can't be removed
(as otherwise we'll lose the container cgroup information forever). Suggested by @lifubang.

Appropriate test cases were added to avoid future regressions.

Fixes #4047.
Fixes #4040.