### PR TITLE
ci/gha: bump golangci-lint[-action]

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,12 +34,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache: false # golangci-lint-action does its own caching
       - name: install deps
         run: |
           sudo apt -q update
           sudo apt -qy install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v5
         with:
           version: v1.54
       # Extra linters, only checking new code from a pull request.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.54
+          version: v1.57
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -399,7 +399,6 @@ func setupConsole(socket *os.File, config *initConfig, mount bool) error {
 			Height: config.ConsoleHeight,
 			Width:  config.ConsoleWidth,
 		})
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Replaces #4253.

* bump golangci/golangci-lint-action to v5
* bump golangci-lint to v1.57