### PR TITLE
libct: Remove old comment

### DIFF
--- a/libcontainer/configs/validate/validator_test.go
+++ b/libcontainer/configs/validate/validator_test.go
@@ -395,12 +395,10 @@ func TestValidateMounts(t *testing.T) {
 		isErr bool
 		dest  string
 	}{
-		// TODO (runc v1.x.x): make these relative paths an error. See https://github.com/opencontainers/runc/pull/3004
 		{isErr: false, dest: "not/an/abs/path"},
 		{isErr: false, dest: "./rel/path"},
 		{isErr: false, dest: "./rel/path"},
 		{isErr: false, dest: "../../path"},
-
 		{isErr: false, dest: "/abs/path"},
 		{isErr: false, dest: "/abs/but/../unclean"},
 	}


### PR DESCRIPTION
We changed it in PR:
	https://github.com/opencontainers/runtime-spec/pull/1225

But we missed to remove this comment.