### PR TITLE
Makefile: fixup for Go 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION ?= $(shell cat ./VERSION)
 LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
 
+# Since Go 1.23, we have to add -checklinkname=0 linker flag for rlimit workaround.
+GO_MINOR := $(shell $(GO) version | sed 's/.* go1\.\([0-9]*\)[. -].*/\1/')
+ifeq ($(shell test $(GO_MINOR) -gt 22; echo $$?),0)
+  LDFLAGS_COMMON += -checklinkname=0
+endif
+
 GOARCH := $(shell $(GO) env GOARCH)
 
 GO_BUILDMODE :=


### PR DESCRIPTION
It is no longer possible to compile runc with rlimit hack from commit da68c8e3 with Go 1.23 (devel at the moment), it errors out:

> link: github.com/opencontainers/runc/libcontainer/system: invalid reference to syscall.origRlimitNofile

Go 1.23 implements some restrictions wrt accessing internal symbols, and to work around those, we need to add a checklinkname=0 linker flag.

Alas, this flag is not supported in older versions, so the logic is added to check go version and add the flag conditionally.

Fixes: #4287 