### PR TITLE
Revert "Temporary set vagrant to 2.4.1-1"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,8 +42,7 @@ task:
     echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
     sudo sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
     apt-get update
-    # Temporary set vagrant to 2.4.1-1  because of https://github.com/hashicorp/vagrant/pull/13532
-    apt-get install -y libvirt-daemon libvirt-daemon-system vagrant=2.4.1-1
+    apt-get install -y libvirt-daemon libvirt-daemon-system vagrant
     systemctl enable --now libvirtd
     apt-get build-dep -y vagrant ruby-libvirt
     apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev


### PR DESCRIPTION
This reverts commit 5000f1697c7562e8fbc725da99e457949d4db1c6.

Because vagrant v2.4.3 has out, and this version includes the bug patch mentioned in #4514.
Please see: https://github.com/hashicorp/vagrant/blob/v2.4.3/CHANGELOG.md
