### PR TITLE
fix a debug msg for user ns in nsexec

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -902,7 +902,7 @@ void nsexec(void)
 					bail("failed to sync with parent: write(SYNC_USERMAP_PLS)");
 
 				/* ... wait for mapping ... */
-				write_log(DEBUG, "request stage-0 to map user namespace");
+				write_log(DEBUG, "waiting stage-0 to complete the mapping of user namespace");
 				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
 					bail("failed to sync with parent: read(SYNC_USERMAP_ACK)");
 				if (s != SYNC_USERMAP_ACK)


### PR DESCRIPTION
When I was using `runc --debug` to run a container with user ns, I saw two debug msgs `request stage-0 to map user namespace`, it would make users confused.

At the first I thought runc requested stage-0 two times to map user ns? But after looked into the code, there are two same debug msgs in nsexec:
https://github.com/opencontainers/runc/blob/6b9b2c3d/libcontainer/nsenter/nsexec.c#L899 