### PR TITLE
[1.1] allow overriding VERSION value in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PROJECT := github.com/opencontainers/runc
 BUILDTAGS ?= seccomp
 
 COMMIT ?= $(shell git describe --dirty --long --always)
-VERSION := $(shell cat ./VERSION)
+VERSION ?= $(shell cat ./VERSION)
 LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
 
 GOARCH := $(shell $(GO) env GOARCH)


### PR DESCRIPTION
This is a backport of #4269.

----

this allows using a custom version string while building runc without modifying the VERSION file


(cherry picked from commit 9d9273c926450a2f6f658768e3238b7082ec878d)