### PR TITLE
script/*: fix gpg usage wrt keyboxd

### DIFF
--- a/script/release_sign.sh
+++ b/script/release_sign.sh
@@ -105,10 +105,10 @@ set -x
 tmp_gpgdir="$(mktemp -d --tmpdir "$project-sign-tmpkeyring.XXXXXX")"
 trap 'rm -r "$tmp_gpgdir"' EXIT
 
-tmp_runc_gpgflags=("--no-default-keyring" "--keyring=$tmp_gpgdir/$project.keyring")
+tmp_runc_gpgflags=("--homedir=$tmp_gpgdir" "--no-default-keyring" "--keyring=$project.keyring")
 gpg "${tmp_runc_gpgflags[@]}" --import <"$root/$project.keyring"
 
-tmp_seccomp_gpgflags=("--no-default-keyring" "--keyring=$tmp_gpgdir/seccomp.keyring")
+tmp_seccomp_gpgflags=("--homedir=$tmp_gpgdir" "--no-default-keyring" "--keyring=seccomp.keyring")
 gpg "${tmp_seccomp_gpgflags[@]}" --recv-keys 0x47A68FCE37C7D7024FD65E11356CE62C2B524099
 gpg "${tmp_seccomp_gpgflags[@]}" --recv-keys 0x7100AADFAE6E6E940D2E0AD655E45A5AE8CA7C8A
 


### PR DESCRIPTION
I used script/keyring_validate.sh, which gave me this error:

> [*] User cyphar in runc.keyring is not a maintainer!

Apparently, when gnupg 2.4.1+ sees a fresh install (i.e. no ~/.gnupg directory), it configures itself to use keyboxd instead of keyring files, and when just silently ignores options like --keyring and --no-default-keyring, working with keyboxd all the time.

The only way I found to make it not use keyboxd is to set --homedir. Let's do that when we explicitly want a separate keyring.

Similar change is made to script/release_key.sh.

Also, change "--import --import-options=show-only" to "--show-keys" which is a shortcut. When using this, there is no need to protect the default keyring since this command does not read or modify it.