### PR TITLE
ci/gha: add all-done jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,3 +233,11 @@ jobs:
       env:
         EXTRA_BUILDTAGS: ${{ matrix.dmz }}
       run: sudo -E PATH="$PATH" -- make GOARCH=386 localunittest
+
+  all-done:
+    needs:
+    - test
+    - cross-i386
+    runs-on: ubuntu-24.04
+    steps:
+    - run: echo "All jobs completed"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -234,3 +234,22 @@ jobs:
         cd tests/integration
         ./bootstrap-get-images.sh > get-images.sh
         git diff --exit-code
+
+  all-done:
+    needs:
+      - cfmt
+      - codespell
+      - commit
+      - compile-buildtags
+      - deps
+      - get-images
+      - go-fix
+      - keyring
+      - lint
+      - release
+      - shellcheck
+      - shfmt
+      - space-at-eol
+    runs-on: ubuntu-24.04
+    steps:
+    - run: echo "All jobs completed"


### PR DESCRIPTION
The sole reason is to simplify branch protection rules, requiring just these to be passed.

~~Currently a draft, pending #4374 #4360 merge.~~