### PR TITLE
libct/configs: move cgroup configs to libct/cgroups

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -2,8 +2,6 @@ package cgroups
 
 import (
 	"errors"
-
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 var (
@@ -21,8 +19,8 @@ var (
 	// [github.com/opencontainers/runc/libcontainer/cgroups/devices]
 	// package is imported, it is set to nil, so cgroup managers can't
 	// manage devices.
-	DevicesSetV1 func(path string, r *configs.Resources) error
-	DevicesSetV2 func(path string, r *configs.Resources) error
+	DevicesSetV1 func(path string, r *Resources) error
+	DevicesSetV2 func(path string, r *Resources) error
 )
 
 type Manager interface {
@@ -42,7 +40,7 @@ type Manager interface {
 	GetStats() (*Stats, error)
 
 	// Freeze sets the freezer cgroup to the specified state.
-	Freeze(state configs.FreezerState) error
+	Freeze(state FreezerState) error
 
 	// Destroy removes cgroup.
 	Destroy() error
@@ -54,7 +52,7 @@ type Manager interface {
 	// Set sets cgroup resources parameters/limits. If the argument is nil,
 	// the resources specified during Manager creation (or the previous call
 	// to Set) are used.
-	Set(r *configs.Resources) error
+	Set(r *Resources) error
 
 	// GetPaths returns cgroup path(s) to save in a state file in order to
 	// restore later.
@@ -67,10 +65,10 @@ type Manager interface {
 	GetPaths() map[string]string
 
 	// GetCgroups returns the cgroup data as configured.
-	GetCgroups() (*configs.Cgroup, error)
+	GetCgroups() (*Cgroup, error)
 
 	// GetFreezerState retrieves the current FreezerState of the cgroup.
-	GetFreezerState() (configs.FreezerState, error)
+	GetFreezerState() (FreezerState, error)
 
 	// Exists returns whether the cgroup path exists or not.
 	Exists() bool

--- a/libcontainer/cgroups/config_blkio_device.go
+++ b/libcontainer/cgroups/config_blkio_device.go
@@ -1,4 +1,4 @@
-package configs
+package cgroups
 
 import "fmt"
 

--- a/libcontainer/cgroups/config_hugepages.go
+++ b/libcontainer/cgroups/config_hugepages.go
@@ -1,4 +1,4 @@
-package configs
+package cgroups
 
 type HugepageLimit struct {
 	// which type of hugepage to limit.

--- a/libcontainer/cgroups/config_ifprio_map.go
+++ b/libcontainer/cgroups/config_ifprio_map.go
@@ -1,4 +1,4 @@
-package configs
+package cgroups
 
 import (
 	"fmt"

--- a/libcontainer/cgroups/config_linux.go
+++ b/libcontainer/cgroups/config_linux.go
@@ -1,4 +1,4 @@
-package configs
+package cgroups
 
 import (
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"

--- a/libcontainer/cgroups/config_rdma.go
+++ b/libcontainer/cgroups/config_rdma.go
@@ -1,4 +1,4 @@
-package configs
+package cgroups
 
 // LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11)
 type LinuxRdma struct {

--- a/libcontainer/cgroups/config_unsupported.go
+++ b/libcontainer/cgroups/config_unsupported.go
@@ -1,6 +1,6 @@
 //go:build !linux
 
-package configs
+package cgroups
 
 // Cgroup holds properties of a cgroup on Linux
 // TODO Windows: This can ultimately be entirely factored out on Windows as

--- a/libcontainer/cgroups/devices/systemd.go
+++ b/libcontainer/cgroups/devices/systemd.go
@@ -11,13 +11,13 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
 // systemdProperties takes the configured device rules and generates a
 // corresponding set of systemd properties to configure the devices correctly.
-func systemdProperties(r *configs.Resources, sdVer int) ([]systemdDbus.Property, error) {
+func systemdProperties(r *cgroups.Resources, sdVer int) ([]systemdDbus.Property, error) {
 	if r.SkipDevices {
 		return nil, nil
 	}

--- a/libcontainer/cgroups/devices/systemd_test.go
+++ b/libcontainer/cgroups/devices/systemd_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
@@ -28,11 +27,11 @@ func TestPodSkipDevicesUpdate(t *testing.T) {
 	}
 
 	podName := "system-runc_test_pod" + t.Name() + ".slice"
-	podConfig := &configs.Cgroup{
+	podConfig := &cgroups.Cgroup{
 		Systemd: true,
 		Parent:  "system.slice",
 		Name:    podName,
-		Resources: &configs.Resources{
+		Resources: &cgroups.Resources{
 			PidsLimit:   42,
 			Memory:      32 * 1024 * 1024,
 			SkipDevices: true,
@@ -47,11 +46,11 @@ func TestPodSkipDevicesUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	containerConfig := &configs.Cgroup{
+	containerConfig := &cgroups.Cgroup{
 		Parent:      podName,
 		ScopePrefix: "test",
 		Name:        "PodSkipDevicesUpdate",
-		Resources: &configs.Resources{
+		Resources: &cgroups.Resources{
 			Devices: []*devices.Rule{
 				// Allow access to /dev/null.
 				{
@@ -124,10 +123,10 @@ func testSkipDevices(t *testing.T, skipDevices bool, expected []string) {
 		t.Skip("Test requires root.")
 	}
 
-	podConfig := &configs.Cgroup{
+	podConfig := &cgroups.Cgroup{
 		Parent: "system.slice",
 		Name:   "system-runc_test_pods.slice",
-		Resources: &configs.Resources{
+		Resources: &cgroups.Resources{
 			SkipDevices: skipDevices,
 		},
 	}
@@ -140,11 +139,11 @@ func testSkipDevices(t *testing.T, skipDevices bool, expected []string) {
 		t.Fatal(err)
 	}
 
-	config := &configs.Cgroup{
+	config := &cgroups.Cgroup{
 		Parent:      "system-runc_test_pods.slice",
 		ScopePrefix: "test",
 		Name:        "SkipDevices",
-		Resources: &configs.Resources{
+		Resources: &cgroups.Resources{
 			Devices: []*devices.Rule{
 				// Allow access to /dev/full only.
 				{
@@ -262,7 +261,7 @@ func BenchmarkFindDeviceGroup(b *testing.B) {
 	}
 }
 
-func newManager(t *testing.T, config *configs.Cgroup) (m cgroups.Manager) {
+func newManager(t *testing.T, config *cgroups.Cgroup) (m cgroups.Manager) {
 	t.Helper()
 	var err error
 

--- a/libcontainer/cgroups/devices/v1.go
+++ b/libcontainer/cgroups/devices/v1.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/moby/sys/userns"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
 var testingSkipFinalCheck bool
 
-func setV1(path string, r *configs.Resources) error {
+func setV1(path string, r *cgroups.Resources) error {
 	if userns.RunningInUserNS() || r.SkipDevices {
 		return nil
 	}

--- a/libcontainer/cgroups/devices/v1_test.go
+++ b/libcontainer/cgroups/devices/v1_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
@@ -35,7 +34,7 @@ func TestSetV1Allow(t *testing.T) {
 		}
 	}
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		Devices: []*devices.Rule{
 			{
 				Type:        devices.CharDevice,

--- a/libcontainer/cgroups/devices/v2.go
+++ b/libcontainer/cgroups/devices/v2.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/sys/userns"
 	"golang.org/x/sys/unix"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
@@ -27,7 +27,7 @@ func isRWM(perms devices.Permissions) bool {
 
 // This is similar to the logic applied in crun for handling errors from bpf(2)
 // <https://github.com/containers/crun/blob/0.17/src/libcrun/cgroup.c#L2438-L2470>.
-func canSkipEBPFError(r *configs.Resources) bool {
+func canSkipEBPFError(r *cgroups.Resources) bool {
 	// If we're running in a user namespace we can ignore eBPF rules because we
 	// usually cannot use bpf(2), as well as rootless containers usually don't
 	// have the necessary privileges to mknod(2) device inodes or access
@@ -51,7 +51,7 @@ func canSkipEBPFError(r *configs.Resources) bool {
 	return true
 }
 
-func setV2(dirPath string, r *configs.Resources) error {
+func setV2(dirPath string, r *cgroups.Resources) error {
 	if r.SkipDevices {
 		return nil
 	}

--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type BlkioGroup struct {
@@ -20,11 +19,11 @@ func (s *BlkioGroup) Name() string {
 	return "blkio"
 }
 
-func (s *BlkioGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *BlkioGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *BlkioGroup) Set(path string, r *configs.Resources) error {
+func (s *BlkioGroup) Set(path string, r *cgroups.Resources) error {
 	s.detectWeightFilenames(path)
 	if r.BlkioWeight != 0 {
 		if err := cgroups.WriteFile(path, s.weightFilename, strconv.FormatUint(uint64(r.BlkioWeight), 10)); err != nil {

--- a/libcontainer/cgroups/fs/blkio_test.go
+++ b/libcontainer/cgroups/fs/blkio_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -184,7 +183,7 @@ func TestBlkioSetWeight(t *testing.T) {
 			weightFilename: strconv.Itoa(weightBefore),
 		})
 		// Apply new configuration
-		r := &configs.Resources{
+		r := &cgroups.Resources{
 			BlkioWeight: weightAfter,
 		}
 		blkio := &BlkioGroup{}
@@ -224,10 +223,10 @@ func TestBlkioSetWeightDevice(t *testing.T) {
 			weightDeviceFilename: weightDeviceBefore,
 		})
 		// Apply new configuration
-		wd := configs.NewWeightDevice(8, 0, 500, 0)
+		wd := cgroups.NewWeightDevice(8, 0, 500, 0)
 		weightDeviceAfter := wd.WeightString()
-		r := &configs.Resources{
-			BlkioWeightDevice: []*configs.WeightDevice{wd},
+		r := &cgroups.Resources{
+			BlkioWeightDevice: []*cgroups.WeightDevice{wd},
 		}
 		blkio := &BlkioGroup{}
 		if err := blkio.Set(path, r); err != nil {
@@ -255,8 +254,8 @@ func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 		weightDeviceBefore = "8:0 400"
 	)
 
-	wd1 := configs.NewWeightDevice(8, 0, 500, 0)
-	wd2 := configs.NewWeightDevice(8, 16, 500, 0)
+	wd1 := cgroups.NewWeightDevice(8, 0, 500, 0)
+	wd2 := cgroups.NewWeightDevice(8, 16, 500, 0)
 	// we cannot actually set and check both because normal os.WriteFile
 	// when writing to cgroup file will overwrite the whole file content instead
 	// of updating it as the kernel is doing. Just check the second device
@@ -272,8 +271,8 @@ func TestBlkioSetMultipleWeightDevice(t *testing.T) {
 		blkio.weightDeviceFilename: weightDeviceBefore,
 	})
 
-	r := &configs.Resources{
-		BlkioWeightDevice: []*configs.WeightDevice{wd1, wd2},
+	r := &cgroups.Resources{
+		BlkioWeightDevice: []*cgroups.WeightDevice{wd1, wd2},
 	}
 	if err := blkio.Set(path, r); err != nil {
 		t.Fatal(err)
@@ -745,15 +744,15 @@ func TestBlkioSetThrottleReadBpsDevice(t *testing.T) {
 		throttleBefore = `8:0 1024`
 	)
 
-	td := configs.NewThrottleDevice(8, 0, 2048)
+	td := cgroups.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
 	writeFileContents(t, path, map[string]string{
 		"blkio.throttle.read_bps_device": throttleBefore,
 	})
 
-	r := &configs.Resources{
-		BlkioThrottleReadBpsDevice: []*configs.ThrottleDevice{td},
+	r := &cgroups.Resources{
+		BlkioThrottleReadBpsDevice: []*cgroups.ThrottleDevice{td},
 	}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(path, r); err != nil {
@@ -776,15 +775,15 @@ func TestBlkioSetThrottleWriteBpsDevice(t *testing.T) {
 		throttleBefore = `8:0 1024`
 	)
 
-	td := configs.NewThrottleDevice(8, 0, 2048)
+	td := cgroups.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
 	writeFileContents(t, path, map[string]string{
 		"blkio.throttle.write_bps_device": throttleBefore,
 	})
 
-	r := &configs.Resources{
-		BlkioThrottleWriteBpsDevice: []*configs.ThrottleDevice{td},
+	r := &cgroups.Resources{
+		BlkioThrottleWriteBpsDevice: []*cgroups.ThrottleDevice{td},
 	}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(path, r); err != nil {
@@ -807,15 +806,15 @@ func TestBlkioSetThrottleReadIOpsDevice(t *testing.T) {
 		throttleBefore = `8:0 1024`
 	)
 
-	td := configs.NewThrottleDevice(8, 0, 2048)
+	td := cgroups.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
 	writeFileContents(t, path, map[string]string{
 		"blkio.throttle.read_iops_device": throttleBefore,
 	})
 
-	r := &configs.Resources{
-		BlkioThrottleReadIOPSDevice: []*configs.ThrottleDevice{td},
+	r := &cgroups.Resources{
+		BlkioThrottleReadIOPSDevice: []*cgroups.ThrottleDevice{td},
 	}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(path, r); err != nil {
@@ -838,15 +837,15 @@ func TestBlkioSetThrottleWriteIOpsDevice(t *testing.T) {
 		throttleBefore = `8:0 1024`
 	)
 
-	td := configs.NewThrottleDevice(8, 0, 2048)
+	td := cgroups.NewThrottleDevice(8, 0, 2048)
 	throttleAfter := td.String()
 
 	writeFileContents(t, path, map[string]string{
 		"blkio.throttle.write_iops_device": throttleBefore,
 	})
 
-	r := &configs.Resources{
-		BlkioThrottleWriteIOPSDevice: []*configs.ThrottleDevice{td},
+	r := &cgroups.Resources{
+		BlkioThrottleWriteIOPSDevice: []*cgroups.ThrottleDevice{td},
 	}
 	blkio := &BlkioGroup{}
 	if err := blkio.Set(path, r); err != nil {

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"golang.org/x/sys/unix"
 )
 
@@ -19,7 +18,7 @@ func (s *CpuGroup) Name() string {
 	return "cpu"
 }
 
-func (s *CpuGroup) Apply(path string, r *configs.Resources, pid int) error {
+func (s *CpuGroup) Apply(path string, r *cgroups.Resources, pid int) error {
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return err
 	}
@@ -34,7 +33,7 @@ func (s *CpuGroup) Apply(path string, r *configs.Resources, pid int) error {
 	return cgroups.WriteCgroupProc(path, pid)
 }
 
-func (s *CpuGroup) SetRtSched(path string, r *configs.Resources) error {
+func (s *CpuGroup) SetRtSched(path string, r *cgroups.Resources) error {
 	var period string
 	if r.CpuRtPeriod != 0 {
 		period = strconv.FormatUint(r.CpuRtPeriod, 10)
@@ -64,7 +63,7 @@ func (s *CpuGroup) SetRtSched(path string, r *configs.Resources) error {
 	return nil
 }
 
-func (s *CpuGroup) Set(path string, r *configs.Resources) error {
+func (s *CpuGroup) Set(path string, r *cgroups.Resources) error {
 	if r.CpuShares != 0 {
 		shares := r.CpuShares
 		if err := cgroups.WriteFile(path, "cpu.shares", strconv.FormatUint(shares, 10)); err != nil {

--- a/libcontainer/cgroups/fs/cpu_test.go
+++ b/libcontainer/cgroups/fs/cpu_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func TestCpuSetShares(t *testing.T) {
@@ -22,7 +21,7 @@ func TestCpuSetShares(t *testing.T) {
 		"cpu.shares": strconv.Itoa(sharesBefore),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		CpuShares: sharesAfter,
 	}
 	cpu := &CpuGroup{}
@@ -63,7 +62,7 @@ func TestCpuSetBandWidth(t *testing.T) {
 		"cpu.rt_period_us":  strconv.Itoa(rtPeriodBefore),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		CpuQuota:     quotaAfter,
 		CpuBurst:     &burstAfter,
 		CpuPeriod:    periodAfter,
@@ -191,7 +190,7 @@ func TestCpuSetRtSchedAtApply(t *testing.T) {
 		"cpu.rt_period_us":  strconv.Itoa(rtPeriodBefore),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		CpuRtRuntime: rtRuntimeAfter,
 		CpuRtPeriod:  rtPeriodAfter,
 	}

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -34,11 +33,11 @@ func (s *CpuacctGroup) Name() string {
 	return "cpuacct"
 }
 
-func (s *CpuacctGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *CpuacctGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *CpuacctGroup) Set(_ string, _ *configs.Resources) error {
+func (s *CpuacctGroup) Set(_ string, _ *cgroups.Resources) error {
 	return nil
 }
 

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type CpusetGroup struct{}
@@ -20,11 +19,11 @@ func (s *CpusetGroup) Name() string {
 	return "cpuset"
 }
 
-func (s *CpusetGroup) Apply(path string, r *configs.Resources, pid int) error {
+func (s *CpusetGroup) Apply(path string, r *cgroups.Resources, pid int) error {
 	return s.ApplyDir(path, r, pid)
 }
 
-func (s *CpusetGroup) Set(path string, r *configs.Resources) error {
+func (s *CpusetGroup) Set(path string, r *cgroups.Resources) error {
 	if r.CpusetCpus != "" {
 		if err := cgroups.WriteFile(path, "cpuset.cpus", r.CpusetCpus); err != nil {
 			return err
@@ -141,7 +140,7 @@ func (s *CpusetGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }
 
-func (s *CpusetGroup) ApplyDir(dir string, r *configs.Resources, pid int) error {
+func (s *CpusetGroup) ApplyDir(dir string, r *cgroups.Resources, pid int) error {
 	// This might happen if we have no cpuset cgroup mounted.
 	// Just do nothing and don't fail.
 	if dir == "" {
@@ -237,7 +236,7 @@ func isEmptyCpuset(str string) bool {
 	return str == "" || str == "\n"
 }
 
-func (s *CpusetGroup) ensureCpusAndMems(path string, r *configs.Resources) error {
+func (s *CpusetGroup) ensureCpusAndMems(path string, r *cgroups.Resources) error {
 	if err := s.Set(path, r); err != nil {
 		return err
 	}

--- a/libcontainer/cgroups/fs/cpuset_test.go
+++ b/libcontainer/cgroups/fs/cpuset_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -49,7 +48,7 @@ func TestCPUSetSetCpus(t *testing.T) {
 		"cpuset.cpus": cpusBefore,
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		CpusetCpus: cpusAfter,
 	}
 	cpuset := &CpusetGroup{}
@@ -78,7 +77,7 @@ func TestCPUSetSetMems(t *testing.T) {
 		"cpuset.mems": memsBefore,
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		CpusetMems: memsAfter,
 	}
 	cpuset := &CpusetGroup{}

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type DevicesGroup struct{}
@@ -11,7 +10,7 @@ func (s *DevicesGroup) Name() string {
 	return "devices"
 }
 
-func (s *DevicesGroup) Apply(path string, r *configs.Resources, pid int) error {
+func (s *DevicesGroup) Apply(path string, r *cgroups.Resources, pid int) error {
 	if r.SkipDevices {
 		return nil
 	}
@@ -24,7 +23,7 @@ func (s *DevicesGroup) Apply(path string, r *configs.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *DevicesGroup) Set(path string, r *configs.Resources) error {
+func (s *DevicesGroup) Set(path string, r *cgroups.Resources) error {
 	if cgroups.DevicesSetV1 == nil {
 		if len(r.Devices) == 0 {
 			return nil

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -19,19 +18,19 @@ func (s *FreezerGroup) Name() string {
 	return "freezer"
 }
 
-func (s *FreezerGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *FreezerGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {
+func (s *FreezerGroup) Set(path string, r *cgroups.Resources) (Err error) {
 	switch r.Freezer {
-	case configs.Frozen:
+	case cgroups.Frozen:
 		defer func() {
 			if Err != nil {
 				// Freezing failed, and it is bad and dangerous
 				// to leave the cgroup in FROZEN or FREEZING
 				// state, so (try to) thaw it back.
-				_ = cgroups.WriteFile(path, "freezer.state", string(configs.Thawed))
+				_ = cgroups.WriteFile(path, "freezer.state", string(cgroups.Thawed))
 			}
 		}()
 
@@ -64,11 +63,11 @@ func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {
 				// the chances to succeed in freezing
 				// in case new processes keep appearing
 				// in the cgroup.
-				_ = cgroups.WriteFile(path, "freezer.state", string(configs.Thawed))
+				_ = cgroups.WriteFile(path, "freezer.state", string(cgroups.Thawed))
 				time.Sleep(10 * time.Millisecond)
 			}
 
-			if err := cgroups.WriteFile(path, "freezer.state", string(configs.Frozen)); err != nil {
+			if err := cgroups.WriteFile(path, "freezer.state", string(cgroups.Frozen)); err != nil {
 				return err
 			}
 
@@ -87,7 +86,7 @@ func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {
 			switch state {
 			case "FREEZING":
 				continue
-			case string(configs.Frozen):
+			case string(cgroups.Frozen):
 				if i > 1 {
 					logrus.Debugf("frozen after %d retries", i)
 				}
@@ -99,9 +98,9 @@ func (s *FreezerGroup) Set(path string, r *configs.Resources) (Err error) {
 		}
 		// Despite our best efforts, it got stuck in FREEZING.
 		return errors.New("unable to freeze")
-	case configs.Thawed:
-		return cgroups.WriteFile(path, "freezer.state", string(configs.Thawed))
-	case configs.Undefined:
+	case cgroups.Thawed:
+		return cgroups.WriteFile(path, "freezer.state", string(cgroups.Thawed))
+	case cgroups.Undefined:
 		return nil
 	default:
 		return fmt.Errorf("Invalid argument '%s' to freezer.state", string(r.Freezer))
@@ -112,7 +111,7 @@ func (s *FreezerGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }
 
-func (s *FreezerGroup) GetState(path string) (configs.FreezerState, error) {
+func (s *FreezerGroup) GetState(path string) (cgroups.FreezerState, error) {
 	for {
 		state, err := cgroups.ReadFile(path, "freezer.state")
 		if err != nil {
@@ -121,11 +120,11 @@ func (s *FreezerGroup) GetState(path string) (configs.FreezerState, error) {
 			if os.IsNotExist(err) || errors.Is(err, unix.ENODEV) {
 				err = nil
 			}
-			return configs.Undefined, err
+			return cgroups.Undefined, err
 		}
 		switch strings.TrimSpace(state) {
 		case "THAWED":
-			return configs.Thawed, nil
+			return cgroups.Thawed, nil
 		case "FROZEN":
 			// Find out whether the cgroup is frozen directly,
 			// or indirectly via an ancestor.
@@ -136,15 +135,15 @@ func (s *FreezerGroup) GetState(path string) (configs.FreezerState, error) {
 				if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ENODEV) {
 					err = nil
 				}
-				return configs.Frozen, err
+				return cgroups.Frozen, err
 			}
 			switch self {
 			case "0\n":
-				return configs.Thawed, nil
+				return cgroups.Thawed, nil
 			case "1\n":
-				return configs.Frozen, nil
+				return cgroups.Frozen, nil
 			default:
-				return configs.Undefined, fmt.Errorf(`unknown "freezer.self_freezing" state: %q`, self)
+				return cgroups.Undefined, fmt.Errorf(`unknown "freezer.self_freezing" state: %q`, self)
 			}
 		case "FREEZING":
 			// Make sure we get a stable freezer state, so retry if the cgroup
@@ -152,7 +151,7 @@ func (s *FreezerGroup) GetState(path string) (configs.FreezerState, error) {
 			time.Sleep(1 * time.Millisecond)
 			continue
 		default:
-			return configs.Undefined, fmt.Errorf("unknown freezer.state %q", state)
+			return cgroups.Undefined, fmt.Errorf("unknown freezer.state %q", state)
 		}
 	}
 }

--- a/libcontainer/cgroups/fs/freezer_test.go
+++ b/libcontainer/cgroups/fs/freezer_test.go
@@ -3,19 +3,19 @@ package fs
 import (
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func TestFreezerSetState(t *testing.T) {
 	path := tempDir(t, "freezer")
 
 	writeFileContents(t, path, map[string]string{
-		"freezer.state": string(configs.Frozen),
+		"freezer.state": string(cgroups.Frozen),
 	})
 
-	r := &configs.Resources{
-		Freezer: configs.Thawed,
+	r := &cgroups.Resources{
+		Freezer: cgroups.Thawed,
 	}
 	freezer := &FreezerGroup{}
 	if err := freezer.Set(path, r); err != nil {
@@ -26,7 +26,7 @@ func TestFreezerSetState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if value != string(configs.Thawed) {
+	if value != string(cgroups.Thawed) {
 		t.Fatal("Got the wrong value, set freezer.state failed.")
 	}
 }
@@ -34,9 +34,9 @@ func TestFreezerSetState(t *testing.T) {
 func TestFreezerSetInvalidState(t *testing.T) {
 	path := tempDir(t, "freezer")
 
-	const invalidArg configs.FreezerState = "Invalid"
+	const invalidArg cgroups.FreezerState = "Invalid"
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		Freezer: invalidArg,
 	}
 	freezer := &FreezerGroup{}

--- a/libcontainer/cgroups/fs/fs_test.go
+++ b/libcontainer/cgroups/fs/fs_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func BenchmarkGetStats(b *testing.B) {
@@ -19,9 +18,9 @@ func BenchmarkGetStats(b *testing.B) {
 		cgroups.TestMode = true
 	}()
 
-	cg := &configs.Cgroup{
+	cg := &cgroups.Cgroup{
 		Path:      "/some/kind/of/a/path/here",
-		Resources: &configs.Resources{},
+		Resources: &cgroups.Resources{},
 	}
 	m, err := NewManager(cg, nil)
 	if err != nil {

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type HugetlbGroup struct{}
@@ -16,11 +15,11 @@ func (s *HugetlbGroup) Name() string {
 	return "hugetlb"
 }
 
-func (s *HugetlbGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *HugetlbGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *HugetlbGroup) Set(path string, r *configs.Resources) error {
+func (s *HugetlbGroup) Set(path string, r *cgroups.Resources) error {
 	const suffix = ".limit_in_bytes"
 	skipRsvd := false
 

--- a/libcontainer/cgroups/fs/hugetlb_test.go
+++ b/libcontainer/cgroups/fs/hugetlb_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -42,9 +41,9 @@ func TestHugetlbSetHugetlb(t *testing.T) {
 		})
 	}
 
-	r := &configs.Resources{}
+	r := &cgroups.Resources{}
 	for _, pageSize := range cgroups.HugePageSizes() {
-		r.HugetlbLimit = []*configs.HugepageLimit{
+		r.HugetlbLimit = []*cgroups.HugepageLimit{
 			{
 				Pagesize: pageSize,
 				Limit:    hugetlbAfter,

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -30,7 +29,7 @@ func (s *MemoryGroup) Name() string {
 	return "memory"
 }
 
-func (s *MemoryGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *MemoryGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
@@ -66,7 +65,7 @@ func setSwap(path string, val int64) error {
 	return cgroups.WriteFile(path, cgroupMemorySwapLimit, strconv.FormatInt(val, 10))
 }
 
-func setMemoryAndSwap(path string, r *configs.Resources) error {
+func setMemoryAndSwap(path string, r *cgroups.Resources) error {
 	// If the memory update is set to -1 and the swap is not explicitly
 	// set, we should also set swap to -1, it means unlimited memory.
 	if r.Memory == -1 && r.MemorySwap == 0 {
@@ -108,7 +107,7 @@ func setMemoryAndSwap(path string, r *configs.Resources) error {
 	return nil
 }
 
-func (s *MemoryGroup) Set(path string, r *configs.Resources) error {
+func (s *MemoryGroup) Set(path string, r *cgroups.Resources) error {
 	if err := setMemoryAndSwap(path, r); err != nil {
 		return err
 	}

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -53,7 +52,7 @@ func TestMemorySetMemory(t *testing.T) {
 		"memory.soft_limit_in_bytes": strconv.Itoa(reservationBefore),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		Memory:            memoryAfter,
 		MemoryReservation: reservationAfter,
 	}
@@ -91,7 +90,7 @@ func TestMemorySetMemoryswap(t *testing.T) {
 		"memory.memsw.limit_in_bytes": strconv.Itoa(memoryswapBefore),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		MemorySwap: memoryswapAfter,
 	}
 	memory := &MemoryGroup{}
@@ -128,7 +127,7 @@ func TestMemorySetMemoryLargerThanSwap(t *testing.T) {
 		"memory.failcnt":            "0",
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		Memory:     memoryAfter,
 		MemorySwap: memoryswapAfter,
 	}
@@ -169,7 +168,7 @@ func TestMemorySetSwapSmallerThanMemory(t *testing.T) {
 		"memory.memsw.limit_in_bytes": strconv.Itoa(memoryswapBefore),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		Memory:     memoryAfter,
 		MemorySwap: memoryswapAfter,
 	}
@@ -205,7 +204,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 		"memory.swappiness": strconv.Itoa(swappinessBefore),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		MemorySwappiness: &swappinessAfter,
 	}
 	memory := &MemoryGroup{}
@@ -418,7 +417,7 @@ func TestMemorySetOomControl(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
-	r := &configs.Resources{}
+	r := &cgroups.Resources{}
 	if err := memory.Set(path, r); err != nil {
 		t.Fatal(err)
 	}

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type NameGroup struct {
@@ -14,7 +13,7 @@ func (s *NameGroup) Name() string {
 	return s.GroupName
 }
 
-func (s *NameGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *NameGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	if s.Join {
 		// Ignore errors if the named cgroup does not exist.
 		_ = apply(path, pid)
@@ -22,7 +21,7 @@ func (s *NameGroup) Apply(path string, _ *configs.Resources, pid int) error {
 	return nil
 }
 
-func (s *NameGroup) Set(_ string, _ *configs.Resources) error {
+func (s *NameGroup) Set(_ string, _ *cgroups.Resources) error {
 	return nil
 }
 

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type NetClsGroup struct{}
@@ -13,11 +12,11 @@ func (s *NetClsGroup) Name() string {
 	return "net_cls"
 }
 
-func (s *NetClsGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *NetClsGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *NetClsGroup) Set(path string, r *configs.Resources) error {
+func (s *NetClsGroup) Set(path string, r *cgroups.Resources) error {
 	if r.NetClsClassid != 0 {
 		if err := cgroups.WriteFile(path, "net_cls.classid", strconv.FormatUint(uint64(r.NetClsClassid), 10)); err != nil {
 			return err

--- a/libcontainer/cgroups/fs/net_cls_test.go
+++ b/libcontainer/cgroups/fs/net_cls_test.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -20,7 +20,7 @@ func TestNetClsSetClassid(t *testing.T) {
 		"net_cls.classid": strconv.FormatUint(classidBefore, 10),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		NetClsClassid: classidAfter,
 	}
 	netcls := &NetClsGroup{}

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type NetPrioGroup struct{}
@@ -11,11 +10,11 @@ func (s *NetPrioGroup) Name() string {
 	return "net_prio"
 }
 
-func (s *NetPrioGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *NetPrioGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *NetPrioGroup) Set(path string, r *configs.Resources) error {
+func (s *NetPrioGroup) Set(path string, r *cgroups.Resources) error {
 	for _, prioMap := range r.NetPrioIfpriomap {
 		if err := cgroups.WriteFile(path, "net_prio.ifpriomap", prioMap.CgroupString()); err != nil {
 			return err

--- a/libcontainer/cgroups/fs/net_prio_test.go
+++ b/libcontainer/cgroups/fs/net_prio_test.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-var prioMap = []*configs.IfPrioMap{
+var prioMap = []*cgroups.IfPrioMap{
 	{
 		Interface: "test",
 		Priority:  5,
@@ -18,7 +18,7 @@ var prioMap = []*configs.IfPrioMap{
 func TestNetPrioSetIfPrio(t *testing.T) {
 	path := tempDir(t, "net_prio")
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		NetPrioIfpriomap: prioMap,
 	}
 	netPrio := &NetPrioGroup{}

--- a/libcontainer/cgroups/fs/paths.go
+++ b/libcontainer/cgroups/fs/paths.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
@@ -21,7 +20,7 @@ var (
 
 const defaultCgroupRoot = "/sys/fs/cgroup"
 
-func initPaths(cg *configs.Cgroup) (map[string]string, error) {
+func initPaths(cg *cgroups.Cgroup) (map[string]string, error) {
 	root, err := rootPath()
 	if err != nil {
 		return nil, err
@@ -136,7 +135,7 @@ func rootPath() (string, error) {
 	return cgroupRoot, nil
 }
 
-func innerPath(c *configs.Cgroup) (string, error) {
+func innerPath(c *cgroups.Cgroup) (string, error) {
 	if (c.Name != "" || c.Parent != "") && c.Path != "" {
 		return "", errors.New("cgroup: either Path or Name and Parent should be used")
 	}

--- a/libcontainer/cgroups/fs/paths_test.go
+++ b/libcontainer/cgroups/fs/paths_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func TestInvalidCgroupPath(t *testing.T) {
@@ -65,7 +64,7 @@ func TestInvalidCgroupPath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.test, func(t *testing.T) {
-			config := &configs.Cgroup{Path: tc.path, Name: tc.name, Parent: tc.parent}
+			config := &cgroups.Cgroup{Path: tc.path, Name: tc.name, Parent: tc.parent}
 
 			inner, err := innerPath(config)
 			if err != nil {

--- a/libcontainer/cgroups/fs/perf_event.go
+++ b/libcontainer/cgroups/fs/perf_event.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type PerfEventGroup struct{}
@@ -11,11 +10,11 @@ func (s *PerfEventGroup) Name() string {
 	return "perf_event"
 }
 
-func (s *PerfEventGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *PerfEventGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *PerfEventGroup) Set(_ string, _ *configs.Resources) error {
+func (s *PerfEventGroup) Set(_ string, _ *cgroups.Resources) error {
 	return nil
 }
 

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type PidsGroup struct{}
@@ -15,11 +14,11 @@ func (s *PidsGroup) Name() string {
 	return "pids"
 }
 
-func (s *PidsGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *PidsGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *PidsGroup) Set(path string, r *configs.Resources) error {
+func (s *PidsGroup) Set(path string, r *cgroups.Resources) error {
 	if r.PidsLimit != 0 {
 		// "max" is the fallback value.
 		limit := "max"

--- a/libcontainer/cgroups/fs/pids_test.go
+++ b/libcontainer/cgroups/fs/pids_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -21,7 +20,7 @@ func TestPidsSetMax(t *testing.T) {
 		"pids.max": "max",
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		PidsLimit: maxLimited,
 	}
 	pids := &PidsGroup{}
@@ -45,7 +44,7 @@ func TestPidsSetUnlimited(t *testing.T) {
 		"pids.max": strconv.Itoa(maxLimited),
 	})
 
-	r := &configs.Resources{
+	r := &cgroups.Resources{
 		PidsLimit: maxUnlimited,
 	}
 	pids := &PidsGroup{}

--- a/libcontainer/cgroups/fs/rdma.go
+++ b/libcontainer/cgroups/fs/rdma.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type RdmaGroup struct{}
@@ -12,11 +11,11 @@ func (s *RdmaGroup) Name() string {
 	return "rdma"
 }
 
-func (s *RdmaGroup) Apply(path string, _ *configs.Resources, pid int) error {
+func (s *RdmaGroup) Apply(path string, _ *cgroups.Resources, pid int) error {
 	return apply(path, pid)
 }
 
-func (s *RdmaGroup) Set(path string, r *configs.Resources) error {
+func (s *RdmaGroup) Set(path string, r *cgroups.Resources) error {
 	return fscommon.RdmaSet(path, r)
 }
 

--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -13,12 +13,12 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-func isCpuSet(r *configs.Resources) bool {
+func isCPUSet(r *configs.Resources) bool {
 	return r.CpuWeight != 0 || r.CpuQuota != 0 || r.CpuPeriod != 0 || r.CPUIdle != nil || r.CpuBurst != nil
 }
 
-func setCpu(dirPath string, r *configs.Resources) error {
-	if !isCpuSet(r) {
+func setCPU(dirPath string, r *configs.Resources) error {
+	if !isCPUSet(r) {
 		return nil
 	}
 

--- a/libcontainer/cgroups/fs2/cpu.go
+++ b/libcontainer/cgroups/fs2/cpu.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-func isCPUSet(r *configs.Resources) bool {
+func isCPUSet(r *cgroups.Resources) bool {
 	return r.CpuWeight != 0 || r.CpuQuota != 0 || r.CpuPeriod != 0 || r.CPUIdle != nil || r.CpuBurst != nil
 }
 
-func setCPU(dirPath string, r *configs.Resources) error {
+func setCPU(dirPath string, r *cgroups.Resources) error {
 	if !isCPUSet(r) {
 		return nil
 	}

--- a/libcontainer/cgroups/fs2/cpuset.go
+++ b/libcontainer/cgroups/fs2/cpuset.go
@@ -2,14 +2,13 @@ package fs2
 
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-func isCpusetSet(r *configs.Resources) bool {
+func isCpusetSet(r *cgroups.Resources) bool {
 	return r.CpusetCpus != "" || r.CpusetMems != ""
 }
 
-func setCpuset(dirPath string, r *configs.Resources) error {
+func setCpuset(dirPath string, r *cgroups.Resources) error {
 	if !isCpusetSet(r) {
 		return nil
 	}

--- a/libcontainer/cgroups/fs2/create.go
+++ b/libcontainer/cgroups/fs2/create.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func supportedControllers() (string, error) {
@@ -18,7 +17,7 @@ func supportedControllers() (string, error) {
 // based on (1) controllers available and (2) resources that are being set.
 // We don't check "pseudo" controllers such as
 // "freezer" and "devices".
-func needAnyControllers(r *configs.Resources) (bool, error) {
+func needAnyControllers(r *cgroups.Resources) (bool, error) {
 	if r == nil {
 		return false, nil
 	}
@@ -64,12 +63,12 @@ func needAnyControllers(r *configs.Resources) (bool, error) {
 // containsDomainController returns whether the current config contains domain controller or not.
 // Refer to: http://man7.org/linux/man-pages/man7/cgroups.7.html
 // As at Linux 4.19, the following controllers are threaded: cpu, perf_event, and pids.
-func containsDomainController(r *configs.Resources) bool {
+func containsDomainController(r *cgroups.Resources) bool {
 	return isMemorySet(r) || isIoSet(r) || isCPUSet(r) || isHugeTlbSet(r)
 }
 
 // CreateCgroupPath creates cgroupv2 path, enabling all the supported controllers.
-func CreateCgroupPath(path string, c *configs.Cgroup) (Err error) {
+func CreateCgroupPath(path string, c *cgroups.Cgroup) (Err error) {
 	if !strings.HasPrefix(path, UnifiedMountpoint) {
 		return fmt.Errorf("invalid cgroup path %s", path)
 	}

--- a/libcontainer/cgroups/fs2/create.go
+++ b/libcontainer/cgroups/fs2/create.go
@@ -48,7 +48,7 @@ func needAnyControllers(r *configs.Resources) (bool, error) {
 	if isIoSet(r) && have("io") {
 		return true, nil
 	}
-	if isCpuSet(r) && have("cpu") {
+	if isCPUSet(r) && have("cpu") {
 		return true, nil
 	}
 	if isCpusetSet(r) && have("cpuset") {
@@ -65,7 +65,7 @@ func needAnyControllers(r *configs.Resources) (bool, error) {
 // Refer to: http://man7.org/linux/man-pages/man7/cgroups.7.html
 // As at Linux 4.19, the following controllers are threaded: cpu, perf_event, and pids.
 func containsDomainController(r *configs.Resources) bool {
-	return isMemorySet(r) || isIoSet(r) || isCpuSet(r) || isHugeTlbSet(r)
+	return isMemorySet(r) || isIoSet(r) || isCPUSet(r) || isHugeTlbSet(r)
 }
 
 // CreateCgroupPath creates cgroupv2 path, enabling all the supported controllers.

--- a/libcontainer/cgroups/fs2/defaultpath.go
+++ b/libcontainer/cgroups/fs2/defaultpath.go
@@ -25,13 +25,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 const UnifiedMountpoint = "/sys/fs/cgroup"
 
-func defaultDirPath(c *configs.Cgroup) (string, error) {
+func defaultDirPath(c *cgroups.Cgroup) (string, error) {
 	if (c.Name != "" || c.Parent != "") && c.Path != "" {
 		return "", fmt.Errorf("cgroup: either Path or Name and Parent should be used, got %+v", c)
 	}

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type parseError = fscommon.ParseError
 
 type Manager struct {
-	config *configs.Cgroup
+	config *cgroups.Cgroup
 	// dirPath is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope"
 	dirPath string
 	// controllers is content of "cgroup.controllers" file.
@@ -25,7 +24,7 @@ type Manager struct {
 // NewManager creates a manager for cgroup v2 unified hierarchy.
 // dirPath is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope".
 // If dirPath is empty, it is automatically set using config.
-func NewManager(config *configs.Cgroup, dirPath string) (*Manager, error) {
+func NewManager(config *cgroups.Cgroup, dirPath string) (*Manager, error) {
 	if dirPath == "" {
 		var err error
 		dirPath, err = defaultDirPath(config)
@@ -143,7 +142,7 @@ func (m *Manager) GetStats() (*cgroups.Stats, error) {
 	return st, nil
 }
 
-func (m *Manager) Freeze(state configs.FreezerState) error {
+func (m *Manager) Freeze(state cgroups.FreezerState) error {
 	if m.config.Resources == nil {
 		return errors.New("cannot toggle freezer: cgroups not configured for container")
 	}
@@ -162,7 +161,7 @@ func (m *Manager) Path(_ string) string {
 	return m.dirPath
 }
 
-func (m *Manager) Set(r *configs.Resources) error {
+func (m *Manager) Set(r *cgroups.Resources) error {
 	if r == nil {
 		return nil
 	}
@@ -218,7 +217,7 @@ func (m *Manager) Set(r *configs.Resources) error {
 	return nil
 }
 
-func setDevices(dirPath string, r *configs.Resources) error {
+func setDevices(dirPath string, r *cgroups.Resources) error {
 	if cgroups.DevicesSetV2 == nil {
 		if len(r.Devices) > 0 {
 			return cgroups.ErrDevicesUnsupported
@@ -260,11 +259,11 @@ func (m *Manager) GetPaths() map[string]string {
 	return paths
 }
 
-func (m *Manager) GetCgroups() (*configs.Cgroup, error) {
+func (m *Manager) GetCgroups() (*cgroups.Cgroup, error) {
 	return m.config, nil
 }
 
-func (m *Manager) GetFreezerState() (configs.FreezerState, error) {
+func (m *Manager) GetFreezerState() (cgroups.FreezerState, error) {
 	return getFreezer(m.dirPath)
 }
 
@@ -285,7 +284,7 @@ func (m *Manager) OOMKillCount() (uint64, error) {
 	return c, err
 }
 
-func CheckMemoryUsage(dirPath string, r *configs.Resources) error {
+func CheckMemoryUsage(dirPath string, r *cgroups.Resources) error {
 	if !r.MemoryCheckBeforeUpdate {
 		return nil
 	}

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -182,7 +182,7 @@ func (m *Manager) Set(r *configs.Resources) error {
 		return err
 	}
 	// cpu (since kernel 4.15)
-	if err := setCpu(m.dirPath, r); err != nil {
+	if err := setCPU(m.dirPath, r); err != nil {
 		return err
 	}
 	// devices (since kernel 4.15, pseudo-controller)

--- a/libcontainer/cgroups/fs2/hugetlb.go
+++ b/libcontainer/cgroups/fs2/hugetlb.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-func isHugeTlbSet(r *configs.Resources) bool {
+func isHugeTlbSet(r *cgroups.Resources) bool {
 	return len(r.HugetlbLimit) > 0
 }
 
-func setHugeTlb(dirPath string, r *configs.Resources) error {
+func setHugeTlb(dirPath string, r *cgroups.Resources) error {
 	if !isHugeTlbSet(r) {
 		return nil
 	}

--- a/libcontainer/cgroups/fs2/io.go
+++ b/libcontainer/cgroups/fs2/io.go
@@ -11,10 +11,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-func isIoSet(r *configs.Resources) bool {
+func isIoSet(r *cgroups.Resources) bool {
 	return r.BlkioWeight != 0 ||
 		len(r.BlkioWeightDevice) > 0 ||
 		len(r.BlkioThrottleReadBpsDevice) > 0 ||
@@ -37,7 +36,7 @@ func bfqDeviceWeightSupported(bfq *os.File) bool {
 	return err != nil
 }
 
-func setIo(dirPath string, r *configs.Resources) error {
+func setIo(dirPath string, r *cgroups.Resources) error {
 	if !isIoSet(r) {
 		return nil
 	}

--- a/libcontainer/cgroups/fs2/memory.go
+++ b/libcontainer/cgroups/fs2/memory.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 // numToStr converts an int64 value to a string for writing to a
@@ -32,11 +31,11 @@ func numToStr(value int64) (ret string) {
 	return ret
 }
 
-func isMemorySet(r *configs.Resources) bool {
+func isMemorySet(r *cgroups.Resources) bool {
 	return r.MemoryReservation != 0 || r.Memory != 0 || r.MemorySwap != 0
 }
 
-func setMemory(dirPath string, r *configs.Resources) error {
+func setMemory(dirPath string, r *cgroups.Resources) error {
 	if !isMemorySet(r) {
 		return nil
 	}

--- a/libcontainer/cgroups/fs2/pids.go
+++ b/libcontainer/cgroups/fs2/pids.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-func isPidsSet(r *configs.Resources) bool {
+func isPidsSet(r *cgroups.Resources) bool {
 	return r.PidsLimit != 0
 }
 
-func setPids(dirPath string, r *configs.Resources) error {
+func setPids(dirPath string, r *cgroups.Resources) error {
 	if !isPidsSet(r) {
 		return nil
 	}

--- a/libcontainer/cgroups/fscommon/rdma.go
+++ b/libcontainer/cgroups/fscommon/rdma.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 // parseRdmaKV parses raw string to RdmaEntry.
@@ -99,7 +99,7 @@ func RdmaGetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }
 
-func createCmdString(device string, limits configs.LinuxRdma) string {
+func createCmdString(device string, limits cgroups.LinuxRdma) string {
 	cmdString := device
 	if limits.HcaHandles != nil {
 		cmdString += " hca_handle=" + strconv.FormatUint(uint64(*limits.HcaHandles), 10)
@@ -111,7 +111,7 @@ func createCmdString(device string, limits configs.LinuxRdma) string {
 }
 
 // RdmaSet sets RDMA resources.
-func RdmaSet(path string, r *configs.Resources) error {
+func RdmaSet(path string, r *cgroups.Resources) error {
 	for device, limits := range r.Rdma {
 		if err := cgroups.WriteFile(path, "rdma.max", createCmdString(device, limits)); err != nil {
 			return err

--- a/libcontainer/cgroups/fscommon/rdma_test.go
+++ b/libcontainer/cgroups/fscommon/rdma_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 /* Roadmap for future */
@@ -27,8 +27,8 @@ func TestRdmaSet(t *testing.T) {
 	maxHandles := uint32(100)
 	maxObjects := uint32(300)
 
-	rdmaStubResource := &configs.Resources{
-		Rdma: map[string]configs.LinuxRdma{
+	rdmaStubResource := &cgroups.Resources{
+		Rdma: map[string]cgroups.LinuxRdma{
 			rdmaDevice: {
 				HcaHandles: &maxHandles,
 				HcaObjects: &maxObjects,

--- a/libcontainer/cgroups/manager/manager_test.go
+++ b/libcontainer/cgroups/manager/manager_test.go
@@ -3,8 +3,8 @@ package manager
 import (
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 // TestNilResources checks that a cgroup manager do not panic when
@@ -27,14 +27,14 @@ func TestNilResourcesSystemd(t *testing.T) {
 }
 
 func testNilResources(t *testing.T, systemd bool) {
-	cg := &configs.Cgroup{} // .Resources is nil
+	cg := &cgroups.Cgroup{} // .Resources is nil
 	cg.Systemd = systemd
 	mgr, err := New(cg)
 	if err != nil {
 		// Some managers require non-nil Resources during
 		// instantiation -- provide and retry. In such case
 		// we're mostly testing Set(nil) below.
-		cg.Resources = &configs.Resources{}
+		cg.Resources = &cgroups.Resources{}
 		mgr, err = New(cg)
 		if err != nil {
 			t.Fatal(err)
@@ -42,7 +42,7 @@ func testNilResources(t *testing.T, systemd bool) {
 	}
 	_ = mgr.Apply(-1)
 	_ = mgr.Set(nil)
-	_ = mgr.Freeze(configs.Thawed)
+	_ = mgr.Freeze(cgroups.Thawed)
 	_ = mgr.Exists()
 	_, _ = mgr.GetAllPids()
 	_, _ = mgr.GetCgroups()

--- a/libcontainer/cgroups/manager/new.go
+++ b/libcontainer/cgroups/manager/new.go
@@ -9,13 +9,12 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 // New returns the instance of a cgroup manager, which is chosen
 // based on the local environment (whether cgroup v1 or v2 is used)
 // and the config (whether config.Systemd is set or not).
-func New(config *configs.Cgroup) (cgroups.Manager, error) {
+func New(config *cgroups.Cgroup) (cgroups.Manager, error) {
 	return NewWithPaths(config, nil)
 }
 
@@ -27,7 +26,7 @@ func New(config *configs.Cgroup) (cgroups.Manager, error) {
 //
 // For cgroup v2, the only key allowed is "" (empty string), and the value
 // is the unified cgroup path.
-func NewWithPaths(config *configs.Cgroup, paths map[string]string) (cgroups.Manager, error) {
+func NewWithPaths(config *cgroups.Cgroup, paths map[string]string) (cgroups.Manager, error) {
 	if config == nil {
 		return nil, errors.New("cgroups/manager.New: config must not be nil")
 	}

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -38,7 +37,7 @@ var (
 	// [github.com/opencontainers/runc/libcontainer/cgroups/devices]
 	// package is imported, it is set to nil, so cgroup managers can't
 	// configure devices.
-	GenerateDeviceProps func(r *configs.Resources, sdVer int) ([]systemdDbus.Property, error)
+	GenerateDeviceProps func(r *cgroups.Resources, sdVer int) ([]systemdDbus.Property, error)
 )
 
 // NOTE: This function comes from package github.com/coreos/go-systemd/util
@@ -97,7 +96,7 @@ func newProp(name string, units interface{}) systemdDbus.Property {
 	}
 }
 
-func getUnitName(c *configs.Cgroup) string {
+func getUnitName(c *cgroups.Cgroup) string {
 	// by default, we create a scope unless the user explicitly asks for a slice.
 	if !strings.HasSuffix(c.Name, ".slice") {
 		return c.ScopePrefix + "-" + c.Name + ".scope"
@@ -351,7 +350,7 @@ func addCpuset(cm *dbusConnManager, props *[]systemdDbus.Property, cpus, mems st
 
 // generateDeviceProperties takes the configured device rules and generates a
 // corresponding set of systemd properties to configure the devices correctly.
-func generateDeviceProperties(r *configs.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
+func generateDeviceProperties(r *cgroups.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
 	if GenerateDeviceProps == nil {
 		if len(r.Devices) > 0 {
 			return nil, cgroups.ErrDevicesUnsupported

--- a/libcontainer/cgroups/systemd/devices.go
+++ b/libcontainer/cgroups/systemd/devices.go
@@ -5,7 +5,7 @@ import (
 
 	dbus "github.com/godbus/dbus/v5"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 // freezeBeforeSet answers whether there is a need to freeze the cgroup before
@@ -17,7 +17,7 @@ import (
 // (unlike our fs driver, they will happily write deny-all rules to running
 // containers). So we have to freeze the container to avoid the container get
 // an occasional "permission denied" error.
-func (m *LegacyManager) freezeBeforeSet(unitName string, r *configs.Resources) (needsFreeze, needsThaw bool, err error) {
+func (m *LegacyManager) freezeBeforeSet(unitName string, r *cgroups.Resources) (needsFreeze, needsThaw bool, err error) {
 	// Special case for SkipDevices, as used by Kubernetes to create pod
 	// cgroups with allow-all device policy).
 	if r.SkipDevices {
@@ -60,13 +60,13 @@ func (m *LegacyManager) freezeBeforeSet(unitName string, r *configs.Resources) (
 	if err != nil {
 		return
 	}
-	if freezerState == configs.Frozen {
+	if freezerState == cgroups.Frozen {
 		// Already frozen, and should stay frozen.
 		needsFreeze = false
 		needsThaw = false
 	}
 
-	if r.Freezer == configs.Frozen {
+	if r.Freezer == cgroups.Frozen {
 		// Will be frozen anyway -- no need to thaw.
 		needsThaw = false
 	}

--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -7,10 +7,9 @@ import (
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-func newManager(t *testing.T, config *configs.Cgroup) (m cgroups.Manager) {
+func newManager(t *testing.T, config *cgroups.Cgroup) (m cgroups.Manager) {
 	t.Helper()
 	var err error
 
@@ -82,10 +81,10 @@ func TestUnitExistsIgnored(t *testing.T) {
 		t.Skip("Test requires root.")
 	}
 
-	podConfig := &configs.Cgroup{
+	podConfig := &cgroups.Cgroup{
 		Parent:    "system.slice",
 		Name:      "system-runc_test_exists.slice",
-		Resources: &configs.Resources{},
+		Resources: &cgroups.Resources{},
 	}
 	// Create "pods" cgroup (a systemd slice to hold containers).
 	pm := newManager(t, podConfig)

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -12,17 +12,16 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type LegacyManager struct {
 	mu      sync.Mutex
-	cgroups *configs.Cgroup
+	cgroups *cgroups.Cgroup
 	paths   map[string]string
 	dbus    *dbusConnManager
 }
 
-func NewLegacyManager(cg *configs.Cgroup, paths map[string]string) (*LegacyManager, error) {
+func NewLegacyManager(cg *cgroups.Cgroup, paths map[string]string) (*LegacyManager, error) {
 	if cg.Rootless {
 		return nil, errors.New("cannot use rootless systemd cgroups manager on cgroup v1")
 	}
@@ -49,7 +48,7 @@ type subsystem interface {
 	// GetStats returns the stats, as 'stats', corresponding to the cgroup under 'path'.
 	GetStats(path string, stats *cgroups.Stats) error
 	// Set sets cgroup resource limits.
-	Set(path string, r *configs.Resources) error
+	Set(path string, r *cgroups.Resources) error
 }
 
 var errSubsystemDoesNotExist = errors.New("cgroup: subsystem does not exist")
@@ -72,7 +71,7 @@ var legacySubsystems = []subsystem{
 	&fs.NameGroup{GroupName: "misc"},
 }
 
-func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
+func genV1ResourcesProperties(r *cgroups.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
 
 	deviceProperties, err := generateDeviceProperties(r, cm)
@@ -112,7 +111,7 @@ func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]syst
 }
 
 // initPaths figures out and returns paths to cgroups.
-func initPaths(c *configs.Cgroup) (map[string]string, error) {
+func initPaths(c *cgroups.Cgroup) (map[string]string, error) {
 	slice := "system.slice"
 	if c.Parent != "" {
 		var err error
@@ -275,7 +274,7 @@ func getSubsystemPath(slice, unit, subsystem string) (string, error) {
 	return filepath.Join(mountpoint, slice, unit), nil
 }
 
-func (m *LegacyManager) Freeze(state configs.FreezerState) error {
+func (m *LegacyManager) Freeze(state cgroups.FreezerState) error {
 	err := m.doFreeze(state)
 	if err == nil {
 		m.cgroups.Resources.Freezer = state
@@ -285,13 +284,13 @@ func (m *LegacyManager) Freeze(state configs.FreezerState) error {
 
 // doFreeze is the same as Freeze but without
 // changing the m.cgroups.Resources.Frozen field.
-func (m *LegacyManager) doFreeze(state configs.FreezerState) error {
+func (m *LegacyManager) doFreeze(state cgroups.FreezerState) error {
 	path, ok := m.paths["freezer"]
 	if !ok {
 		return errSubsystemDoesNotExist
 	}
 	freezer := &fs.FreezerGroup{}
-	resources := &configs.Resources{Freezer: state}
+	resources := &cgroups.Resources{Freezer: state}
 	return freezer.Set(path, resources)
 }
 
@@ -328,7 +327,7 @@ func (m *LegacyManager) GetStats() (*cgroups.Stats, error) {
 	return stats, nil
 }
 
-func (m *LegacyManager) Set(r *configs.Resources) error {
+func (m *LegacyManager) Set(r *cgroups.Resources) error {
 	if r == nil {
 		return nil
 	}
@@ -347,13 +346,13 @@ func (m *LegacyManager) Set(r *configs.Resources) error {
 	}
 
 	if needsFreeze {
-		if err := m.doFreeze(configs.Frozen); err != nil {
+		if err := m.doFreeze(cgroups.Frozen); err != nil {
 			// If freezer cgroup isn't supported, we just warn about it.
 			logrus.Infof("freeze container before SetUnitProperties failed: %v", err)
 			// skip update the cgroup while frozen failed. #3803
 			if !errors.Is(err, errSubsystemDoesNotExist) {
 				if needsThaw {
-					if thawErr := m.doFreeze(configs.Thawed); thawErr != nil {
+					if thawErr := m.doFreeze(cgroups.Thawed); thawErr != nil {
 						logrus.Infof("thaw container after doFreeze failed: %v", thawErr)
 					}
 				}
@@ -363,7 +362,7 @@ func (m *LegacyManager) Set(r *configs.Resources) error {
 	}
 	setErr := setUnitProperties(m.dbus, unitName, properties...)
 	if needsThaw {
-		if err := m.doFreeze(configs.Thawed); err != nil {
+		if err := m.doFreeze(cgroups.Thawed); err != nil {
 			logrus.Infof("thaw container after SetUnitProperties failed: %v", err)
 		}
 	}
@@ -391,14 +390,14 @@ func (m *LegacyManager) GetPaths() map[string]string {
 	return m.paths
 }
 
-func (m *LegacyManager) GetCgroups() (*configs.Cgroup, error) {
+func (m *LegacyManager) GetCgroups() (*cgroups.Cgroup, error) {
 	return m.cgroups, nil
 }
 
-func (m *LegacyManager) GetFreezerState() (configs.FreezerState, error) {
+func (m *LegacyManager) GetFreezerState() (cgroups.FreezerState, error) {
 	path, ok := m.paths["freezer"]
 	if !ok {
-		return configs.Undefined, nil
+		return cgroups.Undefined, nil
 	}
 	freezer := &fs.FreezerGroup{}
 	return freezer.GetState(path)

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
@@ -26,14 +25,14 @@ const (
 
 type UnifiedManager struct {
 	mu      sync.Mutex
-	cgroups *configs.Cgroup
+	cgroups *cgroups.Cgroup
 	// path is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope"
 	path  string
 	dbus  *dbusConnManager
 	fsMgr cgroups.Manager
 }
 
-func NewUnifiedManager(config *configs.Cgroup, path string) (*UnifiedManager, error) {
+func NewUnifiedManager(config *cgroups.Cgroup, path string) (*UnifiedManager, error) {
 	m := &UnifiedManager{
 		cgroups: config,
 		path:    path,
@@ -199,7 +198,7 @@ func unifiedResToSystemdProps(cm *dbusConnManager, res map[string]string) (props
 	return props, nil
 }
 
-func genV2ResourcesProperties(dirPath string, r *configs.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
+func genV2ResourcesProperties(dirPath string, r *cgroups.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
 	// We need this check before setting systemd properties, otherwise
 	// the container is OOM-killed and the systemd unit is removed
 	// before we get to fsMgr.Set().
@@ -461,7 +460,7 @@ func (m *UnifiedManager) initPath() error {
 	return nil
 }
 
-func (m *UnifiedManager) Freeze(state configs.FreezerState) error {
+func (m *UnifiedManager) Freeze(state cgroups.FreezerState) error {
 	return m.fsMgr.Freeze(state)
 }
 
@@ -477,7 +476,7 @@ func (m *UnifiedManager) GetStats() (*cgroups.Stats, error) {
 	return m.fsMgr.GetStats()
 }
 
-func (m *UnifiedManager) Set(r *configs.Resources) error {
+func (m *UnifiedManager) Set(r *cgroups.Resources) error {
 	if r == nil {
 		return nil
 	}
@@ -499,11 +498,11 @@ func (m *UnifiedManager) GetPaths() map[string]string {
 	return paths
 }
 
-func (m *UnifiedManager) GetCgroups() (*configs.Cgroup, error) {
+func (m *UnifiedManager) GetCgroups() (*cgroups.Cgroup, error) {
 	return m.cgroups, nil
 }
 
-func (m *UnifiedManager) GetFreezerState() (configs.FreezerState, error) {
+func (m *UnifiedManager) GetFreezerState() (cgroups.FreezerState, error) {
 	return m.fsMgr.GetFreezerState()
 }
 

--- a/libcontainer/configs/cgroup_deprecated.go
+++ b/libcontainer/configs/cgroup_deprecated.go
@@ -1,0 +1,26 @@
+package configs // Deprecated: use [github.com/opencontainers/runc/libcontainer/cgroups].
+
+import "github.com/opencontainers/runc/libcontainer/cgroups"
+
+type (
+	Cgroup         = cgroups.Cgroup
+	Resources      = cgroups.Resources
+	FreezerState   = cgroups.FreezerState
+	LinuxRdma      = cgroups.LinuxRdma
+	BlockIODevice  = cgroups.BlockIODevice
+	WeightDevice   = cgroups.WeightDevice
+	ThrottleDevice = cgroups.ThrottleDevice
+	HugepageLimit  = cgroups.HugepageLimit
+	IfPrioMap      = cgroups.IfPrioMap
+)
+
+const (
+	Undefined = cgroups.Undefined
+	Frozen    = cgroups.Frozen
+	Thawed    = cgroups.Thawed
+)
+
+var (
+	NewWeightDevice   = cgroups.NewWeightDevice
+	NewThrottleDevice = cgroups.NewThrottleDevice
+)

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -417,7 +417,7 @@ func (c *Container) signal(s os.Signal) error {
 		// does nothing until it's thawed. Only thaw the cgroup
 		// for SIGKILL.
 		if paused, _ := c.isPaused(); paused {
-			_ = c.cgroupManager.Freeze(configs.Thawed)
+			_ = c.cgroupManager.Freeze(cgroups.Thawed)
 		}
 	}
 	return nil
@@ -742,7 +742,7 @@ func (c *Container) Pause() error {
 	}
 	switch status {
 	case Running, Created:
-		if err := c.cgroupManager.Freeze(configs.Frozen); err != nil {
+		if err := c.cgroupManager.Freeze(cgroups.Frozen); err != nil {
 			return err
 		}
 		return c.state.transition(&pausedState{
@@ -766,7 +766,7 @@ func (c *Container) Resume() error {
 	if status != Paused {
 		return ErrNotPaused
 	}
-	if err := c.cgroupManager.Freeze(configs.Thawed); err != nil {
+	if err := c.cgroupManager.Freeze(cgroups.Thawed); err != nil {
 		return err
 	}
 	return c.state.transition(&runningState{
@@ -886,7 +886,7 @@ func (c *Container) isPaused() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return state == configs.Frozen, nil
+	return state == cgroups.Frozen, nil
 }
 
 func (c *Container) currentState() *State {

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -32,7 +32,7 @@ func (m *mockCgroupManager) Apply(pid int) error {
 	return nil
 }
 
-func (m *mockCgroupManager) Set(_ *configs.Resources) error {
+func (m *mockCgroupManager) Set(_ *cgroups.Resources) error {
 	return nil
 }
 
@@ -57,16 +57,16 @@ func (m *mockCgroupManager) Path(subsys string) string {
 	return m.paths[subsys]
 }
 
-func (m *mockCgroupManager) Freeze(state configs.FreezerState) error {
+func (m *mockCgroupManager) Freeze(_ cgroups.FreezerState) error {
 	return nil
 }
 
-func (m *mockCgroupManager) GetCgroups() (*configs.Cgroup, error) {
+func (m *mockCgroupManager) GetCgroups() (*cgroups.Cgroup, error) {
 	return nil, nil
 }
 
-func (m *mockCgroupManager) GetFreezerState() (configs.FreezerState, error) {
-	return configs.Thawed, nil
+func (m *mockCgroupManager) GetFreezerState() (cgroups.FreezerState, error) {
+	return cgroups.Thawed, nil
 }
 
 type mockProcess struct {
@@ -243,8 +243,8 @@ func TestGetContainerStateAfterUpdate(t *testing.T) {
 				{Type: configs.NEWUTS},
 				{Type: configs.NEWIPC},
 			},
-			Cgroups: &configs.Cgroup{
-				Resources: &configs.Resources{
+			Cgroups: &cgroups.Cgroup{
+				Resources: &cgroups.Resources{
 					Memory: 1024,
 				},
 			},

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -9,6 +9,7 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"golang.org/x/sys/unix"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/manager"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/configs/validate"
@@ -82,7 +83,7 @@ func Create(root, id string, config *configs.Config) (*Container, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get cgroup freezer state: %w", err)
 	}
-	if st == configs.Frozen {
+	if st == cgroups.Frozen {
 		return nil, errors.New("container's cgroup unexpectedly frozen")
 	}
 

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -43,8 +44,8 @@ func TestFactoryLoadContainer(t *testing.T) {
 		expectedConfig = &configs.Config{
 			Rootfs: "/mycontainer/root",
 			Hooks:  expectedHooks,
-			Cgroups: &configs.Cgroup{
-				Resources: &configs.Resources{},
+			Cgroups: &cgroups.Cgroup{
+				Resources: &cgroups.Resources{},
 			},
 		}
 		expectedState = &State{

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -696,12 +696,12 @@ func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
 		}
 	}
 
-	if err := m.Freeze(configs.Frozen); err != nil {
+	if err := m.Freeze(cgroups.Frozen); err != nil {
 		logrus.Warn(err)
 	}
 	pids, err := m.GetAllPids()
 	if err != nil {
-		if err := m.Freeze(configs.Thawed); err != nil {
+		if err := m.Freeze(cgroups.Thawed); err != nil {
 			logrus.Warn(err)
 		}
 		return err
@@ -712,7 +712,7 @@ func signalAllProcesses(m cgroups.Manager, s unix.Signal) error {
 			logrus.Warnf("kill %d: %v", pid, err)
 		}
 	}
-	if err := m.Freeze(configs.Thawed); err != nil {
+	if err := m.Freeze(cgroups.Thawed); err != nil {
 		logrus.Warn(err)
 	}
 

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -472,7 +472,7 @@ func testFreeze(t *testing.T, withSystemd bool, useSet bool) {
 	if !useSet {
 		err = container.Pause()
 	} else {
-		config.Cgroups.Resources.Freezer = configs.Frozen
+		config.Cgroups.Resources.Freezer = cgroups.Frozen
 		err = container.Set(*config)
 	}
 	ok(t, err)
@@ -486,7 +486,7 @@ func testFreeze(t *testing.T, withSystemd bool, useSet bool) {
 	if !useSet {
 		err = container.Resume()
 	} else {
-		config.Cgroups.Resources.Freezer = configs.Thawed
+		config.Cgroups.Resources.Freezer = cgroups.Thawed
 		err = container.Set(*config)
 	}
 	ok(t, err)

--- a/libcontainer/integration/template_test.go
+++ b/libcontainer/integration/template_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/specconv"
@@ -99,9 +100,9 @@ func newTemplateConfig(t testing.TB, p *tParam) *configs.Config {
 			{Type: configs.NEWPID},
 			{Type: configs.NEWNET},
 		}),
-		Cgroups: &configs.Cgroup{
+		Cgroups: &cgroups.Cgroup{
 			Systemd: p.systemd,
-			Resources: &configs.Resources{
+			Resources: &cgroups.Resources{
 				MemorySwappiness: nil,
 				Devices:          allowedDevices,
 			},

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -697,7 +697,7 @@ func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
 	return sp, nil
 }
 
-func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*configs.Cgroup, error) {
+func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*cgroups.Cgroup, error) {
 	var (
 		myCgroupPath string
 
@@ -706,10 +706,10 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
 		name             = opts.CgroupName
 	)
 
-	c := &configs.Cgroup{
+	c := &cgroups.Cgroup{
 		Systemd:   useSystemdCgroup,
 		Rootless:  opts.RootlessCgroups,
-		Resources: &configs.Resources{},
+		Resources: &cgroups.Resources{},
 	}
 
 	if useSystemdCgroup {
@@ -853,40 +853,40 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
 					if wd.LeafWeight != nil {
 						leafWeight = *wd.LeafWeight
 					}
-					weightDevice := configs.NewWeightDevice(wd.Major, wd.Minor, weight, leafWeight)
+					weightDevice := cgroups.NewWeightDevice(wd.Major, wd.Minor, weight, leafWeight)
 					c.Resources.BlkioWeightDevice = append(c.Resources.BlkioWeightDevice, weightDevice)
 				}
 				for _, td := range r.BlockIO.ThrottleReadBpsDevice {
 					rate := td.Rate
-					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					throttleDevice := cgroups.NewThrottleDevice(td.Major, td.Minor, rate)
 					c.Resources.BlkioThrottleReadBpsDevice = append(c.Resources.BlkioThrottleReadBpsDevice, throttleDevice)
 				}
 				for _, td := range r.BlockIO.ThrottleWriteBpsDevice {
 					rate := td.Rate
-					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					throttleDevice := cgroups.NewThrottleDevice(td.Major, td.Minor, rate)
 					c.Resources.BlkioThrottleWriteBpsDevice = append(c.Resources.BlkioThrottleWriteBpsDevice, throttleDevice)
 				}
 				for _, td := range r.BlockIO.ThrottleReadIOPSDevice {
 					rate := td.Rate
-					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					throttleDevice := cgroups.NewThrottleDevice(td.Major, td.Minor, rate)
 					c.Resources.BlkioThrottleReadIOPSDevice = append(c.Resources.BlkioThrottleReadIOPSDevice, throttleDevice)
 				}
 				for _, td := range r.BlockIO.ThrottleWriteIOPSDevice {
 					rate := td.Rate
-					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					throttleDevice := cgroups.NewThrottleDevice(td.Major, td.Minor, rate)
 					c.Resources.BlkioThrottleWriteIOPSDevice = append(c.Resources.BlkioThrottleWriteIOPSDevice, throttleDevice)
 				}
 			}
 			for _, l := range r.HugepageLimits {
-				c.Resources.HugetlbLimit = append(c.Resources.HugetlbLimit, &configs.HugepageLimit{
+				c.Resources.HugetlbLimit = append(c.Resources.HugetlbLimit, &cgroups.HugepageLimit{
 					Pagesize: l.Pagesize,
 					Limit:    l.Limit,
 				})
 			}
 			if len(r.Rdma) > 0 {
-				c.Resources.Rdma = make(map[string]configs.LinuxRdma, len(r.Rdma))
+				c.Resources.Rdma = make(map[string]cgroups.LinuxRdma, len(r.Rdma))
 				for k, v := range r.Rdma {
-					c.Resources.Rdma[k] = configs.LinuxRdma{
+					c.Resources.Rdma[k] = cgroups.LinuxRdma{
 						HcaHandles: v.HcaHandles,
 						HcaObjects: v.HcaObjects,
 					}
@@ -897,7 +897,7 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
 					c.Resources.NetClsClassid = *r.Network.ClassID
 				}
 				for _, m := range r.Network.Priorities {
-					c.Resources.NetPrioIfpriomap = append(c.Resources.NetPrioIfpriomap, &configs.IfPrioMap{
+					c.Resources.NetPrioIfpriomap = append(c.Resources.NetPrioIfpriomap, &cgroups.IfPrioMap{
 						Interface: m.Name,
 						Priority:  int64(m.Priority),
 					})

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
@@ -185,7 +186,7 @@ func (p *pausedState) destroy() error {
 	if p.c.hasInit() {
 		return ErrPaused
 	}
-	if err := p.c.cgroupManager.Freeze(configs.Thawed); err != nil {
+	if err := p.c.cgroupManager.Freeze(cgroups.Thawed); err != nil {
 		return err
 	}
 	return destroy(p.c)

--- a/tests/cmd/sd-helper/helper.go
+++ b/tests/cmd/sd-helper/helper.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func usage() {
@@ -57,7 +56,7 @@ func main() {
 	}
 }
 
-func newManager(config *configs.Cgroup) (cgroups.Manager, error) {
+func newManager(config *cgroups.Cgroup) (cgroups.Manager, error) {
 	if cgroups.IsCgroup2UnifiedMode() {
 		return systemd.NewUnifiedManager(config, "")
 	}
@@ -65,10 +64,10 @@ func newManager(config *configs.Cgroup) (cgroups.Manager, error) {
 }
 
 func unitCommand(cmd, name, parent string) error {
-	podConfig := &configs.Cgroup{
+	podConfig := &cgroups.Cgroup{
 		Name:      name,
 		Parent:    parent,
-		Resources: &configs.Resources{},
+		Resources: &cgroups.Resources{},
 	}
 	pm, err := newManager(podConfig)
 	if err != nil {


### PR DESCRIPTION
This PR moves cgroup-related configuration from libcontainer/configs to libcontainer/cgroups,
while providing backward-compatible aliases.

This is the first step to implement the proposal to [split libcontainer/cgroups out of runc](https://github.com/opencontainers/tob/blob/main/proposals/cgroups.md) (which stems from [this k8s discussion](https://github.com/kubernetes/kubernetes/issues/128157#issuecomment-2427394891)).