### PR TITLE
[backport 1.1] join the cgroup after the initial setup finished

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -407,6 +407,13 @@ func (p *initProcess) start() (retErr error) {
 		}
 	}()
 
+	// We should join the cgroup after the initial setup finished,
+	// but before runc init clone new children processes. (#4427)
+	err = <-waitInit
+	if err != nil {
+		return err
+	}
+
 	// Do this before syncing with child so that no children can escape the
 	// cgroup. We don't need to worry about not doing this and not being root
 	// because we'd be using the rootless cgroup manager in that case.
@@ -420,10 +427,6 @@ func (p *initProcess) start() (retErr error) {
 	}
 	if _, err := io.Copy(p.messageSockPair.parent, p.bootstrapData); err != nil {
 		return fmt.Errorf("can't copy bootstrap data to pipe: %w", err)
-	}
-	err = <-waitInit
-	if err != nil {
-		return err
 	}
 
 	childPid, err := p.getChildPid()


### PR DESCRIPTION
This is the backport of #4438.
----
We should join the cgroup after the initial setup finished,
but before runc init clone new children processes. (https://github.com/opencontainers/runc/issues/4427)

Because we should try our best to reduce the influence of
memory cgroup accounting from all runc init processes
before we start the container init process.

If we cherry pick this commit to release-1.1, it will eliminate
the impacts of memory accounting from ensure_clone_binary.


(cherry picked from commit 4f6000e7004eec3da217ed8c4ec4dafe6b9169d6)