### PR TITLE
Revert "libcontainer: seccomp: pass around *os.File for notifyfd"

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -704,17 +704,17 @@ func sysSeccompSetFilter(flags uint, filter []unix.SockFilter) (fd int, err erro
 // patches said filter to handle -ENOSYS in a much nicer manner than the
 // default libseccomp default action behaviour, and loads the patched filter
 // into the kernel for the current process.
-func PatchAndLoad(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (*os.File, error) {
+func PatchAndLoad(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (int, error) {
 	// Generate a patched filter.
 	fprog, err := enosysPatchFilter(config, filter)
 	if err != nil {
-		return nil, fmt.Errorf("error patching filter: %w", err)
+		return -1, fmt.Errorf("error patching filter: %w", err)
 	}
 
 	// Get the set of libseccomp flags set.
 	seccompFlags, noNewPrivs, err := filterFlags(config, filter)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch seccomp filter flags: %w", err)
+		return -1, fmt.Errorf("unable to fetch seccomp filter flags: %w", err)
 	}
 
 	// Set no_new_privs if it was requested, though in runc we handle
@@ -722,14 +722,15 @@ func PatchAndLoad(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (*os.F
 	if noNewPrivs {
 		logrus.Warnf("potentially misconfigured filter -- setting no_new_privs in seccomp path")
 		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
-			return nil, fmt.Errorf("error enabling no_new_privs bit: %w", err)
+			return -1, fmt.Errorf("error enabling no_new_privs bit: %w", err)
 		}
 	}
 
 	// Finally, load the filter.
 	fd, err := sysSeccompSetFilter(seccompFlags, fprog)
 	if err != nil {
-		return nil, fmt.Errorf("error loading seccomp filter: %w", err)
+		return -1, fmt.Errorf("error loading seccomp filter: %w", err)
 	}
-	return os.NewFile(uintptr(fd), "[seccomp filter]"), nil
+
+	return fd, nil
 }

--- a/libcontainer/seccomp/seccomp_unsupported.go
+++ b/libcontainer/seccomp/seccomp_unsupported.go
@@ -4,7 +4,6 @@ package seccomp
 
 import (
 	"errors"
-	"os"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -13,11 +12,11 @@ import (
 var ErrSeccompNotEnabled = errors.New("seccomp: config provided but seccomp not supported")
 
 // InitSeccomp does nothing because seccomp is not supported.
-func InitSeccomp(config *configs.Seccomp) (*os.File, error) {
+func InitSeccomp(config *configs.Seccomp) (int, error) {
 	if config != nil {
-		return nil, ErrSeccompNotEnabled
+		return -1, ErrSeccompNotEnabled
 	}
-	return nil, nil
+	return -1, nil
 }
 
 // FlagSupported tells if a provided seccomp flag is supported.

--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -83,8 +83,9 @@ function scmp_act_notify_template() {
 }
 
 # Test important syscalls (some might be executed by runc) work fine when handled by the agent. noNewPrivileges FALSE.
+# fcntl: https://github.com/opencontainers/runc/issues/4328
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY important syscalls noNewPrivileges false)" {
-	scmp_act_notify_template "/bin/true" false '"execve","openat","open","read","close"'
+	scmp_act_notify_template "/bin/true" false '"execve","openat","open","read","close","fcntl"'
 
 	runc run test_busybox
 	[ "$status" -eq 0 ]
@@ -92,7 +93,7 @@ function scmp_act_notify_template() {
 
 # Test important syscalls (some might be executed by runc) work fine when handled by the agent. noNewPrivileges TRUE.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY important syscalls noNewPrivileges true)" {
-	scmp_act_notify_template "/bin/true" true '"execve","openat","open","read","close"'
+	scmp_act_notify_template "/bin/true" true '"execve","openat","open","read","close","fcntl"'
 
 	runc run test_busybox
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Fix #4328 

## Commit 1: Revert "libcontainer: seccomp: pass around *os.File for notifyfd"
This reverts commit 20b95f23ca33cb1751ee0b5318e1d5f3676032c6.
    
> Conflicts:
>       libcontainer/init_linux.go

## Commit 2: seccomp-notify.bats: add fcntl to the important syscall list
For:
- #4328
