### PR TITLE
libcontainer/cgroups/fs: remove todo since strings.Fields performs well 

### DIFF
--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -91,7 +91,7 @@ func getCpuUsageBreakdown(path string) (uint64, uint64, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	// TODO: use strings.SplitN instead.
+
 	fields := strings.Fields(data)
 	if len(fields) < 4 || fields[0] != userField || fields[2] != systemField {
 		return 0, 0, malformedLine(path, file, data)

--- a/libcontainer/cgroups/fs/cpuacct_test.go
+++ b/libcontainer/cgroups/fs/cpuacct_test.go
@@ -95,3 +95,18 @@ func TestCpuacctStatsWithoutUsageAll(t *testing.T) {
 			expectedStats, actualStats.CpuStats.CpuUsage)
 	}
 }
+
+func BenchmarkGetCpuUsageBreakdown(b *testing.B) {
+	path := tempDir(b, "cpuacct")
+	writeFileContents(b, path, map[string]string{
+		"cpuacct.stat": cpuAcctStatContents,
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := getCpuUsageBreakdown(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/libcontainer/cgroups/fs/util_test.go
+++ b/libcontainer/cgroups/fs/util_test.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 // tempDir creates a new test directory for the specified subsystem.
-func tempDir(t *testing.T, subsystem string) string {
+func tempDir(t testing.TB, subsystem string) string {
 	path := filepath.Join(t.TempDir(), subsystem)
 	// Ensure the full mock cgroup path exists.
 	if err := os.Mkdir(path, 0o755); err != nil {
@@ -29,7 +29,7 @@ func tempDir(t *testing.T, subsystem string) string {
 
 // writeFileContents writes the specified contents on the mock of the specified
 // cgroup files.
-func writeFileContents(t *testing.T, path string, fileContents map[string]string) {
+func writeFileContents(t testing.TB, path string, fileContents map[string]string) {
 	for file, contents := range fileContents {
 		err := cgroups.WriteFile(path, file, contents)
 		if err != nil {


### PR DESCRIPTION
Initially, this was a commit to switch from `strings.Fields` to
`strings.SplitN` in getCpuUsageBreakdown, since `strings.Fields`
was probably slower than `strings.SplitN` in some old Go versions.

Afterwards, `strings.Cut` was also considered for potential
speed improvements.

After writing a benchmark test, we learned that:
 - `strings.Fields` performance is now adequate;
 - `strings.SplitN` is slower than `strings.Fields`;
 - `strings.Cut` had <5% performance gain from `strings.Fields`;

So, remove the TODO and keep the benchmark test.

The following are benchmark differences using `strings.Fields`,
`strings.SplitN`, and `strings.Cut`.

Below, you can find the benchmark differences.

```bash
# original implementation
$ go test -run 1234 -bench . -benchmem -count 8 . > strings.Fields

# update the implementation to use strings.SplitN
$ vim cpuacct.go 
$ go test -run 1234 -bench . -benchmem -count 8 . > strings.SplitN

# update the implementation to use strings.Cut
$ vim cpuacct.go 
$ go test -run 1234 -bench . -benchmem -count 8 . > strings.Cut

# compare the implementations
$ benchstat strings.Fields strings.SplitN strings.Cut
goos: linux
goarch: amd64
pkg: github.com/opencontainers/runc/libcontainer/cgroups/fs
cpu: QEMU TCG CPU version 2.5+
                       │ strings.Fields │          strings.SplitN           │            strings.Cut            │
                       │     sec/op     │   sec/op     vs base              │   sec/op     vs base              │
GetCpuUsageBreakdown-5      15.78µ ± 1%   16.51µ ± 1%  +4.62% (p=0.000 n=8)   15.56µ ± 2%  -1.39% (p=0.050 n=8)

                       │ strings.Fields │           strings.SplitN           │            strings.Cut             │
                       │      B/op      │     B/op      vs base              │     B/op      vs base              │
GetCpuUsageBreakdown-5     1.945Ki ± 0%   1.977Ki ± 0%  +1.61% (p=0.000 n=8)   1.883Ki ± 0%  -3.21% (p=0.000 n=8)

                       │ strings.Fields │           strings.SplitN           │            strings.Cut            │
                       │   allocs/op    │  allocs/op   vs base               │ allocs/op   vs base               │
GetCpuUsageBreakdown-5      10.000 ± 0%   12.000 ± 0%  +20.00% (p=0.000 n=8)   9.000 ± 0%  -10.00% (p=0.000 n=8)
```

### Different implementations
Below, you can find the different implementations.

#### `strings.Fields`
```go
// Returns user and kernel usage breakdown in nanoseconds.
func getCpuUsageBreakdown(path string) (uint64, uint64, error) {
	var userModeUsage, kernelModeUsage uint64
	const (
		userField   = "user"
		systemField = "system"
		file        = cgroupCpuacctStat
	)

	// Expected format:
	// user <usage in ticks>
	// system <usage in ticks>
	data, err := cgroups.ReadFile(path, file)
	if err != nil {
		return 0, 0, err
	}
	// TODO: use strings.SplitN instead.
	fields := strings.Fields(data)
	if len(fields) < 4 || fields[0] != userField || fields[2] != systemField {
		return 0, 0, malformedLine(path, file, data)
	}
	if userModeUsage, err = strconv.ParseUint(fields[1], 10, 64); err != nil {
		return 0, 0, &parseError{Path: path, File: file, Err: err}
	}
	if kernelModeUsage, err = strconv.ParseUint(fields[3], 10, 64); err != nil {
		return 0, 0, &parseError{Path: path, File: file, Err: err}
	}

	return (userModeUsage * nanosecondsInSecond) / clockTicks, (kernelModeUsage * nanosecondsInSecond) / clockTicks, nil
}
```

#### `strings.SplitN`
```go
// Returns user and kernel usage breakdown in nanoseconds.
func getCpuUsageBreakdown(path string) (uint64, uint64, error) {
	var userModeUsage, kernelModeUsage uint64
	const (
		userField   = "user"
		systemField = "system"
		file        = cgroupCpuacctStat
	)

	// Expected format:
	// user <usage in ticks>
	// system <usage in ticks>
	data, err := cgroups.ReadFile(path, file)
	if err != nil {
		return 0, 0, err
	}

	lines := strings.SplitN(data, "\n", 2)
	if len(lines) < 2 {
		return 0, 0, malformedLine(path, file, data)
	}

	userLine := lines[0]
	userLineFields := strings.SplitN(userLine, " ", 2)
	if len(userLineFields) != 2 || userLineFields[0] != userField {
		return 0, 0, malformedLine(path, file, data)
	}

	userUsageInTicks := strings.TrimSpace(userLineFields[1])
	if userModeUsage, err = strconv.ParseUint(userUsageInTicks, 10, 64); err != nil {
		return 0, 0, &parseError{Path: path, File: file, Err: err}
	}

	systemLine := lines[1]
	systemLineFields := strings.SplitN(systemLine, " ", 2)
	if len(systemLineFields) != 2 || systemLineFields[0] != systemField {
		return 0, 0, malformedLine(path, file, data)
	}

	systemUsageInTicks := strings.TrimSpace(systemLineFields[1])
	if kernelModeUsage, err = strconv.ParseUint(systemUsageInTicks, 10, 64); err != nil {
		return 0, 0, &parseError{Path: path, File: file, Err: err}
	}

	return (userModeUsage * nanosecondsInSecond) / clockTicks, (kernelModeUsage * nanosecondsInSecond) / clockTicks, nil
}
```

#### `strings.Cut`
```go
// Returns user and kernel usage breakdown in nanoseconds.
func getCpuUsageBreakdown(path string) (uint64, uint64, error) {
	var userModeUsage, kernelModeUsage uint64
	const (
		userField   = "user"
		systemField = "system"
		file        = cgroupCpuacctStat
	)

	// Expected format:
	// user <usage in ticks>
	// system <usage in ticks>
	data, err := cgroups.ReadFile(path, file)
	if err != nil {
		return 0, 0, err
	}

	userLine, systemLine, found := strings.Cut(data, "\n")
	if !found {
		return 0, 0, malformedLine(path, file, data)
	}

	userFieldWord, userUsageInTicks, found := strings.Cut(userLine, " ")
	if !found || userFieldWord != userField {
		return 0, 0, malformedLine(path, file, data)
	}

	userUsageInTicks = strings.TrimSpace(userUsageInTicks)
	if userModeUsage, err = strconv.ParseUint(userUsageInTicks, 10, 64); err != nil {
		return 0, 0, &parseError{Path: path, File: file, Err: err}
	}

	systemFieldWord, systemUsageInTicks, found := strings.Cut(systemLine, " ")
	if !found || systemFieldWord != systemField {
		return 0, 0, malformedLine(path, file, data)
	}

	systemUsageInTicks = strings.TrimSpace(systemUsageInTicks)
	if kernelModeUsage, err = strconv.ParseUint(systemUsageInTicks, 10, 64); err != nil {
		return 0, 0, &parseError{Path: path, File: file, Err: err}
	}

	return (userModeUsage * nanosecondsInSecond) / clockTicks, (kernelModeUsage * nanosecondsInSecond) / clockTicks, nil
}
```