### PR TITLE
change go minimum version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,9 @@ A third party security audit was performed by Cure53, you can see the full repor
 
 ## Building
 
-`runc` only supports Linux. It must be built with Go version 1.21 or higher.
+`runc` only supports Linux. See the header of [`go.mod`](./go mod) for the required Go version.
 
 ### Pre-Requisites
-
-#### Go
-
-NOTE: if building with Go 1.22.x, make sure to use 1.22.4 or a later version
-(see [issue #4233](https://github.com/opencontainers/runc/issues/4233) for
-more details).
 
 #### Utilities and Libraries
 


### PR DESCRIPTION


In the readme there are two statements

1. the minimum version of go for runc is v1.21
2. if you use go v1.22 make sure it's newer than 1.22.4 due to a bug

when i use go v1.21 in Dockerfile for testing I got error

```
+ exec make localunittest TESTFLAGS=
rm -f libcontainer/dmz/binary/runc-dmz
go generate -tags "seccomp urfave_cli_no_docs" ./libcontainer/dmz
go: go.mod requires go >= 1.22 (running go 1.21.13; GOTOOLCHAIN=local)
make: *** [Makefile:116: runc-dmz] Error 1
make: *** [Makefile:161: unittest] Error 2
```

but with go v1.22 and v1.23 it was ok. so i change minimum version to 1.22.4 and delete the warning
