### PR TITLE
[1.1]: Increase memory.max in cgroups.bats

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -259,7 +259,7 @@ convert_hugetlb_size() {
 				"memory.min":   "131072",
 				"memory.low":   "524288",
 				"memory.high": "5242880",
-				"memory.max": "10485760",
+				"memory.max": "20484096",
 				"memory.swap.max": "20971520",
 				"pids.max": "99",
 				"cpu.max": "10000 100000",
@@ -276,7 +276,7 @@ convert_hugetlb_size() {
 	echo "$output" | grep -q '^memory.min:131072$'
 	echo "$output" | grep -q '^memory.low:524288$'
 	echo "$output" | grep -q '^memory.high:5242880$'
-	echo "$output" | grep -q '^memory.max:10485760$'
+	echo "$output" | grep -q '^memory.max:20484096$'
 	echo "$output" | grep -q '^memory.swap.max:20971520$'
 	echo "$output" | grep -q '^pids.max:99$'
 	echo "$output" | grep -q '^cpu.max:10000 100000$'
@@ -284,7 +284,7 @@ convert_hugetlb_size() {
 	check_systemd_value "MemoryMin" 131072
 	check_systemd_value "MemoryLow" 524288
 	check_systemd_value "MemoryHigh" 5242880
-	check_systemd_value "MemoryMax" 10485760
+	check_systemd_value "MemoryMax" 20484096
 	check_systemd_value "MemorySwapMax" 20971520
 	check_systemd_value "TasksMax" 99
 	check_cpu_quota 10000 100000 "100ms"
@@ -304,7 +304,7 @@ convert_hugetlb_size() {
 			}
 			| .linux.resources.unified |= {
 				"memory.min": "131072",
-				"memory.max": "10485760",
+				"memory.max": "40484864",
 				"pids.max": "42",
 				"cpu.max": "5000 50000",
 				"cpu.weight": "42"
@@ -319,7 +319,7 @@ convert_hugetlb_size() {
 
 	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
 	[ "$status" -eq 0 ]
-	[ "$output" = '10485760' ]
+	[ "$output" = '40484864' ]
 
 	runc exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
This is a backport of https://github.com/opencontainers/runc/pull/4020 for 1.1.

When trying to create a release for 1.1, CI starting failing. This PR in main fixed it, so I'm backporting it.