### PR TITLE
helpers.bash: no need to add word pattern operator in awk

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -132,7 +132,7 @@ function init_cgroup_paths() {
 		CGROUP_SUBSYSTEMS=$(awk '!/^#/ {print $1}' /proc/cgroups)
 		local g base_path
 		for g in ${CGROUP_SUBSYSTEMS}; do
-			base_path=$(awk '$(NF-2) == "cgroup" && $NF ~ /\<'"${g}"'\>/ { print $5; exit }' /proc/self/mountinfo)
+			base_path=$(awk '$(NF-2) == "cgroup" && ($NF ~ /'"${g}"',/ || $NF ~ /'"${g}"'$/) { print $5; exit }' /proc/self/mountinfo)
 			test -z "$base_path" && continue
 			eval CGROUP_"${g^^}"_BASE_PATH="${base_path}"
 		done


### PR DESCRIPTION
When I run integration tests in my local machine, I got some errors, I found out my `awk` doesn't support `\< />`.
```
root@acmcoder:~/runc# awk '$NF ~ /\<main\>/ { print $NF; exit }' ./run.go
root@acmcoder:~/runc# awk '$NF ~ /main/ { print $NF; exit }' ./run.go
main
root@acmcoder:~/runc# auname -a
Linux acmcoder 5.4.0-169-generic #187-Ubuntu SMP Thu Nov 23 14:52:28 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
```
I think it's not necessary to add this operator in awk.