### PR TITLE
clean cached rlimit nofile in go runtime

### DIFF
--- a/tests/integration/resources.bats
+++ b/tests/integration/resources.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_busybox
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+@test "runc run with RLIMIT_NOFILE" {
+	update_config '.process.args = ["/bin/sh", "-c", "ulimit -n"]'
+	update_config '.process.capabilities.bounding = ["CAP_SYS_RESOURCE"]'
+	update_config '.process.rlimits = [{"type": "RLIMIT_NOFILE", "hard": 10000, "soft": 10000}]'
+
+	runc run test_hello
+	[ "$status" -eq 0 ]
+
+	[[ "${output}" == "10000" ]]
+}


### PR DESCRIPTION
fix:#4195
In a relatively new runc version, in other words a new go version (in my environment the go version is go1.20.13),
the runtime will cache the value of rlimit nofile, which will cause the container's rlimit nofile configuration to not take effect. This problem must occur when the customer configures the CAP_SYS_RESOURCE permission.

refer to:[commit](// https://github.com/golang/go/commit/f5eef58e4381259cbd84b3f2074c79607fb5c821#diff-ec665e9789f8cf5cd1828ad7fa9f0ff4ebc1f5b5dd0fc82a296da5c07da7ece6)

go runtime caches rlimit-nofile during startup phase
![image](https://github.com/opencontainers/runc/assets/48054568/33b11305-bb83-421f-b693-386e8bf49824)

and before exec,runtime will reset rlimit-nofile.
![image](https://github.com/opencontainers/runc/assets/48054568/463fc5b7-b629-4b6e-82fb-2363d79a8e82)
