### PR TITLE
Disable runc-dmz by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill remap-rootfs:
 
 .PHONY: clean
 clean:
-	rm -f runc runc-* libcontainer/dmz/runc-dmz
+	rm -f runc runc-* libcontainer/dmz/binary/runc-dmz
 	rm -f contrib/cmd/recvtty/recvtty
 	rm -f contrib/cmd/sd-helper/sd-helper
 	rm -f contrib/cmd/seccompagent/seccompagent

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ make BUILDTAGS=""
 | Build Tag     | Feature                               | Enabled by Default | Dependencies        |
 |---------------|---------------------------------------|--------------------|---------------------|
 | `seccomp`     | Syscall filtering using `libseccomp`. | yes                | `libseccomp`        |
-| `!runc_nodmz` | Reduce memory usage for CVE-2019-5736 protection by using a small C binary, [see `memfd-bind` for more details][contrib-memfd-bind]. `runc_nodmz` disables this feature and causes runc to use a different protection mechanism which will further increases memory usage temporarily during container startup. This feature can also be disabled at runtime by setting the `RUNC_DMZ=legacy` environment variable. | yes ||
+| `!runc_nodmz` | Reduce memory usage for CVE-2019-5736 protection by using a small C binary, [see `memfd-bind` for more details][contrib-memfd-bind]. `runc_nodmz` disables this **experimental feature** and causes runc to use a different protection mechanism which will further increases memory usage temporarily during container startup. To enable this feature you also need to set the `RUNC_DMZ=true` environment variable. | yes ||
 | `runc_dmz_selinux_nocompat` | Disables a SELinux DMZ workaround (new distros should set this). See [dmz README] for details. | no ||
 
 The following build tags were used earlier, but are now obsoleted:

--- a/contrib/cmd/memfd-bind/README.md
+++ b/contrib/cmd/memfd-bind/README.md
@@ -36,12 +36,12 @@ much memory usage they can use:
 
 * `runc-dmz` is (depending on which libc it was compiled with) between 10kB and
   1MB in size, and a copy is created once per process spawned inside a
-  container by runc (both the pid1 and every `runc exec`). There are
-  circumstances where using `runc-dmz` will fail in ways that runc cannot
-  predict ahead of time (such as restrictive LSMs applied to containers), in
-  which case users can disable it with the `RUNC_DMZ=legacy` setting.
-  `runc-dmz` also requires an additional `execve` over the other options,
-  though since the binary is so small the cost is probably not even noticeable.
+  container by runc (both the pid1 and every `runc exec`). The `RUNC_DMZ=true`
+  environment variable needs to be set to opt-in. There are circumstances where
+  using `runc-dmz` will fail in ways that runc cannot predict ahead of time (such
+  as restrictive LSMs applied to containers).  `runc-dmz` also requires an
+  additional `execve` over the other options, though since the binary is so small
+  the cost is probably not even noticeable.
 
 * The classic method of making a copy of the entire `runc` binary during
   container process setup takes up about 10MB per process spawned inside the

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -323,14 +323,14 @@ function check_exec_debug() {
 	[ "$status" -eq 0 ]
 }
 
-@test "RUNC_DMZ=legacy runc exec [execve error]" {
+@test "runc exec [execve error]" {
 	cat <<EOF >rootfs/run.sh
 #!/mmnnttbb foo bar
 sh
 EOF
 	chmod +x rootfs/run.sh
-	RUNC_DMZ=legacy runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	RUNC_DMZ=legacy runc exec -t test_busybox /run.sh
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc exec -t test_busybox /run.sh
 	[ "$status" -ne 0 ]
 
 	# After the sync socket closed, we should not send error to parent

--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -39,15 +39,14 @@ function teardown() {
 }
 
 # https://github.com/opencontainers/runc/issues/4057
-@test "runc run (custom selinux label)" {
+@test "runc run (custom selinux label, RUNC_DMZ=true)" {
 	update_config '	  .process.selinuxLabel |= "system_u:system_r:container_t:s0:c4,c5"
 			| .process.args = ["/bin/true"]'
-	runc run tst
+	RUNC_DMZ=true runc run tst
 	[ "$status" -eq 0 ]
 }
 
-@test "runc run (custom selinux label, RUNC_DMZ=legacy)" {
-	export RUNC_DMZ=legacy
+@test "runc run (custom selinux label)" {
 	update_config '	  .process.selinuxLabel |= "system_u:system_r:container_t:s0:c4,c5"
 			| .process.args = ["/bin/true"]'
 	runc run tst


### PR DESCRIPTION
There are several issues that we caught at the last minute. Several maintainers said it seems safer to disable it by default, so let's do that.

runc-dmz is marked as experimental and besides the build tag you need to opt-in with `RUNC_DMZ=true` to use it.

Future PRs can go further and maybe even remove the buildtag, simplifying the CI (and the time it takes to run).


---

cc @cyphar @kolyshkin @lifubang 