### PR TITLE
[1.1] [hotfix] nsenter: refuse to build with Go 1.22 on glibc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased 1.1.z]
 
+> **NOTE**: runc currently will not work properly when compiled with Go 1.22 or
+> newer. This is due to some unfortunate glibc behaviour that Go 1.22
+> exacerbates in a way that results in containers not being able to start on
+> some systems. [See this issue for more information.][runc-4233].
+
+[runc-4233]: https://github.com/opencontainers/runc/issues/4233
+
 ## [1.1.12] - 2024-01-31
 
 > Now you're thinking with Portals™!

--- a/libcontainer/nsenter/nsenter_go122.go
+++ b/libcontainer/nsenter/nsenter_go122.go
@@ -1,0 +1,15 @@
+//go:build go1.22
+
+package nsenter
+
+/*
+// We know for sure that glibc has issues with pthread_self() when called from
+// Go after nsenter has run. This is likely a more general problem with how we
+// ignore the rules in signal-safety(7), and so it's possible musl will also
+// have issues, but as this is just a hotfix let's only block glibc builds.
+#include <features.h>
+#ifdef __GLIBC__
+#  error "runc does not currently work properly with Go >=1.22. See <https://github.com/opencontainers/runc/issues/4233>."
+#endif
+*/
+import "C"


### PR DESCRIPTION
This is a backport of #4234 to release-1.1 branch.

----

We will almost certainly need to eventually rework nsenter to:

 1. Figure out a way to make pthread_self() not break after nsenter runs (probably not possible, because the core issue is likely that we are ignoring the rules of signal-safety(7)); or
 2. Do an other re-exec of /proc/self/exe to execute the Go half of "runc init" -- after we've done the nsenter setup. This would reset all of the process state and ensure we have a clean glibc state for Go, but it would make runc slower...

For now, just block Go 1.22 builds to avoid having broken runcs floating around until we resolve the issue. It seems possible for musl to also have an issue, but it appears to work and so for now just block glibc builds.

Note that this will only block builds for anything that uses nsenter -- so users of our (internal) libcontainer libraries should be fine. Only users that are starting containers using nsenter to actually start containers will see the error (which is precisely what we want).


(cherry picked from commit e377e16846b8997a4ef52d7044cf0efcecac5e2e)