### PR TITLE
Add `runc_nocriu` build tag to opt out of c/r

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,8 +76,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
+      - name: install deps
+        run: |
+          sudo apt update
+          sudo apt -y install libseccomp-dev
       - name: compile with no build tags
         run: make BUILDTAGS=""
+      - name: compile with runc_nocriu build tag
+        run: make EXTRA_BUILDTAGS="runc_nocriu"
 
   codespell:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -103,9 +103,17 @@ e.g. to disable seccomp:
 make BUILDTAGS=""
 ```
 
+To add some more build tags to the default set, use the `EXTRA_BUILDTAGS`
+make variable, e.g. to disable checkpoint/restore:
+
+```bash
+make EXTRA_BUILDTAGS="runc_nocriu"
+```
+
 | Build Tag     | Feature                               | Enabled by Default | Dependencies        |
 |---------------|---------------------------------------|--------------------|---------------------|
 | `seccomp`     | Syscall filtering using `libseccomp`. | yes                | `libseccomp`        |
+| `runc_nocriu` | **Disables** runc checkpoint/restore. | no                 | `criu`              |
 
 The following build tags were used earlier, but are now obsoleted:
  - **runc_nodmz** (since runc v1.2.1 runc dmz binary is dropped)

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	criu "github.com/checkpoint-restore/go-criu/v6/rpc"
 	"github.com/moby/sys/userns"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -132,6 +131,7 @@ func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
 		StatusFd:                context.Int("status-fd"),
 		LsmProfile:              context.String("lsm-profile"),
 		LsmMountContext:         context.String("lsm-mount-context"),
+		ManageCgroupsMode:       context.String("manage-cgroups-mode"),
 	}
 
 	// CRIU options below may or may not be set.
@@ -150,21 +150,6 @@ func criuOptions(context *cli.Context) (*libcontainer.CriuOpts, error) {
 			Address: address,
 			Port:    int32(portInt),
 		}
-	}
-
-	switch context.String("manage-cgroups-mode") {
-	case "":
-		// do nothing
-	case "soft":
-		opts.ManageCgroupsMode = criu.CriuCgMode_SOFT
-	case "full":
-		opts.ManageCgroupsMode = criu.CriuCgMode_FULL
-	case "strict":
-		opts.ManageCgroupsMode = criu.CriuCgMode_STRICT
-	case "ignore":
-		opts.ManageCgroupsMode = criu.CriuCgMode_IGNORE
-	default:
-		return nil, errors.New("Invalid manage-cgroups-mode value")
 	}
 
 	// runc doesn't manage network devices and their configuration.

--- a/libcontainer/criu_disabled_linux.go
+++ b/libcontainer/criu_disabled_linux.go
@@ -1,0 +1,15 @@
+//go:build runc_nocriu
+
+package libcontainer
+
+import "errors"
+
+var ErrNoCR = errors.New("this runc binary has not been compiled with checkpoint/restore support enabled (runc_nocriu)")
+
+func (c *Container) Restore(process *Process, criuOpts *CriuOpts) error {
+	return ErrNoCR
+}
+
+func (c *Container) Checkpoint(criuOpts *CriuOpts) error {
+	return ErrNoCR
+}

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -295,6 +295,11 @@ func (c *Container) Checkpoint(criuOpts *CriuOpts) error {
 		return errors.New("invalid directory to save checkpoint")
 	}
 
+	cgMode, err := criuCgMode(criuOpts.ManageCgroupsMode)
+	if err != nil {
+		return err
+	}
+
 	// Since a container can be C/R'ed multiple times,
 	// the checkpoint directory may already exist.
 	if err := os.Mkdir(criuOpts.ImagesDirectory, 0o700); err != nil && !os.IsExist(err) {
@@ -309,22 +314,23 @@ func (c *Container) Checkpoint(criuOpts *CriuOpts) error {
 	defer imageDir.Close()
 
 	rpcOpts := criurpc.CriuOpts{
-		ImagesDirFd:     proto.Int32(int32(imageDir.Fd())),
-		LogLevel:        proto.Int32(4),
-		LogFile:         proto.String(logFile),
-		Root:            proto.String(c.config.Rootfs),
-		ManageCgroups:   proto.Bool(true),
-		NotifyScripts:   proto.Bool(true),
-		Pid:             proto.Int32(int32(c.initProcess.pid())),
-		ShellJob:        proto.Bool(criuOpts.ShellJob),
-		LeaveRunning:    proto.Bool(criuOpts.LeaveRunning),
-		TcpEstablished:  proto.Bool(criuOpts.TcpEstablished),
-		ExtUnixSk:       proto.Bool(criuOpts.ExternalUnixConnections),
-		FileLocks:       proto.Bool(criuOpts.FileLocks),
-		EmptyNs:         proto.Uint32(criuOpts.EmptyNs),
-		OrphanPtsMaster: proto.Bool(true),
-		AutoDedup:       proto.Bool(criuOpts.AutoDedup),
-		LazyPages:       proto.Bool(criuOpts.LazyPages),
+		ImagesDirFd:       proto.Int32(int32(imageDir.Fd())),
+		LogLevel:          proto.Int32(4),
+		LogFile:           proto.String(logFile),
+		Root:              proto.String(c.config.Rootfs),
+		ManageCgroups:     proto.Bool(true), // Obsoleted by ManageCgroupsMode.
+		ManageCgroupsMode: &cgMode,
+		NotifyScripts:     proto.Bool(true),
+		Pid:               proto.Int32(int32(c.initProcess.pid())),
+		ShellJob:          proto.Bool(criuOpts.ShellJob),
+		LeaveRunning:      proto.Bool(criuOpts.LeaveRunning),
+		TcpEstablished:    proto.Bool(criuOpts.TcpEstablished),
+		ExtUnixSk:         proto.Bool(criuOpts.ExternalUnixConnections),
+		FileLocks:         proto.Bool(criuOpts.FileLocks),
+		EmptyNs:           proto.Uint32(criuOpts.EmptyNs),
+		OrphanPtsMaster:   proto.Bool(true),
+		AutoDedup:         proto.Bool(criuOpts.AutoDedup),
+		LazyPages:         proto.Bool(criuOpts.LazyPages),
 	}
 
 	// if criuOpts.WorkDirectory is not set, criu default is used.
@@ -379,12 +385,6 @@ func (c *Container) Checkpoint(criuOpts *CriuOpts) error {
 	if criuOpts.ParentImage != "" {
 		rpcOpts.ParentImg = proto.String(criuOpts.ParentImage)
 		rpcOpts.TrackMem = proto.Bool(true)
-	}
-
-	// append optional manage cgroups mode
-	if criuOpts.ManageCgroupsMode != 0 {
-		mode := criuOpts.ManageCgroupsMode
-		rpcOpts.ManageCgroupsMode = &mode
 	}
 
 	var t criurpc.CriuReqType
@@ -634,6 +634,12 @@ func (c *Container) Restore(process *Process, criuOpts *CriuOpts) error {
 	if criuOpts.ImagesDirectory == "" {
 		return errors.New("invalid directory to restore checkpoint")
 	}
+
+	cgMode, err := criuCgMode(criuOpts.ManageCgroupsMode)
+	if err != nil {
+		return err
+	}
+
 	logDir := criuOpts.ImagesDirectory
 	imageDir, err := os.Open(criuOpts.ImagesDirectory)
 	if err != nil {
@@ -663,22 +669,23 @@ func (c *Container) Restore(process *Process, criuOpts *CriuOpts) error {
 	req := &criurpc.CriuReq{
 		Type: &t,
 		Opts: &criurpc.CriuOpts{
-			ImagesDirFd:     proto.Int32(int32(imageDir.Fd())),
-			EvasiveDevices:  proto.Bool(true),
-			LogLevel:        proto.Int32(4),
-			LogFile:         proto.String(logFile),
-			RstSibling:      proto.Bool(true),
-			Root:            proto.String(root),
-			ManageCgroups:   proto.Bool(true),
-			NotifyScripts:   proto.Bool(true),
-			ShellJob:        proto.Bool(criuOpts.ShellJob),
-			ExtUnixSk:       proto.Bool(criuOpts.ExternalUnixConnections),
-			TcpEstablished:  proto.Bool(criuOpts.TcpEstablished),
-			FileLocks:       proto.Bool(criuOpts.FileLocks),
-			EmptyNs:         proto.Uint32(criuOpts.EmptyNs),
-			OrphanPtsMaster: proto.Bool(true),
-			AutoDedup:       proto.Bool(criuOpts.AutoDedup),
-			LazyPages:       proto.Bool(criuOpts.LazyPages),
+			ImagesDirFd:       proto.Int32(int32(imageDir.Fd())),
+			EvasiveDevices:    proto.Bool(true),
+			LogLevel:          proto.Int32(4),
+			LogFile:           proto.String(logFile),
+			RstSibling:        proto.Bool(true),
+			Root:              proto.String(root),
+			ManageCgroups:     proto.Bool(true), // Obsoleted by ManageCgroupsMode.
+			ManageCgroupsMode: &cgMode,
+			NotifyScripts:     proto.Bool(true),
+			ShellJob:          proto.Bool(criuOpts.ShellJob),
+			ExtUnixSk:         proto.Bool(criuOpts.ExternalUnixConnections),
+			TcpEstablished:    proto.Bool(criuOpts.TcpEstablished),
+			FileLocks:         proto.Bool(criuOpts.FileLocks),
+			EmptyNs:           proto.Uint32(criuOpts.EmptyNs),
+			OrphanPtsMaster:   proto.Bool(true),
+			AutoDedup:         proto.Bool(criuOpts.AutoDedup),
+			LazyPages:         proto.Bool(criuOpts.LazyPages),
 		},
 	}
 
@@ -755,12 +762,6 @@ func (c *Container) Restore(process *Process, criuOpts *CriuOpts) error {
 
 	if criuOpts.EmptyNs&unix.CLONE_NEWNET == 0 {
 		c.restoreNetwork(req, criuOpts)
-	}
-
-	// append optional manage cgroups mode
-	if criuOpts.ManageCgroupsMode != 0 {
-		mode := criuOpts.ManageCgroupsMode
-		req.Opts.ManageCgroupsMode = &mode
 	}
 
 	var (
@@ -1183,4 +1184,21 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 		}
 	}
 	return nil
+}
+
+func criuCgMode(mode string) (criurpc.CriuCgMode, error) {
+	switch mode {
+	case "":
+		return criurpc.CriuCgMode_DEFAULT, nil
+	case "soft":
+		return criurpc.CriuCgMode_SOFT, nil
+	case "full":
+		return criurpc.CriuCgMode_FULL, nil
+	case "strict":
+		return criurpc.CriuCgMode_STRICT, nil
+	case "ignore":
+		return criurpc.CriuCgMode_IGNORE, nil
+	default:
+		return 0, errors.New("invalid manage-cgroups-mode value")
+	}
 }

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -1,3 +1,5 @@
+//go:build !runc_nocriu
+
 package libcontainer
 
 import (

--- a/libcontainer/criu_opts_linux.go
+++ b/libcontainer/criu_opts_linux.go
@@ -1,7 +1,5 @@
 package libcontainer
 
-import criu "github.com/checkpoint-restore/go-criu/v6/rpc"
-
 type CriuPageServerInfo struct {
 	Address string // IP address of CRIU page server
 	Port    int32  // port number of CRIU page server
@@ -24,11 +22,16 @@ type CriuOpts struct {
 	PreDump                 bool               // call criu predump to perform iterative checkpoint
 	PageServer              CriuPageServerInfo // allow to dump to criu page server
 	VethPairs               []VethPairName     // pass the veth to criu when restore
-	ManageCgroupsMode       criu.CriuCgMode    // dump or restore cgroup mode
 	EmptyNs                 uint32             // don't c/r properties for namespace from this mask
 	AutoDedup               bool               // auto deduplication for incremental dumps
 	LazyPages               bool               // restore memory pages lazily using userfaultfd
 	StatusFd                int                // fd for feedback when lazy server is ready
 	LsmProfile              string             // LSM profile used to restore the container
 	LsmMountContext         string             // LSM mount context value to use during restore
+
+	// ManageCgroupsMode tells how criu should manage cgroups during
+	// checkpoint or restore. Possible values are: "soft", "full",
+	// "strict", "ignore", or "" (empty string) for criu default.
+	// See https://criu.org/CGroups for more details.
+	ManageCgroupsMode string
 }


### PR DESCRIPTION
This allows to make a 17% smaller runc binary by not compiling in
checkpoint/restore support.   

It turns out that google.golang.org/protobuf package, used by go-criu,
is quite big, and go linker can't drop unused stuff if reflection is
used anywhere in the code.
    
Currently there's no alternative to using protobuf in go-criu, and since
not all users use c/r, let's provide them an option for a smaller
binary.
    
For the reference, here's top10 biggest vendored packages, as reported
by gsa[1]:
    
    $ gsa runc | grep vendor | head
    │ 8.59%   │ google.golang.org/protobuf                  │ 1.3 MB │ vendor    │
    │ 5.76%   │ github.com/opencontainers/runc              │ 865 kB │ vendor    │
    │ 4.05%   │ github.com/cilium/ebpf                      │ 608 kB │ vendor    │
    │ 2.86%   │ github.com/godbus/dbus/v5                   │ 429 kB │ vendor    │
    │ 1.25%   │ github.com/urfave/cli                       │ 188 kB │ vendor    │
    │ 0.90%   │ github.com/vishvananda/netlink              │ 135 kB │ vendor    │
    │ 0.59%   │ github.com/sirupsen/logrus                  │ 89 kB  │ vendor    │
    │ 0.56%   │ github.com/checkpoint-restore/go-criu/v6    │ 84 kB  │ vendor    │
    │ 0.51%   │ golang.org/x/sys                            │ 76 kB  │ vendor    │
    │ 0.47%   │ github.com/seccomp/libseccomp-golang        │ 71 kB  │ vendor    │
    
And here is a total binary size saving when `runc_nocriu` is used.
    
For non-stripped binaries:
    
    $ gsa runc-cr runc-nocr | tail -3
    │ -17.04% │ runc-cr                                  │ 15 MB    │ 12 MB    │ -2.6 MB │
    │         │ runc-nocr                                │          │          │         │
    └─────────┴──────────────────────────────────────────┴──────────┴──────────┴─────────┘
    
And for stripped binaries:
    
    │ -17.01% │ runc-cr-stripped                         │ 11 MB    │ 8.8 MB   │ -1.8 MB │
    │         │ runc-nocr-stripped                       │          │          │         │
    └─────────┴──────────────────────────────────────────┴──────────┴──────────┴─────────┘
    
[1]: https://github.com/Zxilly/go-size-analyzer