### PR TITLE
memfd-bind: fixup systemd unit file and README

### DIFF
--- a/contrib/cmd/memfd-bind/README.md
+++ b/contrib/cmd/memfd-bind/README.md
@@ -25,7 +25,7 @@ The provided `memfd-bind@.service` file can be used to get systemd to manage
 this daemon. You can supply the path like so:
 
 ```
-% systemctl start memfd-bind@/usr/bin/runc
+% systemctl start memfd-bind@$(systemd-escape -p /usr/bin/runc)
 ```
 
 Thus, there are three ways of protecting against CVE-2019-5736, in order of how

--- a/contrib/cmd/memfd-bind/memfd-bind@.service
+++ b/contrib/cmd/memfd-bind/memfd-bind@.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Manage memfd-bind of %I
+Description=Manage memfd-bind of %f
 Documentation=https://github.com/opencontainers/runc
 
 [Service]
 Type=simple
-ExecStart=memfd-bind "%I"
-ExecStop=memfd-bind --cleanup "%I"
+ExecStart=memfd-bind "%f"
+ExecStop=memfd-bind --cleanup "%f"
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/cmd/memfd-bind/memfd-bind@.service
+++ b/contrib/cmd/memfd-bind/memfd-bind@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Manage memfd-bind of %f
-Documentation=https://github.com/opencontainers/runc
+Documentation=https://github.com/opencontainers/runc/blob/main/contrib/cmd/memfd-bind/README.md
 
 [Service]
 Type=simple


### PR DESCRIPTION
The example of starting memfd-bind via systemd in README did not work
for me (Fedora 40, systemd 255):
```console    
# systemctl status memfd-bind@/usr/bin/runc
Invalid unit name "memfd-bind@/usr/bin/runc" escaped as "memfd-bind@-usr-bin-runc" (maybe you should use systemd-escape?).
   ○ memfd-bind@-usr-bin-runc.service
        Loaded: bad-setting (Reason: Unit memfd-bind@-usr-bin-runc.service has a bad unit file setting.)
        Active: inactive (dead)
          Docs: https://github.com/opencontainers/runc
```
So, let's use systemd-escape -p ("path") in the README example,
and use %f in the systemd unit file to prepend the slash to the
filename.
