### PR TITLE
tests/int: swap-related fixes

### DIFF
--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -57,7 +57,10 @@ func setMemory(dirPath string, r *configs.Resources) error {
 	// never write empty string to `memory.swap.max`, it means set to 0.
 	if swapStr != "" {
 		if err := cgroups.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
-			return err
+			// If swap is not enabled, silently ignore setting to max or disabling it.
+			if !(errors.Is(err, os.ErrNotExist) && (swapStr == "max" || swapStr == "0")) {
+				return err
+			}
 		}
 	}
 

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -121,7 +121,7 @@ function init_cgroup_paths() {
 		CGROUP_BASE_PATH=/sys/fs/cgroup
 
 		# Find any cgroup.freeze files...
-		if [ -n "$(find "$CGROUP_BASE_PATH" -type f -name "cgroup.freeze" -print -quit)" ]; then
+		if [ -n "$(find "$CGROUP_BASE_PATH" -maxdepth 2 -type f -name "cgroup.freeze" -print -quit)" ]; then
 			CGROUP_SUBSYSTEMS+=" freezer"
 		fi
 	else
@@ -460,7 +460,7 @@ function requires() {
 			init_cgroup_paths
 			[ -v CGROUP_V1 ] && p="$CGROUP_CPU_BASE_PATH"
 			[ -v CGROUP_V2 ] && p="$CGROUP_BASE_PATH"
-			if [ -z "$(find "$p" -name cpu.idle -print -quit)" ]; then
+			if [ -z "$(find "$p" -maxdepth 2 -type f -name cpu.idle -print -quit)" ]; then
 				skip_me=1
 			fi
 			;;
@@ -476,7 +476,7 @@ function requires() {
 				p="$CGROUP_BASE_PATH"
 				f="cpu.max.burst"
 			fi
-			if [ -z "$(find "$p" -name "$f" -print -quit)" ]; then
+			if [ -z "$(find "$p" -maxdepth 2 -type f -name "$f" -print -quit)" ]; then
 				skip_me=1
 			fi
 			;;

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -451,8 +451,14 @@ function requires() {
 			;;
 		cgroups_swap)
 			init_cgroup_paths
-			if [ -v CGROUP_V1 ] && [ ! -e "${CGROUP_MEMORY_BASE_PATH}/memory.memsw.limit_in_bytes" ]; then
-				skip_me=1
+			if [ -v CGROUP_V1 ]; then
+				if [ ! -e "${CGROUP_MEMORY_BASE_PATH}/memory.memsw.limit_in_bytes" ]; then
+					skip_me=1
+				fi
+			elif [ -v CGROUP_V2 ]; then
+				if [ -z "$(find "$CGROUP_BASE_PATH" -maxdepth 2 -type f -name memory.swap.max -print -quit)" ]; then
+					skip_me=1
+				fi
 			fi
 			;;
 		cgroups_cpu_idle)


### PR DESCRIPTION
- Fixes a few minor issues with integration tests.
- cgroup v2: do not set swap to 0 or unlimited when it's not available.

See individual commits for details.

Fixes #4166