### PR TITLE
support cgroup v1 mounted with noprefix

### DIFF
--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -6,12 +6,47 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 )
+
+var (
+	cpusetLock     sync.Mutex
+	cpusetPrefix   = "cpuset."
+	cpusetFastPath bool
+)
+
+func cpusetFile(path string, name string) string {
+	cpusetLock.Lock()
+	defer cpusetLock.Unlock()
+
+	// Only the v1 cpuset cgroup is allowed to mount with noprefix.
+	// See kernel source: https://github.com/torvalds/linux/blob/2e1b3cc9d7f790145a80cb705b168f05dab65df2/kernel/cgroup/cgroup-v1.c#L1070
+	// Cpuset cannot be mounted with and without prefix simultaneously.
+	// Commonly used in Android environments.
+
+	if cpusetFastPath {
+		return cpusetPrefix + name
+	}
+
+	err := unix.Access(filepath.Join(path, cpusetPrefix+name), unix.F_OK)
+	if err == nil {
+		// Use the fast path only if we can access one type of mount for cpuset already
+		cpusetFastPath = true
+	} else {
+		err = unix.Access(filepath.Join(path, name), unix.F_OK)
+		if err == nil {
+			cpusetPrefix = ""
+			cpusetFastPath = true
+		}
+	}
+
+	return cpusetPrefix + name
+}
 
 type CpusetGroup struct{}
 
@@ -25,12 +60,12 @@ func (s *CpusetGroup) Apply(path string, r *cgroups.Resources, pid int) error {
 
 func (s *CpusetGroup) Set(path string, r *cgroups.Resources) error {
 	if r.CpusetCpus != "" {
-		if err := cgroups.WriteFile(path, "cpuset.cpus", r.CpusetCpus); err != nil {
+		if err := cgroups.WriteFile(path, cpusetFile(path, "cpus"), r.CpusetCpus); err != nil {
 			return err
 		}
 	}
 	if r.CpusetMems != "" {
-		if err := cgroups.WriteFile(path, "cpuset.mems", r.CpusetMems); err != nil {
+		if err := cgroups.WriteFile(path, cpusetFile(path, "mems"), r.CpusetMems); err != nil {
 			return err
 		}
 	}
@@ -82,57 +117,57 @@ func getCpusetStat(path string, file string) ([]uint16, error) {
 func (s *CpusetGroup) GetStats(path string, stats *cgroups.Stats) error {
 	var err error
 
-	stats.CPUSetStats.CPUs, err = getCpusetStat(path, "cpuset.cpus")
+	stats.CPUSetStats.CPUs, err = getCpusetStat(path, cpusetFile(path, "cpus"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.CPUExclusive, err = fscommon.GetCgroupParamUint(path, "cpuset.cpu_exclusive")
+	stats.CPUSetStats.CPUExclusive, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "cpu_exclusive"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.Mems, err = getCpusetStat(path, "cpuset.mems")
+	stats.CPUSetStats.Mems, err = getCpusetStat(path, cpusetFile(path, "mems"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.MemHardwall, err = fscommon.GetCgroupParamUint(path, "cpuset.mem_hardwall")
+	stats.CPUSetStats.MemHardwall, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "mem_hardwall"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.MemExclusive, err = fscommon.GetCgroupParamUint(path, "cpuset.mem_exclusive")
+	stats.CPUSetStats.MemExclusive, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "mem_exclusive"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.MemoryMigrate, err = fscommon.GetCgroupParamUint(path, "cpuset.memory_migrate")
+	stats.CPUSetStats.MemoryMigrate, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "memory_migrate"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.MemorySpreadPage, err = fscommon.GetCgroupParamUint(path, "cpuset.memory_spread_page")
+	stats.CPUSetStats.MemorySpreadPage, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "memory_spread_page"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.MemorySpreadSlab, err = fscommon.GetCgroupParamUint(path, "cpuset.memory_spread_slab")
+	stats.CPUSetStats.MemorySpreadSlab, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "memory_spread_slab"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.MemoryPressure, err = fscommon.GetCgroupParamUint(path, "cpuset.memory_pressure")
+	stats.CPUSetStats.MemoryPressure, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "memory_pressure"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.SchedLoadBalance, err = fscommon.GetCgroupParamUint(path, "cpuset.sched_load_balance")
+	stats.CPUSetStats.SchedLoadBalance, err = fscommon.GetCgroupParamUint(path, cpusetFile(path, "sched_load_balance"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	stats.CPUSetStats.SchedRelaxDomainLevel, err = fscommon.GetCgroupParamInt(path, "cpuset.sched_relax_domain_level")
+	stats.CPUSetStats.SchedRelaxDomainLevel, err = fscommon.GetCgroupParamInt(path, cpusetFile(path, "sched_relax_domain_level"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -171,10 +206,10 @@ func (s *CpusetGroup) ApplyDir(dir string, r *cgroups.Resources, pid int) error 
 }
 
 func getCpusetSubsystemSettings(parent string) (cpus, mems string, err error) {
-	if cpus, err = cgroups.ReadFile(parent, "cpuset.cpus"); err != nil {
+	if cpus, err = cgroups.ReadFile(parent, cpusetFile(parent, "cpus")); err != nil {
 		return
 	}
-	if mems, err = cgroups.ReadFile(parent, "cpuset.mems"); err != nil {
+	if mems, err = cgroups.ReadFile(parent, cpusetFile(parent, "mems")); err != nil {
 		return
 	}
 	return cpus, mems, nil
@@ -220,12 +255,12 @@ func cpusetCopyIfNeeded(current, parent string) error {
 	}
 
 	if isEmptyCpuset(currentCpus) {
-		if err := cgroups.WriteFile(current, "cpuset.cpus", parentCpus); err != nil {
+		if err := cgroups.WriteFile(current, cpusetFile(current, "cpus"), parentCpus); err != nil {
 			return err
 		}
 	}
 	if isEmptyCpuset(currentMems) {
-		if err := cgroups.WriteFile(current, "cpuset.mems", parentMems); err != nil {
+		if err := cgroups.WriteFile(current, cpusetFile(current, "mems"), parentMems); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Android mounts cgroup v1 with noprefix. Related to https://github.com/opencontainers/runc/issues/4443

```
# mount | grep cgroup
none on /dev/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
none on /dev/cpuctl type cgroup (rw,nosuid,nodev,noexec,relatime,cpu)
none on /dev/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset,noprefix,release_agent=/sbin/cpuset_release_agent)
none on /dev/memcg type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
none on /dev/stune type cgroup (rw,nosuid,nodev,noexec,relatime,schedtune)
none on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime)
```

```
ls -l /dev/cpuset
total 0
drwxr-xr-x. 2 system system 0 May 29  1970 background
drwxr-xr-x. 2 system system 0 May 29  1970 camera-daemon
-rw-r--r--. 1 root   root   0 Nov  5 19:48 cgroup.clone_children
-rw-rw-r--. 1 system system 0 May 29  1970 cgroup.procs
-r--r--r--. 1 root   root   0 Nov  5 19:48 cgroup.sane_behavior
-rw-r--r--. 1 root   root   0 Nov  5 19:48 cpu_exclusive
-rw-r--r--. 1 root   root   0 May 29  1970 cpus
-r--r--r--. 1 root   root   0 Nov  5 19:48 effective_cpus
-r--r--r--. 1 root   root   0 Nov  5 19:48 effective_mems
drwxr-xr-x. 2 system system 0 May 29  1970 foreground
-rw-r--r--. 1 root   root   0 Nov  5 19:48 mem_exclusive
-rw-r--r--. 1 root   root   0 Nov  5 19:48 mem_hardwall
-rw-r--r--. 1 root   root   0 Nov  5 19:48 memory_migrate
-r--r--r--. 1 root   root   0 Nov  5 19:48 memory_pressure
-rw-r--r--. 1 root   root   0 Nov  5 19:48 memory_pressure_enabled
-rw-r--r--. 1 root   root   0 Nov  5 19:48 memory_spread_page
-rw-r--r--. 1 root   root   0 Nov  5 19:48 memory_spread_slab
-rw-r--r--. 1 root   root   0 May 29  1970 mems
-rw-r--r--. 1 root   root   0 Nov  5 19:48 notify_on_release
-rw-r--r--. 1 root   root   0 Nov  5 19:48 release_agent
drwxr-xr-x. 2 system system 0 May 29  1970 restricted
-rw-r--r--. 1 root   root   0 Nov  5 19:48 sched_load_balance
-rw-r--r--. 1 root   root   0 Nov  5 19:48 sched_relax_domain_level
drwxrwxr-x. 2 system system 0 May 29  1970 system-background
-rw-rw-r--. 1 system system 0 May 29  1970 tasks
drwxr-xr-x. 2 system system 0 May 29  1970 top-app
```