### PR TITLE
[CI] ensure we can download the specific version's go

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,7 +119,7 @@ task:
     # Install Go.
     PREFIX="https://go.dev/dl/"
     # Find out the latest minor release URL.
-    eval $(curl -fsSL "${PREFIX}?mode=json" | jq -r  --arg Ver "$GO_VERSION" '.[] | select(.version | startswith("go\($Ver)")) | .files[] | select(.os == "linux" and .arch == "amd64" and .kind == "archive") | "filename=\"" + .filename + "\""')
+    filename=$(curl -fsSL "${PREFIX}?mode=json&include=all" | jq -r --arg Ver "go$GO_VERSION." '. | map(select(.version | contains($Ver))) | first | .files[] | select(.os == "linux" and .arch == "amd64" and .kind == "archive") | .filename')
     curl -fsSL "$PREFIX$filename" | tar Cxz /usr/local
     # install bats
     cd /tmp


### PR DESCRIPTION
It seems that there are only two latest stable versions go in the content downloaded from `https://go.dev/dl/?mode=json`, so if we can't update the go's version in time, it will cause CI failure.

Please see: https://github.com/opencontainers/runc/pull/4374#issuecomment-2287882511
The relate error logs:
```
# Install Go.
PREFIX="https://go.dev/dl/"
# Find out the latest minor release URL.
eval $(curl -fsSL "${PREFIX}?mode=json" | jq -r  --arg Ver "$GO_VERSION" '.[] | select(.version | startswith("go\($Ver)")) | .files[] | select(.os == "linux" and .arch == "amd64" and .kind == "archive") | "filename=\"" + .filename + "\""')
curl -fsSL "$PREFIX$filename" | tar Cxz /usr/local

gzip: stdin: not in gzip format
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
curl: (23) Failed writing body (360 != 1408)
```