### PR TITLE
libct: Improve error msg when idmap is not supported

### DIFF
--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -258,7 +258,12 @@ func mountFd(nsHandles *userns.Handles, m *configs.Mount) (*mountSource, error) 
 			Attr_set:  unix.MOUNT_ATTR_IDMAP,
 			Userns_fd: uint64(usernsFile.Fd()),
 		}); err != nil {
-			return nil, fmt.Errorf("failed to set MOUNT_ATTR_IDMAP on %s: %w", m.Source, err)
+			extraMsg := ""
+			if err == unix.EINVAL {
+				extraMsg = " (maybe the filesystem used doesn't support idmap mounts on this kernel?)"
+			}
+
+			return nil, fmt.Errorf("failed to set MOUNT_ATTR_IDMAP on %s: %w%s", m.Source, err, extraMsg)
 		}
 	} else {
 		var err error


### PR DESCRIPTION
This gives a more clear error message when idmap mounts are not supported on the source filesystem. For example, a k8s user will see this now in kubectl describe pod:

	  Warning  Failed     2s (x2 over 4s)  kubelet, 127.0.0.1  Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: failed to fulfil mount request: failed to set MOUNT_ATTR_IDMAP on /var/lib/kubelet/pods/f037a704-742c-40fe-8dbf-17ed9225c4df/volumes/kubernetes.io~empty-dir/hugepage: invalid argument (maybe the source filesystem doesn't support idmap mounts on this kernel?): unknown

This gives a hint on where to look at.

This come-up when looking at this bug report: https://github.com/containers/crun/issues/1380

cc @cyphar 