### PR TITLE
tests/int: use gawk where needed

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -132,7 +132,8 @@ function init_cgroup_paths() {
 		CGROUP_SUBSYSTEMS=$(awk '!/^#/ {print $1}' /proc/cgroups)
 		local g base_path
 		for g in ${CGROUP_SUBSYSTEMS}; do
-			base_path=$(awk '$(NF-2) == "cgroup" && $NF ~ /\<'"${g}"'\>/ { print $5; exit }' /proc/self/mountinfo)
+			# This uses gawk-specific feature (\< ... \>).
+			base_path=$(gawk '$(NF-2) == "cgroup" && $NF ~ /\<'"${g}"'\>/ { print $5; exit }' /proc/self/mountinfo)
 			test -z "$base_path" && continue
 			eval CGROUP_"${g^^}"_BASE_PATH="${base_path}"
 		done


### PR DESCRIPTION
This expression is specific to GNU awk (gawk), so if someone has other version of awk installed, this won't work and it's not easy to see why.

Explicitly requiring gawk here is better.

Revert "tests/int/helpers: gawk -> awk"

This reverts commit 4e65118d02b19963d49a6e0b12326123dd21c956.

Reported-by: lifubang <lifubang@acmcoder.com>