### PR TITLE
MAINTAINERS: move crosbymichael to EMERITUS; remove chief maintainer role

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -7,5 +7,6 @@ contributions to our collective success:
  * Andrei Vagin (@avagin)
  * Rohit Jnagal (@rjnagal)
  * Victor Marmol (@vmarmol)
+ * Michael Crosby (@crosbymichael)
 
 We thank these members for their service to the OCI community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,3 @@
-Michael Crosby <michael@thepasture.io> (@crosbymichael)
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
 Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)
 Qiang Huang <h.huangqiang@huawei.com> (@hqhq)

--- a/MAINTAINERS_GUIDE.md
+++ b/MAINTAINERS_GUIDE.md
@@ -70,19 +70,6 @@ Overall the maintainer system works because of mutual respect across the
 maintainers of the project.  The maintainers trust one another to make decisions
 in the best interests of the project.  Sometimes maintainers can disagree and
 this is part of a healthy project to represent the point of views of various people.
-In the case where maintainers cannot find agreement on a specific change the
-role of a Chief Maintainer comes into play.
-
-The Chief Maintainer for the project is responsible for overall architecture
-of the project to maintain conceptual integrity.  Large decisions and
-architecture changes should be reviewed by the chief maintainer.
-The current chief maintainer for the project is Michael Crosby (@crosbymichael).
-
-Even though the maintainer system is built on trust, if there is a conflict
-with the chief maintainer on a decision, their decision can be challenged
-and brought to the technical oversight board if two-thirds of the
-maintainers vote for an appeal. It is expected that this would be a
-very exceptional event.
 
 
 ### How are maintainers added?
@@ -97,9 +84,8 @@ Just contributing does not make you a maintainer, it is about building trust
 with the current maintainers of the project and being a person that they can
 depend on and trust to make decisions in the best interest of the project.  The
 final vote to add a new maintainer should be approved by over 66% of the current
-maintainers with the chief maintainer having veto power.  In case of a veto,
-conflict resolution rules expressed above apply.  The voting period is
-five business days on the Pull Request to add the new maintainer.
+maintainers. The voting period is five business days on the Pull Request
+to add the new maintainer.
 
 
 ### What is expected of maintainers?
@@ -111,10 +97,7 @@ issues where they are pinged.  Being a maintainer is a time consuming commitment
 not be taken lightly.
 
 When a maintainer is unable to perform the required duties they can be removed with
-a vote by 66% of the current maintainers with the chief maintainer having veto power.
+a vote by 66% of the current maintainers.
 The voting period is ten business days.  Issues related to a maintainer's performance should
 be discussed with them among the other maintainers so that they are not surprised by
 a pull request removing them.
-
-
-


### PR DESCRIPTION
I talked to Michael, he says he is stepping down as a maintainer, being
busy with other stuff.

Thank you for all the hard work that you did!

----

Since Michael Crosby is stepping down, and we don't want to nominate
someone else to be a chief maintainer, let's remove the role.
