### PR TITLE
tests/int/checkpoint: rm double logging

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -89,8 +89,6 @@ function runc_restore_with_pipes() {
 		echo "__runc restore $name failed (status: $ret)"
 		exec {err_w}>&-
 		cat <&${err_r}
-		echo "CRIU log errors (if any):"
-		grep -B 5 Error "$workdir"/*.log ./image-dir/*.log || true
 		fail "runc restore failed"
 	fi
 
@@ -110,7 +108,6 @@ function simple_cr() {
 	for _ in $(seq 2); do
 		# checkpoint the running container
 		runc "$@" checkpoint --work-path ./work-dir test_busybox
-		grep -B 5 Error ./work-dir/dump.log || true
 		[ "$status" -eq 0 ]
 
 		# after checkpoint busybox is no longer running
@@ -118,7 +115,6 @@ function simple_cr() {
 
 		# restore from checkpoint
 		runc "$@" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-		grep -B 5 Error ./work-dir/restore.log || true
 		[ "$status" -eq 0 ]
 
 		# busybox should be back up and running
@@ -188,7 +184,6 @@ function simple_cr() {
 	mkdir image-dir
 	mkdir work-dir
 	runc checkpoint --parent-path ../parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
-	grep -B 5 Error ./work-dir/dump.log || true
 	[ "$status" -eq 0 ]
 
 	# check parent path is valid
@@ -240,8 +235,6 @@ function simple_cr() {
 	exec {lazy_w}>&-
 	# shellcheck disable=SC2116,SC2086
 	out=$(echo $out) # rm newlines
-	# show errors if there are any before we fail
-	grep -B5 Error ./work-dir/dump.log || true
 	# expecting \0 which od prints as
 	[ "$out" = "0000000 000000 0000001" ]
 
@@ -302,7 +295,6 @@ function simple_cr() {
 		# checkpoint the running container; this automatically tells CRIU to
 		# handle the network namespace defined in config.json as an external
 		runc checkpoint --work-path ./work-dir test_busybox
-		grep -B 5 Error ./work-dir/dump.log || true
 		[ "$status" -eq 0 ]
 
 		# after checkpoint busybox is no longer running
@@ -310,7 +302,6 @@ function simple_cr() {
 
 		# restore from checkpoint; this should restore the container into the existing network namespace
 		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-		grep -B 5 Error ./work-dir/restore.log || true
 		[ "$status" -eq 0 ]
 
 		# busybox should be back up and running
@@ -353,7 +344,6 @@ function simple_cr() {
 
 	# checkpoint the running container
 	runc checkpoint --work-path ./work-dir test_busybox
-	grep -B 5 Error ./work-dir/dump.log || true
 	[ "$status" -eq 0 ]
 	run ! test -f ./work-dir/"$tmplog1"
 	test -f ./work-dir/"$tmplog2"
@@ -364,7 +354,6 @@ function simple_cr() {
 	test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
 	# restore from checkpoint
 	runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-	grep -B 5 Error ./work-dir/restore.log || true
 	[ "$status" -eq 0 ]
 	run ! test -f ./work-dir/"$tmplog1"
 	test -f ./work-dir/"$tmplog2"
@@ -398,7 +387,6 @@ function simple_cr() {
 
 	# checkpoint the running container
 	runc checkpoint --work-path ./work-dir test_busybox
-	grep -B 5 Error ./work-dir/dump.log || true
 	[ "$status" -eq 0 ]
 
 	# after checkpoint busybox is no longer running
@@ -410,7 +398,6 @@ function simple_cr() {
 
 	# restore from checkpoint
 	runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-	grep -B 5 Error ./work-dir/restore.log || true
 	[ "$status" -eq 0 ]
 
 	# busybox should be back up and running
@@ -430,7 +417,6 @@ function simple_cr() {
 	test -d "$orig_path"
 
 	runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
-	grep -B 5 Error ./work-dir/dump.log || true
 	[ "$status" -eq 0 ]
 	testcontainer test_busybox checkpointed
 	# Check that the cgroup is gone.
@@ -440,7 +426,6 @@ function simple_cr() {
 	set_cgroups_path # Changes the path.
 	runc restore -d --manage-cgroups-mode ignore --pid-file pid \
 		--work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-	grep -B 5 Error ./work-dir/restore.log || true
 	[ "$status" -eq 0 ]
 	testcontainer test_busybox running
 


### PR DESCRIPTION
Since PR #3816 (commit c77aaa3f) the tail of criu log is printed by runc, so there's no need to do the same thing in tests.

Related to #3711.