### PR TITLE
fix checkpoint/restore tests on actuated-arm64

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -48,8 +48,7 @@ func (c *Container) checkCriuFeatures(criuOpts *CriuOpts, rpcOpts *criurpc.CriuO
 
 	err := c.criuSwrk(nil, req, criuOpts, nil)
 	if err != nil {
-		logrus.Debugf("%s", err)
-		return errors.New("CRIU feature check failed")
+		return fmt.Errorf("CRIU feature check failed: %w", err)
 	}
 
 	var missingFeatures []string

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -30,7 +30,7 @@ var criuFeatures *criurpc.CriuFeatures
 
 var ErrCriuMissingFeatures = errors.New("criu is missing features")
 
-func (c *Container) checkCriuFeatures(criuOpts *CriuOpts, rpcOpts *criurpc.CriuOpts, criuFeat *criurpc.CriuFeatures) error {
+func (c *Container) checkCriuFeatures(criuOpts *CriuOpts, criuFeat *criurpc.CriuFeatures) error {
 	t := criurpc.CriuReqType_FEATURE_CHECK
 
 	// make sure the features we are looking for are really not from
@@ -38,11 +38,7 @@ func (c *Container) checkCriuFeatures(criuOpts *CriuOpts, rpcOpts *criurpc.CriuO
 	criuFeatures = nil
 
 	req := &criurpc.CriuReq{
-		Type: &t,
-		// Theoretically this should not be necessary but CRIU
-		// segfaults if Opts is empty.
-		// Fixed in CRIU  2.12
-		Opts:     rpcOpts,
+		Type:     &t,
 		Features: criuFeat,
 	}
 
@@ -397,7 +393,7 @@ func (c *Container) Checkpoint(criuOpts *CriuOpts) error {
 			MemTrack: proto.Bool(true),
 		}
 
-		if err := c.checkCriuFeatures(criuOpts, &rpcOpts, &feat); err != nil {
+		if err := c.checkCriuFeatures(criuOpts, &feat); err != nil {
 			return err
 		}
 
@@ -411,7 +407,7 @@ func (c *Container) Checkpoint(criuOpts *CriuOpts) error {
 		feat := criurpc.CriuFeatures{
 			LazyPages: proto.Bool(true),
 		}
-		if err := c.checkCriuFeatures(criuOpts, &rpcOpts, &feat); err != nil {
+		if err := c.checkCriuFeatures(criuOpts, &feat); err != nil {
 			return err
 		}
 

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -40,12 +40,9 @@ func showFile(t *testing.T, fname string) {
 }
 
 func TestUsernsCheckpoint(t *testing.T) {
-	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
-		t.Skip("Test requires userns.")
-	}
 	cmd := exec.Command("criu", "check", "--feature", "userns")
 	if err := cmd.Run(); err != nil {
-		t.Skip("Unable to c/r a container with userns")
+		t.Skip("Test requires userns")
 	}
 	testCheckpoint(t, true)
 }

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"bytes"
-	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,11 +13,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func criuFeature(feature string) bool {
+	return exec.Command("criu", "check", "--feature", feature).Run() == nil
+}
+
 func TestUsernsCheckpoint(t *testing.T) {
-	cmd := exec.Command("criu", "check", "--feature", "userns")
-	if err := cmd.Run(); err != nil {
-		t.Skip("Test requires userns")
-	}
 	testCheckpoint(t, true)
 }
 
@@ -39,6 +38,10 @@ func testCheckpoint(t *testing.T, userns bool) {
 	out, err := exec.Command("rpm", "-q", "criu").CombinedOutput()
 	if err == nil && regexp.MustCompile(`^criu-3\.17-[123]\.el9`).Match(out) {
 		t.Skip("Test requires criu >= 3.17-4 on CentOS Stream 9.")
+	}
+
+	if userns && !criuFeature("userns") {
+		t.Skip("Test requires userns")
 	}
 
 	config := newTemplateConfig(t, &tParam{userns: userns})
@@ -74,26 +77,28 @@ func testCheckpoint(t *testing.T, userns bool) {
 	ok(t, err)
 
 	tmp := t.TempDir()
+	var parentImage string
 
-	parentDir := filepath.Join(tmp, "criu-parent")
-	preDumpOpts := &libcontainer.CriuOpts{
-		ImagesDirectory: parentDir,
-		WorkDirectory:   parentDir,
-		PreDump:         true,
-	}
-
-	if err := container.Checkpoint(preDumpOpts); err != nil {
-		if errors.Is(err, libcontainer.ErrCriuMissingFeatures) {
-			t.Skip(err)
+	// Test pre-dump if mem_dirty_track is available.
+	if criuFeature("mem_dirty_track") {
+		parentImage = "../criu-parent"
+		parentDir := filepath.Join(tmp, "criu-parent")
+		preDumpOpts := &libcontainer.CriuOpts{
+			ImagesDirectory: parentDir,
+			WorkDirectory:   parentDir,
+			PreDump:         true,
 		}
-		t.Fatal(err)
-	}
 
-	state, err := container.Status()
-	ok(t, err)
+		if err := container.Checkpoint(preDumpOpts); err != nil {
+			t.Fatal(err)
+		}
 
-	if state != libcontainer.Running {
-		t.Fatal("Unexpected preDump state: ", state)
+		state, err := container.Status()
+		ok(t, err)
+
+		if state != libcontainer.Running {
+			t.Fatal("Unexpected preDump state: ", state)
+		}
 	}
 
 	imagesDir := filepath.Join(tmp, "criu")
@@ -101,14 +106,14 @@ func testCheckpoint(t *testing.T, userns bool) {
 	checkpointOpts := &libcontainer.CriuOpts{
 		ImagesDirectory: imagesDir,
 		WorkDirectory:   imagesDir,
-		ParentImage:     "../criu-parent",
+		ParentImage:     parentImage,
 	}
 
 	if err := container.Checkpoint(checkpointOpts); err != nil {
 		t.Fatal(err)
 	}
 
-	state, err = container.Status()
+	state, err := container.Status()
 	ok(t, err)
 
 	if state != libcontainer.Stopped {

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"os"
@@ -14,30 +13,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer"
 	"golang.org/x/sys/unix"
 )
-
-func showFile(t *testing.T, fname string) {
-	t.Helper()
-	t.Logf("=== %s ===\n", fname)
-
-	f, err := os.Open(fname)
-	if err != nil {
-		t.Log(err)
-		return
-	}
-	defer f.Close() //nolint: errcheck
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		t.Log(scanner.Text())
-	}
-
-	if err := scanner.Err(); err != nil {
-		t.Log(err)
-		return
-	}
-
-	t.Logf("=== END ===\n")
-}
 
 func TestUsernsCheckpoint(t *testing.T) {
 	cmd := exec.Command("criu", "check", "--feature", "userns")
@@ -106,10 +81,8 @@ func testCheckpoint(t *testing.T, userns bool) {
 		WorkDirectory:   parentDir,
 		PreDump:         true,
 	}
-	preDumpLog := filepath.Join(preDumpOpts.WorkDirectory, "dump.log")
 
 	if err := container.Checkpoint(preDumpOpts); err != nil {
-		showFile(t, preDumpLog)
 		if errors.Is(err, libcontainer.ErrCriuMissingFeatures) {
 			t.Skip(err)
 		}
@@ -130,11 +103,8 @@ func testCheckpoint(t *testing.T, userns bool) {
 		WorkDirectory:   imagesDir,
 		ParentImage:     "../criu-parent",
 	}
-	dumpLog := filepath.Join(checkpointOpts.WorkDirectory, "dump.log")
-	restoreLog := filepath.Join(checkpointOpts.WorkDirectory, "restore.log")
 
 	if err := container.Checkpoint(checkpointOpts); err != nil {
-		showFile(t, dumpLog)
 		t.Fatal(err)
 	}
 
@@ -168,7 +138,6 @@ func testCheckpoint(t *testing.T, userns bool) {
 	_ = restoreStdinR.Close()
 	defer restoreStdinW.Close() //nolint: errcheck
 	if err != nil {
-		showFile(t, restoreLog)
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
While investigating #4274 I found a few issues and rough edges with our c/r tests.

This, together with https://github.com/checkpoint-restore/criu/pull/2403 (which is already [applied to CRIU package](https://github.com/opencontainers/runc/pull/4276#issuecomment-2104283949) we use) fixes CI failures we see now.
 
 Fixes: #4274.