### PR TITLE
ci/golangci-lint: add checks permission

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      checks: write # to allow the action to annotate code in the PR.
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This permission is now needed so that the linter can annotate code in a PR (see [1]).

[1] https://github.com/golangci/golangci-lint-action/pull/931/commits/bc1904f0c946172fc1821908fc41649db49f0334