### PR TITLE
[1.1] Fix codespell warnings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
-      run: pip install codespell
+      run: pip install codespell==v2.3.0
     - name: run codespell
       run: codespell
 

--- a/features.go
+++ b/features.go
@@ -27,7 +27,7 @@ var featuresCommand = cli.Command{
 			return err
 		}
 
-		tru := true
+		t := true
 
 		feat := features.Features{
 			OCIVersionMin: "1.0.0",
@@ -43,23 +43,23 @@ var featuresCommand = cli.Command{
 				Namespaces:   specconv.KnownNamespaces(),
 				Capabilities: capabilities.KnownCapabilities(),
 				Cgroup: &features.Cgroup{
-					V1:          &tru,
-					V2:          &tru,
-					Systemd:     &tru,
-					SystemdUser: &tru,
+					V1:          &t,
+					V2:          &t,
+					Systemd:     &t,
+					SystemdUser: &t,
 				},
 				Apparmor: &features.Apparmor{
-					Enabled: &tru,
+					Enabled: &t,
 				},
 				Selinux: &features.Selinux{
-					Enabled: &tru,
+					Enabled: &t,
 				},
 			},
 		}
 
 		if seccomp.Enabled {
 			feat.Linux.Seccomp = &features.Seccomp{
-				Enabled:   &tru,
+				Enabled:   &t,
 				Actions:   seccomp.KnownActions(),
 				Operators: seccomp.KnownOperators(),
 				Archs:     seccomp.KnownArchs(),

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -168,9 +168,8 @@ func setupIO(process *libcontainer.Process, rootuid, rootgid int, createTTY, det
 	return setupProcessPipes(process, rootuid, rootgid)
 }
 
-// createPidFile creates a file with the processes pid inside it atomically
-// it creates a temp file with the paths filename + '.' infront of it
-// then renames the file
+// createPidFile creates a file containing the PID,
+// doing so atomically (via create and rename).
 func createPidFile(path string, process *libcontainer.Process) error {
 	pid, err := process.Pid()
 	if err != nil {


### PR DESCRIPTION
This is a backport of #4291 and #4301 to release-1.1 branch.

----
./features.go:30: tru ==> through, true
...
./utils_linux.go:147: infront ==> in front


(cherry picked from commit 177c7d4f590dd6efc6fdff139aba728c694e90ad)

----
CI should not fail and require attention every time a new codespell version is released.


(cherry picked from commit b24fc9d2c44bc6e53b9a6ea580e96348181e2f27)