### PR TITLE
libcontainer/cgroup2: Export Kernel usage to stats metrics

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -231,6 +231,9 @@ func rootStatsFromMeminfo(stats *cgroups.Stats) error {
 	// sum swap usage as combined mem+swap usage for consistency as well.
 	stats.MemoryStats.Usage.Usage = stats.MemoryStats.Stats["anon"] + stats.MemoryStats.Stats["file"]
 	stats.MemoryStats.Usage.Limit = math.MaxUint64
+	stats.MemoryStats.KernelUsage = cgroups.MemoryData{
+		Usage: stats.MemoryStats.Stats["kernel_stack"] + stats.MemoryStats.Stats["slab"],
+	}
 	stats.MemoryStats.SwapUsage.Usage = (swap_total - swap_free) * 1024
 	stats.MemoryStats.SwapUsage.Limit = math.MaxUint64
 	stats.MemoryStats.SwapUsage.Usage += stats.MemoryStats.Usage.Usage


### PR DESCRIPTION
Fix: #4059

Calculate the kernel usage metric by using `kernel_stack` and `slab` fields in `memory.stats`