### PR TITLE
[1.1] libcontainer: force apps to think fips is enabled/disabled for testing

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -602,6 +602,7 @@ func checkProcMount(rootfs, dest, source string) error {
 		"/proc/slabinfo",
 		"/proc/net/dev",
 		"/proc/sys/kernel/ns_last_pid",
+		"/proc/sys/crypto/fips_enabled",
 	}
 	for _, valid := range validProcMounts {
 		path, err := filepath.Rel(filepath.Join(rootfs, valid), dest)

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -46,6 +46,14 @@ func TestCheckMountDestNsLastPid(t *testing.T) {
 	}
 }
 
+func TestCheckCryptoFipsEnabled(t *testing.T) {
+	dest := "/rootfs/proc/sys/crypto/fips_enabled"
+	err := checkProcMount("/rootfs", dest, "/proc")
+	if err != nil {
+		t.Fatalf("/proc/sys/crypto/fips_enabled should not return an error: %v", err)
+	}
+}
+
 func TestNeedsSetupDev(t *testing.T) {
 	config := &configs.Config{
 		Mounts: []*configs.Mount{


### PR DESCRIPTION
This is a backport of https://github.com/opencontainers/runc/pull/4246 to release-1.1. Original description follows.

The motivation behind this change is to provide a flexible mechanism for containers within a Kubernetes cluster to opt out of `FIPS` mode when necessary. This change enables apps to simulate `FIPS` mode being enabled or disabled for testing. Users can control whether apps believe `FIPS` mode is on or off by manipulating `/proc/sys/crypto/fips_enabled`.