### PR TITLE
Fixed spelling mistake in the Makefile at .PHONY vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ shfmt:
 localshfmt:
 	shfmt -d -w .
 
-.PHONY: venodr
+.PHONY: vendor
 vendor:
 	$(GO) mod tidy
 	$(GO) mod vendor


### PR DESCRIPTION
* Simple error correction of a spelling mistake which was introduced at commit b8f75f3