### PR TITLE
libct/seccomp/patchbpf: use binary.NativeEndian

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 // #cgo pkg-config: libseccomp
@@ -110,7 +109,7 @@ func parseProgram(rdr io.Reader) ([]bpf.RawInstruction, error) {
 		// Read the next instruction. We have to use NativeEndian because
 		// seccomp_export_bpf outputs the program in *host* endian-ness.
 		var insn unix.SockFilter
-		if err := binary.Read(rdr, utils.NativeEndian, &insn); err != nil {
+		if err := binary.Read(rdr, binary.NativeEndian, &insn); err != nil {
 			if errors.Is(err, io.EOF) {
 				// Parsing complete.
 				break

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -1,13 +1,11 @@
 package utils
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -15,20 +13,6 @@ import (
 const (
 	exitSignalOffset = 128
 )
-
-// NativeEndian is the native byte order of the host system.
-var NativeEndian binary.ByteOrder
-
-func init() {
-	// Copied from <golang.org/x/net/internal/socket/sys.go>.
-	i := uint32(1)
-	b := (*[4]byte)(unsafe.Pointer(&i))
-	if b[0] == 1 {
-		NativeEndian = binary.LittleEndian
-	} else {
-		NativeEndian = binary.BigEndian
-	}
-}
 
 // ExitStatus returns the correct exit status for a process based on if it
 // was signaled or exited cleanly


### PR DESCRIPTION
It is available since Go 1.21 and is defined during compile time (i.e. based on GOARCH during build).