### PR TITLE
Close sync pipe explicitly in exec

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -129,6 +129,11 @@ func (l *linuxSetnsInit) Init() error {
 		}
 	}
 
+	// Close the pipe to signal that we have completed our init.
+	// Please keep this because we don't want to get a pipe write error if
+	// there is an error from `execve` after all fds closed.
+	_ = l.pipe.Close()
+
 	// Close the log pipe fd so the parent's ForwardLogs can exit.
 	logrus.Debugf("setns_init: about to exec")
 	if err := l.logPipe.Close(); err != nil {

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -338,5 +338,5 @@ EOF
 	# Although we never close the sync socket when doing exec,
 	# but we need to keep this test to ensure this behavior is always right.
 	[ ${#lines[@]} -eq 1 ]
-	[[ ${lines[0]} = *"exec failed: unable to start container process: exec /run.sh: no such file or directory"* ]]
+	[[ ${lines[0]} = *"exec /run.sh: no such file or directory"* ]]
 }


### PR DESCRIPTION
Fix #4183 
To simplify the implemention, we can keep it the same as in `standard_init_linux.go`.

----
Recent CVE-2024-21626 fix (commit f2f16213) broke a recently added test (commit 0bc4732c, #4173) because if exec fails, runc is unable to communicate the error back to the parent.

Let's not close syncPipe.

This fixes the following test failure:

```console
# bats tests/integration/exec.bats 
...
 ✗ RUNC_DMZ=legacy runc exec [execve error]
   (in test file tests/integration/exec.bats, line 340)
     `[ ${#lines[@]} -eq 1 ]' failed
   runc spec (status=0):
   
   runc run -d --console-socket /tmp/bats-run-77CvQx/runc.JurXM2/tty/sock test_busybox (status=0):
   
   runc exec -t test_busybox /run.sh (status=255):
   writing sync procError: write sync: bad file descriptor
   exec /run.sh: no such file or directory

```