### PR TITLE
set the default value of CpuBurst to nil instead of 0

### DIFF
--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -344,6 +344,14 @@ EOF
 	[ "$status" -eq 0 ]
 	check_cpu_burst 500000
 
+	# issue: https://github.com/opencontainers/runc/issues/4210
+	# for systemd, cpu-burst value will be cleared, it's a known issue.
+	if [ ! -v RUNC_USE_SYSTEMD ]; then
+		runc update test_update --memory 100M
+		[ "$status" -eq 0 ]
+		check_cpu_burst 500000
+	fi
+
 	runc update test_update --cpu-period 900000 --cpu-burst 0
 	[ "$status" -eq 0 ]
 	check_cpu_burst 0


### PR DESCRIPTION
Fix #4210 

We should set the default of `CpuBurst` to nil instead of 0 when we are updating a container's resource limit.