### PR TITLE
libct: don't close syncPipe

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -154,7 +154,7 @@ func (l *linuxSetnsInit) Init() error {
 	// that all O_CLOEXEC file descriptors have already been closed and thus
 	// the second execve(2) from runc-dmz cannot access internal file
 	// descriptors from runc.
-	if err := utils.UnsafeCloseFrom(l.config.PassedFilesCount + 3); err != nil {
+	if err := utils.UnsafeCloseFrom(l.config.PassedFilesCount+3, int(l.pipe.File().Fd())); err != nil {
 		return err
 	}
 	return system.Exec(name, l.config.Args, os.Environ())

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -296,7 +296,7 @@ func (l *linuxStandardInit) Init() error {
 	// that all O_CLOEXEC file descriptors have already been closed and thus
 	// the second execve(2) from runc-dmz cannot access internal file
 	// descriptors from runc.
-	if err := utils.UnsafeCloseFrom(l.config.PassedFilesCount + 3); err != nil {
+	if err := utils.UnsafeCloseFrom(l.config.PassedFilesCount+3, int(l.pipe.File().Fd())); err != nil {
 		return err
 	}
 	return system.Exec(name, l.config.Args, os.Environ())


### PR DESCRIPTION
Recent CVE-2024-21626 fix (commit f2f16213) broke a recently added test (commit 0bc4732c, #4173) because if exec fails, runc is unable to communicate the error back to the parent.

Let's not close syncPipe.

This fixes the following test failure:

```console
# bats tests/integration/exec.bats 
...
 ✗ RUNC_DMZ=legacy runc exec [execve error]
   (in test file tests/integration/exec.bats, line 340)
     `[ ${#lines[@]} -eq 1 ]' failed
   runc spec (status=0):
   
   runc run -d --console-socket /tmp/bats-run-77CvQx/runc.JurXM2/tty/sock test_busybox (status=0):
   
   runc exec -t test_busybox /run.sh (status=255):
   writing sync procError: write sync: bad file descriptor
   exec /run.sh: no such file or directory

```