### PR TITLE
libcontainer: force apps to think fips is enabled/disabled for testing

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -783,6 +783,7 @@ func checkProcMount(rootfs, dest string, m mountEntry) error {
 		"/proc/slabinfo",
 		"/proc/net/dev",
 		"/proc/sys/kernel/ns_last_pid",
+		"/proc/sys/crypto/fips_enabled",
 	}
 	for _, valid := range validProcMounts {
 		path, err := filepath.Rel(filepath.Join(rootfs, valid), dest)

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -134,6 +134,21 @@ func TestCheckMountDestNsLastPid(t *testing.T) {
 	}
 }
 
+func TestCheckCryptoFipsEnabled(t *testing.T) {
+	m := mountEntry{
+		Mount: &configs.Mount{
+			Destination: "/proc/sys/crypto/fips_enabled",
+			Source:      "tmpfs",
+			Device:      "tmpfs",
+		},
+	}
+	dest := "/rootfs/proc/sys/crypto/fips_enabled"
+	err := checkProcMount("/rootfs", dest, m)
+	if err != nil {
+		t.Fatalf("/proc/sys/crypto/fips_enabled should not return an error: %v", err)
+	}
+}
+
 func TestNeedsSetupDev(t *testing.T) {
 	config := &configs.Config{
 		Mounts: []*configs.Mount{


### PR DESCRIPTION
The motivation behind this change is to provide a flexible mechanism for containers within a Kubernetes cluster to opt out of `FIPS` mode when necessary. This change enables apps to simulate `FIPS` mode being enabled or disabled for testing. Users can control whether apps believe `FIPS` mode is on or off by manipulating `/proc/sys/crypto/fips_enabled`.