### PR TITLE
Add ErrCgroupNotExist

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -394,6 +394,11 @@ func (c *Container) Signal(s os.Signal) error {
 				// https://github.com/opencontainers/runc/pull/4395#pullrequestreview-2291179652
 				return c.signal(s)
 			}
+			// For not rootless container, if there is no init process and no cgroup,
+			// it means that the container is not running.
+			if errors.Is(err, ErrCgroupNotExist) && !c.hasInit() {
+				err = ErrNotRunning
+			}
 			return fmt.Errorf("unable to kill all processes: %w", err)
 		}
 		return nil

--- a/libcontainer/error.go
+++ b/libcontainer/error.go
@@ -3,11 +3,12 @@ package libcontainer
 import "errors"
 
 var (
-	ErrExist      = errors.New("container with given ID already exists")
-	ErrInvalidID  = errors.New("invalid container ID format")
-	ErrNotExist   = errors.New("container does not exist")
-	ErrPaused     = errors.New("container paused")
-	ErrRunning    = errors.New("container still running")
-	ErrNotRunning = errors.New("container not running")
-	ErrNotPaused  = errors.New("container not paused")
+	ErrExist          = errors.New("container with given ID already exists")
+	ErrInvalidID      = errors.New("invalid container ID format")
+	ErrNotExist       = errors.New("container does not exist")
+	ErrPaused         = errors.New("container paused")
+	ErrRunning        = errors.New("container still running")
+	ErrNotRunning     = errors.New("container not running")
+	ErrNotPaused      = errors.New("container not paused")
+	ErrCgroupNotExist = errors.New("cgroup not exist")
 )

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -695,11 +695,9 @@ func setupPersonality(config *configs.Config) error {
 
 // signalAllProcesses freezes then iterates over all the processes inside the
 // manager's cgroups sending the signal s to them.
-//
-// signalAllProcesses returns ErrNotRunning when the cgroup does not exist.
 func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
 	if !m.Exists() {
-		return ErrNotRunning
+		return ErrCgroupNotExist
 	}
 	// Use cgroup.kill, if available.
 	if s == unix.SIGKILL {


### PR DESCRIPTION
For some rootless container, runc has no access to cgroup, But the container is still running. So we should return the `ErrNotRunning` and `ErrCgroupNotExist` error seperatlly.

Follow up of #4395, please see https://github.com/opencontainers/runc/pull/4395#discussion_r1757069353