### PR TITLE
tests/int/tty: increase the timeout

### DIFF
--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -171,15 +171,13 @@ function teardown() {
 EOF
 	)
 
-	# run the exec
+	# Run the detached exec.
 	runc exec -t --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" -p <(echo "$tty_info_with_consize_size") test_busybox
 	[ "$status" -eq 0 ]
-
-	# check the pid was generated
 	[ -e pid.txt ]
 
-	# wait for the process to finish
-	timeout 5 tail --pid="$(head -n 1 pid.txt)" -f /dev/null
+	# Wait for the exec to finish.
+	wait_pids_gone 100 0.5 "$(cat pid.txt)"
 
 	tty_info=$(
 		cat <<EOF


### PR DESCRIPTION
Earlier, commit fce8dd4d (PR #2692) already increased this timeout from 1 to 5 seconds. Yet, I just saw this timeout being hit in actuated-arm CI ([here](https://github.com/opencontainers/runc/actions/runs/8840455799/job/24275831162?pr=4259#step:16:266), from #4259).

Increase the timeout again, this time from 5 to 50 (100 * 0.5) seconds.

Also, use `wait_pids_gone`, and improve some comments.