### PR TITLE
ci: pin codespell

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
-      run: pip install codespell
+      run: pip install codespell==v2.3.0
     - name: run codespell
       run: codespell
 


### PR DESCRIPTION
CI should not fail and require attention every time a new codespell version is released.