### PR TITLE
tests/int: skip "update memory vs CheckBeforeUpdate" on EL9

### DIFF
--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -852,6 +852,8 @@ EOF
 }
 
 @test "update memory vs CheckBeforeUpdate" {
+	exclude_os almalinux-9.4 # See https://github.com/opencontainers/runc/issues/4454
+
 	requires cgroups_v2
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 


### PR DESCRIPTION
This test case is frequently hanging recently. Might be caused by a recent kernel update from 5.14.0-427.33.1.el9_4.x86_64 to 5.14.0-427.37.1.el9_4.x86_64.

Could not reproduce locally.

Let's skip it for now.

Fixes: #4454 