### PR TITLE
dmz: overlay: minor fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ The following build tags were used earlier, but are now obsoleted:
  - **apparmor** (since runc v1.0.0-rc93 the feature is always enabled)
  - **selinux**  (since runc v1.0.0-rc93 the feature is always enabled)
 
- [contrib-memfd-bind]: /contrib/cmd/memfd-bind/README.md
-
 ### Running the test suite
 
 `runc` currently supports running its test suite via Docker.

--- a/contrib/cmd/memfd-bind/README.md
+++ b/contrib/cmd/memfd-bind/README.md
@@ -1,6 +1,15 @@
 ## memfd-bind ##
 
-`runc` normally has to make a binary copy of itself when constructing a
+> **NOTE**: Since runc 1.2.0, runc will now use a private overlayfs mount to
+> protect the runc binary. This protection is far more light-weight than
+> memfd-bind, and for most users this should obviate the need for `memfd-bind`
+> entirely. Rootless containers will still make a memfd copy (unless you are
+> using `runc` itself inside a user namespace -- a-la
+> [`rootlesskit`][rootlesskit]), but `memfd-bind` is not particularly useful
+> for rootless container users anyway (see [Caveats](#Caveats) for more
+> details).
+
+`runc` sometimes has to make a binary copy of itself when constructing a
 container process in order to defend against certain container runtime attacks
 such as CVE-2019-5736.
 
@@ -37,6 +46,8 @@ much memory usage they can use:
 * The classic method of making a copy of the entire `runc` binary during
   container process setup takes up about 10MB per process spawned inside the
   container by runc (both pid1 and `runc exec`).
+
+[rootlesskit]: https://github.com/rootless-containers/rootlesskit
 
 ### Caveats ###
 


### PR DESCRIPTION
In addition to some documentation fixes, fix the `xino` dmesg log issue.

<hr>

If /run/runc and /usr/bin are on different filesystems, overlayfs may
enable the xino feature which results in the following log message:

  kernel: overlayfs: "xino" feature enabled using 3 upper inode bits.

Each time we have to protect /proc/self/exe. So disable xino to remove
the log message (we don't care about the inode numbers of the files
anyway).

Fixes #4508
Closes #4506
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>