### PR TITLE
[1.1] libct/system: ClearRlimitNofileCache for go 1.23

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"unsafe"
 
 	"github.com/containerd/console"
@@ -87,9 +88,7 @@ func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd,
 
 	// Clean the RLIMIT_NOFILE cache in go runtime.
 	// Issue: https://github.com/opencontainers/runc/issues/4195
-	if containsRlimit(config.Rlimits, unix.RLIMIT_NOFILE) {
-		system.ClearRlimitNofileCache()
-	}
+	maybeClearRlimitNofileCache(config.Rlimits)
 
 	switch t {
 	case initSetns:
@@ -268,7 +267,6 @@ func setupConsole(socket *os.File, config *initConfig, mount bool) error {
 			Height: config.ConsoleHeight,
 			Width:  config.ConsoleWidth,
 		})
-
 		if err != nil {
 			return err
 		}
@@ -525,13 +523,16 @@ func setupRoute(config *configs.Config) error {
 	return nil
 }
 
-func containsRlimit(limits []configs.Rlimit, resource int) bool {
+func maybeClearRlimitNofileCache(limits []configs.Rlimit) {
 	for _, rlimit := range limits {
-		if rlimit.Type == resource {
-			return true
+		if rlimit.Type == syscall.RLIMIT_NOFILE {
+			system.ClearRlimitNofileCache(&syscall.Rlimit{
+				Cur: rlimit.Soft,
+				Max: rlimit.Hard,
+			})
+			return
 		}
 	}
-	return false
 }
 
 func setupRlimits(limits []configs.Rlimit, pid int) error {

--- a/libcontainer/system/rlimit_linux.go
+++ b/libcontainer/system/rlimit_linux.go
@@ -1,0 +1,15 @@
+//go:build go1.23
+
+package system
+
+import (
+	"syscall"
+)
+
+// ClearRlimitNofileCache clears go runtime's nofile rlimit cache. The argument
+// is process RLIMIT_NOFILE values. Relies on go.dev/cl/588076.
+func ClearRlimitNofileCache(lim *syscall.Rlimit) {
+	// Ignore the return values since we only need to clean the cache,
+	// the limit is going to be set via unix.Prlimit elsewhere.
+	_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, lim)
+}

--- a/libcontainer/system/rlimit_linux_go122.go
+++ b/libcontainer/system/rlimit_linux_go122.go
@@ -1,19 +1,21 @@
-//go:build go1.19
+//go:build go1.19 && !go1.23
+
+// TODO: remove this file once go 1.22 is no longer supported.
 
 package system
 
 import (
 	"sync/atomic"
 	"syscall"
-
-	_ "unsafe" // for go:linkname
+	_ "unsafe" // Needed for go:linkname to work.
 )
 
 //go:linkname syscallOrigRlimitNofile syscall.origRlimitNofile
 var syscallOrigRlimitNofile atomic.Pointer[syscall.Rlimit]
 
-// ClearRlimitNofileCache is to clear go runtime's nofile rlimit cache.
-func ClearRlimitNofileCache() {
+// ClearRlimitNofileCache clears go runtime's nofile rlimit cache.
+// The argument is process RLIMIT_NOFILE values.
+func ClearRlimitNofileCache(_ *syscall.Rlimit) {
 	// As reported in issue #4195, the new version of go runtime(since 1.19)
 	// will cache rlimit-nofile. Before executing execve, the rlimit-nofile
 	// of the process will be restored with the cache. In runc, this will

--- a/libcontainer/system/rlimit_stub.go
+++ b/libcontainer/system/rlimit_stub.go
@@ -2,5 +2,6 @@
 
 package system
 
-func ClearRlimitNofileCache() {
-}
+import "syscall"
+
+func ClearRlimitNofileCache(_ *syscall.Rlimit) {}


### PR DESCRIPTION
This is a backport of #4290 to release-1.1 branch.

----

Go 1.23 tightens access to internal symbols, and even puts runc into "hall of shame" for using an internal symbol (recently added by commit da68c8e3). So, while not impossible, it becomes harder to access those internal symbols, and it is a bad idea in general.

Since Go 1.23 includes https://go.dev/cl/588076, we can clean the internal rlimit cache by setting the RLIMIT_NOFILE for ourselves, essentially disabling the rlimit cache.

Once Go 1.22 is no longer supported, we will remove the go:linkname hack.

(cherry picked from commit 584afc675650e87ecc443896f56aed27a0064dc0)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>