### PR TITLE
[1.2] libct/nsenter: become root after joining userns

### DIFF
--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -505,6 +505,12 @@ void join_namespaces(char *nslist)
 		if (setns(ns->fd, flag) < 0)
 			bail("failed to setns into %s namespace", ns->type);
 
+		/* See https://github.com/opencontainers/runc/issues/4466. */
+		if (flag == CLONE_NEWUSER) {
+			if (setresuid(0, 0, 0) < 0)
+				bail("failed to become root in user namespace");
+		}
+
 		close(ns->fd);
 	}
 


### PR DESCRIPTION
Containerd pre-creates userns and netns before calling runc, which results in the current code not working when SELinux is enabled, resulting in the following error:

> runc create failed: unable to start container process: error during container init: error mounting "mqueue" to rootfs at "/dev/mqueue": setxattr /path/to/rootfs/dev/mqueue: operation not permitted

The solution (kudos to @lifubang, @fuweid, and @rata) is to become root in the user namespace right after we join it.

Fixes #4466.