### PR TITLE
cc_platform.mk: only use when GOARCH is set explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ SHELL = /bin/bash
 CONTAINER_ENGINE := docker
 GO ?= go
 
-# Get CC values for cross-compilation.
+# Get CC value for cross-compilation if GOARCH is explicitly specified.
+ifneq ($(filter environment command line,$(origin GOARCH)),)
 include cc_platform.mk
+endif
 
 PREFIX ?= /usr/local
 BINDIR := $(PREFIX)/sbin

--- a/libcontainer/dmz/Makefile
+++ b/libcontainer/dmz/Makefile
@@ -1,5 +1,11 @@
-# Get GO, GOARCH and CC values for cross-compilation.
-include ../../cc_platform.mk
+# Get CC value for cross-compilation if GOARCH is explicitly specified.
+ifneq ($(filter environment command line,$(origin GOARCH)),)
+	include ../../cc_platform.mk
+else
+	# Assume native compilation.
+	GO ?= go
+	GOARCH ?= $(shell $(GO) env GOARCH)
+endif
 
 # List of GOARCH that nolibc supports, from:
 # 	https://go.dev/doc/install/source#environment (with GOOS=linux)


### PR DESCRIPTION
Current cc_platform.mk code assumes that if the value of GOARCH is the same as `go env GOARCH` output, we have a native build. This assumption is not correct when xx [1] is used to build runc (as it sets GOARCH etc in ~/.config/go/env file).

Let's only include cc_platform when GOARCH is set from the environment of the command line.

[1]: https://github.com/tonistiigi/xx

Related: #4346, https://github.com/moby/moby/pull/48160, https://github.com/moby/moby/pull/47666.