### PR TITLE
refactor init and setns process

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -609,14 +609,16 @@ func (c *Container) newInitProcess(p *Process, cmd *exec.Cmd, comm *processComm)
 	}
 
 	init := &initProcess{
-		cmd:             cmd,
-		comm:            comm,
-		manager:         c.cgroupManager,
+		containerProcess: containerProcess{
+			cmd:           cmd,
+			comm:          comm,
+			manager:       c.cgroupManager,
+			config:        c.newInitConfig(p),
+			process:       p,
+			bootstrapData: data,
+			container:     c,
+		},
 		intelRdtManager: c.intelRdtManager,
-		config:          c.newInitConfig(p),
-		container:       c,
-		process:         p,
-		bootstrapData:   data,
 	}
 	c.initProcess = init
 	return init, nil
@@ -632,15 +634,18 @@ func (c *Container) newSetnsProcess(p *Process, cmd *exec.Cmd, comm *processComm
 		return nil, err
 	}
 	proc := &setnsProcess{
-		cmd:             cmd,
+		containerProcess: containerProcess{
+			cmd:           cmd,
+			comm:          comm,
+			manager:       c.cgroupManager,
+			config:        c.newInitConfig(p),
+			process:       p,
+			bootstrapData: data,
+			container:     c,
+		},
 		cgroupPaths:     state.CgroupPaths,
 		rootlessCgroups: c.config.RootlessCgroups,
 		intelRdtPath:    state.IntelRdtPath,
-		comm:            comm,
-		manager:         c.cgroupManager,
-		config:          c.newInitConfig(p),
-		process:         p,
-		bootstrapData:   data,
 		initProcessPid:  state.InitProcessPid,
 	}
 	if len(p.SubCgroupPaths) > 0 {


### PR DESCRIPTION
Because the `initProcess` and `setnsProcess` have many same fields, and they are all in a big file `process_linux.go`, so let's do some refactor to this file:

1. Introduce a common parent struct `containerProcess`, let both `initProcess` and `setnsProcess` are inherited from it;

2. ~~Move `initProcess` and `setnsProcess` definition and implementation out of `process_linux.go`, let them in their own seperate files: `init_process_linux.go` and `setns_process_linux.go`, it will make more clear when reading and changing the code.~~
EDIT: the second refactor could be refactored after the release-1.1 is EOL.

This refactor doesn't change any logic, and it's the first step of #4309 . After this refactor, both `initProcess` and `setnsProcess` can be treated as `containerProcess`, we can only need to write some logic for `containerProcess`, and then could be used for both `initProcess` and `setnsProcess`.