### PR TITLE
runc delete: fix for rootless cgroup + ro cgroupfs

### DIFF
--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -251,11 +251,21 @@ again:
 // RemovePath aims to remove cgroup path. It does so recursively,
 // by removing any subdirectories (sub-cgroups) first.
 func RemovePath(path string) error {
-	// Try the fast path first.
+	// Try the fast path first; don't retry on EBUSY yet.
 	if err := rmdir(path, false); err == nil {
 		return nil
 	}
 
+	// There are many reasons why rmdir can fail, including:
+	// 1. cgroup have existing sub-cgroups;
+	// 2. cgroup (still) have some processes (that are about to vanish);
+	// 3. lack of permission (one example is read-only /sys/fs/cgroup mount,
+	//    in which case rmdir returns EROFS even for for a non-existent path,
+	//    see issue 4518).
+	//
+	// Using os.ReadDir here kills two birds with one stone: check if
+	// the directory exists (handling scenario 3 above), and use
+	// directory contents to remove sub-cgroups (handling scenario 1).
 	infos, err := os.ReadDir(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -263,14 +273,16 @@ func RemovePath(path string) error {
 		}
 		return err
 	}
+	// Let's remove sub-cgroups, if any.
 	for _, info := range infos {
 		if info.IsDir() {
-			// We should remove subcgroup first.
 			if err = RemovePath(filepath.Join(path, info.Name())); err != nil {
 				return err
 			}
 		}
 	}
+	// Finally, try rmdir again, this time with retries on EBUSY,
+	// which may help with scenario 2 above.
 	return rmdir(path, true)
 }
 


### PR DESCRIPTION
This is an alternative to #4520.

----

An issue with runc 1.2.0 was reported to buildkit and then here (#4518),
in which `runc delete` returns with an error, with the log saying:
    
> unable to destroy container: unable to remove container's cgroup: open /sys/fs/cgroup/snschvixiy3s74w74fjantrdg: no such file or directory
    
Apparently, what happens is runc is running with no cgroup access
(because /sys/fs/cgroup is mounted read-only). In this case error to
create a cgroup path (in runc create/run) is ignored, but cgroup removal
(in runc delete) is not.
    
This is caused by commit d3d7f7d, which changes the cgroup removal
logic in `RemovePath`, and contains a bug. In the current code, if the
initial rmdir has failed (in this case with `EROFS`), but the subsequent
`os.ReadDir` returns `ENOENT`, that error it is ultimately returned
(instead of being ignored -- since the path does not  exist, there is
nothing to remove).
    
This PR fixes the issue in 3 commits:
1. A minimal but sufficient fix for the issue, targeted for quick review and backport to v1.2.2.
2. An improvement to RemovePath logic (originally suggested by @thaJeztah [here](https://github.com/opencontainers/runc/pull/4520#pullrequestreview-2426512896)
3. An improvement to RemovePath comments, better explaining what's going on.

Only the first commit is changing the logic and fixing the issue -- the rest is mostly
cosmetic and "nice to have".

Fixes: #4518.

TODO: add a test case.