### PR TITLE
Rlimit cache rework for Go 1.23+

### DIFF
--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -8,28 +8,12 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"sync/atomic"
 	"syscall"
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
-
-//go:linkname syscallOrigRlimitNofile syscall.origRlimitNofile
-var syscallOrigRlimitNofile atomic.Pointer[syscall.Rlimit]
-
-// ClearRlimitNofileCache is to clear go runtime's nofile rlimit cache.
-func ClearRlimitNofileCache() {
-	// As reported in issue #4195, the new version of go runtime(since 1.19)
-	// will cache rlimit-nofile. Before executing execve, the rlimit-nofile
-	// of the process will be restored with the cache. In runc, this will
-	// cause the rlimit-nofile setting by the parent process for the container
-	// to become invalid. It can be solved by clearing this cache. But
-	// unfortunately, go stdlib doesn't provide such function, so we need to
-	// link to the private var `origRlimitNofile` in package syscall to hack.
-	syscallOrigRlimitNofile.Store(nil)
-}
 
 type ParentDeathSignal int
 

--- a/libcontainer/system/rlimit_linux.go
+++ b/libcontainer/system/rlimit_linux.go
@@ -1,0 +1,15 @@
+//go:build go1.23
+
+package system
+
+import (
+	"syscall"
+)
+
+// ClearRlimitNofileCache clears go runtime's nofile rlimit cache. The argument
+// is process RLIMIT_NOFILE values. Relies on go.dev/cl/588076.
+func ClearRlimitNofileCache(lim *syscall.Rlimit) {
+	// Ignore the return values since we only need to clean the cache,
+	// the limit is going to be set via unix.Prlimit elsewhere.
+	_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, lim)
+}

--- a/libcontainer/system/rlimit_linux_go122.go
+++ b/libcontainer/system/rlimit_linux_go122.go
@@ -1,0 +1,27 @@
+//go:build !go1.23
+
+// TODO: remove this file once go 1.22 is no longer supported.
+
+package system
+
+import (
+	"sync/atomic"
+	"syscall"
+	_ "unsafe" // Needed for go:linkname to work.
+)
+
+//go:linkname syscallOrigRlimitNofile syscall.origRlimitNofile
+var syscallOrigRlimitNofile atomic.Pointer[syscall.Rlimit]
+
+// ClearRlimitNofileCache clears go runtime's nofile rlimit cache.
+// The argument is process RLIMIT_NOFILE values.
+func ClearRlimitNofileCache(_ *syscall.Rlimit) {
+	// As reported in issue #4195, the new version of go runtime(since 1.19)
+	// will cache rlimit-nofile. Before executing execve, the rlimit-nofile
+	// of the process will be restored with the cache. In runc, this will
+	// cause the rlimit-nofile setting by the parent process for the container
+	// to become invalid. It can be solved by clearing this cache. But
+	// unfortunately, go stdlib doesn't provide such function, so we need to
+	// link to the private var `origRlimitNofile` in package syscall to hack.
+	syscallOrigRlimitNofile.Store(nil)
+}


### PR DESCRIPTION
Go 1.23 tightens access to internal symbols, and even puts runc into
"hall of shame" for using an internal symbol (recently added by commit
da68c8e3). So, while not impossible, it becomes harder to access those
internal symbols, and it is a bad idea in general.
    
Since Go 1.23 includes https://go.dev/cl/588076,  we can clean the
internal rlimit cache by setting the RLIMIT_NOFILE for ourselves,
essentially disabling the rlimit cache.

Once Go 1.22 is no longer supported, we will remove the go:linkname hack.