### PR TITLE
improvements around bootstrapData

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -618,7 +618,6 @@ func (c *Container) newInitProcess(p *Process, cmd *exec.Cmd, comm *processComm)
 
 func (c *Container) newSetnsProcess(p *Process, cmd *exec.Cmd, comm *processComm) (*setnsProcess, error) {
 	cmd.Env = append(cmd.Env, "_LIBCONTAINER_INITTYPE="+string(initSetns))
-	state := c.currentState()
 	// for setns process, we don't have to set cloneflags as the process namespaces
 	// will only be set via setns syscall
 	data, err := c.bootstrapData(0)
@@ -627,15 +626,15 @@ func (c *Container) newSetnsProcess(p *Process, cmd *exec.Cmd, comm *processComm
 	}
 	proc := &setnsProcess{
 		cmd:             cmd,
-		cgroupPaths:     state.CgroupPaths,
+		cgroupPaths:     c.cgroupManager.GetPaths(),
 		rootlessCgroups: c.config.RootlessCgroups,
-		intelRdtPath:    state.IntelRdtPath,
+		intelRdtPath:    c.intelRdtPath(),
 		comm:            comm,
 		manager:         c.cgroupManager,
 		config:          c.newInitConfig(p),
 		process:         p,
 		bootstrapData:   data,
-		initProcessPid:  state.InitProcessPid,
+		initProcessPid:  c.initProcess.pid(),
 	}
 	if len(p.SubCgroupPaths) > 0 {
 		if add, ok := p.SubCgroupPaths[""]; ok {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -889,6 +889,13 @@ func (c *Container) isPaused() (bool, error) {
 	return state == configs.Frozen, nil
 }
 
+func (c *Container) intelRdtPath() string {
+	if c.intelRdtManager == nil {
+		return ""
+	}
+	return c.intelRdtManager.GetPath()
+}
+
 func (c *Container) currentState() *State {
 	var (
 		startTime           uint64
@@ -901,10 +908,6 @@ func (c *Container) currentState() *State {
 		externalDescriptors = c.initProcess.externalDescriptors()
 	}
 
-	intelRdtPath := ""
-	if c.intelRdtManager != nil {
-		intelRdtPath = c.intelRdtManager.GetPath()
-	}
 	state := &State{
 		BaseState: BaseState{
 			ID:                   c.ID(),
@@ -915,7 +918,7 @@ func (c *Container) currentState() *State {
 		},
 		Rootless:            c.config.RootlessEUID && c.config.RootlessCgroups,
 		CgroupPaths:         c.cgroupManager.GetPaths(),
-		IntelRdtPath:        intelRdtPath,
+		IntelRdtPath:        c.intelRdtPath(),
 		NamespacePaths:      make(map[configs.NamespaceType]string),
 		ExternalDescriptors: externalDescriptors,
 	}


### PR DESCRIPTION
The main thing here is removal of unnecessary data juggling around namespace paths (before this PR, they are converted from a list to a map to a list of strings to a string). A few other minor things here and there.

Seeing the following improvement using `BenchmarkExecTrue`:
```
goos: linux
goarch: amd64
pkg: github.com/opencontainers/runc/libcontainer/integration
cpu: 12th Gen Intel(R) Core(TM) i7-12800H
            │  before-ns  │             after-ns              │
            │   sec/op    │   sec/op     vs base              │
ExecTrue-20   3.972m ± 2%   3.697m ± 1%  -6.94% (p=0.000 n=8)

            │  before-ns   │              after-ns               │
            │     B/op     │     B/op      vs base               │
ExecTrue-20   26.43Ki ± 0%   21.53Ki ± 1%  -18.54% (p=0.000 n=8)

            │ before-ns  │             after-ns              │
            │ allocs/op  │ allocs/op   vs base               │
ExecTrue-20   244.0 ± 0%   172.0 ± 0%  -29.51% (p=0.000 n=8)
```