### PR TITLE
ci/gha: switch to ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, actuated-arm64-6cpu-8gb]
+        os: [ubuntu-20.04, ubuntu-24.04, actuated-arm64-6cpu-8gb]
         go-version: [1.20.x, 1.21.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
@@ -158,6 +158,12 @@ jobs:
       with:
         bats-version: 1.9.0
 
+    - name: Allow userns for runc
+      # https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15
+      if: matrix.os == 'ubuntu-24.04'
+      run: |
+        sed "s;^profile runc /usr/sbin/;profile runc-test $PWD/;" < /etc/apparmor.d/runc | sudo apparmor_parser
+
     - name: unit test
       if: matrix.rootless != 'rootless'
       env:
@@ -174,7 +180,7 @@ jobs:
         sudo cp $HOME/rootless.key /home/rootless/.ssh/id_ecdsa
         sudo cp $HOME/rootless.key.pub /home/rootless/.ssh/authorized_keys
         sudo chown -R rootless.rootless /home/rootless
-        sudo chmod a+X $HOME # for Ubuntu 22.04
+        sudo chmod a+X $HOME # for Ubuntu 22.04 and later
 
     - name: integration test (fs driver)
       run: sudo -E PATH="$PATH" script -e -c 'make local${{ matrix.rootless }}integration'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   keyring:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: check runc.keyring
@@ -26,7 +26,7 @@ jobs:
       contents: read
       pull-requests: read
       checks: write # to allow the action to annotate code in the PR.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,7 +48,7 @@ jobs:
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
   compile-buildtags:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # Don't ignore C warnings. Note that the output of "go env CGO_CFLAGS" by default is "-g -O2", so we keep them.
       CGO_CFLAGS: -g -O2 -Werror
@@ -62,24 +62,24 @@ jobs:
         run: make BUILDTAGS=""
 
   codespell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
-      run: pip install codespell==v2.3.0
+      run: pip install --break-system-packages codespell==v2.3.0
     - name: run codespell
       run: codespell
 
   shfmt:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: shfmt
       run: make shfmt
 
   shellcheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: install shellcheck
@@ -110,7 +110,7 @@ jobs:
       - run: if git -P grep -I -n '\s$'; then echo "^^^ extra whitespace at EOL, please fix"; exit 1; fi
 
   deps:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: install go
@@ -125,7 +125,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Only check commits on pull requests.
     if: github.event_name == 'pull_request'
     steps:
@@ -143,7 +143,7 @@ jobs:
           error: 'Subject too long (max 72)'
 
   cfmt:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@v4
@@ -161,7 +161,7 @@ jobs:
 
   release:
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@v4
@@ -192,7 +192,7 @@ jobs:
 
 
   get-images:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Let's replace ubuntu-22.04 with ubuntu-24.04 where we can, and keep
ubuntu-20.04 to test cgroup v1 stuff.
    
Leave ubuntu-22.04 for these jobs only:
 - ci/cross-i386 (issue with systemctl restart hang after apt install)
 - ~~validate/codespell (pip install won't work)~~ **UPDATE: fixed**
    
These issues can be addressed separately later.
    
The only kludge we have to add is enable userns for runc binary being
tested (as userns is disabled by apparmor system-wide by default now,
see [1]).
    
[1] https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15
