### PR TITLE
Add new ParseCgroupFileUnified method for k8s usage

### DIFF
--- a/libcontainer/cgroups/utils_test.go
+++ b/libcontainer/cgroups/utils_test.go
@@ -387,6 +387,34 @@ func TestParseCgroupString(t *testing.T) {
 	}
 }
 
+func TestParseCgroupFromReaderUnified(t *testing.T) {
+	const data = `10:devices:/user.slice
+	9:net_cls,net_prio:/
+	8:blkio:/
+	7:freezer:/
+	6:perf_event:/
+	5:cpuset:/
+	4:memory:/
+	3:pids:/user.slice/user-1000.slice/user@1000.service
+	2:cpu,cpuacct:/
+	1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
+	0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service`
+	r := strings.NewReader(data)
+	paths, unified, err := parseCgroupFromReaderUnified(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for subsystem, path := range paths {
+		if subsystem == "" {
+			t.Fatalf("empty subsystem for %q", path)
+		}
+	}
+	unifiedExpected := "/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service"
+	if unified != unifiedExpected {
+		t.Fatalf("expected %q, got %q", unifiedExpected, unified)
+	}
+}
+
 func TestIgnoreCgroup2Mount(t *testing.T) {
 	subsystems := map[string]bool{
 		"cpuset":       false,


### PR DESCRIPTION
In order to get k8s to drop usage of BOTH cgroups implementations in opencontainers/runc AND containerd/cgroups, we have to review what is being used in k8s from the latter. One thing that popped up is the following method defined in containerd/cgroups:

https://github.com/containerd/cgroups/blob/main/utils.go#L96-L98

Which is used here:

https://github.com/kubernetes/kubernetes/blob/69e30cd642be6eedaf320c98845f853ff52eff65/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go#L355

Please do advise if there is a better way to do the same using existing methods here or we can add a new method in this PR that adjusts the existing implementation a bit to return the additional unified path.

Test case and code is adapted from containerd/cgroups:
- https://github.com/containerd/cgroups/blob/190de3b04503d788a7b3a6849450de33a88b9f01/utils_test.go
- https://github.com/containerd/cgroups/blob/190de3b04503d788a7b3a6849450de33a88b9f01/utils.go