### PR TITLE
libct/cap: no need to load capabilities

### DIFF
--- a/libcontainer/capabilities/capabilities.go
+++ b/libcontainer/capabilities/capabilities.go
@@ -65,9 +65,6 @@ func New(capConfig *configs.Capabilities) (*Caps, error) {
 	if c.pid, err = capability.NewPid2(0); err != nil {
 		return nil, err
 	}
-	if err = c.pid.Load(); err != nil {
-		return nil, err
-	}
 	if len(unknownCaps) > 0 {
 		logrus.Warn("ignoring unknown or unavailable capabilities: ", mapKeys(unknownCaps))
 	}


### PR DESCRIPTION
We are not really interested in the capabilities of the current process, so there is no need to load those.

This results in some performance improvement since now the capability package don't have to parse `/proc/self/status`.