### PR TITLE
update spec-conformance.md(rsvd hugetlb cgroup and idmapped-mounts)

### DIFF
--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -10,13 +10,6 @@ Spec version | Feature                                  | PR
 v1.1.0       | `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` | [#3862](https://github.com/opencontainers/runc/pull/3862)
 v1.1.0       | `.process.ioPriority`                    | [#3783](https://github.com/opencontainers/runc/pull/3783)
 
-
-The following features are implemented with some limitations:
-Spec version | Feature                                  | Limitation
--------------|------------------------------------------|----------------------------------------------------------
-v1.1.0       | `.[]mounts.uidMappings`                  | Requires using UserNS with identical uidMappings
-v1.1.0       | `.[]mounts.gidMappings`                  | Requires using UserNS with identical gidMappings
-
 ## Architectures
 
 The following architectures are supported:

--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -8,7 +8,6 @@ The following features are not implemented yet:
 Spec version | Feature                                  | PR
 -------------|------------------------------------------|----------------------------------------------------------
 v1.1.0       | `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` | [#3862](https://github.com/opencontainers/runc/pull/3862)
-v1.1.0       | rsvd hugetlb cgroup                      | TODO ([#3859](https://github.com/opencontainers/runc/issues/3859))
 v1.1.0       | `.process.ioPriority`                    | [#3783](https://github.com/opencontainers/runc/pull/3783)
 
 


### PR DESCRIPTION
1. The issue "Support rsvd hugetlb cgroup (#3859)" has been implemented in (#4073), and has been backported to 1.1 in (#4077 ).
2. We have implemented idmapped-mounts with no limitations in #3985 .
So we should update the doc.