### PR TITLE
[ci] update go version to 1.21 in cirrus ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ task:
   env:
     HOME: /root
     CIRRUS_WORKING_DIR: /home/runc
-    GO_VERSION: "1.20"
+    GO_VERSION: "1.21"
     BATS_VERSION: "v1.9.0"
     RPMS: gcc git iptables jq glibc-static libseccomp-devel make criu fuse-sshfs container-selinux
     # yamllint disable rule:key-duplicates


### PR DESCRIPTION
As go has released v1.22.0, so there is no 1.20.x in `https://go.dev/dl/?mode=json` anymore.
Let's update go version to `1.21.x`  in cirrus ci.

This will fix the error:
```
# Find out the latest minor release URL.
eval $(curl -fsSL "${PREFIX}?mode=json" | jq -r  --arg Ver "$GO_VERSION" '.[] | select(.version | startswith("go\($Ver)")) | .files[] | select(.os == "linux" and .arch == "amd64" and .kind == "archive") | "filename=\"" + .filename + "\""')
curl -fsSL "$PREFIX$filename" | tar Cxz /usr/local
gzip: stdin: not in gzip format
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
curl: (23) Failed writing body (679 != 1401)
```