### PR TITLE
libct/cg: fix an error of cgroup path removal

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -267,11 +267,12 @@ func RemovePath(path string) error {
 		return err
 	}
 	for _, info := range infos {
-		if info.IsDir() {
-			// We should remove subcgroup first.
-			if err = RemovePath(filepath.Join(path, info.Name())); err != nil {
-				break
-			}
+		if !info.IsDir() {
+			continue
+		}
+		// We should remove subcgroup first.
+		if err = RemovePath(filepath.Join(path, info.Name())); err != nil {
+			return err
 		}
 	}
 	if err == nil {

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -230,6 +230,11 @@ func rmdir(path string, retry bool) error {
 	tries := 10
 
 again:
+	// If we remove a non-exist dir in a ro mount point, it will
+	// return EROFS in `unix.Rmdir`, so we need to check first.
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
 	err := unix.Rmdir(path)
 	switch err { // nolint:errorlint // unix errors are bare
 	case nil, unix.ENOENT:

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -257,7 +257,13 @@ func RemovePath(path string) error {
 	}
 
 	infos, err := os.ReadDir(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Please keep this error eraser, or else it will return ErrNotExist
+			// for cgroupv2.
+			// Please see https://github.com/opencontainers/runc/issues/4518
+			return nil
+		}
 		return err
 	}
 	for _, info := range infos {


### PR DESCRIPTION
For cgroup path removal, when we try a fast way to remove the cgroup
path, there may be a small possibility race to return an error, though
the path was removed successfully, for example: EINTR, or other errors.
Then we will fall back to the traditional path walk removal, but there
is a regression if the path has been sucessfully removed, which was
introduced by d3d7f7d in #4102. We should erase the ErrNotExist error
when we open the cgroup path.

Fix: #4518 