### PR TITLE
Add Go 1.23, drop 1.21

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ task:
   env:
     HOME: /root
     CIRRUS_WORKING_DIR: /home/runc
-    GO_VERSION: "1.21"
+    GO_VERSION: "1.22"
     BATS_VERSION: "v1.9.0"
     RPMS: gcc git iptables jq glibc-static libseccomp-devel make criu fuse-sshfs container-selinux
     # yamllint disable rule:key-duplicates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-24.04, actuated-arm64-6cpu-8gb]
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.22.x, 1.23.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
         criu: ["", "criu-dev"]
@@ -33,7 +33,7 @@ jobs:
           # Disable most of criu-dev jobs, as they are expensive
           # (need to compile criu) and don't add much value/coverage.
           - criu: criu-dev
-            go-version: 1.21.x
+            go-version: 1.22.x
           - criu: criu-dev
             rootless: rootless
           - criu: criu-dev
@@ -45,12 +45,12 @@ jobs:
           - dmz: runc_nodmz
             os: ubuntu-20.04
           - dmz: runc_nodmz
-            go-version: 1.21.x
+            go-version: 1.22.x
           - dmz: runc_nodmz
             rootless: rootless
           - dmz: runc_nodmz
             race: -race
-          - go-version: 1.21.x
+          - go-version: 1.22.x
             os: actuated-arm64-6cpu-8gb
           - race: "-race"
             os: actuated-arm64-6cpu-8gb

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.60
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/runc
 
-go 1.21
+go 1.22
 
 require (
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0

--- a/libcontainer/cgroups/fs/blkio_test.go
+++ b/libcontainer/cgroups/fs/blkio_test.go
@@ -1,7 +1,6 @@
 package fs
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -478,7 +477,7 @@ func TestBlkioStatsNoFilesBFQDebug(t *testing.T) {
 		actualStats := *cgroups.NewStats()
 		err := cpuset.GetStats(path, &actualStats)
 		if err != nil {
-			t.Errorf(fmt.Sprintf("test case '%s' failed unexpectedly: %s", testCase.desc, err))
+			t.Errorf("%s: want no error, got: %+v", testCase.desc, err)
 		}
 	}
 }
@@ -592,7 +591,7 @@ func TestBlkioStatsNoFilesCFQ(t *testing.T) {
 		actualStats := *cgroups.NewStats()
 		err := cpuset.GetStats(path, &actualStats)
 		if err != nil {
-			t.Errorf(fmt.Sprintf("test case '%s' failed unexpectedly: %s", testCase.desc, err))
+			t.Errorf("%s: want no error, got %+v", testCase.desc, err)
 		}
 	}
 }

--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -202,7 +202,7 @@ exit 0
 	})
 
 	if err := cmdHook.Run(state); err != nil {
-		t.Errorf(fmt.Sprintf("Expected error to not occur but it was %+v", err))
+		t.Errorf("Want no error, got: %+v", err)
 	}
 }
 


### PR DESCRIPTION
As of #4290, we are already prepared, so the only things left to do are:
 - drop Go 1.21;
 - add Go 1.23;
 - for a few jobs that were using Go 1.21, switch to 1.22;
    
Also, bump go to 1.22 in go.mod.

🔔 For CI, see #4375.