### PR TITLE
libct: decouple libct/cg/devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+ * libcontainer/cgroups users who want to manage cgroup devices need to explicitly
+   import libcontainer/cgroups/devices. (#3452, #4248)
+
 ## [1.2.0-rc.1] - 2024-04-03
 
 > There's a frood who really knows where his towel is.

--- a/libcontainer/README.md
+++ b/libcontainer/README.md
@@ -8,11 +8,13 @@ It allows you to manage the lifecycle of the container performing additional ope
 after the container is created.
 
 
-#### Container
+## Container
 A container is a self contained execution environment that shares the kernel of the
 host system and which is (optionally) isolated from other containers in the system.
 
-#### Using libcontainer
+## Using libcontainer
+
+### Container init
 
 Because containers are spawned in a two step process you will need a binary that
 will be executed as the init process for the container. In libcontainer, we use
@@ -27,7 +29,24 @@ For details on how runc implements such "init", see
 [init.go](https://github.com/opencontainers/runc/blob/master/init.go)
 and [libcontainer/init_linux.go](https://github.com/opencontainers/runc/blob/master/libcontainer/init_linux.go).
 
-Then to create a container you first have to create a configuration
+### Device management
+
+If you want containers that have access to some devices, you need to import
+this package into your code:
+
+```go
+    import (
+        _ "github.com/opencontainers/runc/libcontainer/cgroups/devices"
+    )
+```
+
+Without doing this, libcontainer cgroup manager won't be able to set up device
+access rules, and will fail if devices are specified in the container
+configuration.
+
+### Container creation
+
+To create a container you first have to create a configuration
 struct describing how the container is to be created. A sample would look similar to this:
 
 ```go
@@ -274,7 +293,7 @@ state, err := container.State()
 ```
 
 
-#### Checkpoint & Restore
+## Checkpoint & Restore
 
 libcontainer now integrates [CRIU](http://criu.org/) for checkpointing and restoring containers.
 This lets you save the state of a process running inside a container to disk, and then restore

--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -12,7 +12,8 @@ var (
 	ErrDevicesUnsupported = errors.New("cgroup manager is not configured to set device rules")
 
 	// DevicesSetV1 and DevicesSetV2 are functions to set devices for
-	// cgroup v1 and v2, respectively. Unless libcontainer/cgroups/devices
+	// cgroup v1 and v2, respectively. Unless
+	// [github.com/opencontainers/runc/libcontainer/cgroups/devices]
 	// package is imported, it is set to nil, so cgroup managers can't
 	// manage devices.
 	DevicesSetV1 func(path string, r *configs.Resources) error

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -33,6 +33,11 @@ var (
 	isRunningSystemdOnce sync.Once
 	isRunningSystemd     bool
 
+	// GenerateDeviceProps is a function to generate systemd device
+	// properties, used by Set methods. Unless
+	// [github.com/opencontainers/runc/libcontainer/cgroups/devices]
+	// package is imported, it is set to nil, so cgroup managers can't
+	// configure devices.
 	GenerateDeviceProps func(r *configs.Resources, sdVer int) ([]systemdDbus.Property, error)
 )
 

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -9,8 +9,6 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"golang.org/x/sys/unix"
 
-	//nolint:revive // Enable cgroup manager to manage devices
-	_ "github.com/opencontainers/runc/libcontainer/cgroups/devices"
 	"github.com/opencontainers/runc/libcontainer/cgroups/manager"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/configs/validate"

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	//nolint:revive // Enable cgroup manager to manage devices
+	_ "github.com/opencontainers/runc/libcontainer/cgroups/devices"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
 


### PR DESCRIPTION
This is the last step of refactoring done in #3452, which is needed to use runc/libct v1.2 in kubernetes and other libcontainer users (to avoid massive cilium/ebpf dependency).

----

Commit b6967fa84c26 moved the functionality of managing cgroup devices into a separate package, and decoupled libcontainer/cgroups from it.

Yet, some software (e.g. cadvisor) may need to use libcontainer package, which imports libcontainer/cgroups/devices, thus making it impossible to use libcontainer without bringing in cgroup/devices dependency.

In fact, we only need to manage devices in runc binary, so move the import to main.go.

The need to import libct/cg/dev in order to manage devices is already documented in libcontainer/cgroups. Let's improve that:
 - update that documentation;
 - add a similar note to libcontainer/cgroups/systemd;
 - add a note to libct README.
