### PR TITLE
go.mod: Force 1.22.4 as min go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/opencontainers/runc
 
 go 1.22
 
+// Suggest toolchain 1.22.4 due to a fix in golang for libcontainer/nsenter/.
+// For more info, see: #4233
+// Note that toolchain does not impose a requirement on other modules using runc.
+toolchain go1.22.4
+
 require (
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0
 	github.com/cilium/ebpf v0.16.0


### PR DESCRIPTION
Go since 1.21 enforces the "go" version in go.mod as a minimum version[1]. As documented in the 1.2.0-rc.1 release notes, 1.22.4 is needed.

Let's enforce it.

[1]: https://go.dev/doc/toolchain

---
@kolyshkin @lifubang PTAL