### PR TITLE
libct/nsenter: become root after joining userns

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -505,6 +505,17 @@ void join_namespaces(char *nslist)
 		if (setns(ns->fd, flag) < 0)
 			bail("failed to setns into %s namespace", ns->type);
 
+		/*
+		 * If we change user namespaces, make sure we switch to root in the
+		 * namespace (this matches the logic for unshare(CLONE_NEWUSER)), lots
+		 * of things can break if we aren't the right user. See
+		 * <https://github.com/opencontainers/runc/issues/4466> for one example.
+		 */
+		if (flag == CLONE_NEWUSER) {
+			if (setresuid(0, 0, 0) < 0)
+				bail("failed to become root in user namespace");
+		}
+
 		close(ns->fd);
 	}
 


### PR DESCRIPTION
Containerd pre-creates userns and netns before calling runc, which
results in the current code not working when SELinux is enabled,
resulting in the following error:

> runc create failed: unable to start container process: error during
container init: error mounting "mqueue" to rootfs at "/dev/mqueue":
setxattr /path/to/rootfs/dev/mqueue: operation not permitted

The solution is to become root in the user namespace right after
we join it.

Fixes #4466.

Co-authored-by: Wei Fu <fuweid89@gmail.com>
Co-authored-by: Kir Kolyshkin <kolyshkin@gmail.com>
Co-authored-by: Aleksa Sarai <cyphar@cyphar.com>
Signed-off-by: lifubang <lifubang@acmcoder.com>