### PR TITLE
ci: update to setup bats action from bats-core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,8 +154,8 @@ jobs:
         EXTRA_BUILDTAGS: ${{ matrix.dmz }}
       run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
 
-    - name: install bats
-      uses: mig4/setup-bats@v1
+    - name: Setup Bats and bats libs
+      uses: bats-core/bats-action@2.0.0
       with:
         bats-version: 1.9.0
 


### PR DESCRIPTION
mig4/setup-bats is now unmaintained(last commit in Sep 2021). bats-core/bats-action can be used as a replacement maintained by the bats-core team.

this also removes deprecated notices while runnig the ci workflow