### PR TITLE
[ci] use go mod instead of go get in spec.bats

### DIFF
--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -31,11 +31,11 @@ function teardown() {
 
 	git clone https://github.com/opencontainers/runtime-spec.git
 	(cd runtime-spec && git reset --hard "$SPEC_REF")
-	SCHEMA='runtime-spec/schema/config-schema.json'
-	[ -e "$SCHEMA" ]
 
-	GO111MODULE=auto go get github.com/xeipuuv/gojsonschema
-	GO111MODULE=auto go build runtime-spec/schema/validate.go
+	cd runtime-spec/schema
+	go mod init runtime-spec
+	go mod tidy
+	go build ./validate.go
 
-	./validate "$SCHEMA" config.json
+	./validate config-schema.json ../../config.json
 }


### PR DESCRIPTION
When we run integration test in go 1.22, it got an error:
```
 ✗ spec validator
   (in test file tests/integration/spec.bats, line 37)
     `GO111MODULE=auto go get github.com/xeipuuv/gojsonschema' failed
   runc spec (status=0):
   
   Cloning into 'runtime-spec'...
   HEAD is now at 36852b0 version: release v1.2.0
   go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

Although we have not supported go 1.22 yet, but I think we should update the spec.bat first.