### PR TITLE
libct: rm initWaiter

### DIFF
--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -52,8 +52,6 @@ func TestNsenterValidPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	initWaiter(t, parent)
-
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("nsenter error: %v", err)
 	}
@@ -94,7 +92,6 @@ func TestNsenterInvalidPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	initWaiter(t, parent)
 	if err := cmd.Wait(); err == nil {
 		t.Fatalf("nsenter exits with a zero exit status")
 	}
@@ -133,7 +130,6 @@ func TestNsenterIncorrectPathType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	initWaiter(t, parent)
 	if err := cmd.Wait(); err == nil {
 		t.Fatalf("nsenter error: %v", err)
 	}
@@ -177,8 +173,6 @@ func TestNsenterChildLogging(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	initWaiter(t, parent)
-
 	getLogs(t, logread)
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("nsenter error: %v", err)
@@ -206,22 +200,6 @@ func newPipe(t *testing.T) (parent *os.File, child *os.File) {
 		child.Close()
 	})
 	return
-}
-
-// initWaiter reads back the initial \0 from runc init
-func initWaiter(t *testing.T, r io.Reader) {
-	inited := make([]byte, 1)
-	n, err := r.Read(inited)
-	if err == nil {
-		if n < 1 {
-			err = errors.New("short read")
-		} else if inited[0] != 0 {
-			err = fmt.Errorf("unexpected %d != 0", inited[0])
-		} else {
-			return
-		}
-	}
-	t.Fatalf("waiting for init preliminary setup: %v", err)
 }
 
 func reapChildren(t *testing.T, parent *os.File) {

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -571,13 +571,6 @@ void nsexec(void)
 		return;
 	}
 
-	/*
-	 * Inform the parent we're past initial setup.
-	 * For the other side of this, see initWaiter.
-	 */
-	if (write(pipenum, "", 1) != 1)
-		bail("could not inform the parent we are past initial setup");
-
 	write_log(DEBUG, "=> nsexec container setup");
 
 	/* Parse all of the netlink configuration. */

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -140,16 +140,11 @@ func (p *setnsProcess) start() (retErr error) {
 		return fmt.Errorf("error starting setns process: %w", err)
 	}
 
-	waitInit := initWaiter(p.comm.initSockParent)
 	defer func() {
 		if retErr != nil {
 			if newOom, err := p.manager.OOMKillCount(); err == nil && newOom != oom {
 				// Someone in this cgroup was killed, this _might_ be us.
 				retErr = fmt.Errorf("%w (possibly OOM-killed)", retErr)
-			}
-			werr := <-waitInit
-			if werr != nil {
-				logrus.WithError(werr).Warn()
 			}
 			err := ignoreTerminateErrors(p.terminate())
 			if err != nil {
@@ -162,10 +157,6 @@ func (p *setnsProcess) start() (retErr error) {
 		if _, err := io.Copy(p.comm.initSockParent, p.bootstrapData); err != nil {
 			return fmt.Errorf("error copying bootstrap data to pipe: %w", err)
 		}
-	}
-	err = <-waitInit
-	if err != nil {
-		return err
 	}
 	if err := p.execSetns(); err != nil {
 		return fmt.Errorf("error executing setns process: %w", err)
@@ -536,7 +527,6 @@ func (p *initProcess) start() (retErr error) {
 		return fmt.Errorf("unable to start init: %w", err)
 	}
 
-	waitInit := initWaiter(p.comm.initSockParent)
 	defer func() {
 		if retErr != nil {
 			// Find out if init is killed by the kernel's OOM killer.
@@ -557,11 +547,6 @@ func (p *initProcess) start() (retErr error) {
 				} else {
 					retErr = errors.New(oomError)
 				}
-			}
-
-			werr := <-waitInit
-			if werr != nil {
-				logrus.WithError(werr).Warn()
 			}
 
 			// Terminate the process to ensure we can remove cgroups.
@@ -600,10 +585,6 @@ func (p *initProcess) start() (retErr error) {
 	}
 	if _, err := io.Copy(p.comm.initSockParent, p.bootstrapData); err != nil {
 		return fmt.Errorf("can't copy bootstrap data to pipe: %w", err)
-	}
-	err = <-waitInit
-	if err != nil {
-		return err
 	}
 
 	childPid, err := p.getChildPid()
@@ -973,31 +954,6 @@ func (p *Process) InitializeIO(rootuid, rootgid int) (i *IO, err error) {
 		}
 	}
 	return i, nil
-}
-
-// initWaiter returns a channel to wait on for making sure
-// runc init has finished the initial setup.
-func initWaiter(r io.Reader) chan error {
-	ch := make(chan error, 1)
-	go func() {
-		defer close(ch)
-
-		inited := make([]byte, 1)
-		n, err := r.Read(inited)
-		if err == nil {
-			if n < 1 {
-				err = errors.New("short read")
-			} else if inited[0] != 0 {
-				err = fmt.Errorf("unexpected %d != 0", inited[0])
-			} else {
-				ch <- nil
-				return
-			}
-		}
-		ch <- fmt.Errorf("waiting for init preliminary setup: %w", err)
-	}()
-
-	return ch
 }
 
 func setIOPriority(ioprio *configs.IOPriority) error {


### PR DESCRIPTION
This initWaiter logic was introduced by commit 4ecff8d9 (PR #2855), but since the logic of /proc/self/exe was moved out of runc init in commit 0e9a335 (PR #3987), this seems unnecessary to have initWaiter.

Remove it.

This essentially reverts commit 4ecff8d9.