### PR TITLE
Terminate execution for criu that does not meet version requirements

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -186,7 +186,7 @@ func criuNsToKey(t configs.NamespaceType) string {
 
 func (c *Container) handleCheckpointingExternalNamespaces(rpcOpts *criurpc.CriuOpts, t configs.NamespaceType) error {
 	if !c.criuSupportsExtNS(t) {
-		return nil
+		return fmt.Errorf("criu lacks support for external %s namespace during checkpointing process (old criu version?)", configs.NsName(t))
 	}
 
 	nsPath := c.config.Namespaces.PathOf(t)
@@ -246,7 +246,7 @@ func (c *Container) handleRestoringNamespaces(rpcOpts *criurpc.CriuOpts, extraFi
 
 func (c *Container) handleRestoringExternalNamespaces(rpcOpts *criurpc.CriuOpts, extraFiles *[]*os.File, t configs.NamespaceType) error {
 	if !c.criuSupportsExtNS(t) {
-		return nil
+		return fmt.Errorf("criu lacks support for external %s namespace during the restoration process (old criu version?)", configs.NsName(t))
 	}
 
 	nsPath := c.config.Namespaces.PathOf(t)


### PR DESCRIPTION
_This is a carry of #4431._

Fixes: #4381.

When the criu version does not meet the requirements, execution will be terminated directly to prevent unpredictable behavior.