### PR TITLE
Reduce the delete delay with an exponential wait

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -15,8 +15,8 @@ import (
 
 func killContainer(container *libcontainer.Container) error {
 	_ = container.Signal(unix.SIGKILL)
-	for i := 0; i < 100; i++ {
-		time.Sleep(100 * time.Millisecond)
+	for i := 0; i < 12; i++ {
+		time.Sleep((1 << i) * time.Millisecond)
 		if err := container.Signal(unix.Signal(0)); err != nil {
 			return container.Destroy()
 		}


### PR DESCRIPTION
Currently in the `killContainer`, after send SigKill, we have to wait at least 100ms and then check if the process exit. it is a little bit long, especially for those pod with many containers in, when `crictl rmp -f` the pod, the delay may even exceed 1s.

Here we changed it to an exponential wait, that the max wait time will be 2 secs(2^11), so the total wait time is approximatly 4s, which I think is in the same level of current 10s(100ms * 100).