### PR TITLE
ci: revert #4020

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -303,7 +303,7 @@ convert_hugetlb_size() {
 				"memory.min":   "131072",
 				"memory.low":   "524288",
 				"memory.high": "5242880",
-				"memory.max": "20484096",
+				"memory.max": "10485760",
 				"pids.max": "99",
 				"cpu.max": "10000 100000",
 				"cpu.weight": "42"
@@ -319,14 +319,14 @@ convert_hugetlb_size() {
 	echo "$output" | grep -q '^memory.min:131072$'
 	echo "$output" | grep -q '^memory.low:524288$'
 	echo "$output" | grep -q '^memory.high:5242880$'
-	echo "$output" | grep -q '^memory.max:20484096$'
+	echo "$output" | grep -q '^memory.max:10485760$'
 	echo "$output" | grep -q '^pids.max:99$'
 	echo "$output" | grep -q '^cpu.max:10000 100000$'
 
 	check_systemd_value "MemoryMin" 131072
 	check_systemd_value "MemoryLow" 524288
 	check_systemd_value "MemoryHigh" 5242880
-	check_systemd_value "MemoryMax" 20484096
+	check_systemd_value "MemoryMax" 10485760
 	check_systemd_value "TasksMax" 99
 	check_cpu_quota 10000 100000 "100ms"
 	check_cpu_weight 42
@@ -368,7 +368,7 @@ convert_hugetlb_size() {
 			}
 			| .linux.resources.unified |= {
 				"memory.min": "131072",
-				"memory.max": "40484864",
+				"memory.max": "10485760",
 				"pids.max": "42",
 				"cpu.max": "5000 50000",
 				"cpu.weight": "42"
@@ -383,7 +383,7 @@ convert_hugetlb_size() {
 
 	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
 	[ "$status" -eq 0 ]
-	[ "$output" = '40484864' ]
+	[ "$output" = '10485760' ]
 
 	runc exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
we need (#4020) because of (#3931), at that time, we removed the bindfd logic, and the
memfd logic will use more memory than before, but we have not yet moved binary clone from
runc init to runc parent process, so we need to increase memory limit in CI.
As we have moved the runc binary clone logic from runc init to runc parent process in
(#3987), so the memory usage of binary clone will not be included in container's memory
cgroup accounting. Now we can support run a simple container with lower memory usage the
same as before.

Signed-off-by: lifubang <lifubang@acmcoder.com>