### PR TITLE
Fix cpu burst test failure on newer kernels

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -260,29 +260,29 @@ function get_cgroup_value() {
 	cat "$cgroup/$1"
 }
 
-# Helper to check a if value in a cgroup file matches the expected one.
+# Check if a value in a cgroup file $1 matches $2.
 function check_cgroup_value() {
-	local current
-	current="$(get_cgroup_value "$1")"
-	local expected=$2
+	local got
+	got="$(get_cgroup_value "$1")"
+	local want=$2
 
-	echo "current $current !? $expected"
-	[ "$current" = "$expected" ]
+	echo "$1: got $got, want $want"
+	[ "$got" = "$want" ]
 }
 
-# Helper to check a value in systemd.
+# Check if a value of systemd unit property $1 matches $2 or $3 (if specified).
 function check_systemd_value() {
 	[ ! -v RUNC_USE_SYSTEMD ] && return
 	local source="$1"
 	[ "$source" = "unsupported" ] && return
-	local expected="$2"
-	local expected2="${3:-}"
+	local want="$2"
+	local want2="${3:-}"
 	local user=""
 	[ $EUID -ne 0 ] && user="--user"
 
-	current=$(systemctl show $user --property "$source" "$SD_UNIT_NAME" | awk -F= '{print $2}')
-	echo "systemd $source: current $current !? $expected $expected2"
-	[ "$current" = "$expected" ] || [[ -n "$expected2" && "$current" = "$expected2" ]]
+	got=$(systemctl show $user --property "$source" "$SD_UNIT_NAME" | awk -F= '{print $2}')
+	echo "systemd $source: got $got, want $want $want2"
+	[ "$got" = "$want" ] || [[ -n "$want2" && "$got" = "$want2" ]]
 }
 
 function check_cpu_quota() {


### PR DESCRIPTION
A kernel bug which resulted in cpu.max.burst value read which is 1000
times smaller than it should be has recently been fixed (see [1]).
    
Adapt the test so it works with either broken or fixed kernel.
    
[1]: https://lore.kernel.org/all/20240424132438.514720-1-serein.chengyu@huawei.com/

Fixes: #4373

🔔 **For CI, see #4375.**