### PR TITLE
Fix codespell warnings

### DIFF
--- a/features.go
+++ b/features.go
@@ -27,7 +27,7 @@ var featuresCommand = cli.Command{
 			return err
 		}
 
-		tru := true
+		t := true
 
 		feat := features.Features{
 			OCIVersionMin: "1.0.0",
@@ -43,24 +43,24 @@ var featuresCommand = cli.Command{
 				Namespaces:   specconv.KnownNamespaces(),
 				Capabilities: capabilities.KnownCapabilities(),
 				Cgroup: &features.Cgroup{
-					V1:          &tru,
-					V2:          &tru,
-					Systemd:     &tru,
-					SystemdUser: &tru,
-					Rdma:        &tru,
+					V1:          &t,
+					V2:          &t,
+					Systemd:     &t,
+					SystemdUser: &t,
+					Rdma:        &t,
 				},
 				Apparmor: &features.Apparmor{
-					Enabled: &tru,
+					Enabled: &t,
 				},
 				Selinux: &features.Selinux{
-					Enabled: &tru,
+					Enabled: &t,
 				},
 				IntelRdt: &features.IntelRdt{
-					Enabled: &tru,
+					Enabled: &t,
 				},
 				MountExtensions: &features.MountExtensions{
 					IDMap: &features.IDMap{
-						Enabled: &tru,
+						Enabled: &t,
 					},
 				},
 			},
@@ -74,7 +74,7 @@ var featuresCommand = cli.Command{
 
 		if seccomp.Enabled {
 			feat.Linux.Seccomp = &features.Seccomp{
-				Enabled:        &tru,
+				Enabled:        &t,
 				Actions:        seccomp.KnownActions(),
 				Operators:      seccomp.KnownOperators(),
 				Archs:          seccomp.KnownArchs(),

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -143,9 +143,8 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, det
 	return setupProcessPipes(process, rootuid, rootgid)
 }
 
-// createPidFile creates a file with the processes pid inside it atomically
-// it creates a temp file with the paths filename + '.' infront of it
-// then renames the file
+// createPidFile creates a file containing the PID,
+// doing so atomically (via create and rename).
 func createPidFile(path string, process *libcontainer.Process) error {
 	pid, err := process.Pid()
 	if err != nil {


### PR DESCRIPTION
Recently released codespell 2.3.0 finds some new issues:

```
./features.go:30: tru ==> through, true
...
./utils_linux.go:147: infront ==> in front
```

Fix those.