### PR TITLE
libct/cg: write unified resources line by line

### DIFF
--- a/libcontainer/cgroups/file_test.go
+++ b/libcontainer/cgroups/file_test.go
@@ -73,3 +73,25 @@ func TestOpenat2(t *testing.T) {
 		fd.Close()
 	}
 }
+
+func BenchmarkWriteFile(b *testing.B) {
+	TestMode = true
+	defer func() { TestMode = false }()
+
+	dir := b.TempDir()
+	tc := []string{
+		"one",
+		"one\ntwo\nthree",
+		"10:200 foo=bar boo=far\n300:1200 something=other\ndefault 45000\n",
+		"\n\n\n\n\n\n\n\n",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, val := range tc {
+			if err := WriteFileByLine(dir, "file", val); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -238,7 +238,7 @@ func (m *Manager) setUnified(res map[string]string) error {
 		if strings.Contains(k, "/") {
 			return fmt.Errorf("unified resource %q must be a file name (no slashes)", k)
 		}
-		if err := cgroups.WriteFile(m.dirPath, k, v); err != nil {
+		if err := cgroups.WriteFileByLine(m.dirPath, k, v); err != nil {
 			// Check for both EPERM and ENOENT since O_CREAT is used by WriteFile.
 			if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
 				// Check if a controller is available,


### PR DESCRIPTION
It has been pointed out (in #4182) that some controllers can not accept multiple lines of output at once. In particular, io.max can only set one device at a time.

Practically, the only multi-line resource values we can get come from unified.* -- let's write those line by line.

Add a test case.

Reported-by: Tao Shen <shentaoskyking@gmail.com>

Closes: #4182 