### PR TITLE
Makefile: Don't read COMMIT, BUILDTAGS, EXTRA_BUILDTAGS from env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
-BUILDTAGS ?= seccomp urfave_cli_no_docs
+EXTRA_BUILDTAGS :=
+BUILDTAGS := seccomp urfave_cli_no_docs
 BUILDTAGS += $(EXTRA_BUILDTAGS)
 
-COMMIT ?= $(shell git describe --dirty --long --always)
+COMMIT := $(shell git describe --dirty --long --always)
 EXTRA_VERSION :=
 VERSION := $(shell cat ./VERSION)$(EXTRA_VERSION)
 LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)


### PR DESCRIPTION
We recently switched VERSION to be read from env vars (#4270). This
broke several projects, as they were building runc and using a `VERSION`
env var for, e.g. the containerd version.

When fixing that in #4370, we discussed to consider doing the same for
these variables too
(https://github.com/opencontainers/runc/pull/4370#pullrequestreview-2240030944).

Let's stop reading them from env vars, as it is very easy to do it by
mistake (e.g. compile runc and define a COMMIT env var, not to override
the commit shown in `runc --version`) and users that want can still
override them if they want to. For example, with:

        make EXTRA_BUILDTAGS=runc_nodmz