### PR TITLE
runc update: fix logic by distinguishing nil from zero

### DIFF
--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/sirupsen/logrus"
 )
 
 func isCpuSet(r *configs.Resources) bool {
@@ -30,7 +31,9 @@ func setCpu(dirPath string, r *configs.Resources) error {
 
 	// NOTE: .CpuShares is not used here. Conversion is the caller's responsibility.
 	if r.CpuWeight != 0 {
-		if err := cgroups.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(r.CpuWeight, 10)); err != nil {
+		if r.CPUIdle != nil && *r.CPUIdle != 0 {
+			logrus.Warn("CPU weight can't be set when CPU idle is enabled -- ignoring")
+		} else if err := cgroups.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(r.CpuWeight, 10)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
(1) Prior to this commit, commands like `runc update --cpuset-cpus=1` were implying to set cpu burst to "0" (which does not mean "leave it as is"). This was failing when the kernel does not support cpu burst: `openat2 /sys/fs/cgroup/runc-cgroups-integration-test/test-cgroup-22167/cpu.max.burst: no such file or directory`

(the above is extracted from #4142 by @AkihiroSuda and further simplified)

(2)  Also, solve the issue of re-setting cpu-burst to 0 when other
parameters are being set.

(3) This also solves the issue of re-setting cpu-period to default value when cpu-quota was not set (#4225).

Test cases for (2) and (3) are added (mostly taken from #4226 by @lifubang)