### PR TITLE
bug:fix fd doesn't close in time

### DIFF
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -260,6 +260,7 @@ func (l *linuxStandardInit) Init() error {
 		return &os.PathError{Op: "write exec fifo", Path: fifoPath, Err: err}
 	}
 
+	_ = unix.Close(fd)
 	// Close the O_PATH fifofd fd before exec because the kernel resets
 	// dumpable in the wrong order. This has been fixed in newer kernels, but
 	// we keep this to ensure CVE-2016-9962 doesn't re-emerge on older kernels.


### PR DESCRIPTION
I add some sleep 
```
	s := l.config.SpecState
	s.Pid = unix.Getpid()
	s.Status = specs.StateCreated
	if err := l.config.Config.Hooks.Run(configs.StartContainer, s); err != nil {
		return err
	}
	time.Sleep(time.Second*30)
```
and find   io.ReadAll(execFifo) will hang 30s.
```
func readFromExecFifo(execFifo io.Reader) error {
	data, err := io.ReadAll(execFifo)
	if err != nil {
		return err
	}
	if len(data) <= 0 {
		return errors.New("cannot start an already running container")
	}
	return nil
}
```