### PR TITLE
skip set cpu.weight when cpu.idle is enabled in cgroups v2

### DIFF
--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -29,7 +29,8 @@ func setCpu(dirPath string, r *configs.Resources) error {
 	}
 
 	// NOTE: .CpuShares is not used here. Conversion is the caller's responsibility.
-	if r.CpuWeight != 0 {
+	// can not set cpu.weight if cpu.idle is enabled
+	if r.CpuWeight != 0 && (r.CPUIdle == nil || *r.CPUIdle == 0) {
 		if err := cgroups.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(r.CpuWeight, 10)); err != nil {
 			return err
 		}


### PR DESCRIPTION
In cgroups v2, setting `cpu.weight` when `cpu.idle==1` will fail with `Invalid argument`

This pr fixed this situation, consistent with https://github.com/opencontainers/runc/blob/main/libcontainer/cgroups/systemd/v2.go#L119 