### PR TITLE
[hotfix] nsenter: refuse to build with Go 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
     - name: install go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.x # Latest stable
+        go-version: 1.21.x # TODO: switch to 1.x (latest stable) once Go 1.22 vs glibc issue is fixed.
 
     - name: unit test
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **NOTE**: runc currently will not work properly when compiled with Go 1.22 or
+> newer. This is due to some unfortunate glibc behaviour that Go 1.22
+> exacerbates in a way that results in containers not being able to start on
+> some systems. [See this issue for more information.][runc-4233].
+
 ### Deprecated
 
  * `runc` option `--criu` is now ignored (with a warning), and the option will
@@ -46,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    code (this was due to how s390x does syscall multiplexing). (#3474)
  * Remove tun/tap from the default device rules. (#3468)
  * specconv: avoid mapping "acl" to MS_POSIXACL. (#3739)
+
+[runc-4233]: https://github.com/opencontainers/runc/issues/4233
 
 ## [1.1.8] - 2023-07-20
 

--- a/libcontainer/nsenter/nsenter_go122.go
+++ b/libcontainer/nsenter/nsenter_go122.go
@@ -1,0 +1,15 @@
+//go:build go1.22
+
+package nsenter
+
+/*
+// We know for sure that glibc has issues with pthread_self() when called from
+// Go after nsenter has run. This is likely a more general problem with how we
+// ignore the rules in signal-safety(7), and so it's possible musl will also
+// have issues, but as this is just a hotfix let's only block glibc builds.
+#include <features.h>
+#ifdef __GLIBC__
+#  error "runc does not currently work properly with Go >=1.22. See <https://github.com/opencontainers/runc/issues/4233>."
+#endif
+*/
+import "C"


### PR DESCRIPTION
We will almost certainly need to eventually rework nsenter to:

 1. Figure out a way to make pthread_self() not break after nsenter runs
    (probably not possible, because the core issue is likely that we are
    ignoring the rules of signal-safety(7)); or
 2. Do an other re-exec of /proc/self/exe to execute the Go half of
    "runc init" -- after we've done the nsenter setup. This would reset
    all of the process state and ensure we have a clean glibc state for
    Go, but it would make runc slower...

For now, just block Go 1.22 builds to avoid having broken runcs floating
around until we resolve the issue. It seems possible for musl to also
have an issue, but it appears to work and so for now just block glibc
builds.

Note that this will only block builds for anything that uses nsenter --
so users of our (internal) libcontainer libraries should be fine. Only
users that are starting containers using nsenter to actually start
containers will see the error (which is precisely what we want).

See #4233
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>