### PR TITLE
refactor: move some c code to go

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -27,6 +27,11 @@ type IDMap struct {
 	Size        int64 `json:"size"`
 }
 
+// ToString is to serialize the IDMap to a string.
+func (i IDMap) ToString() string {
+	return fmt.Sprintf("%d %d %d", i.ContainerID, i.HostID, i.Size)
+}
+
 // Seccomp represents syscall restrictions
 // By default, only the native architecture of the kernel is allowed to be used
 // for syscalls. Additional architectures can be added by specifying them in

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1123,7 +1123,7 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 					})
 				}
 			}
-			if requiresRootOrMappingTool(c.config) {
+			if requiresRootOrMappingTool(c.config.GIDMappings) {
 				r.AddData(&Boolmsg{
 					Type:  SetgroupAttr,
 					Value: true,
@@ -1186,9 +1186,9 @@ func ignoreTerminateErrors(err error) error {
 	return err
 }
 
-func requiresRootOrMappingTool(c *configs.Config) bool {
+func requiresRootOrMappingTool(gidMappings []configs.IDMap) bool {
 	gidMap := []configs.IDMap{
 		{ContainerID: 0, HostID: int64(os.Getegid()), Size: 1},
 	}
-	return !reflect.DeepEqual(c.GIDMappings, gidMap)
+	return !reflect.DeepEqual(gidMappings, gidMap)
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -536,6 +536,10 @@ func (c *Container) newParentProcess(p *Process) (parentProcess, error) {
 	cmd.Env = append(cmd.Env,
 		"_LIBCONTAINER_INITPIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
 	)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, comm.stage1SockChild)
+	cmd.Env = append(cmd.Env,
+		"_LIBCONTAINER_STAGE1PIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
+	)
 	cmd.ExtraFiles = append(cmd.ExtraFiles, comm.syncSockChild.File())
 	cmd.Env = append(cmd.Env,
 		"_LIBCONTAINER_SYNCPIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
@@ -1022,17 +1026,6 @@ func (c *Container) orderNamespacePaths(namespaces map[configs.NamespaceType]str
 	return paths, nil
 }
 
-func encodeIDMapping(idMap []configs.IDMap) ([]byte, error) {
-	data := bytes.NewBuffer(nil)
-	for _, im := range idMap {
-		line := fmt.Sprintf("%d %d %d\n", im.ContainerID, im.HostID, im.Size)
-		if _, err := data.WriteString(line); err != nil {
-			return nil, err
-		}
-	}
-	return data.Bytes(), nil
-}
-
 // netlinkError is an error wrapper type for use by custom netlink message
 // types. Panics with errors are wrapped in netlinkError so that the recover
 // in bootstrapData can distinguish intentional panics.
@@ -1079,59 +1072,6 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 		})
 	}
 
-	// write namespace paths only when we are not joining an existing user ns
-	_, joinExistingUser := nsMaps[configs.NEWUSER]
-	if !joinExistingUser {
-		// write uid mappings
-		if len(c.config.UIDMappings) > 0 {
-			if c.config.RootlessEUID {
-				// We resolve the paths for new{u,g}idmap from
-				// the context of runc to avoid doing a path
-				// lookup in the nsexec context.
-				if path, err := exec.LookPath("newuidmap"); err == nil {
-					r.AddData(&Bytemsg{
-						Type:  UidmapPathAttr,
-						Value: []byte(path),
-					})
-				}
-			}
-			b, err := encodeIDMapping(c.config.UIDMappings)
-			if err != nil {
-				return nil, err
-			}
-			r.AddData(&Bytemsg{
-				Type:  UidmapAttr,
-				Value: b,
-			})
-		}
-
-		// write gid mappings
-		if len(c.config.GIDMappings) > 0 {
-			b, err := encodeIDMapping(c.config.GIDMappings)
-			if err != nil {
-				return nil, err
-			}
-			r.AddData(&Bytemsg{
-				Type:  GidmapAttr,
-				Value: b,
-			})
-			if c.config.RootlessEUID {
-				if path, err := exec.LookPath("newgidmap"); err == nil {
-					r.AddData(&Bytemsg{
-						Type:  GidmapPathAttr,
-						Value: []byte(path),
-					})
-				}
-			}
-			if requiresRootOrMappingTool(c.config.GIDMappings) {
-				r.AddData(&Boolmsg{
-					Type:  SetgroupAttr,
-					Value: true,
-				})
-			}
-		}
-	}
-
 	if c.config.OomScoreAdj != nil {
 		// write oom_score_adj
 		r.AddData(&Bytemsg{
@@ -1139,12 +1079,6 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 			Value: []byte(strconv.Itoa(*c.config.OomScoreAdj)),
 		})
 	}
-
-	// write rootless
-	r.AddData(&Boolmsg{
-		Type:  RootlessEUIDAttr,
-		Value: c.config.RootlessEUID,
-	})
 
 	// write boottime and monotonic time ns offsets.
 	if c.config.TimeOffsets != nil {

--- a/libcontainer/container_setup_linux.go
+++ b/libcontainer/container_setup_linux.go
@@ -1,0 +1,147 @@
+package libcontainer
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// NsExecSyncMsg is used for communication between the parent and child during
+// container setup.
+type NsExecSyncMsg uint32
+
+const (
+	SyncUsermapPls NsExecSyncMsg = iota + 0x40
+	SyncUsermapAck
+	SyncRecvPidPls
+	SyncRecvPidAck
+	SyncTimeOffsetsPls
+	SyncTimeOffsetsAck
+)
+
+const bufSize = 4
+
+// setupNsExec is used to help nsexec to setup the container and wait the container's pid.
+func (s *containerProcess) setupNsExec(syncSock *os.File) error {
+	logrus.Debugf("waiting nsexec to report the container's pid")
+	err := ParseNsExecSync(syncSock, func(msg NsExecSyncMsg) error {
+		switch msg {
+		case SyncUsermapPls:
+			logrus.Debugf("nsexec has requested userns mappings")
+			if err := s.setupUsermap(); err != nil {
+				return err
+			}
+			return AckNsExecSync(syncSock, SyncUsermapAck)
+		case SyncTimeOffsetsPls:
+			logrus.Debugf("nsexec has requested to configure timens offsets")
+			if err := system.UpdateTimeNsOffsets(s.cmd.Process.Pid, s.container.config.TimeOffsets); err != nil {
+				return err
+			}
+			return AckNsExecSync(syncSock, SyncTimeOffsetsAck)
+		case SyncRecvPidPls:
+			logrus.Debugf("nsexec has reported pid")
+			var pid uint32
+			if err := binary.Read(syncSock, nl.NativeEndian(), &pid); err != nil {
+				return err
+			}
+			s.childPid = int(pid)
+			return AckNsExecSync(syncSock, SyncRecvPidAck)
+		default:
+			return fmt.Errorf("unexpected message %d", msg)
+		}
+	})
+
+	return err
+}
+
+// setupUsermap is used to set up the user mappings.
+func (s *containerProcess) setupUsermap() error {
+	var uidMapPath, gidMapPath string
+
+	// Enable setgroups(2) if we've been asked to. But we also have to explicitly
+	// disable setgroups(2) if we're creating a rootless container for single-entry
+	// mapping. (this is required since Linux 3.19).
+	// For rootless multi-entry mapping, we should use newuidmap/newgidmap
+	// to do mapping user namespace.
+	if s.config.Config.RootlessEUID && !requiresRootOrMappingTool(s.config.Config.GIDMappings) {
+		_ = system.UpdateSetgroups(s.cmd.Process.Pid, system.SetgroupsDeny)
+	}
+
+	nsMaps := make(map[configs.NamespaceType]string)
+	for _, ns := range s.container.config.Namespaces {
+		if ns.Path != "" {
+			nsMaps[ns.Type] = ns.Path
+		}
+	}
+	_, joinExistingUser := nsMaps[configs.NEWUSER]
+	if !joinExistingUser {
+		// write uid mappings
+		if len(s.container.config.UIDMappings) > 0 {
+			if s.container.config.RootlessEUID {
+				if path, err := exec.LookPath("newuidmap"); err == nil {
+					uidMapPath = path
+				}
+			}
+		}
+
+		// write gid mappings
+		if len(s.container.config.GIDMappings) > 0 {
+			if s.container.config.RootlessEUID {
+				if path, err := exec.LookPath("newgidmap"); err == nil {
+					gidMapPath = path
+				}
+			}
+		}
+	}
+
+	/* Set up mappings. */
+	if err := system.UpdateUidmap(uidMapPath, s.cmd.Process.Pid, s.container.config.UIDMappings); err != nil {
+		return err
+	}
+	return system.UpdateGidmap(gidMapPath, s.cmd.Process.Pid, s.container.config.GIDMappings)
+}
+
+// ParseNsExecSync runs the given callback function on each message received
+// from the child. It will return once the child sends SYNC_RECVPID_PLS.
+func ParseNsExecSync(r io.Reader, fn func(NsExecSyncMsg) error) error {
+	var (
+		msg NsExecSyncMsg
+		buf [bufSize]byte
+	)
+
+	native := nl.NativeEndian()
+
+	for {
+		if _, err := io.ReadAtLeast(r, buf[:], bufSize); err != nil {
+			return err
+		}
+		msg = NsExecSyncMsg(native.Uint32(buf[:]))
+		if err := fn(msg); err != nil {
+			return err
+		}
+		if msg == SyncRecvPidPls {
+			break
+		}
+	}
+	return nil
+}
+
+// AckNsExecSync is used to send a message to the child.
+func AckNsExecSync(f *os.File, msg NsExecSyncMsg) error {
+	var buf [bufSize]byte
+	native := nl.NativeEndian()
+	native.PutUint32(buf[:], uint32(msg))
+	if _, err := unix.Write(int(f.Fd()), buf[:]); err != nil {
+		logrus.Debugf("failed to write message to nsexec: %v", err)
+		return err
+	}
+	return nil
+}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -222,6 +222,24 @@ func startInitialization() (retErr error) {
 		return err
 	}
 
+	if _, err := unix.Setsid(); err != nil {
+		return os.NewSyscallError("setsid", err)
+	}
+
+	if err := unix.Setuid(0); err != nil {
+		return os.NewSyscallError("setuid", err)
+	}
+
+	if err := unix.Setgid(0); err != nil {
+		return os.NewSyscallError("setgid", err)
+	}
+
+	if !config.Config.RootlessEUID && requiresRootOrMappingTool(config.Config.GIDMappings) {
+		if err := unix.Setgroups([]int{0}); err != nil {
+			return os.NewSyscallError("setgroups", err)
+		}
+	}
+
 	// If init succeeds, it will not return, hence none of the defers will be called.
 	return containerInit(it, &config, syncPipe, consoleSocket, pidfdSocket, fifoFile, logPipe)
 }

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -33,11 +33,6 @@ const (
 	initStandard initType = "standard"
 )
 
-type pid struct {
-	Pid           int `json:"stage2_pid"`
-	PidFirstChild int `json:"stage1_pid"`
-}
-
 // network is an internal struct used to setup container networks.
 type network struct {
 	configs.Network

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -11,17 +11,11 @@ import (
 // list of known message types we want to send to bootstrap program
 // The number is randomly chosen to not conflict with known netlink types
 const (
-	InitMsg          uint16 = 62000
-	CloneFlagsAttr   uint16 = 27281
-	NsPathsAttr      uint16 = 27282
-	UidmapAttr       uint16 = 27283
-	GidmapAttr       uint16 = 27284
-	SetgroupAttr     uint16 = 27285
-	OomScoreAdjAttr  uint16 = 27286
-	RootlessEUIDAttr uint16 = 27287
-	UidmapPathAttr   uint16 = 27288
-	GidmapPathAttr   uint16 = 27289
-	TimeOffsetsAttr  uint16 = 27290
+	InitMsg         uint16 = 62000
+	CloneFlagsAttr  uint16 = 27281
+	NsPathsAttr     uint16 = 27282
+	OomScoreAdjAttr uint16 = 27286
+	TimeOffsetsAttr uint16 = 27290
 )
 
 type Int32msg struct {

--- a/libcontainer/nsenter/log.c
+++ b/libcontainer/nsenter/log.c
@@ -58,7 +58,7 @@ void write_log(int level, const char *format, ...)
 		if (stage == NULL)
 			goto out;
 	} else {
-		ret = asprintf(&stage, "nsexec-%d", current_stage);
+		ret = asprintf(&stage, "nsexec-%d", current_stage + 1);
 		if (ret < 0) {
 			stage = NULL;
 			goto out;

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -782,20 +782,6 @@ void nsexec(void)
 			prctl(PR_SET_NAME, (unsigned long)"runc:[2:INIT]", 0, 0, 0);
 			write_log(DEBUG, "~> nsexec stage-2");
 
-			if (setsid() < 0)
-				bail("setsid failed");
-
-			if (setuid(0) < 0)
-				bail("setuid failed");
-
-			if (setgid(0) < 0)
-				bail("setgid failed");
-
-			if (!config.is_rootless_euid && config.is_setgroup) {
-				if (setgroups(0, NULL) < 0)
-					bail("setgroups failed");
-			}
-
 			close(syncfd);
 
 			/* Free netlink data. */

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -37,17 +37,14 @@ enum sync_t {
 	SYNC_USERMAP_ACK = 0x41,	/* Mapping finished by the parent. */
 	SYNC_RECVPID_PLS = 0x42,	/* Tell parent we're sending the PID. */
 	SYNC_RECVPID_ACK = 0x43,	/* PID was correctly received by parent. */
-	SYNC_GRANDCHILD = 0x44,	/* The grandchild is ready to run. */
-	SYNC_CHILD_FINISH = 0x45,	/* The child or grandchild has finished. */
-	SYNC_TIMEOFFSETS_PLS = 0x46,	/* Request parent to write timens offsets. */
-	SYNC_TIMEOFFSETS_ACK = 0x47,	/* Timens offsets were written. */
+	SYNC_TIMEOFFSETS_PLS = 0x44,	/* Request parent to write timens offsets. */
+	SYNC_TIMEOFFSETS_ACK = 0x45,	/* Timens offsets were written. */
 };
 
 #define STAGE_SETUP  -1
 /* longjmp() arguments. */
-#define STAGE_PARENT  0
-#define STAGE_CHILD   1
-#define STAGE_INIT    2
+#define STAGE_CHILD   0
+#define STAGE_INIT    1
 
 /* Stores the current stage of nsexec. */
 int current_stage = STAGE_SETUP;
@@ -102,13 +99,7 @@ struct nlconfig_t {
 #define INIT_MSG		62000
 #define CLONE_FLAGS_ATTR	27281
 #define NS_PATHS_ATTR		27282
-#define UIDMAP_ATTR		27283
-#define GIDMAP_ATTR		27284
-#define SETGROUP_ATTR		27285
 #define OOM_SCORE_ADJ_ATTR	27286
-#define ROOTLESS_EUID_ATTR	27287
-#define UIDMAPPATH_ATTR		27288
-#define GIDMAPPATH_ATTR		27289
 #define TIMENSOFFSET_ATTR	27290
 
 /*
@@ -131,9 +122,6 @@ int setns(int fd, int nstype)
 	return syscall(SYS_setns, fd, nstype);
 }
 #endif
-
-/* XXX: This is ugly. */
-static int syncfd = -1;
 
 static int write_file(char *data, size_t data_len, char *pathfmt, ...)
 {
@@ -161,136 +149,6 @@ static int write_file(char *data, size_t data_len, char *pathfmt, ...)
 out:
 	close(fd);
 	return ret;
-}
-
-enum policy_t {
-	SETGROUPS_DEFAULT = 0,
-	SETGROUPS_ALLOW,
-	SETGROUPS_DENY,
-};
-
-/* This *must* be called before we touch gid_map. */
-static void update_setgroups(int pid, enum policy_t setgroup)
-{
-	char *policy;
-
-	switch (setgroup) {
-	case SETGROUPS_ALLOW:
-		policy = "allow";
-		break;
-	case SETGROUPS_DENY:
-		policy = "deny";
-		break;
-	case SETGROUPS_DEFAULT:
-	default:
-		/* Nothing to do. */
-		return;
-	}
-
-	if (write_file(policy, strlen(policy), "/proc/%d/setgroups", pid) < 0) {
-		/*
-		 * If the kernel is too old to support /proc/pid/setgroups,
-		 * open(2) or write(2) will return ENOENT. This is fine.
-		 */
-		if (errno != ENOENT)
-			bail("failed to write '%s' to /proc/%d/setgroups", policy, pid);
-	}
-}
-
-static int try_mapping_tool(const char *app, int pid, char *map, size_t map_len)
-{
-	int child;
-
-	/*
-	 * If @app is NULL, execve will segfault. Just check it here and bail (if
-	 * we're in this path, the caller is already getting desperate and there
-	 * isn't a backup to this failing). This usually would be a configuration
-	 * or programming issue.
-	 */
-	if (!app)
-		bail("mapping tool not present");
-
-	child = fork();
-	if (child < 0)
-		bail("failed to fork");
-
-	if (!child) {
-#define MAX_ARGV 20
-		char *argv[MAX_ARGV];
-		char *envp[] = { NULL };
-		char pid_fmt[16];
-		int argc = 0;
-		char *next;
-
-		snprintf(pid_fmt, 16, "%d", pid);
-
-		argv[argc++] = (char *)app;
-		argv[argc++] = pid_fmt;
-		/*
-		 * Convert the map string into a list of argument that
-		 * newuidmap/newgidmap can understand.
-		 */
-
-		while (argc < MAX_ARGV) {
-			if (*map == '\0') {
-				argv[argc++] = NULL;
-				break;
-			}
-			argv[argc++] = map;
-			next = strpbrk(map, "\n ");
-			if (next == NULL)
-				break;
-			*next++ = '\0';
-			map = next + strspn(next, "\n ");
-		}
-
-		execve(app, argv, envp);
-		bail("failed to execv");
-	} else {
-		int status;
-
-		while (true) {
-			if (waitpid(child, &status, 0) < 0) {
-				if (errno == EINTR)
-					continue;
-				bail("failed to waitpid");
-			}
-			if (WIFEXITED(status) || WIFSIGNALED(status))
-				return WEXITSTATUS(status);
-		}
-	}
-
-	return -1;
-}
-
-static void update_uidmap(const char *path, int pid, char *map, size_t map_len)
-{
-	if (map == NULL || map_len == 0)
-		return;
-
-	write_log(DEBUG, "update /proc/%d/uid_map to '%s'", pid, map);
-	if (write_file(map, map_len, "/proc/%d/uid_map", pid) < 0) {
-		if (errno != EPERM)
-			bail("failed to update /proc/%d/uid_map", pid);
-		write_log(DEBUG, "update /proc/%d/uid_map got -EPERM (trying %s)", pid, path);
-		if (try_mapping_tool(path, pid, map, map_len))
-			bail("failed to use newuid map on %d", pid);
-	}
-}
-
-static void update_gidmap(const char *path, int pid, char *map, size_t map_len)
-{
-	if (map == NULL || map_len == 0)
-		return;
-
-	write_log(DEBUG, "update /proc/%d/gid_map to '%s'", pid, map);
-	if (write_file(map, map_len, "/proc/%d/gid_map", pid) < 0) {
-		if (errno != EPERM)
-			bail("failed to update /proc/%d/gid_map", pid);
-		write_log(DEBUG, "update /proc/%d/gid_map got -EPERM (trying %s)", pid, path);
-		if (try_mapping_tool(path, pid, map, map_len))
-			bail("failed to use newgid map on %d", pid);
-	}
 }
 
 static void update_oom_score_adj(char *data, size_t len)
@@ -325,11 +183,6 @@ static int clone_parent(jmp_buf *env, int jmpval)
 static uint32_t readint32(char *buf)
 {
 	return *(uint32_t *) buf;
-}
-
-static uint8_t readint8(char *buf)
-{
-	return *(uint8_t *) buf;
 }
 
 static void nl_parse(int fd, struct nlconfig_t *config)
@@ -373,9 +226,6 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 		case CLONE_FLAGS_ATTR:
 			config->cloneflags = readint32(current);
 			break;
-		case ROOTLESS_EUID_ATTR:
-			config->is_rootless_euid = readint8(current);	/* boolean */
-			break;
 		case OOM_SCORE_ADJ_ATTR:
 			config->oom_score_adj = current;
 			config->oom_score_adj_len = payload_len;
@@ -383,25 +233,6 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 		case NS_PATHS_ATTR:
 			config->namespaces = current;
 			config->namespaces_len = payload_len;
-			break;
-		case UIDMAP_ATTR:
-			config->uidmap = current;
-			config->uidmap_len = payload_len;
-			break;
-		case GIDMAP_ATTR:
-			config->gidmap = current;
-			config->gidmap_len = payload_len;
-			break;
-		case UIDMAPPATH_ATTR:
-			config->uidmappath = current;
-			config->uidmappath_len = payload_len;
-			break;
-		case GIDMAPPATH_ATTR:
-			config->gidmappath = current;
-			config->gidmappath_len = payload_len;
-			break;
-		case SETGROUP_ATTR:
-			config->is_setgroup = readint8(current);
 			break;
 		case TIMENSOFFSET_ATTR:
 			config->timensoffset = current;
@@ -664,20 +495,10 @@ void try_unshare(int flags, const char *msg)
 	bail("failed to unshare %s", msg);
 }
 
-static void update_timens_offsets(pid_t pid, char *map, size_t map_len)
-{
-	if (map == NULL || map_len == 0)
-		return;
-	write_log(DEBUG, "update /proc/%d/timens_offsets to '%s'", pid, map);
-	if (write_file(map, map_len, "/proc/%d/timens_offsets", pid) < 0)
-		bail("failed to update /proc/%d/timens_offsets", pid);
-}
-
 void nsexec(void)
 {
-	int pipenum;
+	int pipenum, syncfd;
 	jmp_buf env;
-	int sync_child_pipe[2], sync_grandchild_pipe[2];
 	struct nlconfig_t config = { 0 };
 
 	/*
@@ -693,6 +514,17 @@ void nsexec(void)
 	 */
 	pipenum = getenv_int("_LIBCONTAINER_INITPIPE");
 	if (pipenum < 0) {
+		/* We are not a runc init. Just return to go runtime. */
+		return;
+	}
+
+	/*
+	 * Get the stage1 pipe fd from the environment. The stage1 pipe is used to
+	 * request the parent to do some operations that can't be done in the
+	 * child process.
+	 */
+	syncfd = getenv_int("_LIBCONTAINER_STAGE1PIPE");
+	if (syncfd < 0) {
 		/* We are not a runc init. Just return to go runtime. */
 		return;
 	}
@@ -725,17 +557,6 @@ void nsexec(void)
 		if (prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) < 0)
 			bail("failed to set process as non-dumpable");
 	}
-
-	/* Pipe so we can tell the child when we've finished setting up. */
-	if (socketpair(AF_LOCAL, SOCK_STREAM, 0, sync_child_pipe) < 0)
-		bail("failed to setup sync pipe between parent and child");
-
-	/*
-	 * We need a new socketpair to sync with grandchild so we don't have
-	 * race condition with child.
-	 */
-	if (socketpair(AF_LOCAL, SOCK_STREAM, 0, sync_grandchild_pipe) < 0)
-		bail("failed to setup sync pipe between parent and grandchild");
 
 	/* TODO: Currently we aren't dealing with child deaths properly. */
 
@@ -788,162 +609,6 @@ void nsexec(void)
 
 	switch (setjmp(env)) {
 		/*
-		 * Stage 0: We're in the parent. Our job is just to create a new child
-		 *          (stage 1: STAGE_CHILD) process and write its uid_map and
-		 *          gid_map. That process will go on to create a new process, then
-		 *          it will send us its PID which we will send to the bootstrap
-		 *          process.
-		 */
-	case STAGE_PARENT:{
-			int len;
-			pid_t stage1_pid = -1, stage2_pid = -1;
-			bool stage1_complete, stage2_complete;
-
-			/* For debugging. */
-			current_stage = STAGE_PARENT;
-			prctl(PR_SET_NAME, (unsigned long)"runc:[0:PARENT]", 0, 0, 0);
-			write_log(DEBUG, "~> nsexec stage-0");
-
-			/* Start the process of getting a container. */
-			write_log(DEBUG, "spawn stage-1");
-			stage1_pid = clone_parent(&env, STAGE_CHILD);
-			if (stage1_pid < 0)
-				bail("unable to spawn stage-1");
-
-			syncfd = sync_child_pipe[1];
-			if (close(sync_child_pipe[0]) < 0)
-				bail("failed to close sync_child_pipe[0] fd");
-
-			/*
-			 * State machine for synchronisation with the children. We only
-			 * return once both the child and grandchild are ready.
-			 */
-			write_log(DEBUG, "-> stage-1 synchronisation loop");
-			stage1_complete = false;
-			while (!stage1_complete) {
-				enum sync_t s;
-
-				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
-					bail("failed to sync with stage-1: next state");
-
-				switch (s) {
-				case SYNC_USERMAP_PLS:
-					write_log(DEBUG, "stage-1 requested userns mappings");
-
-					/*
-					 * Enable setgroups(2) if we've been asked to. But we also
-					 * have to explicitly disable setgroups(2) if we're
-					 * creating a rootless container for single-entry mapping.
-					 * i.e. config.is_setgroup == false.
-					 * (this is required since Linux 3.19).
-					 *
-					 * For rootless multi-entry mapping, config.is_setgroup shall be true and
-					 * newuidmap/newgidmap shall be used.
-					 */
-					if (config.is_rootless_euid && !config.is_setgroup)
-						update_setgroups(stage1_pid, SETGROUPS_DENY);
-
-					/* Set up mappings. */
-					update_uidmap(config.uidmappath, stage1_pid, config.uidmap, config.uidmap_len);
-					update_gidmap(config.gidmappath, stage1_pid, config.gidmap, config.gidmap_len);
-
-					s = SYNC_USERMAP_ACK;
-					if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
-						sane_kill(stage1_pid, SIGKILL);
-						sane_kill(stage2_pid, SIGKILL);
-						bail("failed to sync with stage-1: write(SYNC_USERMAP_ACK)");
-					}
-					break;
-				case SYNC_RECVPID_PLS:
-					write_log(DEBUG, "stage-1 requested pid to be forwarded");
-
-					/* Get the stage-2 pid. */
-					if (read(syncfd, &stage2_pid, sizeof(stage2_pid)) != sizeof(stage2_pid)) {
-						sane_kill(stage1_pid, SIGKILL);
-						bail("failed to sync with stage-1: read(stage2_pid)");
-					}
-
-					/* Send ACK. */
-					s = SYNC_RECVPID_ACK;
-					if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
-						sane_kill(stage1_pid, SIGKILL);
-						sane_kill(stage2_pid, SIGKILL);
-						bail("failed to sync with stage-1: write(SYNC_RECVPID_ACK)");
-					}
-
-					/*
-					 * Send both the stage-1 and stage-2 pids back to runc.
-					 * runc needs the stage-2 to continue process management,
-					 * but because stage-1 was spawned with CLONE_PARENT we
-					 * cannot reap it within stage-0 and thus we need to ask
-					 * runc to reap the zombie for us.
-					 */
-					write_log(DEBUG, "forward stage-1 (%d) and stage-2 (%d) pids to runc",
-						  stage1_pid, stage2_pid);
-					len =
-					    dprintf(pipenum, "{\"stage1_pid\":%d,\"stage2_pid\":%d}\n", stage1_pid,
-						    stage2_pid);
-					if (len < 0) {
-						sane_kill(stage1_pid, SIGKILL);
-						sane_kill(stage2_pid, SIGKILL);
-						bail("failed to sync with runc: write(pid-JSON)");
-					}
-					break;
-				case SYNC_TIMEOFFSETS_PLS:
-					write_log(DEBUG, "stage-1 requested timens offsets to be configured");
-					update_timens_offsets(stage1_pid, config.timensoffset, config.timensoffset_len);
-					s = SYNC_TIMEOFFSETS_ACK;
-					if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
-						sane_kill(stage1_pid, SIGKILL);
-						bail("failed to sync with child: write(SYNC_TIMEOFFSETS_ACK)");
-					}
-					break;
-				case SYNC_CHILD_FINISH:
-					write_log(DEBUG, "stage-1 complete");
-					stage1_complete = true;
-					break;
-				default:
-					bail("unexpected sync value: %u", s);
-				}
-			}
-			write_log(DEBUG, "<- stage-1 synchronisation loop");
-
-			/* Now sync with grandchild. */
-			syncfd = sync_grandchild_pipe[1];
-			if (close(sync_grandchild_pipe[0]) < 0)
-				bail("failed to close sync_grandchild_pipe[0] fd");
-
-			write_log(DEBUG, "-> stage-2 synchronisation loop");
-			stage2_complete = false;
-			while (!stage2_complete) {
-				enum sync_t s;
-
-				write_log(DEBUG, "signalling stage-2 to run");
-				s = SYNC_GRANDCHILD;
-				if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
-					sane_kill(stage2_pid, SIGKILL);
-					bail("failed to sync with child: write(SYNC_GRANDCHILD)");
-				}
-
-				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
-					bail("failed to sync with child: next state");
-
-				switch (s) {
-				case SYNC_CHILD_FINISH:
-					write_log(DEBUG, "stage-2 complete");
-					stage2_complete = true;
-					break;
-				default:
-					bail("unexpected sync value: %u", s);
-				}
-			}
-			write_log(DEBUG, "<- stage-2 synchronisation loop");
-			write_log(DEBUG, "<~ nsexec stage-0");
-			exit(0);
-		}
-		break;
-
-		/*
 		 * Stage 1: We're in the first child process. Our job is to join any
 		 *          provided namespaces in the netlink payload and unshare all of
 		 *          the requested namespaces. If we've been asked to CLONE_NEWUSER,
@@ -958,11 +623,6 @@ void nsexec(void)
 
 			/* For debugging. */
 			current_stage = STAGE_CHILD;
-
-			/* We're in a child and thus need to tell the parent if we die. */
-			syncfd = sync_child_pipe[0];
-			if (close(sync_child_pipe[1]) < 0)
-				bail("failed to close sync_child_pipe[1] fd");
 
 			/* For debugging. */
 			prctl(PR_SET_NAME, (unsigned long)"runc:[1:CHILD]", 0, 0, 0);
@@ -1023,9 +683,9 @@ void nsexec(void)
 				/* ... wait for mapping ... */
 				write_log(DEBUG, "waiting stage-0 to complete the mapping of user namespace");
 				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
-					bail("failed to sync with parent: read(SYNC_USERMAP_ACK)");
+					bail("failed to sync with parent: read(SYNC_USERMAP_ACK) got %d", s);
 				if (s != SYNC_USERMAP_ACK)
-					bail("failed to sync with parent: SYNC_USERMAP_ACK: got %u", s);
+					bail("failed to sync with parent: SYNC_USERMAP_ACK");
 
 				/* Revert temporary re-dumpable setting. */
 				if (config.namespaces) {
@@ -1100,12 +760,7 @@ void nsexec(void)
 				bail("failed to sync with parent: SYNC_RECVPID_ACK: got %u", s);
 			}
 
-			write_log(DEBUG, "signal completion to stage-0");
-			s = SYNC_CHILD_FINISH;
-			if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
-				sane_kill(stage2_pid, SIGKILL);
-				bail("failed to sync with parent: write(SYNC_CHILD_FINISH)");
-			}
+			close(syncfd);
 
 			/* Our work is done. [Stage 2: STAGE_INIT] is doing the rest of the work. */
 			write_log(DEBUG, "<~ nsexec stage-1");
@@ -1120,31 +775,12 @@ void nsexec(void)
 		 *          init_linux.go to run.
 		 */
 	case STAGE_INIT:{
-			/*
-			 * We're inside the child now, having jumped from the
-			 * start_child() code after forking in the parent.
-			 */
-			enum sync_t s;
-
 			/* For debugging. */
 			current_stage = STAGE_INIT;
-
-			/* We're in a child and thus need to tell the parent if we die. */
-			syncfd = sync_grandchild_pipe[0];
-			if (close(sync_grandchild_pipe[1]) < 0)
-				bail("failed to close sync_grandchild_pipe[1] fd");
-
-			if (close(sync_child_pipe[0]) < 0)
-				bail("failed to close sync_child_pipe[0] fd");
 
 			/* For debugging. */
 			prctl(PR_SET_NAME, (unsigned long)"runc:[2:INIT]", 0, 0, 0);
 			write_log(DEBUG, "~> nsexec stage-2");
-
-			if (read(syncfd, &s, sizeof(s)) != sizeof(s))
-				bail("failed to sync with parent: read(SYNC_GRANDCHILD)");
-			if (s != SYNC_GRANDCHILD)
-				bail("failed to sync with parent: SYNC_GRANDCHILD: got %u", s);
 
 			if (setsid() < 0)
 				bail("setsid failed");
@@ -1160,14 +796,7 @@ void nsexec(void)
 					bail("setgroups failed");
 			}
 
-			write_log(DEBUG, "signal completion to stage-0");
-			s = SYNC_CHILD_FINISH;
-			if (write(syncfd, &s, sizeof(s)) != sizeof(s))
-				bail("failed to sync with parent: write(SYNC_CHILD_FINISH)");
-
-			/* Close sync pipes. */
-			if (close(sync_grandchild_pipe[0]) < 0)
-				bail("failed to close sync_grandchild_pipe[0] fd");
+			close(syncfd);
 
 			/* Free netlink data. */
 			nl_free(&config);

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -104,6 +104,7 @@ type containerProcess struct {
 	process       *Process
 	bootstrapData io.Reader
 	container     *Container
+	childPid      int
 }
 
 func (p *containerProcess) pid() int {


### PR DESCRIPTION
As mentioned in #3951 , we want to move c code to golang, there are many hard works to do.

This PR has done the first step, move all the stage-0 c code and some of the stage-2 c code to go code, because they are not related to namespaces, and could be implemented by golang.

This refactor brings one benifit, it reduces one process clone when start/run/create a container. But because the stage-1 c code is hard to move to go code, so it brings a Complexity for libct/nsenter, for example, it's hard to write unit tests for nsenter.

Welcome more suggestions.