### PR TITLE
support write multiple items into cgroup v2 file

### DIFF
--- a/libcontainer/cgroups/file.go
+++ b/libcontainer/cgroups/file.go
@@ -57,6 +57,27 @@ func WriteFile(dir, file, data string) error {
 	return nil
 }
 
+// To support write multiple item into one cgroup file like:
+// {"io.max": "252:1 riops=1000 wiops=1000 \n 252:2 riops=2000 wiops=2000"}
+func WriteFileMultipleLines(dir, file, data string) error {
+	fd, err := OpenFile(dir, file, unix.O_WRONLY)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	lines := strings.Split(data, "\n")
+	for _, line := range lines {
+		if strings.TrimSuffix(line, " ") == "" {
+			continue
+		}
+		if _, err := fd.WriteString(line); err != nil {
+			// Having data in the error message helps in debugging.
+			return fmt.Errorf("failed to write %q: %w", line, err)
+		}
+	}
+	return nil
+}
+
 const (
 	cgroupfsDir    = "/sys/fs/cgroup"
 	cgroupfsPrefix = cgroupfsDir + "/"

--- a/libcontainer/cgroups/file_test.go
+++ b/libcontainer/cgroups/file_test.go
@@ -73,3 +73,22 @@ func TestOpenat2(t *testing.T) {
 		fd.Close()
 	}
 }
+
+func TestWriteFileMultipleLines(t *testing.T) {
+	TestMode = true
+	defer func() { TestMode = false }()
+
+	tmpDir := t.TempDir()
+	testcases := []string{
+		"252:1 foo=bar  ",
+		"252:2 foo=bar \n wrong_data \n wrong value",
+		"252:1 foo=bar boo=far\n252:2 nospace=0 \n        default 11111\n",
+		"\n\n\n\n\n\n\n\n",
+	}
+
+	for _, val := range testcases {
+		if err := WriteFileMultipleLines(tmpDir, "file", val); err != nil {
+			t.Errorf("%v", err)
+		}
+	}
+}

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -233,7 +233,7 @@ func (m *Manager) setUnified(res map[string]string) error {
 		if strings.Contains(k, "/") {
 			return fmt.Errorf("unified resource %q must be a file name (no slashes)", k)
 		}
-		if err := cgroups.WriteFile(m.dirPath, k, v); err != nil {
+		if err := cgroups.WriteFileMultipleLines(m.dirPath, k, v); err != nil {
 			// Check for both EPERM and ENOENT since O_CREAT is used by WriteFile.
 			if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
 				// Check if a controller is available,

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -187,6 +187,38 @@ function setup() {
 	[[ "$weights" == *"$major:$minor 444"* ]]
 }
 
+@test "runc run (per-device multiple io.max via unified)" {
+	requires root cgroups_v2
+
+	dd if=/dev/zero of=backing1.img bs=4096 count=1
+	dev1=$(losetup --find --show backing1.img) || skip "unable to create a loop device"
+
+	# Second device.
+	dd if=/dev/zero of=backing2.img bs=4096 count=1
+	dev2=$(losetup --find --show backing2.img) || skip "unable to create a loop device"
+
+	set_cgroups_path
+
+	IFS=$' \t:' read -r major1 minor1 <<<"$(lsblk -nd -o MAJ:MIN "$dev1")"
+	IFS=$' \t:' read -r major2 minor2 <<<"$(lsblk -nd -o MAJ:MIN "$dev2")"
+	update_config '	  .linux.devices += [
+				{path: "'"$dev1"'", type: "b", major: '"$major1"', minor: '"$minor1"'},
+				{path: "'"$dev2"'", type: "b", major: '"$major2"', minor: '"$minor2"'}
+			   ]
+			| .linux.resources.unified |=
+				{"io.max": "'"$major1"':'"$minor1"' riops=500 wiops=500 rbps=1024 wbps=1024\n'"$major2"':'"$minor2"' riops=1000 wiops=1000 rbps=10240 wbps=10240\n"}'
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
+	[ "$status" -eq 0 ]
+
+	# The loop devices are no longer needed.
+	losetup -d "$dev1"
+	losetup -d "$dev2"
+
+	values=$(get_cgroup_value "io.max")
+	grep "^$major1:$minor1 .* riops=500 wiops=500 rbps=1024 wbps=1024$" <<<"$values"
+	grep "^$major2:$minor2 .* riops=1000 wiops=1000 rbps=10240 wbps=10240$" <<<"$values"
+}
+
 @test "runc run (cpu.idle)" {
 	requires cgroups_cpu_idle
 	[ $EUID -ne 0 ] && requires rootless_cgroup


### PR DESCRIPTION
```release-note
This pr is a supplement for cgroup v2 file value write. 
I met that after calculating in kubelet, i got a configs.Resources contains the cup,memory,pid and also cgroup v2 field like io.max and io.weight. the map of Unified in the config might be like: 
{"io.max": "252:1 riops=1000 wiops=1000 \n 252:2 riops=2000 wiops=2000", "io.weight": "252:1 300 \n 252:2 500" }
Currently the unified set can not support write multiple line in one cgroup file.
```