### PR TITLE
replace strings.SplitN with strings.Cut

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -247,15 +247,15 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 	}
 	// Override the user, if passed.
 	if user := context.String("user"); user != "" {
-		u := strings.SplitN(user, ":", 2)
-		if len(u) > 1 {
-			gid, err := strconv.Atoi(u[1])
+		uids, gids, ok := strings.Cut(user, ":")
+		if ok {
+			gid, err := strconv.Atoi(gids)
 			if err != nil {
 				return nil, fmt.Errorf("bad gid: %w", err)
 			}
 			p.User.GID = uint32(gid)
 		}
-		uid, err := strconv.Atoi(u[0])
+		uid, err := strconv.Atoi(uids)
 		if err != nil {
 			return nil, fmt.Errorf("bad uid: %w", err)
 		}

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -282,11 +282,11 @@ func getPageUsageByNUMA(path string) (cgroups.PageUsageByNUMA, error) {
 		line := scanner.Text()
 		columns := strings.SplitN(line, " ", maxColumns)
 		for i, column := range columns {
-			byNode := strings.SplitN(column, "=", 2)
+			key, val, ok := strings.Cut(column, "=")
 			// Some custom kernels have non-standard fields, like
 			//   numa_locality 0 0 0 0 0 0 0 0 0 0
 			//   numa_exectime 0
-			if len(byNode) < 2 {
+			if !ok {
 				if i == 0 {
 					// Ignore/skip those.
 					break
@@ -296,7 +296,6 @@ func getPageUsageByNUMA(path string) (cgroups.PageUsageByNUMA, error) {
 					return stats, malformedLine(path, file, line)
 				}
 			}
-			key, val := byNode[0], byNode[1]
 			if i == 0 { // First column: key is name, val is total.
 				field = getNUMAField(&stats, key)
 				if field == nil { // unknown field (new kernel?)

--- a/libcontainer/cgroups/systemd/cpuset.go
+++ b/libcontainer/cgroups/systemd/cpuset.go
@@ -21,13 +21,13 @@ func RangeToBits(str string) ([]byte, error) {
 		if r == "" {
 			continue
 		}
-		ranges := strings.SplitN(r, "-", 2)
-		if len(ranges) > 1 {
-			start, err := strconv.ParseUint(ranges[0], 10, 32)
+		startr, endr, ok := strings.Cut(r, "-")
+		if ok {
+			start, err := strconv.ParseUint(startr, 10, 32)
 			if err != nil {
 				return nil, err
 			}
-			end, err := strconv.ParseUint(ranges[1], 10, 32)
+			end, err := strconv.ParseUint(endr, 10, 32)
 			if err != nil {
 				return nil, err
 			}
@@ -38,7 +38,7 @@ func RangeToBits(str string) ([]byte, error) {
 				bits.SetBit(bits, int(i), 1)
 			}
 		} else {
-			val, err := strconv.ParseUint(ranges[0], 10, 32)
+			val, err := strconv.ParseUint(startr, 10, 32)
 			if err != nil {
 				return nil, err
 			}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -259,11 +259,10 @@ func containerInit(t initType, config *initConfig, pipe *syncSocket, consoleSock
 // current processes's environment.
 func populateProcessEnvironment(env []string) error {
 	for _, pair := range env {
-		p := strings.SplitN(pair, "=", 2)
-		if len(p) < 2 {
+		name, val, ok := strings.Cut(pair, "=")
+		if !ok {
 			return errors.New("invalid environment variable: missing '='")
 		}
-		name, val := p[0], p[1]
 		if name == "" {
 			return errors.New("invalid environment variable: name cannot be empty")
 		}

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -101,14 +101,14 @@ func SearchLabels(labels []string, key string) (string, bool) {
 func Annotations(labels []string) (bundle string, userAnnotations map[string]string) {
 	userAnnotations = make(map[string]string)
 	for _, l := range labels {
-		parts := strings.SplitN(l, "=", 2)
-		if len(parts) < 2 {
+		name, value, ok := strings.Cut(l, "=")
+		if !ok {
 			continue
 		}
-		if parts[0] == "bundle" {
-			bundle = parts[1]
+		if name == "bundle" {
+			bundle = value
 		} else {
-			userAnnotations[parts[0]] = parts[1]
+			userAnnotations[name] = value
 		}
 	}
 	return


### PR DESCRIPTION
there are some cases in the code that  this pattern used "strings.SplitN(expression, pattern, 2)"

as we see in #4403 strings.Cut has better performance than strings.SplitN.

i changed some of these cases (for rest of them i wasn't sure that it break the functionality or not)