### PR TITLE
never send procError to parent process after sent procReady

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -107,7 +107,11 @@ func startInitialization() (retErr error) {
 
 	defer func() {
 		// If this defer is ever called, this means initialization has failed.
-		// Send the error back to the parent process in the form of an initError.
+		// Send the error back to the parent process in the form of an initError
+		// if the sync socket has not been closed.
+		if syncPipe.isClosed() {
+			return
+		}
 		ierr := initError{Message: retErr.Error()}
 		if err := writeSyncArg(syncPipe, procError, ierr); err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
We have moved the error msg display position in #3385, I think it's reasonable to display the container init msg in one place, but in this PR, we changed an error ignore behavior in https://github.com/opencontainers/runc/blob/main/libcontainer/init_linux.go#L112-L113 .

Yes, we should display the error before `procReady` has sent, but we should ignore after that. So I think we can add a field to indicate whether we have sent `procReady` or not in child process. It's not needed for the parent process, but we can reuse it to remove a local var `seenProcReady`.

Fix #4171 