### PR TITLE
logs.go: fixed logger creation

### DIFF
--- a/libcontainer/logs/logs.go
+++ b/libcontainer/logs/logs.go
@@ -23,6 +23,7 @@ func ForwardLogs(logPipe io.ReadCloser) chan error {
 	}
 
 	go func() {
+		defer close(done)
 		for s.Scan() {
 			processEntry(s.Bytes(), logger)
 		}
@@ -32,7 +33,6 @@ func ForwardLogs(logPipe io.ReadCloser) chan error {
 		// The only error we want to return is when reading from
 		// logPipe has failed.
 		done <- s.Err()
-		close(done)
 	}()
 
 	return done


### PR DESCRIPTION
Previously, the done channel was not closed properly in case of an error returned by logPipe.Close(), potentially leading to a goroutine leak. This commit ensures that the done channel is closed even if there's an error during the closing of logPipe.