### PR TITLE
*: fix several issues with namespace path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vendor/pkg
 /contrib/cmd/fs-idmap/fs-idmap
 /contrib/cmd/memfd-bind/memfd-bind
 /contrib/cmd/pidfd-kill/pidfd-kill
+/contrib/cmd/remap-rootfs/remap-rootfs
 man/man8
 release
 Vagrantfile

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ runc-bin: runc-dmz
 	$(GO_BUILD) -o runc .
 
 .PHONY: all
-all: runc recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill
+all: runc recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill remap-rootfs
 
-.PHONY: recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill
-recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill:
+.PHONY: recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill remap-rootfs
+recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill remap-rootfs:
 	$(GO_BUILD) -o contrib/cmd/$@/$@ ./contrib/cmd/$@
 
 .PHONY: static

--- a/contrib/cmd/remap-rootfs/remap-rootfs.go
+++ b/contrib/cmd/remap-rootfs/remap-rootfs.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/urfave/cli"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const usage = `contrib/cmd/remap-rootfs
+
+remap-rootfs is a helper tool to remap the root filesystem of a Open Container
+Initiative bundle using user namespaces such that the file owners are remapped
+from "host" mappings to the user namespace's mappings.
+
+Effectively, this is a slightly more complicated 'chown -R', and is primarily
+used within runc's integration tests to remap the test filesystem to match the
+test user namespace. Note that calling remap-rootfs multiple times, or changing
+the mapping and then calling remap-rootfs will likely produce incorrect results
+because we do not "un-map" any pre-applied mappings from previous remap-rootfs
+calls.
+
+Note that the bundle is assumed to be produced by a trusted source, and thus
+malicious configuration files will likely not be handled safely.
+
+To use remap-rootfs, simply pass it the path to an OCI bundle (a directory
+containing a config.json):
+
+    $ sudo remap-rootfs ./bundle
+`
+
+func toHostID(mappings []specs.LinuxIDMapping, id uint32) (int, bool) {
+	for _, m := range mappings {
+		if m.ContainerID <= id && id < m.ContainerID+m.Size {
+			return int(m.HostID + id), true
+		}
+	}
+	return -1, false
+}
+
+type inodeID struct {
+	Dev, Ino uint64
+}
+
+func toInodeID(st *syscall.Stat_t) inodeID {
+	return inodeID{Dev: st.Dev, Ino: st.Ino}
+}
+
+func remapRootfs(root string, uidMap, gidMap []specs.LinuxIDMapping) error {
+	seenInodes := make(map[inodeID]struct{})
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		mode := info.Mode()
+		st := info.Sys().(*syscall.Stat_t)
+
+		// Skip symlinks.
+		if mode.Type() == os.ModeSymlink {
+			return nil
+		}
+		// Skip hard-links to files we've already remapped.
+		id := toInodeID(st)
+		if _, seen := seenInodes[id]; seen {
+			return nil
+		}
+		seenInodes[id] = struct{}{}
+
+		// Calculate the new uid:gid.
+		uid := st.Uid
+		newUID, ok1 := toHostID(uidMap, uid)
+		gid := st.Gid
+		newGID, ok2 := toHostID(gidMap, gid)
+
+		// Skip files that cannot be mapped.
+		if !ok1 || !ok2 {
+			niceName := path
+			if relName, err := filepath.Rel(root, path); err == nil {
+				niceName = "/" + relName
+			}
+			fmt.Printf("skipping file %s: cannot remap user %d:%d -> %d:%d\n", niceName, uid, gid, newUID, newGID)
+			return nil
+		}
+		if err := os.Lchown(path, newUID, newGID); err != nil {
+			return err
+		}
+		// Re-apply any setid bits that would be cleared due to chown(2).
+		return os.Chmod(path, mode)
+	})
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "remap-rootfs"
+	app.Usage = usage
+
+	app.Action = func(ctx *cli.Context) error {
+		args := ctx.Args()
+		if len(args) != 1 {
+			return errors.New("exactly one bundle argument must be provided")
+		}
+		bundle := args[0]
+
+		configFile, err := os.Open(filepath.Join(bundle, "config.json"))
+		if err != nil {
+			return err
+		}
+		defer configFile.Close()
+
+		var spec specs.Spec
+		if err := json.NewDecoder(configFile).Decode(&spec); err != nil {
+			return fmt.Errorf("parsing config.json: %w", err)
+		}
+
+		if spec.Root == nil {
+			return errors.New("invalid config.json: root section is null")
+		}
+		rootfs := filepath.Join(bundle, spec.Root.Path)
+
+		if spec.Linux == nil {
+			return errors.New("invalid config.json: linux section is null")
+		}
+		uidMap := spec.Linux.UIDMappings
+		gidMap := spec.Linux.GIDMappings
+		if len(uidMap) == 0 && len(gidMap) == 0 {
+			fmt.Println("skipping remapping -- no userns mappings specified")
+			return nil
+		}
+
+		return remapRootfs(rootfs, uidMap, gidMap)
+	}
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}

--- a/libcontainer/configs/config_linux.go
+++ b/libcontainer/configs/config_linux.go
@@ -1,12 +1,13 @@
 package configs
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
-	errNoUIDMap   = errors.New("User namespaces enabled, but no uid mappings found.")
-	errNoUserMap  = errors.New("User namespaces enabled, but no user mapping found.")
-	errNoGIDMap   = errors.New("User namespaces enabled, but no gid mappings found.")
-	errNoGroupMap = errors.New("User namespaces enabled, but no group mapping found.")
+	errNoUIDMap = errors.New("user namespaces enabled, but no uid mappings found")
+	errNoGIDMap = errors.New("user namespaces enabled, but no gid mappings found")
 )
 
 // Please check https://man7.org/linux/man-pages/man2/personality.2.html for const details.
@@ -31,7 +32,7 @@ func (c Config) HostUID(containerId int) (int, error) {
 		}
 		id, found := c.hostIDFromMapping(containerId, c.UIDMappings)
 		if !found {
-			return -1, errNoUserMap
+			return -1, fmt.Errorf("user namespaces enabled, but no mapping found for uid %d", containerId)
 		}
 		return id, nil
 	}
@@ -54,7 +55,7 @@ func (c Config) HostGID(containerId int) (int, error) {
 		}
 		id, found := c.hostIDFromMapping(containerId, c.GIDMappings)
 		if !found {
-			return -1, errNoGroupMap
+			return -1, fmt.Errorf("user namespaces enabled, but no mapping found for gid %d", containerId)
 		}
 		return id, nil
 	}

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/userns"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"golang.org/x/sys/unix"
@@ -1550,6 +1551,11 @@ func TestInitJoinNetworkAndUser(t *testing.T) {
 	config2 := newTemplateConfig(t, &tParam{userns: true})
 	config2.Namespaces.Add(configs.NEWNET, netns1)
 	config2.Namespaces.Add(configs.NEWUSER, userns1)
+	// Emulate specconv.setupUserNamespace().
+	uidMap, gidMap, err := userns.GetUserNamespaceMappings(userns1)
+	ok(t, err)
+	config2.UIDMappings = uidMap
+	config2.GIDMappings = gidMap
 	config2.Cgroups.Path = "integration/test2"
 	container2, err := newContainer(t, config2)
 	ok(t, err)

--- a/libcontainer/userns/userns_maps.c
+++ b/libcontainer/userns/userns_maps.c
@@ -1,0 +1,79 @@
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <sched.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+/*
+ * All of the code here is run inside an aync-signal-safe context, so we need
+ * to be careful to not call any functions that could cause issues. In theory,
+ * since we are a Go program, there are fewer restrictions in practice, it's
+ * better to be safe than sorry.
+ *
+ * The only exception is exit, which we need to call to make sure we don't
+ * return into runc.
+ */
+
+void bail(int pipefd, const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	vdprintf(pipefd, fmt, args);
+	va_end(args);
+
+	exit(1);
+}
+
+int spawn_userns_cat(char *userns_path, char *path, int outfd, int errfd)
+{
+	char buffer[4096] = { 0 };
+
+	pid_t child = fork();
+	if (child != 0)
+		return child;
+	/* in child */
+
+	/* Join the target userns. */
+	int nsfd = open(userns_path, O_RDONLY);
+	if (nsfd < 0)
+		bail(errfd, "open userns path %s failed: %m", userns_path);
+
+	int err = setns(nsfd, CLONE_NEWUSER);
+	if (err < 0)
+		bail(errfd, "setns %s failed: %m", userns_path);
+
+	close(nsfd);
+
+	/* Pipe the requested file contents. */
+	int fd = open(path, O_RDONLY);
+	if (fd < 0)
+		bail(errfd, "open %s in userns %s failed: %m", path, userns_path);
+
+	int nread, ntotal = 0;
+	while ((nread = read(fd, buffer, sizeof(buffer))) != 0) {
+		if (nread < 0)
+			bail(errfd, "read bytes from %s failed (after %d total bytes read): %m", path, ntotal);
+		ntotal += nread;
+
+		int nwritten = 0;
+		while (nwritten < nread) {
+			int n = write(outfd, buffer, nread - nwritten);
+			if (n < 0)
+				bail(errfd, "write %d bytes from %s failed (after %d bytes written): %m",
+				     nread - nwritten, path, nwritten);
+			nwritten += n;
+		}
+		if (nread != nwritten)
+			bail(errfd, "mismatch for bytes read and written: %d read != %d written", nread, nwritten);
+	}
+
+	close(fd);
+	close(outfd);
+	close(errfd);
+
+	/* We must exit here, otherwise we would return into a forked runc. */
+	exit(0);
+}

--- a/libcontainer/userns/userns_maps_linux.go
+++ b/libcontainer/userns/userns_maps_linux.go
@@ -1,0 +1,171 @@
+//go:build linux
+
+package userns
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"unsafe"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/sirupsen/logrus"
+)
+
+/*
+#include <stdlib.h>
+extern int spawn_userns_cat(char *userns_path, char *path, int outfd, int errfd);
+*/
+import "C"
+
+func parseIdmapData(data []byte) (ms []configs.IDMap, err error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		var m configs.IDMap
+		line := scanner.Text()
+		if _, err := fmt.Sscanf(line, "%d %d %d", &m.ContainerID, &m.HostID, &m.Size); err != nil {
+			return nil, fmt.Errorf("parsing id map failed: invalid format in line %q: %w", line, err)
+		}
+		ms = append(ms, m)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("parsing id map failed: %w", err)
+	}
+	return ms, nil
+}
+
+// Do something equivalent to nsenter --user=<nsPath> cat <path>, but more
+// efficiently. Returns the contents of the requested file from within the user
+// namespace.
+func spawnUserNamespaceCat(nsPath string, path string) ([]byte, error) {
+	rdr, wtr, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create pipe for userns spawn failed: %w", err)
+	}
+	defer rdr.Close()
+	defer wtr.Close()
+
+	errRdr, errWtr, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create error pipe for userns spawn failed: %w", err)
+	}
+	defer errRdr.Close()
+	defer errWtr.Close()
+
+	cNsPath := C.CString(nsPath)
+	defer C.free(unsafe.Pointer(cNsPath))
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	childPid := C.spawn_userns_cat(cNsPath, cPath, C.int(wtr.Fd()), C.int(errWtr.Fd()))
+
+	if childPid < 0 {
+		return nil, fmt.Errorf("failed to spawn fork for userns")
+	} else if childPid == 0 {
+		// this should never happen
+		panic("runc executing inside fork child -- unsafe state!")
+	}
+
+	// We are in the parent -- close the write end of the pipe before reading.
+	wtr.Close()
+	output, err := io.ReadAll(rdr)
+	rdr.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading from userns spawn failed: %w", err)
+	}
+
+	// Ditto for the error pipe.
+	errWtr.Close()
+	errOutput, err := io.ReadAll(errRdr)
+	errRdr.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading from userns spawn error pipe failed: %w", err)
+	}
+	errOutput = bytes.TrimSpace(errOutput)
+
+	// Clean up the child.
+	child, err := os.FindProcess(int(childPid))
+	if err != nil {
+		return nil, fmt.Errorf("could not find userns spawn process: %w", err)
+	}
+	state, err := child.Wait()
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for userns spawn process: %w", err)
+	}
+	if !state.Success() {
+		errStr := string(errOutput)
+		if errStr == "" {
+			errStr = fmt.Sprintf("unknown error (status code %d)", state.ExitCode())
+		}
+		return nil, fmt.Errorf("userns spawn: %s", errStr)
+	} else if len(errOutput) > 0 {
+		// We can just ignore weird output in the error pipe if the process
+		// didn't bail(), but for completeness output for debugging.
+		logrus.Debugf("userns spawn succeeded but unexpected error message found: %s", string(errOutput))
+	}
+	// The subprocess succeeded, return whatever it wrote to the pipe.
+	return output, nil
+}
+
+func GetUserNamespaceMappings(nsPath string) (uidMap, gidMap []configs.IDMap, err error) {
+	var (
+		pid         int
+		extra       rune
+		tryFastPath bool
+	)
+
+	// nsPath is usually of the form /proc/<pid>/ns/user, which means that we
+	// already have a pid that is part of the user namespace and thus we can
+	// just use the pid to read from /proc/<pid>/*id_map.
+	//
+	// Note that Sscanf doesn't consume the whole input, so we check for any
+	// trailing data with %c. That way, we can be sure the pattern matched
+	// /proc/$pid/ns/user _exactly_ iff n === 1.
+	if n, _ := fmt.Sscanf(nsPath, "/proc/%d/ns/user%c", &pid, &extra); n == 1 {
+		tryFastPath = pid > 0
+	}
+
+	for _, mapType := range []struct {
+		name  string
+		idMap *[]configs.IDMap
+	}{
+		{"uid_map", &uidMap},
+		{"gid_map", &gidMap},
+	} {
+		var mapData []byte
+
+		if tryFastPath {
+			path := fmt.Sprintf("/proc/%d/%s", pid, mapType.name)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				// Do not error out here -- we need to try the slow path if the
+				// fast path failed.
+				logrus.Debugf("failed to use fast path to read %s from userns %s (error: %s), falling back to slow userns-join path", mapType.name, nsPath, err)
+			} else {
+				mapData = data
+			}
+		} else {
+			logrus.Debugf("cannot use fast path to read %s from userns %s, falling back to slow userns-join path", mapType.name, nsPath)
+		}
+
+		if mapData == nil {
+			// We have to actually join the namespace if we cannot take the
+			// fast path. The path is resolved with respect to the child
+			// process, so just use /proc/self.
+			data, err := spawnUserNamespaceCat(nsPath, "/proc/self/"+mapType.name)
+			if err != nil {
+				return nil, nil, err
+			}
+			mapData = data
+		}
+		idMap, err := parseIdmapData(mapData)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse %s of userns %s: %w", mapType.name, nsPath, err)
+		}
+		*mapType.idMap = idMap
+	}
+
+	return uidMap, gidMap, nil
+}

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -10,6 +10,72 @@ function teardown() {
 	teardown_bundle
 }
 
+# See also: "kill KILL [host pidns + init gone]" test in kill.bats.
+#
+# This needs to be placed at the top of the bats file to work around
+# a shellcheck bug. See <https://github.com/koalaman/shellcheck/issues/2873>.
+function test_runc_delete_host_pidns() {
+	requires cgroups_freezer
+
+	update_config '	  .linux.namespaces -= [{"type": "pid"}]'
+	set_cgroups_path
+	if [ $EUID -ne 0 ]; then
+		requires rootless_cgroup
+		# Apparently, for rootless test, when using systemd cgroup manager,
+		# newer versions of systemd clean up the container as soon as its init
+		# process is gone. This is all fine and dandy, except it prevents us to
+		# test this case, thus we skip the test.
+		#
+		# It is not entirely clear which systemd version got this feature:
+		# v245 works fine, and v249 does not.
+		if [ -v RUNC_USE_SYSTEMD ] && [ "$(systemd_version)" -gt 245 ]; then
+			skip "rootless+systemd conflicts with systemd > 245"
+		fi
+		# Can't mount real /proc when rootless + no pidns,
+		# so change it to a bind-mounted one from the host.
+		update_config '	  .mounts |= map((select(.type == "proc")
+					| .type = "none"
+					| .source = "/proc"
+					| .options = ["rbind", "nosuid", "nodev", "noexec"]
+				  ) // .)'
+	fi
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+	cgpath=$(get_cgroup_path "pids")
+	init_pid=$(cat "$cgpath"/cgroup.procs)
+
+	# Start a few more processes.
+	for _ in 1 2 3 4 5; do
+		__runc exec -d test_busybox sleep 1h
+	done
+
+	# Now kill the container's init process. Since the container do
+	# not have own PID ns, its init is no special and the container
+	# will still be up and running.
+	kill -9 "$init_pid"
+
+	# Get the list of all container processes.
+	pids=$(cat "$cgpath"/cgroup.procs)
+	echo "pids: $pids"
+	# Sanity check -- make sure all processes exist.
+	for p in $pids; do
+		kill -0 "$p"
+	done
+
+	# Must kill those processes and remove container.
+	runc delete "$@" test_busybox
+	[ "$status" -eq 0 ]
+
+	runc state test_busybox
+	[ "$status" -ne 0 ] # "Container does not exist"
+
+	# Make sure all processes are gone.
+	pids=$(cat "$cgpath"/cgroup.procs) || true # OK if cgroup is gone
+	echo "pids: $pids"
+	[ -z "$pids" ]
+}
+
 @test "runc delete" {
 	# Need a permission to create a cgroup.
 	# XXX(@kolyshkin): currently this test does not handle rootless when
@@ -68,76 +134,8 @@ function teardown() {
 }
 
 # Issue 4047, case "runc delete --force" (different code path).
-# shellcheck disable=SC2030
 @test "runc delete --force [host pidns + init gone]" {
 	test_runc_delete_host_pidns --force
-}
-
-# See also: "kill KILL [host pidns + init gone]" test in kill.bats.
-function test_runc_delete_host_pidns() {
-	requires cgroups_freezer
-
-	update_config '	  .linux.namespaces -= [{"type": "pid"}]'
-	set_cgroups_path
-	if [ $EUID -ne 0 ]; then
-		requires rootless_cgroup
-		# Apparently, for rootless test, when using systemd cgroup manager,
-		# newer versions of systemd clean up the container as soon as its init
-		# process is gone. This is all fine and dandy, except it prevents us to
-		# test this case, thus we skip the test.
-		#
-		# It is not entirely clear which systemd version got this feature:
-		# v245 works fine, and v249 does not.
-		if [ -v RUNC_USE_SYSTEMD ] && [ "$(systemd_version)" -gt 245 ]; then
-			skip "rootless+systemd conflicts with systemd > 245"
-		fi
-		# Can't mount real /proc when rootless + no pidns,
-		# so change it to a bind-mounted one from the host.
-		update_config '	  .mounts |= map((select(.type == "proc")
-					| .type = "none"
-					| .source = "/proc"
-					| .options = ["rbind", "nosuid", "nodev", "noexec"]
-				  ) // .)'
-	fi
-
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	# shellcheck disable=SC2031
-	[ "$status" -eq 0 ]
-	cgpath=$(get_cgroup_path "pids")
-	init_pid=$(cat "$cgpath"/cgroup.procs)
-
-	# Start a few more processes.
-	for _ in 1 2 3 4 5; do
-		__runc exec -d test_busybox sleep 1h
-	done
-
-	# Now kill the container's init process. Since the container do
-	# not have own PID ns, its init is no special and the container
-	# will still be up and running.
-	kill -9 "$init_pid"
-
-	# Get the list of all container processes.
-	pids=$(cat "$cgpath"/cgroup.procs)
-	echo "pids: $pids"
-	# Sanity check -- make sure all processes exist.
-	for p in $pids; do
-		kill -0 "$p"
-	done
-
-	# Must kill those processes and remove container.
-	# shellcheck disable=SC2031
-	runc delete "$@" test_busybox
-	# shellcheck disable=SC2031
-	[ "$status" -eq 0 ]
-
-	runc state test_busybox
-	# shellcheck disable=SC2031
-	[ "$status" -ne 0 ] # "Container does not exist"
-
-	# Make sure all processes are gone.
-	pids=$(cat "$cgpath"/cgroup.procs) || true # OK if cgroup is gone
-	echo "pids: $pids"
-	[ -z "$pids" ]
 }
 
 @test "runc delete --force [paused container]" {
@@ -251,7 +249,6 @@ EOF
 	requires systemd_v244 # Older systemd lacks RuntimeMaxSec support.
 
 	set_cgroups_path
-	# shellcheck disable=SC2016
 	update_config '	  .annotations += {
 				"org.systemd.property.RuntimeMaxSec": "2",
 				"org.systemd.property.TimeoutStopSec": "1"

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -18,6 +18,7 @@ SD_HELPER="${INTEGRATION_ROOT}/../../contrib/cmd/sd-helper/sd-helper"
 SECCOMP_AGENT="${INTEGRATION_ROOT}/../../contrib/cmd/seccompagent/seccompagent"
 FS_IDMAP="${INTEGRATION_ROOT}/../../contrib/cmd/fs-idmap/fs-idmap"
 PIDFD_KILL="${INTEGRATION_ROOT}/../../contrib/cmd/pidfd-kill/pidfd-kill"
+REMAP_ROOTFS="${INTEGRATION_ROOT}/../../contrib/cmd/remap-rootfs/remap-rootfs"
 
 # Some variables may not always be set. Set those to empty value,
 # if unset, to avoid "unbound variable" error.
@@ -655,6 +656,12 @@ function teardown_bundle() {
 	done
 	rm -rf "$ROOT"
 	remove_parent
+}
+
+function remap_rootfs() {
+	[ ! -v ROOT ] && return 0 # nothing to remap
+
+	"$REMAP_ROOTFS" "$ROOT/bundle"
 }
 
 function is_kernel_gte() {

--- a/tests/integration/idmap.bats
+++ b/tests/integration/idmap.bats
@@ -16,7 +16,6 @@ function setup() {
 	# Use other owner for source-2
 	chown 1:1 source-2/foo.txt
 
-	mkdir -p rootfs/{proc,sys,tmp}
 	mkdir -p rootfs/tmp/mount-{1,2}
 	mkdir -p rootfs/mnt/bind-mount-{1,2}
 
@@ -43,6 +42,8 @@ function setup() {
 						]
 					}
 				] '
+
+	remap_rootfs
 }
 
 function teardown() {

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -160,3 +160,73 @@ function teardown() {
 	[[ "$output" = *"Hello World"* ]]
 	[[ "$output" = *"runc-dmz: using /proc/self/exe clone"* ]]
 }
+
+@test "runc run [joining existing container namespaces]" {
+	requires timens
+
+	# Create a detached container with the namespaces we want. We notably want
+	# to include both userns and timens, which require config-related
+	# configuration.
+	if [ $EUID -eq 0 ]; then
+		update_config '.linux.namespaces += [{"type": "user"}]
+			| .linux.uidMappings += [{"containerID": 0, "hostID": 100000, "size": 100}]
+			| .linux.gidMappings += [{"containerID": 0, "hostID": 200000, "size": 200}]'
+		mkdir -p rootfs/{proc,sys,tmp}
+	fi
+	update_config '.linux.namespaces += [{"type": "time"}]
+		| .linux.timeOffsets = {
+			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
+			"boottime": { "secs": 1337, "nanosecs": 3141519 }
+		}'
+	update_config '.process.args = ["sleep", "infinity"]'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" target_ctr
+	[ "$status" -eq 0 ]
+
+	# Modify our container's configuration such that it is just going to
+	# inherit all of the namespaces of the target container.
+	#
+	# NOTE: We cannot join the mount namespace of another container because of
+	# some quirks of the runtime-spec. In particular, we MUST pivot_root into
+	# root.path and root.path MUST be set in the config, so runc cannot just
+	# ignore root.path when joining namespaces (and root.path doesn't exist
+	# inside root.path, for obvious reasons).
+	#
+	# We could hack around this (create a copy of the rootfs inside the rootfs,
+	# or use a simpler mount namespace target), but those wouldn't be similar
+	# tests to the other namespace joining tests.
+	target_pid="$(__runc state target_ctr | jq .pid)"
+	update_config '.linux.namespaces |= map_values(.path = if .type == "mount" then "" else "/proc/'"$target_pid"'/ns/" + ({"network": "net", "mount": "mnt"}[.type] // .type) end)'
+	# Remove the userns and timens configuration (they cannot be changed).
+	update_config '.linux |= (del(.uidMappings) | del(.gidMappings) | del(.timeOffsets))'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" attached_ctr
+	[ "$status" -eq 0 ]
+
+	# Make sure there are two sleep processes in our container.
+	runc exec attached_ctr ps aux
+	[ "$status" -eq 0 ]
+	run -0 grep "sleep infinity" <<<"$output"
+	[ "${#lines[@]}" -eq 2 ]
+
+	# ... that the userns mappings are the same...
+	runc exec attached_ctr cat /proc/self/uid_map
+	[ "$status" -eq 0 ]
+	if [ $EUID -eq 0 ]; then
+		grep -E '^\s+0\s+100000\s+100$' <<<"$output"
+	else
+		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
+	fi
+	runc exec attached_ctr cat /proc/self/gid_map
+	[ "$status" -eq 0 ]
+	if [ $EUID -eq 0 ]; then
+		grep -E '^\s+0\s+200000\s+200$' <<<"$output"
+	else
+		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
+	fi
+
+	# ... as well as the timens offsets.
+	runc exec attached_ctr cat /proc/self/timens_offsets
+	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
+	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
+}

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -171,7 +171,7 @@ function teardown() {
 		update_config '.linux.namespaces += [{"type": "user"}]
 			| .linux.uidMappings += [{"containerID": 0, "hostID": 100000, "size": 100}]
 			| .linux.gidMappings += [{"containerID": 0, "hostID": 200000, "size": 200}]'
-		mkdir -p rootfs/{proc,sys,tmp}
+		remap_rootfs
 	fi
 	update_config '.linux.namespaces += [{"type": "time"}]
 		| .linux.timeOffsets = {

--- a/tests/integration/timens.bats
+++ b/tests/integration/timens.bats
@@ -4,8 +4,6 @@ load helpers
 
 function setup() {
 	setup_busybox
-
-	mkdir -p rootfs/{proc,sys,tmp}
 }
 
 function teardown() {
@@ -63,6 +61,7 @@ function teardown() {
 	update_config ' .linux.namespaces += [{"type": "user"}]
 		| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}]
 		| .linux.gidMappings += [{"hostID": 200000, "containerID": 0, "size": 65534}] '
+	remap_rootfs
 
 	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
 	update_config '.linux.namespaces += [{"type": "time"}]

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -12,7 +12,6 @@ function setup() {
 	# Permissions only to the owner, it is inaccessible to group/others
 	chmod 700 source-inaccessible-{1,2}
 
-	mkdir -p rootfs/{proc,sys,tmp}
 	mkdir -p rootfs/tmp/mount-{1,2}
 
 	to_umount_list="$(mktemp "$BATS_RUN_TMPDIR/userns-mounts.XXXXXX")"
@@ -20,6 +19,7 @@ function setup() {
 		update_config ' .linux.namespaces += [{"type": "user"}]
 			| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}]
 			| .linux.gidMappings += [{"hostID": 200000, "containerID": 0, "size": 65534}] '
+		remap_rootfs
 	fi
 }
 

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -15,15 +15,25 @@ function setup() {
 	mkdir -p rootfs/{proc,sys,tmp}
 	mkdir -p rootfs/tmp/mount-{1,2}
 
+	to_umount_list="$(mktemp "$BATS_RUN_TMPDIR/userns-mounts.XXXXXX")"
 	if [ $EUID -eq 0 ]; then
 		update_config ' .linux.namespaces += [{"type": "user"}]
 			| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}]
-			| .linux.gidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}] '
+			| .linux.gidMappings += [{"hostID": 200000, "containerID": 0, "size": 65534}] '
 	fi
 }
 
 function teardown() {
 	teardown_bundle
+
+	if [ -v to_umount_list ]; then
+		while read -r mount_path; do
+			umount -l "$mount_path" || :
+			rm -f "$mount_path"
+		done <"$to_umount_list"
+		rm -f "$to_umount_list"
+		unset to_umount_list
+	fi
 }
 
 @test "userns with simple mount" {
@@ -82,4 +92,75 @@ function teardown() {
 	# Make sure this is real cgroupfs.
 	runc exec test_busybox cat /sys/fs/cgroup/{pids,memory}/tasks
 	[ "$status" -eq 0 ]
+}
+
+@test "userns join other container userns" {
+	# Create a detached container with the id-mapping we want.
+	update_config '.process.args = ["sleep", "infinity"]'
+	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
+	[ "$status" -eq 0 ]
+
+	# Configure our container to attach to the first container's userns.
+	target_pid="$(__runc state target_userns | jq .pid)"
+	update_config '.linux.namespaces |= map(if .type == "user" then (.path = "/proc/'"$target_pid"'/ns/" + .type) else . end)
+		| del(.linux.uidMappings)
+		| del(.linux.gidMappings)'
+	runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
+	[ "$status" -eq 0 ]
+
+	runc exec in_userns cat /proc/self/uid_map
+	[ "$status" -eq 0 ]
+	if [ $EUID -eq 0 ]; then
+		grep -E '^\s+0\s+100000\s+65534$' <<<"$output"
+	else
+		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
+	fi
+
+	runc exec in_userns cat /proc/self/gid_map
+	[ "$status" -eq 0 ]
+	if [ $EUID -eq 0 ]; then
+		grep -E '^\s+0\s+200000\s+65534$' <<<"$output"
+	else
+		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
+	fi
+}
+
+@test "userns join other container userns [bind-mounted nsfd]" {
+	requires root
+
+	# Create a detached container with the id-mapping we want.
+	update_config '.process.args = ["sleep", "infinity"]'
+	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
+	[ "$status" -eq 0 ]
+
+	# Bind-mount the first containers userns nsfd to a different path, to
+	# exercise the non-fast-path (where runc has to join the userns to get the
+	# mappings).
+	target_pid="$(__runc state target_userns | jq .pid)"
+	userns_path=$(mktemp "$BATS_RUN_TMPDIR/userns.XXXXXX")
+	mount --bind "/proc/$target_pid/ns/user" "$userns_path"
+	echo "$userns_path" >>"$to_umount_list"
+
+	# Configure our container to attach to the first container's userns.
+	update_config '.linux.namespaces |= map(if .type == "user" then (.path = "'"$userns_path"'") else . end)
+		| del(.linux.uidMappings)
+		| del(.linux.gidMappings)'
+	runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
+	[ "$status" -eq 0 ]
+
+	runc exec in_userns cat /proc/self/uid_map
+	[ "$status" -eq 0 ]
+	if [ $EUID -eq 0 ]; then
+		grep -E '^\s+0\s+100000\s+65534$' <<<"$output"
+	else
+		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
+	fi
+
+	runc exec in_userns cat /proc/self/gid_map
+	[ "$status" -eq 0 ]
+	if [ $EUID -eq 0 ]; then
+		grep -E '^\s+0\s+200000\s+65534$' <<<"$output"
+	else
+		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
+	fi
 }


### PR DESCRIPTION
This fixes #4122 along with several other issues I found while writing integration tests for joining namespace paths. In particular, this fixes the following issues:

 * Starting a container in a target user namespace now works properly.
   - ~~**NOTE** This requires calling the `nsenter` binary. I've taken care to ensure that we don't do this in any context other than the host, but I'm not super happy with this. The other option would be to self-exec but that would require changing up how `runc init` works as well so we could have two self-exec entrypoints. I'm not sure it's worth it.~~
   - I've reimplemented this using CGo, by forking in C code and doing the `setns(2)` there. Technically it's a little dodgy to be doing work after a `fork(2)`, and while we don't do anything too complicated (like heap allocations), I'm not sure I'm comfortable saying that it won't ever have any issues.
 * Time namespace configurations now work with user namespaces (they worked with rootless containers, but not "standard" ones).
 * Disallow configurations where the timens and userns namespaces are configured to join an existing namespace and there are configuration entries for the timens and userns. This is needed because you cannot modify the configuration of these namespace has been configured. Previously we would not use the configuration to configure the container but would use the mapping to figure out how uids and gids map (which was broken).
 * Remap the rootfs when using user namespaces in our integration tests, to get rid of the `mkdir -p rootfs/{proc,sys,dev}` hack.

There is a test I want to add to #3985 which requires these changes (to verify that `idmap` uses the correct user namespace when joining a userns instead of creating a new one).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>