### PR TITLE
Fix tests (mount_sshfs.bats) in debian testing

### DIFF
--- a/tests/integration/mounts_sshfs.bats
+++ b/tests/integration/mounts_sshfs.bats
@@ -390,7 +390,11 @@ function fail_sshfs_bind_flags() {
 	pass_sshfs_bind_flags "nodiratime" "bind"
 	run -0 grep -wq nodiratime <<<"$mnt_flags"
 	# MS_DIRATIME implies MS_RELATIME by default.
-	run -0 grep -wq relatime <<<"$mnt_flags"
+	# Let's check either relatime is set or no other option that removes
+	# relatime semantics is set.
+	# The latter case is needed in debian. For more info, see issue: #4093
+	run -0 grep -wq relatime <<<"$mnt_flags" ||
+		(run ! grep -wqE 'strictatime|norelatime|noatime' <<<"$mnt_flags")
 
 	pass_sshfs_bind_flags "noatime,nodiratime" "bind"
 	run -0 grep -wq noatime <<<"$mnt_flags"


### PR DESCRIPTION
If I apply this PR, it all works fine in Debian testing.

While it seems [adding `atime` can fix](https://github.com/opencontainers/runc/issues/4093#issuecomment-2037054762) the issue on debian, I still think it's better to not share so much state between "different" tests. Starting from scratch seems better to not run into issues about what we share across mounts in "different" tests inside the same bats tests. Performance-wise it doesn't seem relevant and reducing shared state in tests is nice, IMHO :)

I'd really like people to review the second commit in detail, where we check relatime is set or no other options that resets relatime is set. That is needed in my debian to work, but I'd like review to make sure I didn't miss to check any flag there.

Fixes #4093 