### PR TITLE
ci bumps

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.57
+          version: v1.59
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,3 +11,8 @@ linters:
     - errorlint
     - unconvert
     - unparam
+
+linters-settings:
+  govet:
+    enable:
+      - nilness

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -531,7 +531,7 @@ func (c *Container) newParentProcess(p *Process) (parentProcess, error) {
 				logrus.Debug("runc-dmz: using runc-dmz") // used for tests
 			} else if errors.Is(err, dmz.ErrNoDmzBinary) {
 				logrus.Debug("runc-dmz binary not embedded in runc binary, falling back to /proc/self/exe clone")
-			} else if err != nil {
+			} else {
 				return nil, fmt.Errorf("failed to create runc-dmz binary clone: %w", err)
 			}
 		} else {


### PR DESCRIPTION
This bumps golangci-lint, adds another sub-linter for govet (nilness), and fixes the issues found by new/updated linters.