### PR TITLE
Linux Network Devices

### DIFF
--- a/features.go
+++ b/features.go
@@ -63,6 +63,9 @@ var featuresCommand = cli.Command{
 						Enabled: &t,
 					},
 				},
+				NetDevices: &features.NetDevices{
+					Enabled: &t,
+				},
 			},
 			PotentiallyUnsafeConfigAnnotations: []string{
 				"bundle",

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/moby/sys/userns v0.1.0
 	github.com/mrunalp/fileutils v0.5.1
 	github.com/opencontainers/cgroups v0.0.2
-	github.com/opencontainers/runtime-spec v1.2.1
+	github.com/opencontainers/runtime-spec v1.2.2-0.20250401095657-e935f995dd67
 	github.com/opencontainers/selinux v1.12.0
 	github.com/seccomp/libseccomp-golang v0.11.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.17
 	github.com/vishvananda/netlink v1.3.1
+	github.com/vishvananda/netns v0.0.5
 	golang.org/x/net v0.41.0
 	golang.org/x/sys v0.33.0
 	google.golang.org/protobuf v1.36.6
@@ -30,5 +31,4 @@ require (
 	github.com/cilium/ebpf v0.17.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/vishvananda/netns v0.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/mrunalp/fileutils v0.5.1 h1:F+S7ZlNKnrwHfSwdlgNSkKo67ReVf8o9fel6C3dkm
 github.com/mrunalp/fileutils v0.5.1/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/cgroups v0.0.2 h1:A+mAPPMfgKNCEZUUtibESFx06uvhAmvo8sSz3Abwk7o=
 github.com/opencontainers/cgroups v0.0.2/go.mod h1:s8lktyhlGUqM7OSRL5P7eAW6Wb+kWPNvt4qvVfzA5vs=
-github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU8lpJfSlR0xww=
-github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.2.2-0.20250401095657-e935f995dd67 h1:Q+KewUGTMamIe6Q39xCD/T1NC1POmaTlWnhjikCrZHA=
+github.com/opencontainers/runtime-spec v1.2.2-0.20250401095657-e935f995dd67/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -119,6 +119,9 @@ type Config struct {
 	// The device nodes that should be automatically created within the container upon container start.  Note, make sure that the node is marked as allowed in the cgroup as well!
 	Devices []*devices.Device `json:"devices"`
 
+	// NetDevices are key-value pairs, keyed by network device name, moved to the container's network namespace.
+	NetDevices map[string]*LinuxNetDevice `json:"netDevices,omitempty"`
+
 	MountLabel string `json:"mount_label,omitempty"`
 
 	// Hostname optionally sets the container's hostname if provided.

--- a/libcontainer/configs/doc.go
+++ b/libcontainer/configs/doc.go
@@ -1,0 +1,2 @@
+// Package configs defines the structures and constants used for configuring a container
+package configs

--- a/libcontainer/configs/netdevices.go
+++ b/libcontainer/configs/netdevices.go
@@ -1,0 +1,7 @@
+package configs
+
+// LinuxNetDevice represents a single network device to be added to the container's network namespace.
+type LinuxNetDevice struct {
+	// Name of the device in the container namespace.
+	Name string `json:"name,omitempty"`
+}

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -24,6 +24,7 @@ func Validate(config *configs.Config) error {
 		cgroupsCheck,
 		rootfs,
 		network,
+		netdevices,
 		uts,
 		security,
 		namespaces,
@@ -66,6 +67,43 @@ func rootfs(config *configs.Config) error {
 	}
 	if filepath.Clean(config.Rootfs) != cleaned {
 		return errors.New("invalid rootfs: not an absolute path, or a symlink")
+	}
+	return nil
+}
+
+// https://elixir.bootlin.com/linux/v6.12/source/net/core/dev.c#L1066
+func devValidName(name string) bool {
+	if len(name) == 0 || len(name) > unix.IFNAMSIZ {
+		return false
+	}
+	if name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, "/: ") {
+		return false
+	}
+	return true
+}
+
+func netdevices(config *configs.Config) error {
+	if len(config.NetDevices) == 0 {
+		return nil
+	}
+	if !config.Namespaces.Contains(configs.NEWNET) {
+		return errors.New("unable to move network devices without a NET namespace")
+	}
+
+	if config.RootlessEUID || config.RootlessCgroups {
+		return errors.New("network devices are not supported for rootless containers")
+	}
+
+	for name, netdev := range config.NetDevices {
+		if !devValidName(name) {
+			return fmt.Errorf("invalid network device name %q", name)
+		}
+		if netdev.Name != "" && !devValidName(netdev.Name) {
+			return fmt.Errorf("invalid network device name %q", netdev.Name)
+		}
 	}
 	return nil
 }

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -480,6 +480,14 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 			}
 		}
 
+		for name, netdev := range spec.Linux.NetDevices {
+			if config.NetDevices == nil {
+				config.NetDevices = make(map[string]*configs.LinuxNetDevice)
+			}
+			config.NetDevices[name] = &configs.LinuxNetDevice{
+				Name: netdev.Name,
+			}
+		}
 	}
 
 	// Set the host UID that should own the container's cgroup.

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function create_netns() {
+	# Create a temporary name for the test network namespace.
+	tmp=$(mktemp -u)
+	ns_name=$(basename "$tmp")
+
+	# Create the network namespace.
+	ip netns add "$ns_name"
+	ns_path=$(ip netns add "$ns_name" 2>&1 | sed -e 's/.*"\(.*\)".*/\1/')
+}
+
+function delete_netns() {
+	# Delete the namespace only if the ns_name variable is set.
+	[ -v ns_name ] && ip netns del "$ns_name"
+}
+
+function setup() {
+	requires root
+	setup_busybox
+
+	# Create a dummy interface to move to the container.
+	ip link add dummy0 type dummy
+}
+
+function teardown() {
+	ip link del dev dummy0
+	delete_netns
+	teardown_bundle
+}
+
+@test "move network device to container network namespace" {
+	update_config ' .linux.netDevices |= {"dummy0": {} }
+      		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+}
+
+@test "move network device to container network namespace and restore it back" {
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	update_config ' .linux.netDevices |= {"dummy0": {} }'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	# The network namespace owner controls the lifecycle of the interface.
+	# The interface should remain on the namespace after the container was killed.
+	runc delete --force test_busybox
+
+	# Move back the interface to the root namespace (pid 1).
+	ip netns exec "$ns_name" ip link set dev dummy0 netns 1
+
+	# Verify the interface is back in the root network namespace.
+	ip address show dev dummy0
+}
+
+@test "move network device to precreated container network namespace" {
+	update_config ' .linux.netDevices |= {"dummy0": {} }
+      		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
+
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+
+	# Verify the interface is still present in the network namespace.
+	ip netns exec "$ns_name" ip address show dev dummy0
+}
+
+@test "move network device to precreated container network namespace and set ip address with global scope" {
+	update_config ' .linux.netDevices |= {"dummy0": {} }
+      		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
+
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	global_ip="169.254.169.77/32"
+
+	# Set the interface down to avoid possible network problems.
+	# Set a custom address to the interface.
+	ip link set down dev dummy0
+	ip address add "$global_ip" dev dummy0
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"$global_ip "* ]]
+
+	# Verify the interface is still present in the network namespace.
+	run ip netns exec "$ns_name" ip address show dev dummy0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"$global_ip "* ]]
+}
+
+@test "move network device to precreated container network namespace and set ip address without global scope" {
+	update_config ' .linux.netDevices |= {"dummy0": {} }
+      		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
+
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	non_global_ip="127.0.0.33"
+
+	# Set the interface down to avoid possible network problems.
+	# Set a custom address to the interface.
+	ip link set down dev dummy0
+	ip address add "$non_global_ip" dev dummy0
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "$output" != *" $non_global_ip "* ]]
+
+	# Verify the interface is still present in the network namespace.
+	ip netns exec "$ns_name" ip address show dev dummy0
+}
+
+@test "move network device to precreated container network namespace and set mtu" {
+	update_config ' .linux.netDevices |= {"dummy0": {} }
+      		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
+
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	mtu_value=1789
+	# Cet a custom mtu to the interface.
+	ip link set mtu "$mtu_value" dev dummy0
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"mtu $mtu_value "* ]]
+
+	# Verify the interface is still present in the network namespace.
+	run ip netns exec "$ns_name" ip address show dev dummy0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"mtu $mtu_value "* ]]
+}
+
+@test "move network device to precreated container network namespace and set mac address" {
+	update_config ' .linux.netDevices |= {"dummy0": {} }
+      		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
+
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	mac_address="00:11:22:33:44:55"
+	# set a custom mac address to the interface
+	ip link set address "$mac_address" dev dummy0
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"ether $mac_address "* ]]
+
+	# Verify the interface is still present in the network namespace.
+	run ip netns exec "$ns_name" ip address show dev dummy0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"ether $mac_address "* ]]
+}
+
+@test "move network device to precreated container network namespace and rename" {
+	update_config ' .linux.netDevices |= { "dummy0": { "name" : "ctr_dummy0" } }
+      		| .process.args |= ["ip", "address", "show", "dev", "ctr_dummy0"]'
+
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+
+	# Verify the interface is still present in the network namespace.
+	ip netns exec "$ns_name" ip address show dev ctr_dummy0
+}
+
+@test "move network device to precreated container network namespace and rename and set mtu and mac and ip address" {
+	update_config ' .linux.netDevices |= { "dummy0": { "name" : "ctr_dummy0" } }
+	    		| .process.args |= ["ip", "address", "show", "dev", "ctr_dummy0"]'
+
+	# Tell runc which network namespace to use.
+	create_netns
+	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
+
+	mtu_value=1789
+	mac_address="00:11:22:33:44:55"
+	global_ip="169.254.169.77/32"
+
+	# Set a custom mtu to the interface.
+	ip link set mtu "$mtu_value" dev dummy0
+	# Set a custom mac address to the interface.
+	ip link set address "$mac_address" dev dummy0
+	# Set a custom ip address to the interface.
+	ip address add "$global_ip" dev dummy0
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "$output" == *" $global_ip "* ]]
+	[[ "$output" == *"ether $mac_address "* ]]
+	[[ "$output" == *"mtu $mtu_value "* ]]
+
+	# Verify the interface is still present in the network namespace.
+	run ip netns exec "$ns_name" ip address show dev ctr_dummy0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *" $global_ip "* ]]
+	[[ "$output" == *"ether $mac_address "* ]]
+	[[ "$output" == *"mtu $mtu_value "* ]]
+}

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -236,6 +236,8 @@ type Linux struct {
 	Namespaces []LinuxNamespace `json:"namespaces,omitempty"`
 	// Devices are a list of device nodes that are created for the container
 	Devices []LinuxDevice `json:"devices,omitempty"`
+	// NetDevices are key-value pairs, keyed by network device name on the host, moved to the container's network namespace.
+	NetDevices map[string]LinuxNetDevice `json:"netDevices,omitempty"`
 	// Seccomp specifies the seccomp security settings for the container.
 	Seccomp *LinuxSeccomp `json:"seccomp,omitempty"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.
@@ -489,6 +491,12 @@ type LinuxDevice struct {
 	UID *uint32 `json:"uid,omitempty"`
 	// Gid of the device.
 	GID *uint32 `json:"gid,omitempty"`
+}
+
+// LinuxNetDevice represents a single network device to be added to the container's network namespace
+type LinuxNetDevice struct {
+	// Name of the device in the container namespace
+	Name string `json:"name,omitempty"`
 }
 
 // LinuxDeviceCgroup represents a device rule for the devices specified to

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
@@ -48,6 +48,7 @@ type Linux struct {
 	Selinux         *Selinux         `json:"selinux,omitempty"`
 	IntelRdt        *IntelRdt        `json:"intelRdt,omitempty"`
 	MountExtensions *MountExtensions `json:"mountExtensions,omitempty"`
+	NetDevices      *NetDevices      `json:"netDevices,omitempty"`
 }
 
 // Cgroup represents the "cgroup" field.
@@ -140,6 +141,13 @@ type MountExtensions struct {
 type IDMap struct {
 	// Enabled represents whether idmap mounts supports is compiled in.
 	// Unrelated to whether the host supports it or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// NetDevices represents the "netDevices" field.
+type NetDevices struct {
+	// Enabled is true if network devices support is compiled in.
 	// Nil value means "unknown", not "false".
 	Enabled *bool `json:"enabled,omitempty"`
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/opencontainers/cgroups/fscommon
 github.com/opencontainers/cgroups/internal/path
 github.com/opencontainers/cgroups/manager
 github.com/opencontainers/cgroups/systemd
-# github.com/opencontainers/runtime-spec v1.2.1
+# github.com/opencontainers/runtime-spec v1.2.2-0.20250401095657-e935f995dd67
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/runtime-spec/specs-go/features


### PR DESCRIPTION
Implementation of https://github.com/opencontainers/runtime-spec/pull/1271

It implements the new proposal to the OCI spec to be able to specify Network Devices that get attached ~detached~ from the containers (updated to match the merged proposal https://github.com/opencontainers/runtime-spec/pull/1271)