### PR TITLE
tests/int/hooks: fix failed hooks test

### DIFF
--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -37,8 +37,12 @@ function teardown() {
 		# shellcheck disable=SC2016
 		update_config '.hooks |= {"'$hook'": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
 		runc run "test_hook-$hook"
-		[[ "$output" != "Hello World" ]]
 		[ "$status" -ne 0 ]
+		[[ "$output" != *"Hello World"* ]]
 		[[ "$output" == *"error running $hook hook #1:"* ]]
+		# Check the container was never started.
+		runc delete "test_hook-$hook"
+		[ "$status" -eq 1 ]
+		[[ "$output" == *"container does not exist"* ]]
 	done
 }


### PR DESCRIPTION
When reviewing PR #4348, I noticed that it removed the call to parent.terminate when a hook has failed. Yet, this test case did not catch that issue.

Add the check that the container was never fully started after a hook failure.