### PR TITLE
[1.1] Vagrantfile.fedora: bump Fedora to 39

### DIFF
--- a/Vagrantfile.fedora
+++ b/Vagrantfile.fedora
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 # Fedora box is used for testing cgroup v2 support
-  config.vm.box = "fedora/38-cloud-base"
+  config.vm.box = "fedora/39-cloud-base"
   config.vm.provider :virtualbox do |v|
     v.memory = 2048
     v.cpus = 2


### PR DESCRIPTION
This is a backport of #4256 to release-1.1 branch. Just in case :)
