### PR TITLE
Fix set nofile rlimit error

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -136,11 +136,13 @@ func testRlimit(t *testing.T, userns bool) {
 
 	config := newTemplateConfig(t, &tParam{userns: userns})
 
-	// ensure limit is lower than what the config requests to test that in a user namespace
+	// Ensure limit is lower than what the config requests to test that in a user namespace
 	// the Setrlimit call happens early enough that we still have permissions to raise the limit.
+	// Do not change the Cur value to be equal to the Max value, please see:
+	// https://github.com/opencontainers/runc/pull/4265#discussion_r1589666444
 	ok(t, unix.Setrlimit(unix.RLIMIT_NOFILE, &unix.Rlimit{
 		Max: 1024,
-		Cur: 1024,
+		Cur: 512,
 	}))
 
 	out := runContainerOk(t, config, "/bin/sh", "-c", "ulimit -n")

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -268,20 +268,26 @@ func (p *setnsProcess) start() (retErr error) {
 			}
 		}
 	}
-	// set rlimits, this has to be done here because we lose permissions
-	// to raise the limits once we enter a user-namespace
-	if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
-		return fmt.Errorf("error setting rlimits for process: %w", err)
-	}
+
 	if err := utils.WriteJSON(p.comm.initSockParent, p.config); err != nil {
 		return fmt.Errorf("error writing config to pipe: %w", err)
 	}
 
+	var seenProcReady bool
 	ierr := parseSync(p.comm.syncSockParent, func(sync *syncT) error {
 		switch sync.Type {
 		case procReady:
-			// This shouldn't happen.
-			panic("unexpected procReady in setns")
+			seenProcReady = true
+			// Set rlimits, this has to be done here because we lose permissions
+			// to raise the limits once we enter a user-namespace
+			if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
+				return fmt.Errorf("error setting rlimits for ready process: %w", err)
+			}
+
+			// Sync with child.
+			if err := writeSync(p.comm.syncSockParent, procRun); err != nil {
+				return err
+			}
 		case procHooks:
 			// This shouldn't happen.
 			panic("unexpected procHooks in setns")
@@ -339,6 +345,9 @@ func (p *setnsProcess) start() (retErr error) {
 
 	if err := p.comm.syncSockParent.Shutdown(unix.SHUT_WR); err != nil && ierr == nil {
 		return err
+	}
+	if !seenProcReady && ierr == nil {
+		ierr = errors.New("procReady not received")
 	}
 	// Must be done after Shutdown so the child will exit and we can wait for it.
 	if ierr != nil {
@@ -774,7 +783,7 @@ func (p *initProcess) start() (retErr error) {
 			}
 		case procReady:
 			seenProcReady = true
-			// set rlimits, this has to be done here because we lose permissions
+			// Set rlimits, this has to be done here because we lose permissions
 			// to raise the limits once we enter a user-namespace
 			if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
 				return fmt.Errorf("error setting rlimits for ready process: %w", err)

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -49,6 +49,7 @@ func (l *linuxSetnsInit) Init() error {
 			}
 		}
 	}
+
 	if l.config.CreateConsole {
 		if err := setupConsole(l.consoleSocket, l.config, false); err != nil {
 			return err

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -77,6 +77,13 @@ func (l *linuxSetnsInit) Init() error {
 		}
 	}
 
+	// Tell our parent that we're ready to exec. This must be done before the
+	// Seccomp rules have been applied, because we need to be able to read and
+	// write to a socket.
+	if err := syncParentReady(l.pipe); err != nil {
+		return fmt.Errorf("sync ready: %w", err)
+	}
+
 	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
 		return err
 	}

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -8,12 +8,27 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"syscall"
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
+
+//go:linkname syscallOrigRlimitNofile syscall.origRlimitNofile
+var syscallOrigRlimitNofile atomic.Pointer[syscall.Rlimit]
+
+// As reported in issue #4195, the new version of go runtime(since 1.19)
+// will cache rlimit-nofile. Before executing execve, the rlimit-nofile
+// of the process will be restored with the cache. In runc, this will
+// cause the rlimit-nofile setting by the parent process for the container
+// to become invalid. It can be solved by clearing this cache. But
+// unfortunately, go stdlib doesn't provide such function, so we need to
+// link to the private var `origRlimitNofile` in package syscall to hack.
+func ClearRlimitNofileCache() {
+	syscallOrigRlimitNofile.Store(nil)
+}
 
 type ParentDeathSignal int
 

--- a/tests/integration/rlimits.bats
+++ b/tests/integration/rlimits.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	# Do not change the Cur value to be equal to the Max value
+	# Because in some environments, the soft and hard nofile limit have the same value.
+	[ $EUID -eq 0 ] && prlimit --nofile=1024:65536 -p $$
+	setup_busybox
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+# Set and check rlimit_nofile for runc run. Arguments are:
+#  $1: soft limit;
+#  $2: hard limit.
+function run_check_nofile() {
+	soft="$1"
+	hard="$2"
+	update_config ".process.rlimits = [{\"type\": \"RLIMIT_NOFILE\", \"soft\": ${soft}, \"hard\": ${hard}}]"
+	update_config '.process.args = ["/bin/sh", "-c", "ulimit -n; ulimit -H -n"]'
+
+	runc run test_rlimit
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == "${soft}" ]]
+	[[ "${lines[1]}" == "${hard}" ]]
+}
+
+# Set and check rlimit_nofile for runc exec. Arguments are:
+#  $1: soft limit;
+#  $2: hard limit.
+function exec_check_nofile() {
+	soft="$1"
+	hard="$2"
+	update_config ".process.rlimits = [{\"type\": \"RLIMIT_NOFILE\", \"soft\": ${soft}, \"hard\": ${hard}}]"
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_rlimit
+	[ "$status" -eq 0 ]
+
+	runc exec test_rlimit /bin/sh -c "ulimit -n; ulimit -H -n"
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == "${soft}" ]]
+	[[ "${lines[1]}" == "${hard}" ]]
+}
+
+@test "runc run with RLIMIT_NOFILE(The same as system's hard value)" {
+	hard=$(ulimit -n -H)
+	soft="$hard"
+	run_check_nofile "$soft" "$hard"
+}
+
+@test "runc run with RLIMIT_NOFILE(Bigger than system's hard value)" {
+	requires root
+	limit=$(ulimit -n -H)
+	soft=$((limit + 1))
+	hard=$soft
+	run_check_nofile "$soft" "$hard"
+}
+
+@test "runc run with RLIMIT_NOFILE(Smaller than system's hard value)" {
+	limit=$(ulimit -n -H)
+	soft=$((limit - 1))
+	hard=$soft
+	run_check_nofile "$soft" "$hard"
+}
+
+@test "runc exec with RLIMIT_NOFILE(The same as system's hard value)" {
+	hard=$(ulimit -n -H)
+	soft="$hard"
+	exec_check_nofile "$soft" "$hard"
+}
+
+@test "runc exec with RLIMIT_NOFILE(Bigger than system's hard value)" {
+	requires root
+	limit=$(ulimit -n -H)
+	soft=$((limit + 1))
+	hard=$soft
+	exec_check_nofile "$soft" "$hard"
+}
+
+@test "runc exec with RLIMIT_NOFILE(Smaller than system's hard value)" {
+	limit=$(ulimit -n -H)
+	soft=$((limit - 1))
+	hard=$soft
+	exec_check_nofile "$soft" "$hard"
+}


### PR DESCRIPTION
Fix: #4195 
Close: #4237 

## 1. Fix a get/set race between `runc exec` and `syscall.rlimit.init()`
As @ls-ggg has given the detailed steps to reproduce the issue #4195 , and has given the core reason is that the go runtime will cache the value of rlimit nofile. [1] 
When we are running `runc exec` with nofile limit, runc set it in the parent process, it may cause a race with go runtime init. The race condition is in the time when runc parent process set the container child process's nofile limit just after go runtime init has fetched the nofile limit. [2]
So, we should set nofile limit after `syscall.rlimit.init()` completed.

## 2. Fix an edge case caused by nofile rlimit cache in go stdlib
As @kolyshkin have found an edge case for set nofile rlimit by runc, which is also caused by nofile rlimit cache in go stdlib. Although we have a way to resolve the above get/set race, but if the hard value of nofile rlimit configured in `config.json` is bigger than this value of `runc create/run/exec`, it will also be incorrect restored by `syscall.Exec` in `runc init`. So we need to clear the nofile rlimit cache before we start the container initial process if we need to set nofile rlimit for the container.

[1] https://github.com/golang/go/commit/f5eef58e4381259cbd84b3f2074c79607fb5c821#diff-ec665e9789f8cf5cd1828ad7fa9f0ff4ebc1f5b5dd0fc82a296da5c07da7ece6
[2] https://github.com/golang/go/blob/f5eef58e4381259cbd84b3f2074c79607fb5c821/src/syscall/rlimit.go#L34-L35