### PR TITLE
ci/cirrus: disable selinux-dmz kludge for centos-stream-8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -160,10 +160,10 @@ task:
     sed -e "s,PermitRootLogin.*,PermitRootLogin prohibit-password,g" -i /etc/ssh/sshd_config
     systemctl restart sshd
 
-    # Disable the dmz-vs-selinux workaround for distros that have container-selinux >= 2.224.0.
+    # Disable the dmz-vs-selinux workaround for distros that have
+    # container-selinux >= 2.224.0 (CentOS 7 does not have it).
     case $DISTRO in
-    # TODO: remove centos-stream-8.
-    centos-7|centos-stream-8)
+    centos-7)
       # Do nothing.
       ;;
     *)


### PR DESCRIPTION
This is a followup to #4053.

CentOS Stream 8 now comes with container-selinux 2:2.224.0-1.module_el8+712+4cd1bd69, so we only need the kludge for CentOS 7 (which, I guess, is the sole reason why we have this kludge at all).

This is only for CI.