### PR TITLE
ci: update bats-action to v2.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
       run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
 
     - name: Setup Bats and bats libs
-      uses: bats-core/bats-action@2.0.0
+      uses: bats-core/bats-action@2.1.1
       with:
         bats-version: 1.9.0
         support-install: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,10 @@ jobs:
       uses: bats-core/bats-action@2.0.0
       with:
         bats-version: 1.9.0
+        support-install: false
+        assert-install: false
+        detik-install: false
+        file-install: false
 
     - name: Allow userns for runc
       # https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15


### PR DESCRIPTION
- bats-core/bats-action installs a few support libraries by default which are not used by runc. Disable the installation, which will remove `/usr/bin/tar: Permission denied errors`. 

Ref: https://github.com/opencontainers/runc/actions/runs/11019452323/job/30602046848#step:13:59

Sample run: https://github.com/akhilerm/runc/actions/runs/11026954586/job/30624383166#step:13:1

- update bats-action to v2.1.1 that has support for cache key with multiple architectures

Fixes #4411 