### PR TITLE
ci/actuated: re-enable CRIU tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,20 +123,18 @@ jobs:
         sudo apt -y install libseccomp-dev sshfs uidmap
 
     - name: install CRIU
-      # TODO: enable CRIU for actuated: https://github.com/opencontainers/runc/pull/4142#issuecomment-1945408382
-      if: ${{ matrix.os != 'actuated-arm64-6cpu-8gb' && matrix.criu == '' }}
+      if: ${{ matrix.criu == '' }}
       env:
         PREFIX: https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu
       run: |
-        # criu repo
-        REPO=${PREFIX}_$(echo ${{ matrix.os }} | sed 's/.*-//')
+        REPO=${PREFIX}_$(. /etc/os-release && echo $VERSION_ID)
         curl -fSsLl $REPO/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_tools_criu.gpg > /dev/null
         echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
         sudo apt -y install criu
 
     - name: install CRIU (criu ${{ matrix.criu }})
-      if: ${{ matrix.os != 'actuated-arm64-6cpu-8gb' && matrix.criu != '' }}
+      if: ${{ matrix.criu != '' }}
       run: |
         sudo apt -qy install \
           libcap-dev libnet1-dev libnl-3-dev \

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -173,6 +173,10 @@ function simple_cr() {
 }
 
 @test "checkpoint --pre-dump and restore" {
+	# Requires kernel dirty memory tracking (missing on ARM, see
+	# https://github.com/checkpoint-restore/criu/issues/1729).
+	requires criu_feature_mem_dirty_track
+
 	setup_pipes
 	runc_run_with_pipes test_busybox
 
@@ -202,10 +206,8 @@ function simple_cr() {
 }
 
 @test "checkpoint --lazy-pages and restore" {
-	# check if lazy-pages is supported
-	if ! criu check --feature uffd-noncoop; then
-		skip "this criu does not support lazy migration"
-	fi
+	# Requires lazy-pages support.
+	requires criu_feature_uffd-noncoop
 
 	setup_pipes
 	runc_run_with_pipes test_busybox
@@ -274,11 +276,8 @@ function simple_cr() {
 }
 
 @test "checkpoint and restore in external network namespace" {
-	# check if external_net_ns is supported; only with criu 3.10++
-	if ! criu check --feature external_net_ns; then
-		# this criu does not support external_net_ns; skip the test
-		skip "this criu does not support external network namespaces"
-	fi
+	# Requires external network namespaces (criu >= 3.10).
+	requires criu_feature_external_net_ns
 
 	# create a temporary name for the test network namespace
 	tmp=$(mktemp)

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -407,6 +407,12 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		criu_feature_*)
+			var=${var#criu_feature_}
+			if ! criu check --feature "$var"; then
+				skip "requires CRIU feature ${var}"
+			fi
+			;;
 		root)
 			if [ $EUID -ne 0 ]; then
 				skip_me=1


### PR DESCRIPTION
This re-enables [previously disabled](https://github.com/opencontainers/runc/pull/4142#issuecomment-1945408382) CRIU tests for actuated-arm64 as they appear to be working just fine now.

The only test we need to skip is criu pre-dump; apparently, [ARM kernel lacks dirty memory tracking feature](https://github.com/checkpoint-restore/criu/issues/1729).

See individual commits for more details.