### PR TITLE
Fix runc-dmz error printing

### DIFF
--- a/libcontainer/dmz/_dmz.c
+++ b/libcontainer/dmz/_dmz.c
@@ -1,4 +1,7 @@
 #ifdef RUNC_USE_STDLIB
+#  include <linux/limits.h>
+#  include <stdio.h>
+#  include <string.h>
 #  include <unistd.h>
 #else
 #  include "xstat.h"
@@ -11,5 +14,14 @@ int main(int argc, char **argv)
 {
 	if (argc < 1)
 		return 127;
-	return execve(argv[0], argv, environ);
+	int ret = execve(argv[0], argv, environ);
+	if (ret) {
+		/* NOTE: This error message format MUST match Go's format. */
+		char err_msg[5 + PATH_MAX + 1] = "exec ";	// "exec " + argv[0] + '\0'
+		strncat(err_msg, argv[0], PATH_MAX);
+		err_msg[sizeof(err_msg) - 1] = '\0';
+
+		perror(err_msg);
+	}
+	return ret;
 }


### PR DESCRIPTION
This error code is using functions that are present in nolibc too.

When using nolibc, the error is printed like:

	exec /runc.armel: errno=8

When using libc, as its perror() implementation translates the errno to
a message, it is printed like:

	exec /runc.armel: exec format error

Note that when using libc, the error is printed in the same way as
before.

---

We can try to do things to expand errno to a string with nolibc (like using the system's errno definitions and reimplement `strerror()` with those, ignoring locales; or try to send the errno back to go and using go unix package to print it), but it's not clear runc-dmz is a good idea in the first place, so let's go the easy path for now.

We can later revisit this if we want runc-dmz and we want to really reduce the size with nolibc.

Updates: #4170 #4158 