### PR TITLE
let runc work with glibc lt 2.32 in go 1.22.x

### DIFF
--- a/libcontainer/nsenter/nsenter_go122.go
+++ b/libcontainer/nsenter/nsenter_go122.go
@@ -1,15 +1,25 @@
-//go:build go1.22
+//go:build go1.22 && !go1.23
 
 package nsenter
 
 /*
-// We know for sure that glibc has issues with pthread_self() when called from
-// Go after nsenter has run. This is likely a more general problem with how we
-// ignore the rules in signal-safety(7), and so it's possible musl will also
-// have issues, but as this is just a hotfix let's only block glibc builds.
+// In glibc versions older than 2.32 (before commit 4721f95058),
+// pthread_getattr_np does not always initialize the `attr` argument,
+// and when it fails, it results in a NULL pointer dereference in
+// pthread_attr_destroy down the road. This has been fixed in go 1.22.4.
+// We hack this to let runc can work with glibc < 2.32 in go 1.22.x,
+// once runc doesn't support 1.22, we can remove this hack.
+#cgo LDFLAGS: -Wl,--wrap=pthread_getattr_np
 #include <features.h>
-#ifdef __GLIBC__
-#  error "runc does not currently work properly with Go >=1.22. See <https://github.com/opencontainers/runc/issues/4233>."
+#include <pthread.h>
+int __real_pthread_getattr_np (pthread_t __th, pthread_attr_t *__attr);
+int __wrap_pthread_getattr_np (pthread_t __th, pthread_attr_t *__attr) {
+#if __GLIBC__ && defined(__GLIBC_PREREQ)
+# if !__GLIBC_PREREQ(2, 32)
+	pthread_attr_init(__attr);
+# endif
 #endif
+	return __real_pthread_getattr_np(__th, __attr);
+}
 */
 import "C"


### PR DESCRIPTION
For some libct users, it's hard to let them deal with the bug before go 1.22.4 with glibc version < 2.32, so let's do a hack to let runc can work for the entire go 1.22 versions.