### PR TITLE
libct/userns: assorted (godoc) improvements

### DIFF
--- a/libcontainer/userns/userns.go
+++ b/libcontainer/userns/userns.go
@@ -4,5 +4,5 @@ package userns
 // user namespace and memoizes the result. It returns false on non-Linux
 // platforms.
 func RunningInUserNS() bool {
-	return runningInUserNS()
+	return inUserNS()
 }

--- a/libcontainer/userns/userns.go
+++ b/libcontainer/userns/userns.go
@@ -1,4 +1,8 @@
 package userns
 
-// RunningInUserNS detects whether we are currently running in a user namespace.
-var RunningInUserNS = runningInUserNS
+// RunningInUserNS detects whether we are currently running in a Linux
+// user namespace and memoizes the result. It returns false on non-Linux
+// platforms.
+func RunningInUserNS() bool {
+	return runningInUserNS()
+}

--- a/libcontainer/userns/userns_linux_fuzzer.go
+++ b/libcontainer/userns/userns_linux_fuzzer.go
@@ -1,4 +1,4 @@
-//go:build gofuzz
+//go:build linux && gofuzz
 
 package userns
 

--- a/libcontainer/userns/userns_unsupported.go
+++ b/libcontainer/userns/userns_unsupported.go
@@ -2,8 +2,5 @@
 
 package userns
 
-// runningInUserNS is a stub for non-Linux systems
-// Always returns false
-func runningInUserNS() bool {
-	return false
-}
+// inUserNS is a stub for non-Linux systems. Always returns false.
+func inUserNS() bool { return false }

--- a/libcontainer/userns/userns_unsupported.go
+++ b/libcontainer/userns/userns_unsupported.go
@@ -7,9 +7,3 @@ package userns
 func runningInUserNS() bool {
 	return false
 }
-
-// uidMapInUserNS is a stub for non-Linux systems
-// Always returns false
-func uidMapInUserNS(uidMap string) bool {
-	return false
-}


### PR DESCRIPTION
### libct/userns: change RunningInUserNS to a wrapper instead of an alias

This was a poor decision on my side; 4316df8b53cce2933d7f0f3cf4bf87da67459835 (https://github.com/opencontainers/runc/pull/2850)
moved this utility to a separate package, and split the exported function
from the implementation (and stubs). Out of convenience, I used an alias
for the latter part, but there's two downsides to that;

- `RunningInUserNS` being an exported var means that (technically) it can
  be replaced by other code; perhaps that's a "feature", but not one we
  intended it to be used for.
- `RunningInUserNS` being implemented through a var / alias means it's
  also documented as such on [pkg.go.dev], which is confusing.

This patch changes it to a regular function, acting as a wrapper for
the underlying implementations. While at it, also slightly touching
up the GoDoc to describe its functionality / behavior.

[pkg.go.dev]: https://pkg.go.dev/github.com/opencontainers/runc@v1.1.13/libcontainer/userns#RunningInUserNS


### libct/userns: make fuzzer Linux-only, and remove stub for uidMapInUserNS

The fuzzer for this only runs on Linux; rename the file to be Linux-only
so that we don't have to stub out the uidMapInUserNS function.

### libct/userns: implement RunningInUserNS with sync.OnceValue

Now that we dropped support for go < 1.21, we can use this; moving
the sync.once out of the runningInUserNS() implementation would also
allow for it to be more easily tested if we'd decide to.
