### PR TITLE
Makefile: Fix cross-compile in moby when using runc_nodmz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@ SHELL = /bin/bash
 CONTAINER_ENGINE := docker
 GO ?= go
 
-# Get CC values for cross-compilation.
-include cc_platform.mk
-
 PREFIX ?= /usr/local
 BINDIR := $(PREFIX)/sbin
 MANDIR := $(PREFIX)/share/man
@@ -16,6 +13,12 @@ RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
 BUILDTAGS ?= seccomp urfave_cli_no_docs
 BUILDTAGS += $(EXTRA_BUILDTAGS)
+
+# Only include the CC values for cross-compilation when the runc_nodmz build tag is not set.
+# We want to leave everything as untouched as possible when it is set.
+ifneq (runc_nodmz,$(filter runc_nodmz, $(BUILDTAGS)))
+include cc_platform.mk
+endif
 
 COMMIT ?= $(shell git describe --dirty --long --always)
 VERSION ?= $(shell cat ./VERSION)


### PR DESCRIPTION
As suggested by https://github.com/moby/moby/pull/48160#issuecomment-2224234227 it was indeed the include of cc_platform.mk what is causing compilation issues. We were not disabling the include when compiling with runc_nodmz, IMHO  we should avoid including it.

@cyphar can you take a look at the compilation issues in https://github.com/moby/moby/pull/47666 and fix cc_platform.mk?

This seems to fix the compilation in moby (if we use runc_nodmz), although some tests fail. That still needs to be debugged too.

Compilation with this seems to work: https://github.com/moby/moby/actions/runs/9909151362
You can see the changes here: https://github.com/moby/moby/pull/48161

---
One of the reasons to have a build tag to disable runc-dmz is to get rid of possible compile issues introduced by it (it needs to cross-compile a C program).

We were not being strict enough to include this file only when needed. This patch includes it only when not using runc_nodmz.

While we want to fix the compilation issues of runc-dmz in another commit, let's make when using runc_nodmz we don't include more than needed to compile.