### PR TITLE
Revert "allow overriding VERSION value in Makefile" and add EXTRA_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILDTAGS ?= seccomp urfave_cli_no_docs
 BUILDTAGS += $(EXTRA_BUILDTAGS)
 
 COMMIT ?= $(shell git describe --dirty --long --always)
-VERSION ?= $(shell cat ./VERSION)
+VERSION := $(shell cat ./VERSION)
 LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
 
 GOARCH := $(shell $(GO) env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ BUILDTAGS ?= seccomp urfave_cli_no_docs
 BUILDTAGS += $(EXTRA_BUILDTAGS)
 
 COMMIT ?= $(shell git describe --dirty --long --always)
-VERSION := $(shell cat ./VERSION)
+EXTRA_VERSION :=
+VERSION := $(shell cat ./VERSION)$(EXTRA_VERSION)
 LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
 
 GOARCH := $(shell $(GO) env GOARCH)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ sudo make install
 
 `runc` will be installed to `/usr/local/sbin/runc` on your system.
 
+#### Version string customization
+
+You can see the runc version by running `runc --version`. You can append a custom string to the
+version using the `EXTRA_VERSION` make variable when building, e.g.:
+
+```bash
+make EXTRA_VERSION="+build-1"
+```
+
+Bear in mind to include some separator for readability.
+
 #### Build Tags
 
 `runc` supports optional build tags for compiling support of various features,


### PR DESCRIPTION
This reverts commit 9d9273c926450a2f6f658768e3238b7082ec878d. (PR #4270 and #4269) and adds a VERSION_EXTRA make variable (that is not read from env variables) to append a custom suffix for the version.

The reverted commit broke the build for several other projects (see comments here: https://github.com/opencontainers/runc/pull/4270, after the merge) and we don't really need this to be able to set the version without changing the file.

With this commit reverted, we can still run:

	make VERSION="1.2.3"

and it just works. It doesn't take it from an env variable, but that is what broke all the other projects (VERSION is just too generic as an env var, especially for a project like runc that is embedded in many others).

Also, to simplify just adding a custom suffix to the version, a VERSION_EXTRA is added. This seems to be what several users overriding the version need.

---

@akhilerm my understanding is that, without that commit, everything should just work. Let me know if this doesn't work for you.

For example:
```
$ make VERSION="hola"
rm -f libcontainer/dmz/binary/runc-dmz
go generate -tags "seccomp urfave_cli_no_docs " ./libcontainer/dmz
make[1]: Entering directory '/home/rodrigo/src/github.com/opencontainers/runc/libcontainer/dmz'
gcc -fno-asynchronous-unwind-tables -fno-ident -s -Os -nostdlib -lgcc -static -o binary/runc-dmz _dmz.c
strip -gs binary/runc-dmz
make[1]: Leaving directory '/home/rodrigo/src/github.com/opencontainers/runc/libcontainer/dmz'
go build -trimpath "-buildmode=pie"  -tags "seccomp urfave_cli_no_docs " -ldflags "-X main.gitCommit=v1.2.0-rc.2-30-gba613c3d -X main.version=hola " -o runc .

$ ./runc --version
runc version hola
commit: v1.2.0-rc.2-30-gba613c3d
spec: 1.2.0
go: go1.22.5
libseccomp: 2.5.5

```
