### PR TITLE
libct/cg/fs: fix setting rt_period vs rt_runtime

### DIFF
--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -35,14 +35,30 @@ func (s *CpuGroup) Apply(path string, r *configs.Resources, pid int) error {
 }
 
 func (s *CpuGroup) SetRtSched(path string, r *configs.Resources) error {
+	var period string
 	if r.CpuRtPeriod != 0 {
-		if err := cgroups.WriteFile(path, "cpu.rt_period_us", strconv.FormatUint(r.CpuRtPeriod, 10)); err != nil {
-			return err
+		period = strconv.FormatUint(r.CpuRtPeriod, 10)
+		if err := cgroups.WriteFile(path, "cpu.rt_period_us", period); err != nil {
+			// The values of cpu.rt_period_us and cpu.rt_runtime_us
+			// are inter-dependent and need to be set in a proper order.
+			// If the kernel rejects the new period value with EINVAL
+			// and the new runtime value is also being set, let's
+			// ignore the error for now and retry later.
+			if !errors.Is(err, unix.EINVAL) || r.CpuRtRuntime == 0 {
+				return err
+			}
+		} else {
+			period = ""
 		}
 	}
 	if r.CpuRtRuntime != 0 {
 		if err := cgroups.WriteFile(path, "cpu.rt_runtime_us", strconv.FormatInt(r.CpuRtRuntime, 10)); err != nil {
 			return err
+		}
+		if period != "" {
+			if err := cgroups.WriteFile(path, "cpu.rt_period_us", period); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -766,6 +766,17 @@ EOF
 
 	check_cgroup_value "cpu.rt_period_us" 900001
 	check_cgroup_value "cpu.rt_runtime_us" 600001
+
+	# https://github.com/opencontainers/runc/issues/4094
+	runc update test_update_rt --cpu-rt-period 10000 --cpu-rt-runtime 3000
+	[ "$status" -eq 0 ]
+	check_cgroup_value "cpu.rt_period_us" 10000
+	check_cgroup_value "cpu.rt_runtime_us" 3000
+
+	runc update test_update_rt --cpu-rt-period 100000 --cpu-rt-runtime 20000
+	[ "$status" -eq 0 ]
+	check_cgroup_value "cpu.rt_period_us" 100000
+	check_cgroup_value "cpu.rt_runtime_us" 20000
 }
 
 @test "update devices [minimal transition rules]" {


### PR DESCRIPTION
The problem/fix is similar to one in #3084/#3090.

A test case (by @ls-ggg) is copied from #4235.

Fixes: #4094.
Closes: #4235.