### PR TITLE
[1.1] Support Go 1.22, bump some CI deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,13 +46,13 @@ jobs:
         curl -fSsLl $REPO/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_tools_criu.gpg > /dev/null
         echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
-        sudo apt install libseccomp-dev criu sshfs
+        sudo apt -y install libseccomp-dev criu sshfs
 
     - name: install deps (criu ${{ matrix.criu }})
       if: matrix.criu != ''
       run: |
         sudo apt -q update
-        sudo apt -q install libseccomp-dev sshfs \
+        sudo apt -qy install libseccomp-dev sshfs \
           libcap-dev libnet1-dev libnl-3-dev \
           libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
         git clone https://github.com/checkpoint-restore/criu.git ~/criu
@@ -113,7 +113,7 @@ jobs:
         sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to.
 
-        sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib criu
+        sudo apt -qy install libseccomp-dev libseccomp-dev:i386 gcc-multilib criu
 
     - name: install go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: install deps
       if: matrix.criu == ''
@@ -104,7 +104,7 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: install deps
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         rm -rf ~/criu
 
     - name: install go ${{ matrix.go-version }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -119,7 +119,7 @@ jobs:
         sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib criu
 
     - name: install go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
   # However, we do not have 32-bit ARM CI, so we use i386 for testing 32bit stuff.
   # We are not interested in providing official support for i386.
   cross-i386:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 
@@ -113,9 +113,6 @@ jobs:
         sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to.
 
-        # Due to a bug in apt, we have to update it first
-        # (see https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268)
-        sudo apt -q install apt
         sudo apt -q install libseccomp-dev libseccomp-dev:i386 gcc-multilib criu
 
     - name: install go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.20.x, 1.21.x]
+        go-version: [1.17.x, 1.21.x, 1.22.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
         criu: [""]
@@ -63,6 +63,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
 
     - name: build
       run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
@@ -118,7 +119,8 @@ jobs:
     - name: install go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: 1.x # Latest stable
+        check-latest: true
 
     - name: unit test
       run: sudo -E PATH="$PATH" -- make GOARCH=386 localunittest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: false # golangci-lint-action does its own caching
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
       - name: compile with no build tags
@@ -102,7 +102,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: install go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: "${{ env.GO_VERSION }}"
     - name: verify deps

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ on:
       - release-*
   pull_request:
 env:
-  GO_VERSION: 1.20.x
+  GO_VERSION: 1.22.x
 
 jobs:
   keyring:
@@ -104,6 +104,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: "${{ env.GO_VERSION }}"
+        check-latest: true
     - name: verify deps
       run: make verify-dependencies
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install deps
         run: |
           sudo apt -q update
-          sudo apt -q install libseccomp-dev
+          sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v4
         with:
           version: v1.53
@@ -137,7 +137,7 @@ jobs:
     - name: install deps
       run: |
         sudo apt -qq update
-        sudo apt -qq install indent
+        sudo apt -qqy install indent
     - name: cfmt
       run: |
         make cfmt

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,14 +14,14 @@ jobs:
   keyring:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: check runc.keyring
       run: make validate-keyring
 
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v4
@@ -47,7 +47,7 @@ jobs:
       # Don't ignore C warnings. Note that the output of "go env CGO_CFLAGS" by default is "-g -O2", so we keep them.
       CGO_CFLAGS: -g -O2 -Werror
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install go
         uses: actions/setup-go@v4
         with:
@@ -58,7 +58,7 @@ jobs:
   codespell:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install codespell==v2.3.0
@@ -68,14 +68,14 @@ jobs:
   shfmt:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: shfmt
       run: make shfmt
 
   shellcheck:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: vars
         run: |
           echo 'VERSION=v0.8.0' >> $GITHUB_ENV
@@ -100,7 +100,7 @@ jobs:
   deps:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install go
       uses: actions/setup-go@v4
       with:
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: install deps
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       run: make validate-keyring
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,7 +42,7 @@ jobs:
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1 --out-format=github-actions
 
   compile-buildtags:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # Don't ignore C warnings. Note that the output of "go env CGO_CFLAGS" by default is "-g -O2", so we keep them.
       CGO_CFLAGS: -g -O2 -Werror
@@ -56,7 +56,7 @@ jobs:
         run: make BUILDTAGS=""
 
   codespell:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: install deps
@@ -66,14 +66,14 @@ jobs:
       run: codespell
 
   shfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: shfmt
       run: make shfmt
 
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: vars
@@ -98,7 +98,7 @@ jobs:
         run : ./script/check-config.sh
 
   deps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: install go
@@ -110,7 +110,7 @@ jobs:
 
 
   commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Only check commits on pull requests.
     if: github.event_name == 'pull_request'
     steps:
@@ -128,7 +128,7 @@ jobs:
           error: 'Subject too long (max 72)'
 
   cfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout
       uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
 
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.53
+          version: v1.54
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,12 +27,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache: false # golangci-lint-action does its own caching
       - name: install deps
         run: |
           sudo apt -q update
           sudo apt -qy install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v5
         with:
           version: v1.53
       # Extra linters, only checking new code from a pull request.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -121,7 +121,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check subject line length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,72}(\n.*)*$'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -169,7 +169,7 @@ jobs:
     - name: make releaseall
       run: make releaseall
     - name: upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-${{ github.run_id }}
         path: release/*

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,14 +31,14 @@ jobs:
         run: |
           sudo apt -q update
           sudo apt -qy install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v5
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.53
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'
         run: |
-          golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1 --out-format=github-actions
+          golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
   compile-buildtags:
     runs-on: ubuntu-22.04

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
+          version: v1.57
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v4
         with:
           version: v1.53
       # Extra linters, only checking new code from a pull request.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.21
 ARG BATS_VERSION=v1.9.0
 ARG LIBSECCOMP_VERSION=2.5.5
 
-FROM golang:${GO_VERSION}-bullseye
+FROM golang:${GO_VERSION}-bookworm
 ARG DEBIAN_FRONTEND=noninteractive
-ARG CRIU_REPO=https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11
+ARG CRIU_REPO=https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_12
 
 RUN KEYFILE=/usr/share/keyrings/criu-repo-keyring.gpg; \
     wget -nv $CRIU_REPO/Release.key -O- | gpg --dearmor > "$KEYFILE" \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ A third party security audit was performed by Cure53, you can see the full repor
 
 `runc` only supports Linux. It must be built with Go version 1.17 or higher.
 
+NOTE: if building with Go 1.22.x, make sure to use 1.22.4 or a later version
+(see [issue #4233](https://github.com/opencontainers/runc/issues/4233) for
+more details).
+
 In order to enable seccomp support you will need to install `libseccomp` on your platform.
 > e.g. `libseccomp-devel` for CentOS, or `libseccomp-dev` for Ubuntu
 

--- a/libcontainer/user/user.go
+++ b/libcontainer/user/user.go
@@ -197,7 +197,6 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 		for {
 			var line []byte
 			line, isPrefix, err = rd.ReadLine()
-
 			if err != nil {
 				// We should return no error if EOF is reached
 				// without a match.

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -31,11 +31,11 @@ function teardown() {
 
 	git clone https://github.com/opencontainers/runtime-spec.git
 	(cd runtime-spec && git reset --hard "$SPEC_REF")
-	SCHEMA='runtime-spec/schema/config-schema.json'
-	[ -e "$SCHEMA" ]
 
-	GO111MODULE=auto go get github.com/xeipuuv/gojsonschema
-	GO111MODULE=auto go build runtime-spec/schema/validate.go
+	cd runtime-spec/schema
+	go mod init runtime-spec
+	go mod tidy
+	go build ./validate.go
 
-	./validate "$SCHEMA" config.json
+	./validate config-schema.json ../../config.json
 }


### PR DESCRIPTION
This is a partial backport of #4292 and a few other PRs.

High level overview:
 - bump some GHA CI deps
 - allow runc to be compiled with Go 1.22
 - add Go 1.22 to CI matrix
 - build release artefacts using Debian 12 and Go 1.22