### PR TITLE
MAINTAINERS: move dqminh and hqhq to EMERITUS

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -8,5 +8,7 @@ contributions to our collective success:
  * Rohit Jnagal (@rjnagal)
  * Victor Marmol (@vmarmol)
  * Michael Crosby (@crosbymichael)
+ * Daniel, Dao Quang Minh (@dqminh)
+ * Qiang Huang (@hqhq)
 
 We thank these members for their service to the OCI community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,4 @@
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
-Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)
-Qiang Huang <h.huangqiang@huawei.com> (@hqhq)
 Aleksa Sarai <cyphar@cyphar.com> (@cyphar)
 Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (@AkihiroSuda)
 Kir Kolyshkin <kolyshkin@gmail.com> (@kolyshkin)


### PR DESCRIPTION
Daniel @dqminh and Qiang @hqhq are stepping down as runc maintainers,
not being able to contribute as much as they used to.

Thank you for all the hard work!

<hr>

Merging this PR requires a 2/3 vote (6) of everyone in the MAINTAINERS file:

 - [ ] Mrunal Patel (@mrunalp)
 - [x] Daniel, Dao Quang Minh (@dqminh)
 - [x] Qiang Huang (@hqhq)
 - [x] Aleksa Sarai (@cyphar)
 - [ ] Akihiro Suda (@AkihiroSuda)
 - [x] Kir Kolyshkin (@kolyshkin)
 - [x] Sebastiaan van Stijn (@thaJeztah)
 - [x] Li Fu Bang (@lifubang)
 - [ ] Rodrigo Campos (@rata)