### PR TITLE
libct: add/use configs.HasHook

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -332,6 +332,19 @@ const (
 	Poststop HookName = "poststop"
 )
 
+// HasHook checks if config has any hooks with any given names configured.
+func (c *Config) HasHook(names ...HookName) bool {
+	if c.Hooks == nil {
+		return false
+	}
+	for _, h := range names {
+		if len(c.Hooks[h]) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // KnownHookNames returns the known hook names.
 // Used by `runc features`.
 func KnownHookNames() []string {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -350,7 +350,7 @@ func (c *Container) start(process *Process) (retErr error) {
 
 	if process.Init {
 		c.fifo.Close()
-		if c.config.Hooks != nil {
+		if c.config.HasHook(configs.Poststart) {
 			s, err := c.currentOCIState()
 			if err != nil {
 				return err

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -1113,7 +1113,7 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 			return err
 		}
 	case "setup-namespaces":
-		if c.config.Hooks != nil {
+		if c.config.HasHook(configs.Prestart, configs.CreateRuntime) {
 			s, err := c.currentOCIState()
 			if err != nil {
 				return nil

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -740,7 +740,7 @@ func (p *initProcess) start() (retErr error) {
 					return fmt.Errorf("error setting Intel RDT config for procHooks process: %w", err)
 				}
 			}
-			if len(p.config.Config.Hooks) != 0 {
+			if p.config.Config.HasHook(configs.Prestart, configs.CreateRuntime) {
 				s, err := p.container.currentOCIState()
 				if err != nil {
 					return err

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -195,11 +195,12 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 		return &os.PathError{Op: "chdir", Path: config.Rootfs, Err: err}
 	}
 
-	s := iConfig.SpecState
-	s.Pid = unix.Getpid()
-	s.Status = specs.StateCreating
-	if err := iConfig.Config.Hooks.Run(configs.CreateContainer, s); err != nil {
-		return err
+	if s := iConfig.SpecState; s != nil {
+		s.Pid = unix.Getpid()
+		s.Status = specs.StateCreating
+		if err := iConfig.Config.Hooks.Run(configs.CreateContainer, s); err != nil {
+			return err
+		}
 	}
 
 	if config.NoPivotRoot {

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -267,11 +267,12 @@ func (l *linuxStandardInit) Init() error {
 	// https://github.com/torvalds/linux/blob/v4.9/fs/exec.c#L1290-L1318
 	_ = l.fifoFile.Close()
 
-	s := l.config.SpecState
-	s.Pid = unix.Getpid()
-	s.Status = specs.StateCreated
-	if err := l.config.Config.Hooks.Run(configs.StartContainer, s); err != nil {
-		return err
+	if s := l.config.SpecState; s != nil {
+		s.Pid = unix.Getpid()
+		s.Status = specs.StateCreated
+		if err := l.config.Config.Hooks.Run(configs.StartContainer, s); err != nil {
+			return err
+		}
 	}
 
 	// Close all file descriptors we are not passing to the container. This is


### PR DESCRIPTION
1. libct: add/use configs.HasHook
    
    This allows to omit a call to c.currentOCIState (which can be somewhat
    costly when there are many annotations) when the hooks of a given kind
    won't be run.

2. libct: don't pass SpecState to init unless needed
    
    SpecState field of initConfig is only needed to run hooks that are
    executed inside a container -- namely CreateContainer and
    StartContainer.
    
    If these hooks are not configured, there is no need to fill, marshal and
    unmarshal SpecState.
