### PR TITLE
libct/int: skip TestUsernsCheckpoint on CentOS 7

### DIFF
--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/runc/internal/testutil"
 	"github.com/opencontainers/runc/libcontainer"
 	"golang.org/x/sys/unix"
 )
@@ -18,6 +19,7 @@ func criuFeature(feature string) bool {
 }
 
 func TestUsernsCheckpoint(t *testing.T) {
+	testutil.SkipOnCentOS(t, "Flaky (see #4273)", 7)
 	testCheckpoint(t, true)
 }
 

--- a/libcontainer/integration/checkpoint_test.go
+++ b/libcontainer/integration/checkpoint_test.go
@@ -48,6 +48,13 @@ func testCheckpoint(t *testing.T, userns bool) {
 
 	config := newTemplateConfig(t, &tParam{userns: userns})
 	stateDir := t.TempDir()
+	defer func() {
+		out, err := exec.Command("fuser", "-vm", stateDir+"/dev").CombinedOutput()
+		t.Logf("%s", out)
+		if err != nil {
+			t.Logf("exec: %v", err)
+		}
+	}()
 
 	container, err := libcontainer.Create(stateDir, "test", config)
 	ok(t, err)


### PR DESCRIPTION
Fixes #4273 