### PR TITLE
Change minimum version of golang in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,14 @@ All releases are signed by one of the keys listed in the [`runc.keyring` file in
 The reporting process and disclosure communications are outlined [here](https://github.com/opencontainers/org/blob/master/SECURITY.md).
 
 ### Security Audit
+
 A third party security audit was performed by Cure53, you can see the full report [here](https://github.com/opencontainers/runc/blob/master/docs/Security-Audit.pdf).
 
 ## Building
 
-`runc` only supports Linux. It must be built with Go version 1.21 or higher.
+`runc` only supports Linux. It must be built with Go version 1.22.4 or higher.
 
 ### Pre-Requisites
-
-#### Go
-
-NOTE: if building with Go 1.22.x, make sure to use 1.22.4 or a later version
-(see [issue #4233](https://github.com/opencontainers/runc/issues/4233) for
-more details).
 
 #### Utilities and Libraries
 
@@ -61,7 +56,7 @@ apk --update add bash make gcc libseccomp-dev musl-dev linux-headers git
 
 The following dependencies are optional:
 
-* `libseccomp` - only required if you enable seccomp support; to disable, see [Build Tags](#build-tags)
+- `libseccomp` - only required if you enable seccomp support; to disable, see [Build Tags](#build-tags)
 
 ### Build
 
@@ -109,18 +104,19 @@ e.g. to disable seccomp:
 make BUILDTAGS=""
 ```
 
-| Build Tag     | Feature                               | Enabled by Default | Dependencies        |
-|---------------|---------------------------------------|--------------------|---------------------|
-| `seccomp`     | Syscall filtering using `libseccomp`. | yes                | `libseccomp`        |
-| `!runc_nodmz` | Reduce memory usage for CVE-2019-5736 protection by using a small C binary, [see `memfd-bind` for more details][contrib-memfd-bind]. `runc_nodmz` disables this **experimental feature** and causes runc to use a different protection mechanism which will further increases memory usage temporarily during container startup. To enable this feature you also need to set the `RUNC_DMZ=true` environment variable. | yes ||
+| Build Tag     | Feature                                                                                                                                                                                                                                                                                                                                                                                                                | Enabled by Default | Dependencies |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------ |
+| `seccomp`     | Syscall filtering using `libseccomp`.                                                                                                                                                                                                                                                                                                                                                                                  | yes                | `libseccomp` |
+| `!runc_nodmz` | Reduce memory usage for CVE-2019-5736 protection by using a small C binary, [see `memfd-bind` for more details][contrib-memfd-bind]. `runc_nodmz` disables this **experimental feature** and causes runc to use a different protection mechanism which will further increases memory usage temporarily during container startup. To enable this feature you also need to set the `RUNC_DMZ=true` environment variable. | yes                |              |
 
 The following build tags were used earlier, but are now obsoleted:
- - **nokmem** (since runc v1.0.0-rc94 kernel memory settings are ignored)
- - **apparmor** (since runc v1.0.0-rc93 the feature is always enabled)
- - **selinux**  (since runc v1.0.0-rc93 the feature is always enabled)
 
- [contrib-memfd-bind]: /contrib/cmd/memfd-bind/README.md
- [dmz README]: /libcontainer/dmz/README.md
+- **nokmem** (since runc v1.0.0-rc94 kernel memory settings are ignored)
+- **apparmor** (since runc v1.0.0-rc93 the feature is always enabled)
+- **selinux** (since runc v1.0.0-rc93 the feature is always enabled)
+
+[contrib-memfd-bind]: /contrib/cmd/memfd-bind/README.md
+[dmz README]: /libcontainer/dmz/README.md
 
 ### Running the test suite
 
@@ -226,7 +222,6 @@ the `config.json` to remove the `terminal` setting for the simple examples
 below (see more details about [runc terminal handling](docs/terminals.md)).
 Your process field in the `config.json` should look like this below with `"terminal": false` and `"args": ["sleep", "5"]`.
 
-
 ```json
         "process": {
                 "terminal": false,
@@ -282,7 +277,6 @@ Your process field in the `config.json` should look like this below with `"termi
 
 Now we can go through the lifecycle operations in your shell.
 
-
 ```bash
 # run as root
 cd /mycontainer
@@ -304,14 +298,17 @@ runc delete mycontainerid
 This allows higher level systems to augment the containers creation logic with setup of various settings after the container is created and/or before it is deleted. For example, the container's network stack is commonly set up after `create` but before `start`.
 
 #### Rootless containers
+
 `runc` has the ability to run containers without root privileges. This is called `rootless`. You need to pass some parameters to `runc` in order to run rootless containers. See below and compare with the previous version.
 
 **Note:** In order to use this feature, "User Namespaces" must be compiled and enabled in your kernel. There are various ways to do this depending on your distribution:
+
 - Confirm `CONFIG_USER_NS=y` is set in your kernel configuration (normally found in `/proc/config.gz`)
 - Arch/Debian: `echo 1 > /proc/sys/kernel/unprivileged_userns_clone`
 - RHEL/CentOS 7: `echo 28633 > /proc/sys/user/max_user_namespaces`
 
 Run the following commands as an ordinary user:
+
 ```bash
 # Same as the first example
 mkdir ~/mycontainer
@@ -348,12 +345,12 @@ WantedBy=multi-user.target
 
 ## More documentation
 
-* [Spec conformance](./docs/spec-conformance.md)
-* [cgroup v2](./docs/cgroup-v2.md)
-* [Checkpoint and restore](./docs/checkpoint-restore.md)
-* [systemd cgroup driver](./docs/systemd.md)
-* [Terminals and standard IO](./docs/terminals.md)
-* [Experimental features](./docs/experimental.md)
+- [Spec conformance](./docs/spec-conformance.md)
+- [cgroup v2](./docs/cgroup-v2.md)
+- [Checkpoint and restore](./docs/checkpoint-restore.md)
+- [systemd cgroup driver](./docs/systemd.md)
+- [Terminals and standard IO](./docs/terminals.md)
+- [Experimental features](./docs/experimental.md)
 
 ## License
 

--- a/exec.go
+++ b/exec.go
@@ -247,15 +247,15 @@ func getProcess(context *cli.Context, bundle string) (*specs.Process, error) {
 	}
 	// Override the user, if passed.
 	if user := context.String("user"); user != "" {
-		u := strings.SplitN(user, ":", 2)
-		if len(u) > 1 {
-			gid, err := strconv.Atoi(u[1])
+		uids, gids, ok := strings.Cut(user, ":")
+		if ok {
+			gid, err := strconv.Atoi(gids)
 			if err != nil {
 				return nil, fmt.Errorf("bad gid: %w", err)
 			}
 			p.User.GID = uint32(gid)
 		}
-		uid, err := strconv.Atoi(u[0])
+		uid, err := strconv.Atoi(uids)
 		if err != nil {
 			return nil, fmt.Errorf("bad uid: %w", err)
 		}

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -282,21 +282,20 @@ func getPageUsageByNUMA(path string) (cgroups.PageUsageByNUMA, error) {
 		line := scanner.Text()
 		columns := strings.SplitN(line, " ", maxColumns)
 		for i, column := range columns {
-			byNode := strings.SplitN(column, "=", 2)
+			key, val, ok := strings.Cut(column, "=")
 			// Some custom kernels have non-standard fields, like
 			//   numa_locality 0 0 0 0 0 0 0 0 0 0
 			//   numa_exectime 0
-			if len(byNode) < 2 {
-				if i == 0 {
-					// Ignore/skip those.
-					break
-				} else {
+			if !ok {
+				if i != 0 {
 					// The first column was already validated,
 					// so be strict to the rest.
 					return stats, malformedLine(path, file, line)
 				}
+
+				// Ignore/skip those.
+				break
 			}
-			key, val := byNode[0], byNode[1]
 			if i == 0 { // First column: key is name, val is total.
 				field = getNUMAField(&stats, key)
 				if field == nil { // unknown field (new kernel?)

--- a/libcontainer/cgroups/systemd/cpuset.go
+++ b/libcontainer/cgroups/systemd/cpuset.go
@@ -21,13 +21,13 @@ func RangeToBits(str string) ([]byte, error) {
 		if r == "" {
 			continue
 		}
-		ranges := strings.SplitN(r, "-", 2)
-		if len(ranges) > 1 {
-			start, err := strconv.ParseUint(ranges[0], 10, 32)
+		startr, endr, ok := strings.Cut(r, "-")
+		if ok {
+			start, err := strconv.ParseUint(startr, 10, 32)
 			if err != nil {
 				return nil, err
 			}
-			end, err := strconv.ParseUint(ranges[1], 10, 32)
+			end, err := strconv.ParseUint(endr, 10, 32)
 			if err != nil {
 				return nil, err
 			}
@@ -38,7 +38,7 @@ func RangeToBits(str string) ([]byte, error) {
 				bits.SetBit(bits, int(i), 1)
 			}
 		} else {
-			val, err := strconv.ParseUint(ranges[0], 10, 32)
+			val, err := strconv.ParseUint(startr, 10, 32)
 			if err != nil {
 				return nil, err
 			}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -259,11 +259,10 @@ func containerInit(t initType, config *initConfig, pipe *syncSocket, consoleSock
 // current processes's environment.
 func populateProcessEnvironment(env []string) error {
 	for _, pair := range env {
-		p := strings.SplitN(pair, "=", 2)
-		if len(p) < 2 {
+		name, val, ok := strings.Cut(pair, "=")
+		if !ok {
 			return errors.New("invalid environment variable: missing '='")
 		}
-		name, val := p[0], p[1]
 		if name == "" {
 			return errors.New("invalid environment variable: name cannot be empty")
 		}

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -101,14 +101,14 @@ func SearchLabels(labels []string, key string) (string, bool) {
 func Annotations(labels []string) (bundle string, userAnnotations map[string]string) {
 	userAnnotations = make(map[string]string)
 	for _, l := range labels {
-		parts := strings.SplitN(l, "=", 2)
-		if len(parts) < 2 {
+		name, value, ok := strings.Cut(l, "=")
+		if !ok {
 			continue
 		}
-		if parts[0] == "bundle" {
-			bundle = parts[1]
+		if name == "bundle" {
+			bundle = value
 		} else {
-			userAnnotations[parts[0]] = parts[1]
+			userAnnotations[name] = value
 		}
 	}
 	return


### PR DESCRIPTION
In the readme there are two statements 

1. the minimum version of go for runc is v1.21
2.  if you use go v1.22 make sure it's newer than 1.22.4 due to a bug

when i use go v1.21 in Dockerfile for testing I got error

```
+ exec make localunittest TESTFLAGS=
rm -f libcontainer/dmz/binary/runc-dmz
go generate -tags "seccomp urfave_cli_no_docs" ./libcontainer/dmz
go: go.mod requires go >= 1.22 (running go 1.21.13; GOTOOLCHAIN=local)
make: *** [Makefile:116: runc-dmz] Error 1
make: *** [Makefile:161: unittest] Error 2
```

but with go v1.22 and v1.23 it was ok. so i change minimum version to 1.22.4 and delete the warning