### PR TITLE
remove pre-go1.17 build-tags

### DIFF
--- a/contrib/cmd/seccompagent/seccompagent.go
+++ b/contrib/cmd/seccompagent/seccompagent.go
@@ -1,5 +1,4 @@
 //go:build linux && seccomp
-// +build linux,seccomp
 
 package main
 

--- a/contrib/cmd/seccompagent/unsupported.go
+++ b/contrib/cmd/seccompagent/unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux || !seccomp
-// +build !linux !seccomp
 
 package main
 

--- a/libcontainer/apparmor/apparmor_unsupported.go
+++ b/libcontainer/apparmor/apparmor_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package apparmor
 

--- a/libcontainer/capabilities/capabilities.go
+++ b/libcontainer/capabilities/capabilities.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package capabilities
 

--- a/libcontainer/capabilities/capabilities_unsupported.go
+++ b/libcontainer/capabilities/capabilities_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package capabilities

--- a/libcontainer/configs/cgroup_unsupported.go
+++ b/libcontainer/configs/cgroup_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package configs
 

--- a/libcontainer/configs/configs_fuzzer.go
+++ b/libcontainer/configs/configs_fuzzer.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package configs
 

--- a/libcontainer/configs/mount_unsupported.go
+++ b/libcontainer/configs/mount_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package configs
 

--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package configs
 

--- a/libcontainer/configs/namespaces_syscall_unsupported.go
+++ b/libcontainer/configs/namespaces_syscall_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package configs
 

--- a/libcontainer/configs/namespaces_unsupported.go
+++ b/libcontainer/configs/namespaces_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package configs
 

--- a/libcontainer/devices/device_unix.go
+++ b/libcontainer/devices/device_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package devices
 

--- a/libcontainer/devices/device_unix_test.go
+++ b/libcontainer/devices/device_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package devices
 

--- a/libcontainer/dmz/dmz_linux.go
+++ b/libcontainer/dmz/dmz_linux.go
@@ -1,5 +1,4 @@
 //go:build !runc_nodmz
-// +build !runc_nodmz
 
 package dmz
 

--- a/libcontainer/dmz/dmz_unsupported.go
+++ b/libcontainer/dmz/dmz_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux || runc_nodmz
-// +build !linux runc_nodmz
 
 package dmz
 

--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -1,5 +1,4 @@
 //go:build linux && cgo && seccomp
-// +build linux,cgo,seccomp
 
 package integration
 

--- a/libcontainer/nsenter/nsenter.go
+++ b/libcontainer/nsenter/nsenter.go
@@ -1,5 +1,4 @@
 //go:build linux && !gccgo
-// +build linux,!gccgo
 
 package nsenter
 

--- a/libcontainer/nsenter/nsenter_gccgo.go
+++ b/libcontainer/nsenter/nsenter_gccgo.go
@@ -1,5 +1,4 @@
 //go:build linux && gccgo
-// +build linux,gccgo
 
 package nsenter
 

--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -1,5 +1,4 @@
 //go:build cgo && seccomp
-// +build cgo,seccomp
 
 package patchbpf
 

--- a/libcontainer/seccomp/patchbpf/enosys_linux_test.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux_test.go
@@ -1,5 +1,4 @@
 //go:build cgo && seccomp
-// +build cgo,seccomp
 
 package patchbpf
 

--- a/libcontainer/seccomp/patchbpf/enosys_unsupported.go
+++ b/libcontainer/seccomp/patchbpf/enosys_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !linux || !cgo || !seccomp
-// +build !linux !cgo !seccomp
 
 package patchbpf

--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -1,5 +1,4 @@
 //go:build cgo && seccomp
-// +build cgo,seccomp
 
 package seccomp
 

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux || !cgo || !seccomp
-// +build !linux !cgo !seccomp
 
 package seccomp
 

--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package system
 

--- a/libcontainer/userns/userns_fuzzer.go
+++ b/libcontainer/userns/userns_fuzzer.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package userns
 

--- a/libcontainer/userns/userns_unsupported.go
+++ b/libcontainer/userns/userns_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package userns
 

--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package utils
 


### PR DESCRIPTION
Removed pre-go1.17 build-tags with go fix;

    go fix -mod=readonly ./...