### PR TITLE
Try to delete exec fifo file when failure in creation

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -406,7 +406,7 @@ func (c *Container) Signal(s os.Signal) error {
 	return nil
 }
 
-func (c *Container) createExecFifo() error {
+func (c *Container) createExecFifo() (retErr error) {
 	rootuid, err := c.Config().HostRootUID()
 	if err != nil {
 		return err
@@ -423,6 +423,11 @@ func (c *Container) createExecFifo() error {
 	if err := unix.Mkfifo(fifoName, 0o622); err != nil {
 		return &os.PathError{Op: "mkfifo", Path: fifoName, Err: err}
 	}
+	defer func() {
+		if retErr != nil {
+			os.Remove(fifoName)
+		}
+	}()
 	// Ensure permission bits (can be different because of umask).
 	if err := os.Chmod(fifoName, 0o622); err != nil {
 		return err


### PR DESCRIPTION
There is a small possibility error after the exec fifo file has created, so we should try to delete it if we get an error from `createExecFifo`.
This is a possible bug discovered when doing code review, I think we have not meet it in daily usage.