### PR TITLE
CI: add actuated-arm64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, actuated-arm64-6cpu-8gb]
         go-version: [1.20.x, 1.21.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
@@ -50,15 +50,81 @@ jobs:
             rootless: rootless
           - dmz: runc_nodmz
             race: -race
+          - go-version: 1.20.x
+            os: actuated-arm64-6cpu-8gb
+          - race: "-race"
+            os: actuated-arm64-6cpu-8gb
+          - criu: criu-dev
+            os: actuated-arm64-6cpu-8gb
+          - dmz: runc_nodmz
+            os: actuated-arm64-6cpu-8gb
+
     runs-on: ${{ matrix.os }}
 
     steps:
+# https://gist.github.com/alexellis/1f33e581c75e11e161fe613c46180771#file-metering-gha-md
+# vmmeter start
+    - name: Prepare arkade
+      uses: alexellis/arkade-get@master
+      if: matrix.os == 'actuated-arm64-6cpu-8gb'
+      with:
+        crane: latest
+        print-summary: false
+
+    - name: Install vmmeter
+      if: matrix.os == 'actuated-arm64-6cpu-8gb'
+      run: |
+        crane export --platform linux/arm64 ghcr.io/openfaasltd/vmmeter:latest | sudo tar -xvf - -C /usr/local/bin
+
+    - name: Run vmmeter
+      uses: self-actuated/vmmeter-action@master
+      if: matrix.os == 'actuated-arm64-6cpu-8gb'
+# vmmeter end
 
     - name: checkout
       uses: actions/checkout@v4
 
+    - name: Show host info
+      run: |
+        set -x
+        # Sync `set -x` outputs with command ouputs
+        exec 2>&1
+        # Version
+        uname -a
+        cat /etc/os-release
+        # Hardware
+        cat /proc/cpuinfo
+        free -mt
+        # cgroup
+        ls -F /sys/fs/cgroup
+        cat /proc/self/cgroup
+        if [ -e /sys/fs/cgroup/cgroup.controllers ]; then
+          cat /sys/fs/cgroup/cgroup.controllers
+          cat /sys/fs/cgroup/cgroup.subtree_control
+          ls -F /sys/fs/cgroup$(grep -oP '0::\K.*' /proc/self/cgroup)
+        fi
+        # kernel config
+        script/check-config.sh
+
+    - name: start sshd (used for testing rootless with systemd user session)
+      if: ${{ matrix.os == 'actuated-arm64-6cpu-8gb' && matrix.rootless == 'rootless' }}
+      run: |
+        # Generate new keys to fix "sshd: no hostkeys available -- exiting."
+        sudo ssh-keygen -A
+        if ! sudo systemctl start ssh.service; then
+          sudo journalctl -xeu ssh.service
+          exit 1
+        fi
+        ps auxw | grep sshd
+
     - name: install deps
-      if: matrix.criu == ''
+      run: |
+        sudo apt update
+        sudo apt -y install libseccomp-dev sshfs uidmap
+
+    - name: install CRIU
+      # TODO: enable CRIU for actuated: https://github.com/opencontainers/runc/pull/4142#issuecomment-1945408382
+      if: ${{ matrix.os != 'actuated-arm64-6cpu-8gb' && matrix.criu == '' }}
       env:
         PREFIX: https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu
       run: |
@@ -67,13 +133,12 @@ jobs:
         curl -fSsLl $REPO/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_tools_criu.gpg > /dev/null
         echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
-        sudo apt -y install libseccomp-dev criu sshfs
+        sudo apt -y install criu
 
-    - name: install deps (criu ${{ matrix.criu }})
-      if: matrix.criu != ''
+    - name: install CRIU (criu ${{ matrix.criu }})
+      if: ${{ matrix.os != 'actuated-arm64-6cpu-8gb' && matrix.criu != '' }}
       run: |
-        sudo apt -q update
-        sudo apt -qy install libseccomp-dev sshfs \
+        sudo apt -qy install \
           libcap-dev libnet1-dev libnl-3-dev \
           libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
         git clone https://github.com/checkpoint-restore/criu.git ~/criu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,13 +67,13 @@ jobs:
         curl -fSsLl $REPO/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_tools_criu.gpg > /dev/null
         echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
-        sudo apt install libseccomp-dev criu sshfs
+        sudo apt -y install libseccomp-dev criu sshfs
 
     - name: install deps (criu ${{ matrix.criu }})
       if: matrix.criu != ''
       run: |
         sudo apt -q update
-        sudo apt -q install libseccomp-dev sshfs \
+        sudo apt -qy install libseccomp-dev sshfs \
           libcap-dev libnet1-dev libnl-3-dev \
           libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
         git clone https://github.com/checkpoint-restore/criu.git ~/criu
@@ -151,7 +151,7 @@ jobs:
         sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to.
 
-        sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib libgcc-s1:i386 criu
+        sudo apt -qy install libseccomp-dev libseccomp-dev:i386 gcc-multilib libgcc-s1:i386 criu
 
     - name: install go
       uses: actions/setup-go@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,7 @@ jobs:
       - name: install deps
         run: |
           sudo apt -q update
-          sudo apt -q install libseccomp-dev
+          sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v4
         with:
           version: v1.54
@@ -153,7 +153,7 @@ jobs:
     - name: install deps
       run: |
         sudo apt -qq update
-        sudo apt -qq install indent
+        sudo apt -qqy install indent
     - name: cfmt
       run: |
         make cfmt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![gha/validate](https://github.com/opencontainers/runc/workflows/validate/badge.svg)](https://github.com/opencontainers/runc/actions?query=workflow%3Avalidate)
 [![gha/ci](https://github.com/opencontainers/runc/workflows/ci/badge.svg)](https://github.com/opencontainers/runc/actions?query=workflow%3Aci)
 [![CirrusCI](https://api.cirrus-ci.com/github/opencontainers/runc.svg)](https://cirrus-ci.com/github/opencontainers/runc)
+<a href="https://actuated.dev"><img alt="Arm CI sponsored by Actuated" src="https://docs.actuated.dev/images/actuated-badge.png" width="120px"></img></a>
 
 ## Introduction
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -132,7 +132,7 @@ function setup() {
 }
 
 @test "runc run (blkio weight)" {
-	requires cgroups_v2
+	requires cgroups_v2 cgroups_io_weight
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	set_cgroups_path

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -465,6 +465,8 @@ function requires() {
 				p="$CGROUP_CPU_BASE_PATH"
 				f="cpu.cfs_burst_us"
 			elif [ -v CGROUP_V2 ]; then
+				# https://github.com/torvalds/linux/commit/f4183717b370ad28dd0c0d74760142b20e6e7931
+				requires_kernel 5.14
 				p="$CGROUP_BASE_PATH"
 				f="cpu.max.burst"
 			fi

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -472,6 +472,22 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		cgroups_io_weight)
+			local p f1 f2
+			init_cgroup_paths
+			if [ -v CGROUP_V1 ]; then
+				p="$CGROUP_CPU_BASE_PATH"
+				f1="blkio.weight"
+				f2="blkio.bfq.weight"
+			elif [ -v CGROUP_V2 ]; then
+				p="$CGROUP_BASE_PATH"
+				f1="io.weight"
+				f2="io.bfq.weight"
+			fi
+			if [ -z "$(find "$p" -type f \( -name "$f1" -o -name "$f2" \) -print -quit)" ]; then
+				skip_me=1
+			fi
+			;;
 		cgroupns)
 			if [ ! -e "/proc/self/ns/cgroup" ]; then
 				skip_me=1

--- a/tests/integration/testdata/seccomp_syscall_test1.c
+++ b/tests/integration/testdata/seccomp_syscall_test1.c
@@ -57,10 +57,10 @@ int main(void)
 	syscall_assert(raw(process_vm_writev, 0, NULL, 0, NULL, 0, ~0), -EPERM);
 
 	// Multiple arguments with AND rules.
-	syscall_assert(raw(kcmp, 0, 1337, 0, 0, 0), -ESRCH);
-	syscall_assert(raw(kcmp, 0, 0, 0, 0, 0), -EPERM);
-	syscall_assert(raw(kcmp, 500, 1337, 0, 0, 0), -EPERM);
-	syscall_assert(raw(kcmp, 500, 500, 0, 0, 0), -EPERM);
+	syscall_assert(raw(ftruncate, 123456789, 1337), -EBADF);
+	syscall_assert(raw(ftruncate, 123456789, 0), -EPERM);
+	syscall_assert(raw(ftruncate, 500, 1337), -EPERM);
+	syscall_assert(raw(ftruncate, 500, 500), -EPERM);
 
 	// Multiple rules for the same syscall.
 	syscall_assert(raw(dup3, 0, -100, 0xFFFF), -EPERM);

--- a/tests/integration/testdata/seccomp_syscall_test1.json
+++ b/tests/integration/testdata/seccomp_syscall_test1.json
@@ -79,8 +79,6 @@
 				"fstatfs",
 				"fstatfs64",
 				"fsync",
-				"ftruncate",
-				"ftruncate64",
 				"futex",
 				"futex_time64",
 				"futimesat",
@@ -380,12 +378,13 @@
 		{
 			"action": "SCMP_ACT_ALLOW",
 			"names": [
-				"kcmp"
+				"ftruncate",
+				"ftruncate64"
 			],
 			"args": [
 				{
 					"index": 0,
-					"value": 0,
+					"value": 123456789,
 					"op": "SCMP_CMP_EQ"
 				},
 				{


### PR DESCRIPTION
See <https://actuated.dev/blog/arm-ci-cncf-ampere>. 
Thanks to Alex Ellis, Ampere Computing, and Equinix.

- - -

Host information:
* CPU: aarch64 (ARMv8)
* Kernel: 5.10.201
  * Lacks ~`CONFIG_CHECKPOINT_RESTORE`~, `CONFIG_BLK_CGROUP_IOCOST`, etc.
* Cgroup: v2
* OS: Ubuntu 22.04
  * Lacks `newuidmap`, `newgidmap`, etc. (still apt-gettable)
  * `sshd` is not running