### PR TITLE
[1.1] ci: workaround for centos stream 8 being EOLed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -106,6 +106,10 @@ task:
       sysctl --system
       ;;
     centos-stream-8)
+      # CS8 is EOF. As a temp workaround, fix repo URLs to point to vault.
+      for f in /etc/yum.repos.d/*.repo; do \
+        sed -i -e 's,^mirrorlist=,#\0,' -e 's,^#baseurl=http://mirror\.,baseurl=http://vault.,' $f; \
+      done
       yum config-manager --set-enabled powertools # for glibc-static
       ;;
     centos-stream-9)


### PR DESCRIPTION
This is the backport of #4304 to relase-1.1 branch.

----
CS8 is EOL. As a temp workaround, fix repo URLs to point to vault.

(cherry picked from commit 48c4e733f4eaa4ca90c589c1e029e9785ce7a806)