### PR TITLE
Avoid using runc-dmz if capabilities are set as non-root

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -135,7 +135,7 @@ func (l *linuxSetnsInit) Init() error {
 		return &os.PathError{Op: "close log pipe", Path: "fd " + strconv.Itoa(l.logFd), Err: err}
 	}
 
-	if l.dmzExe != nil {
+	if l.dmzExe != nil && l.config.UseDmz {
 		l.config.Args[0] = name
 		return system.Fexecve(l.dmzExe.Fd(), l.config.Args, os.Environ())
 	}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -286,7 +286,7 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	if l.dmzExe != nil {
+	if l.dmzExe != nil && l.config.UseDmz {
 		l.config.Args[0] = name
 		return system.Fexecve(l.dmzExe.Fd(), l.config.Args, os.Environ())
 	}


### PR DESCRIPTION
...unless they are in both the bounding and ambient sets, in which case things work as expected.

Potential fix for #4125