### PR TITLE
ci/gha: add go-fix job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,24 @@ jobs:
         run: |
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
+  go-fix:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+      - name: install deps
+        run: |
+          sudo apt -q update
+          sudo apt -qy install libseccomp-dev
+      - name: run go fix
+        run: |
+          go fix ./...
+          git diff --exit-code
+
   compile-buildtags:
     runs-on: ubuntu-24.04
     env:


### PR DESCRIPTION
Add a CI job to ensure go fix produces no result. Quoting `go doc cmd/fix`:

> Fix finds Go programs that use old APIs and rewrites them to use newer
> ones. After you update to a new Go release, fix helps make the
> necessary changes to your programs.

As expected, the job fails before #4329 is merged.