### PR TITLE
libct.Start: fix locking, do not allow a second container init

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -417,9 +417,6 @@ func (c *Container) createExecFifo() error {
 	}
 
 	fifoName := filepath.Join(c.stateDir, execFifoFilename)
-	if _, err := os.Stat(fifoName); err == nil {
-		return fmt.Errorf("exec fifo %s already exists", fifoName)
-	}
 	if err := unix.Mkfifo(fifoName, 0o622); err != nil {
 		return &os.PathError{Op: "mkfifo", Path: fifoName, Err: err}
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -306,6 +306,9 @@ func (c *Container) start(process *Process) (retErr error) {
 		return errors.New("can't start container with SkipDevices set")
 	}
 	if process.Init {
+		if c.initProcessStartTime != 0 {
+			return errors.New("container already has init process")
+		}
 		if err := c.createExecFifo(); err != nil {
 			return err
 		}

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -115,7 +115,6 @@ func testExecInRlimit(t *testing.T, userns bool) {
 			// increase process rlimit higher than container rlimit to test per-process limit
 			{Type: unix.RLIMIT_NOFILE, Hard: 1026, Soft: 1026},
 		},
-		Init: true,
 	}
 	err = container.Run(ps)
 	ok(t, err)
@@ -359,7 +358,6 @@ func TestExecInEnvironment(t *testing.T) {
 		Stdin:  buffers.Stdin,
 		Stdout: buffers.Stdout,
 		Stderr: buffers.Stderr,
-		Init:   true,
 	}
 	err = container.Run(process2)
 	ok(t, err)


### PR DESCRIPTION
By definition, every container has only 1 init (i.e. PID 1) process.

Apparently, libcontainer API supported running more than 1 "init", and
two tests mistakenly used it. Of course, the second "init" was not
PID 1, but it was started like init and, I guess, some of the Container fields
were set to wrong values.

Let's not allow that, erroring out if we already have init running.

Fix two cases in libct/int which ran two inits inside a container.
Also, fix a locking issue and remove some code that's not needed.
