### PR TITLE
libct: Signal: honor RootlessCgroups

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -695,6 +695,8 @@ func setupPersonality(config *configs.Config) error {
 
 // signalAllProcesses freezes then iterates over all the processes inside the
 // manager's cgroups sending the signal s to them.
+//
+// signalAllProcesses returns ErrNotRunning when the cgroup does not exist.
 func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
 	if !m.Exists() {
 		return ErrNotRunning

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -44,6 +44,7 @@ func destroy(c *Container) error {
 	// and destroy is supposed to remove all the container resources, we need
 	// to kill those processes here.
 	if !c.config.Namespaces.IsPrivate(configs.NEWPID) {
+		// Likely to fail when c.config.RootlessCgroups is true
 		_ = signalAllProcesses(c.cgroupManager, unix.SIGKILL)
 	}
 	if err := c.cgroupManager.Destroy(); err != nil {


### PR DESCRIPTION
`signalAllProcesses()` depends on the cgroup and is expected to fail when runc is running in rootless without an access to the cgroup.

When `RootlessCgroups` is set to `true`, runc just ignores the error from `signalAllProcesses` and may leak some processes running. (See the comments in this PR)
In the future, runc should walk the process tree to avoid such a leak.

Note that `RootlessCgroups` is a misnomer; it is set to `false` despite the name when cgroup v2 delegation is configured.
This is expected to be renamed in a separate commit.

Fix #4394