### PR TITLE
libct/cg/dev: fix TestSetV1Allow panic

### DIFF
--- a/libcontainer/cgroups/devices/v1_test.go
+++ b/libcontainer/cgroups/devices/v1_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
+	"github.com/opencontainers/runc/libcontainer/userns"
 )
 
 func init() {
@@ -17,6 +18,9 @@ func init() {
 }
 
 func TestSetV1Allow(t *testing.T) {
+	if userns.RunningInUserNS() {
+		t.Skip("userns detected; setV1 does nothing")
+	}
 	dir := t.TempDir()
 
 	for file, contents := range map[string]string{


### PR DESCRIPTION
This test panics if userns is detected (such as when run in a rootless docker container) because SetV1 does nothing in this case.

We could fix the panic, but it doesn't make sense to run the test at all.
