### PR TITLE
libct: speedup process.Env handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### libcontainer API
+ * `configs.CommandHook` struct has changed, Command is now a pointer.
+   Also, `configs.NewCommandHook` now accepts a `*Command`. (#4325)
+
 ## [1.2.0] - 2024-10-22
 
 > できるときにできることをやるんだ。それが今だ。

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -434,6 +434,16 @@ func (hooks Hooks) Run(name HookName, state *specs.State) error {
 	return nil
 }
 
+// SetDefaultEnv sets the environment for those CommandHook entries
+// that do not have one set.
+func (hooks HookList) SetDefaultEnv(env []string) {
+	for _, h := range hooks {
+		if ch, ok := h.(CommandHook); ok && len(ch.Env) == 0 {
+			ch.Env = env
+		}
+	}
+}
+
 type Hook interface {
 	// Run executes the hook with the provided state.
 	Run(*specs.State) error
@@ -463,17 +473,17 @@ type Command struct {
 }
 
 // NewCommandHook will execute the provided command when the hook is run.
-func NewCommandHook(cmd Command) CommandHook {
+func NewCommandHook(cmd *Command) CommandHook {
 	return CommandHook{
 		Command: cmd,
 	}
 }
 
 type CommandHook struct {
-	Command
+	*Command
 }
 
-func (c Command) Run(s *specs.State) error {
+func (c *Command) Run(s *specs.State) error {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return err

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -15,7 +15,7 @@ import (
 func TestUnmarshalHooks(t *testing.T) {
 	timeout := time.Second
 
-	hookCmd := configs.NewCommandHook(configs.Command{
+	hookCmd := configs.NewCommandHook(&configs.Command{
 		Path:    "/var/vcap/hooks/hook",
 		Args:    []string{"--pid=123"},
 		Env:     []string{"FOO=BAR"},
@@ -52,7 +52,7 @@ func TestUnmarshalHooksWithInvalidData(t *testing.T) {
 func TestMarshalHooks(t *testing.T) {
 	timeout := time.Second
 
-	hookCmd := configs.NewCommandHook(configs.Command{
+	hookCmd := configs.NewCommandHook(&configs.Command{
 		Path:    "/var/vcap/hooks/hook",
 		Args:    []string{"--pid=123"},
 		Env:     []string{"FOO=BAR"},
@@ -84,7 +84,7 @@ func TestMarshalHooks(t *testing.T) {
 func TestMarshalUnmarshalHooks(t *testing.T) {
 	timeout := time.Second
 
-	hookCmd := configs.NewCommandHook(configs.Command{
+	hookCmd := configs.NewCommandHook(&configs.Command{
 		Path:    "/var/vcap/hooks/hook",
 		Args:    []string{"--pid=123"},
 		Env:     []string{"FOO=BAR"},
@@ -194,7 +194,7 @@ exit 0
 	}
 	defer os.Remove(filename)
 
-	cmdHook := configs.NewCommandHook(configs.Command{
+	cmdHook := configs.NewCommandHook(&configs.Command{
 		Path: filename,
 		Args: []string{filename, "testarg"},
 		Env:  []string{"FOO=BAR"},
@@ -216,7 +216,7 @@ func TestCommandHookRunTimeout(t *testing.T) {
 	}
 	timeout := 100 * time.Millisecond
 
-	cmdHook := configs.NewCommandHook(configs.Command{
+	cmdHook := configs.NewCommandHook(&configs.Command{
 		Path:    "/bin/sleep",
 		Args:    []string{"/bin/sleep", "1"},
 		Timeout: &timeout,

--- a/libcontainer/env.go
+++ b/libcontainer/env.go
@@ -1,0 +1,59 @@
+package libcontainer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// prepareEnv processes a list of environment variables, preparing it
+// for direct consumption by unix.Exec. In particular, it:
+//   - validates each variable is in the NAME=VALUE format and
+//     contains no \0 (nil) bytes;
+//   - removes any duplicates (keeping only the last value for each key)
+//   - sets PATH for the current process, if found in the list.
+//
+// It returns the deduplicated environment, a flag telling whether HOME
+// is present in the input, and an error.
+func prepareEnv(env []string) ([]string, bool, error) {
+	if env == nil {
+		return nil, false, nil
+	}
+	// Deduplication code based on dedupEnv from Go 1.22 os/exec.
+
+	// Construct the output in reverse order, to preserve the
+	// last occurrence of each key.
+	out := make([]string, 0, len(env))
+	saw := make(map[string]bool, len(env))
+	for n := len(env); n > 0; n-- {
+		kv := env[n-1]
+		i := strings.IndexByte(kv, '=')
+		if i == -1 {
+			return nil, false, errors.New("invalid environment variable: missing '='")
+		}
+		if i == 0 {
+			return nil, false, errors.New("invalid environment variable: name cannot be empty")
+		}
+		key := kv[:i]
+		if saw[key] { // Duplicate.
+			continue
+		}
+		saw[key] = true
+		if strings.IndexByte(kv, 0) >= 0 {
+			return nil, false, fmt.Errorf("invalid environment variable %q: contains nul byte (\\x00)", key)
+		}
+		if key == "PATH" {
+			// Needs to be set as it is used for binary lookup.
+			if err := os.Setenv("PATH", kv[i+1:]); err != nil {
+				return nil, false, err
+			}
+		}
+		out = append(out, kv)
+	}
+	// Restore the original order.
+	slices.Reverse(out)
+
+	return out, saw["HOME"], nil
+}

--- a/libcontainer/env_test.go
+++ b/libcontainer/env_test.go
@@ -1,0 +1,40 @@
+package libcontainer
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestPrepareEnvDedup(t *testing.T) {
+	tests := []struct {
+		env, wantEnv []string
+	}{
+		{
+			env:     []string{},
+			wantEnv: []string{},
+		},
+		{
+			env:     []string{"HOME=/root", "FOO=bar"},
+			wantEnv: []string{"HOME=/root", "FOO=bar"},
+		},
+		{
+			env:     []string{"A=a", "A=b", "A=c"},
+			wantEnv: []string{"A=c"},
+		},
+		{
+			env:     []string{"TERM=vt100", "HOME=/home/one", "HOME=/home/two", "TERM=xterm", "HOME=/home/three", "FOO=bar"},
+			wantEnv: []string{"TERM=xterm", "HOME=/home/three", "FOO=bar"},
+		},
+	}
+
+	for _, tc := range tests {
+		env, _, err := prepareEnv(tc.env)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if !slices.Equal(env, tc.wantEnv) {
+			t.Errorf("want %v, got %v", tc.wantEnv, env)
+		}
+	}
+}

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -31,14 +31,14 @@ func TestFactoryLoadContainer(t *testing.T) {
 		id            = "1"
 		expectedHooks = configs.Hooks{
 			configs.Prestart: configs.HookList{
-				configs.CommandHook{Command: configs.Command{Path: "prestart-hook"}},
+				configs.CommandHook{Command: &configs.Command{Path: "prestart-hook"}},
 			},
 			configs.Poststart: configs.HookList{
-				configs.CommandHook{Command: configs.Command{Path: "poststart-hook"}},
+				configs.CommandHook{Command: &configs.Command{Path: "poststart-hook"}},
 			},
 			configs.Poststop: configs.HookList{
 				unserializableHook{},
-				configs.CommandHook{Command: configs.Command{Path: "poststop-hook"}},
+				configs.CommandHook{Command: &configs.Command{Path: "poststop-hook"}},
 			},
 		}
 		expectedConfig = &configs.Config{

--- a/libcontainer/integration/bench_test.go
+++ b/libcontainer/integration/bench_test.go
@@ -1,7 +1,10 @@
 package integration
 
 import (
+	"bytes"
+	"math/rand"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer"
@@ -27,9 +30,7 @@ func BenchmarkExecTrue(b *testing.B) {
 	_ = stdinR.Close()
 	defer func() {
 		_ = stdinW.Close()
-		if _, err := process.Wait(); err != nil {
-			b.Log(err)
-		}
+		waitProcess(process, b)
 	}()
 	ok(b, err)
 
@@ -42,10 +43,81 @@ func BenchmarkExecTrue(b *testing.B) {
 			LogLevel: "0", // Minimize forwardChildLogs involvement.
 		}
 		err := container.Run(exec)
-		if err != nil {
-			b.Fatal("exec failed:", err)
-		}
+		ok(b, err)
 		waitProcess(exec, b)
+	}
+	b.StopTimer()
+}
+
+func genBigEnv(count int) []string {
+	randStr := func(length int) string {
+		const charset = "abcdefghijklmnopqrstuvwxyz0123456789_"
+		b := make([]byte, length)
+		for i := range b {
+			b[i] = charset[rand.Intn(len(charset))]
+		}
+		return string(b)
+	}
+
+	envs := make([]string, count)
+	for i := 0; i < count; i++ {
+		key := strings.ToUpper(randStr(10))
+		value := randStr(20)
+		envs[i] = key + "=" + value
+	}
+
+	return envs
+}
+
+func BenchmarkExecInBigEnv(b *testing.B) {
+	config := newTemplateConfig(b, nil)
+	container, err := newContainer(b, config)
+	ok(b, err)
+	defer destroyContainer(container)
+
+	// Execute a first process in the container
+	stdinR, stdinW, err := os.Pipe()
+	ok(b, err)
+	process := &libcontainer.Process{
+		Cwd:   "/",
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR,
+		Init:  true,
+	}
+	err = container.Run(process)
+	_ = stdinR.Close()
+	defer func() {
+		_ = stdinW.Close()
+		waitProcess(process, b)
+	}()
+	ok(b, err)
+
+	const numEnv = 5000
+	env := append(standardEnvironment, genBigEnv(numEnv)...)
+	// Construct the expected output.
+	var wantOut bytes.Buffer
+	for _, e := range env {
+		wantOut.WriteString(e + "\n")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buffers := newStdBuffers()
+		exec := &libcontainer.Process{
+			Cwd:    "/",
+			Args:   []string{"env"},
+			Env:    env,
+			Stdin:  buffers.Stdin,
+			Stdout: buffers.Stdout,
+			Stderr: buffers.Stderr,
+		}
+		err = container.Run(exec)
+		ok(b, err)
+		waitProcess(exec, b)
+		if !bytes.Equal(buffers.Stdout.Bytes(), wantOut.Bytes()) {
+			b.Fatalf("unexpected output: %s (stderr: %s)", buffers.Stdout, buffers.Stderr)
+		}
 	}
 	b.StopTimer()
 }

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1022,13 +1022,13 @@ func TestHook(t *testing.T) {
 			}),
 		},
 		configs.CreateContainer: configs.HookList{
-			configs.NewCommandHook(configs.Command{
+			configs.NewCommandHook(&configs.Command{
 				Path: "/bin/bash",
 				Args: []string{"/bin/bash", "-c", fmt.Sprintf("touch ./%s", hookFiles[configs.CreateContainer])},
 			}),
 		},
 		configs.StartContainer: configs.HookList{
-			configs.NewCommandHook(configs.Command{
+			configs.NewCommandHook(&configs.Command{
 				Path: "/bin/sh",
 				Args: []string{"/bin/sh", "-c", fmt.Sprintf("touch /%s", hookFiles[configs.StartContainer])},
 			}),

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -25,6 +25,7 @@ type linuxSetnsInit struct {
 	pidfdSocket   *os.File
 	config        *initConfig
 	logPipe       *os.File
+	addHome       bool
 }
 
 func (l *linuxSetnsInit) getSessionRingName() string {
@@ -101,7 +102,7 @@ func (l *linuxSetnsInit) Init() error {
 			return err
 		}
 	}
-	if err := finalizeNamespace(l.config); err != nil {
+	if err := finalizeNamespace(l.config, l.addHome); err != nil {
 		return err
 	}
 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
@@ -154,5 +155,5 @@ func (l *linuxSetnsInit) Init() error {
 	if err := utils.UnsafeCloseFrom(l.config.PassedFilesCount + 3); err != nil {
 		return err
 	}
-	return system.Exec(name, l.config.Args, os.Environ())
+	return system.Exec(name, l.config.Args, l.config.Env)
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -1256,8 +1256,8 @@ func createHooks(rspec *specs.Spec, config *configs.Config) {
 	}
 }
 
-func createCommandHook(h specs.Hook) configs.Command {
-	cmd := configs.Command{
+func createCommandHook(h specs.Hook) *configs.Command {
+	cmd := &configs.Command{
 		Path: h.Path,
 		Args: h.Args,
 		Env:  h.Env,


### PR DESCRIPTION
This is a rework/carry of #1983.

----
    The current implementation sets all the environment variables passed in
    Process.Env in the current process, one by one, then uses os.Environ to
    read those back.
    
    As pointed out in [1], this is slow, as runc calls os.Setenv for every
    variable, and there may be a few thousands of those. Looking into how
    os.Setenv is implemented, it is indeed slow, especially when cgo is
    enabled.
    
    Looking into why it was implemented the way it is, I found commit
    9744d72c and traced it to [2], which discusses the actual reasons.
    It boils down to these two:
    
     - HOME is not passed into container as it is set in setupUser by
       os.Setenv and has no effect on config.Env;
     - there is a need to deduplication of environment variables.
    
    Yet it was decided in [2] to not go ahead with this patch, but
    later [3] was opened with the carry of this patch, and merged.
    
    Now, from what I see:
    
    1. Passing environment to exec is way faster than using os.Setenv and
       os.Environ (tests show ~20x speed improvement in a simple Go test,
       and ~3x improvement in real-world test, see below).
    2. Setting environment variables in the runc context may result is some
       ugly side effects (think GODEBUG, LD_PRELOAD, or _LIBCONTAINER_*).
    3. Nothing in runtime spec says that the environment needs to be
       deduplicated, or the order of preference (whether the first or the
       last value of a variable with the same name is to be used). We should
       stick to what we have in order to maintain backward compatibility.
    
    So, this patch:
     - switches to passing env directly to exec;
     - adds deduplication mechanism to retain backward compatibility;
     - takes care to set PATH from process.Env in the current process
       (so that supplied PATH is used to find the binary to execute),
       also to retain backward compatibility;
     - adds HOME to process.Env if not set.
    
    The benchmark added by the previous commit shows ~3x improvement:
    
                            │   before    │                after                 │
                            │   sec/op    │    sec/op     vs base                │
            ExecInBigEnv-20   61.53m ± 1%   21.87m ± 16%  -64.46% (p=0.000 n=10)

[1]: https://github.com/opencontainers/runc/pull/1983
[2]: https://github.com/docker-archive/libcontainer/pull/418
[3]: https://github.com/docker-archive/libcontainer/pull/432

----
    
Remaining questions (and my answers to those):

Q: Are there any potential regressions (for example, from not setting values from `process.Env` to the current process?
A: Pprobably not; if yes, someone is exploiting some undocumented behavior.

Q: Should deduplication show warnings (maybe promoted to errors later)?
A: For best backward compatibility, let's not do that. Can always be added later (maybe with some addition to runtime-spec).

Q: Whether a default for `PATH` (e.g `"/bin:/usr/bin"` should be added, when `PATH` is not set.
A: This needs to be done in runtime-spec first (document the default for PATH, then add it to runtimes).
