### PR TITLE
Add `runc_nosd` build tag to opt out of systemd support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,6 +84,8 @@ jobs:
         run: make BUILDTAGS=""
       - name: compile with runc_nocriu build tag
         run: make EXTRA_BUILDTAGS="runc_nocriu"
+      - name: compile with runc_nosd tag added
+        run: make EXTRA_BUILDTAGS="runc_nosd"
 
   codespell:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ make EXTRA_BUILDTAGS="runc_nocriu"
 |---------------|---------------------------------------|--------------------|---------------------|
 | `seccomp`     | Syscall filtering using `libseccomp`. | yes                | `libseccomp`        |
 | `runc_nocriu` | **Disables** runc checkpoint/restore. | no                 | `criu`              |
+| `runc_nosd`   | **Disables** systemd cgroup managers. | no                 | systemd             |
 
 The following build tags were used earlier, but are now obsoleted:
  - **runc_nodmz** (since runc v1.2.1 runc dmz binary is dropped)

--- a/libcontainer/cgroups/devices/devices.go
+++ b/libcontainer/cgroups/devices/devices.go
@@ -6,11 +6,10 @@ package devices
 
 import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 )
 
 func init() {
 	cgroups.DevicesSetV1 = setV1
 	cgroups.DevicesSetV2 = setV2
-	systemd.GenerateDeviceProps = systemdProperties
+	initSystemd()
 }

--- a/libcontainer/cgroups/devices/no_systemd.go
+++ b/libcontainer/cgroups/devices/no_systemd.go
@@ -1,0 +1,5 @@
+//go:build linux && runc_nosd
+
+package devices
+
+func initSystemd() {}

--- a/libcontainer/cgroups/devices/systemd.go
+++ b/libcontainer/cgroups/devices/systemd.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package devices
 
 import (

--- a/libcontainer/cgroups/devices/systemd.go
+++ b/libcontainer/cgroups/devices/systemd.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 
@@ -17,12 +16,12 @@ import (
 
 // systemdProperties takes the configured device rules and generates a
 // corresponding set of systemd properties to configure the devices correctly.
-func systemdProperties(r *configs.Resources, sdVer int) ([]systemdDbus.Property, error) {
+func systemdProperties(r *configs.Resources, sdVer int) (configs.SdProperties, error) {
 	if r.SkipDevices {
 		return nil, nil
 	}
 
-	properties := []systemdDbus.Property{
+	properties := configs.SdProperties{
 		// Always run in the strictest white-list mode.
 		newProp("DevicePolicy", "strict"),
 		// Empty the DeviceAllow array before filling it.
@@ -158,8 +157,8 @@ func systemdProperties(r *configs.Resources, sdVer int) ([]systemdDbus.Property,
 	return properties, nil
 }
 
-func newProp(name string, units interface{}) systemdDbus.Property {
-	return systemdDbus.Property{
+func newProp(name string, units interface{}) configs.SdProperty {
+	return configs.SdProperty{
 		Name:  name,
 		Value: dbus.MakeVariant(units),
 	}
@@ -235,10 +234,10 @@ type deviceAllowEntry struct {
 	Perms string
 }
 
-func allowAllDevices() []systemdDbus.Property {
+func allowAllDevices() configs.SdProperties {
 	// Setting mode to auto and removing all DeviceAllow rules
 	// results in allowing access to all devices.
-	return []systemdDbus.Property{
+	return configs.SdProperties{
 		newProp("DevicePolicy", "auto"),
 		newProp("DeviceAllow", []deviceAllowEntry{}),
 	}

--- a/libcontainer/cgroups/devices/systemd.go
+++ b/libcontainer/cgroups/devices/systemd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
@@ -241,4 +242,8 @@ func allowAllDevices() configs.SdProperties {
 		newProp("DevicePolicy", "auto"),
 		newProp("DeviceAllow", []deviceAllowEntry{}),
 	}
+}
+
+func initSystemd() {
+	systemd.GenerateDeviceProps = systemdProperties
 }

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -283,7 +283,7 @@ func systemdVersionAtoi(str string) (int, error) {
 	return ver, nil
 }
 
-func addCpuQuota(cm *dbusConnManager, properties *configs.SdProperties, quota int64, period uint64) {
+func addCPUQuota(cm *dbusConnManager, properties *configs.SdProperties, quota int64, period uint64) {
 	if period != 0 {
 		// systemd only supports CPUQuotaPeriodUSec since v242
 		sdVer := systemdVersion(cm)

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/devices.go
+++ b/libcontainer/cgroups/systemd/devices.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/no_systemd.go
+++ b/libcontainer/cgroups/systemd/no_systemd.go
@@ -1,0 +1,22 @@
+//go:build linux && runc_nosd
+
+package systemd
+
+import (
+	"errors"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func IsRunningSystemd() bool {
+	return false
+}
+
+func NewUnifiedManager(config *configs.Cgroup, path string) (cgroups.Manager, error) {
+	return nil, errors.New("no systemd support")
+}
+
+func NewLegacyManager(cg *configs.Cgroup, paths map[string]string) (cgroups.Manager, error) {
+	return nil, errors.New("no systemd support")
+}

--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/systemd_test.go
+++ b/libcontainer/cgroups/systemd/systemd_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
@@ -113,7 +112,7 @@ func TestUnifiedResToSystemdProps(t *testing.T) {
 		minVer   int
 		res      map[string]string
 		expError bool
-		expProps []systemdDbus.Property
+		expProps configs.SdProperties
 	}{
 		{
 			name: "empty map",
@@ -125,7 +124,7 @@ func TestUnifiedResToSystemdProps(t *testing.T) {
 			res: map[string]string{
 				"cpu.idle": "1",
 			},
-			expProps: []systemdDbus.Property{
+			expProps: configs.SdProperties{
 				newProp("CPUWeight", uint64(0)),
 			},
 		},
@@ -143,7 +142,7 @@ func TestUnifiedResToSystemdProps(t *testing.T) {
 				"cpu.idle":   "1",
 				"cpu.weight": "1000",
 			},
-			expProps: []systemdDbus.Property{
+			expProps: configs.SdProperties{
 				newProp("CPUWeight", uint64(0)),
 			},
 		},
@@ -154,7 +153,7 @@ func TestUnifiedResToSystemdProps(t *testing.T) {
 				"cpu.idle":   "0",
 				"cpu.weight": "1000",
 			},
-			expProps: []systemdDbus.Property{
+			expProps: configs.SdProperties{
 				newProp("CPUWeight", uint64(1000)),
 			},
 		},

--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -93,7 +93,7 @@ func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) (config
 			newProp("CPUShares", r.CpuShares))
 	}
 
-	addCpuQuota(cm, &properties, r.CpuQuota, r.CpuPeriod)
+	addCPUQuota(cm, &properties, r.CpuQuota, r.CpuPeriod)
 
 	if r.BlkioWeight != 0 {
 		properties = append(properties,

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -72,8 +72,8 @@ var legacySubsystems = []subsystem{
 	&fs.NameGroup{GroupName: "misc"},
 }
 
-func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
-	var properties []systemdDbus.Property
+func genV1ResourcesProperties(r *configs.Resources, cm *dbusConnManager) (configs.SdProperties, error) {
+	var properties configs.SdProperties
 
 	deviceProperties, err := generateDeviceProperties(r, cm)
 	if err != nil {
@@ -163,7 +163,7 @@ func (m *LegacyManager) Apply(pid int) error {
 		c          = m.cgroups
 		unitName   = getUnitName(c)
 		slice      = "system.slice"
-		properties []systemdDbus.Property
+		properties configs.SdProperties
 	)
 
 	m.mu.Lock()

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package systemd
 
 import (

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -96,7 +96,7 @@ func unifiedResToSystemdProps(cm *dbusConnManager, res map[string]string) (props
 
 		case "cpu.max":
 			// value: quota [period]
-			quota := int64(0) // 0 means "unlimited" for addCpuQuota, if period is set
+			quota := int64(0) // 0 means "unlimited" for addCPUQuota, if period is set
 			period := defCPUQuotaPeriod
 			sv := strings.Fields(v)
 			if len(sv) < 1 || len(sv) > 2 {
@@ -116,7 +116,7 @@ func unifiedResToSystemdProps(cm *dbusConnManager, res map[string]string) (props
 					return nil, fmt.Errorf("unified resource %q quota value conversion error: %w", k, err)
 				}
 			}
-			addCpuQuota(cm, &props, quota, period)
+			addCPUQuota(cm, &props, quota, period)
 
 		case "cpu.weight":
 			if shouldSetCPUIdle(cm, strings.TrimSpace(res["cpu.idle"])) {
@@ -257,7 +257,7 @@ func genV2ResourcesProperties(dirPath string, r *configs.Resources, cm *dbusConn
 		}
 	}
 
-	addCpuQuota(cm, &properties, r.CpuQuota, r.CpuPeriod)
+	addCPUQuota(cm, &properties, r.CpuQuota, r.CpuPeriod)
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -69,7 +69,7 @@ func shouldSetCPUIdle(cm *dbusConnManager, v string) bool {
 // For the list of keys, see https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 //
 // For the list of systemd unit properties, see systemd.resource-control(5).
-func unifiedResToSystemdProps(cm *dbusConnManager, res map[string]string) (props []systemdDbus.Property, _ error) {
+func unifiedResToSystemdProps(cm *dbusConnManager, res map[string]string) (props configs.SdProperties, _ error) {
 	var err error
 
 	for k, v := range res {
@@ -199,7 +199,7 @@ func unifiedResToSystemdProps(cm *dbusConnManager, res map[string]string) (props
 	return props, nil
 }
 
-func genV2ResourcesProperties(dirPath string, r *configs.Resources, cm *dbusConnManager) ([]systemdDbus.Property, error) {
+func genV2ResourcesProperties(dirPath string, r *configs.Resources, cm *dbusConnManager) (configs.SdProperties, error) {
 	// We need this check before setting systemd properties, otherwise
 	// the container is OOM-killed and the systemd unit is removed
 	// before we get to fsMgr.Set().
@@ -207,7 +207,7 @@ func genV2ResourcesProperties(dirPath string, r *configs.Resources, cm *dbusConn
 		return nil, err
 	}
 
-	var properties []systemdDbus.Property
+	var properties configs.SdProperties
 
 	// NOTE: This is of questionable correctness because we insert our own
 	//       devices eBPF program later. Two programs with identical rules
@@ -285,7 +285,7 @@ func (m *UnifiedManager) Apply(pid int) error {
 	var (
 		c          = m.cgroups
 		unitName   = getUnitName(c)
-		properties []systemdDbus.Property
+		properties configs.SdProperties
 	)
 
 	slice := "system.slice"

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -1,7 +1,6 @@
 package configs
 
 import (
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
@@ -37,7 +36,7 @@ type Cgroup struct {
 	// SystemdProps are any additional properties for systemd,
 	// derived from org.systemd.property.xxx annotations.
 	// Ignored unless systemd is used for managing cgroups.
-	SystemdProps []systemdDbus.Property `json:"-"`
+	SystemdProps SdProperties `json:"-"`
 
 	// Rootless tells if rootless cgroups should be used.
 	Rootless bool

--- a/libcontainer/configs/no_systemd.go
+++ b/libcontainer/configs/no_systemd.go
@@ -1,0 +1,8 @@
+//go:build linux && runc_nosd
+
+package configs
+
+type (
+	SdProperty   = int
+	SdProperties = int
+)

--- a/libcontainer/configs/systemd.go
+++ b/libcontainer/configs/systemd.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package configs
 
 import (

--- a/libcontainer/configs/systemd.go
+++ b/libcontainer/configs/systemd.go
@@ -1,0 +1,10 @@
+package configs
+
+import (
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+)
+
+type (
+	SdProperty   = systemdDbus.Property
+	SdProperties = []systemdDbus.Property
+)

--- a/libcontainer/specconv/no_systemd.go
+++ b/libcontainer/specconv/no_systemd.go
@@ -1,0 +1,20 @@
+//go:build linux && runc_nosd
+
+package specconv
+
+import (
+	"errors"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func initSystemdProps(spec *specs.Spec) (configs.SdProperties, error) {
+	var sp configs.SdProperties
+
+	return sp, nil
+}
+
+func createCgroupConfigSystemd(opts *CreateOpts, c *configs.Cgroup) error {
+	return errors.New("no systemd support")
+}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	dbus "github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
@@ -630,98 +629,6 @@ func getLinuxPersonalityFromStr(domain string) (int, error) {
 		return configs.PerLinux, nil
 	}
 	return -1, fmt.Errorf("invalid personality domain %s", domain)
-}
-
-// Some systemd properties are documented as having "Sec" suffix
-// (e.g. TimeoutStopSec) but are expected to have "USec" suffix
-// here, so let's provide conversion to improve compatibility.
-func convertSecToUSec(value dbus.Variant) (dbus.Variant, error) {
-	var sec uint64
-	const M = 1000000
-	vi := value.Value()
-	switch value.Signature().String() {
-	case "y":
-		sec = uint64(vi.(byte)) * M
-	case "n":
-		sec = uint64(vi.(int16)) * M
-	case "q":
-		sec = uint64(vi.(uint16)) * M
-	case "i":
-		sec = uint64(vi.(int32)) * M
-	case "u":
-		sec = uint64(vi.(uint32)) * M
-	case "x":
-		sec = uint64(vi.(int64)) * M
-	case "t":
-		sec = vi.(uint64) * M
-	case "d":
-		sec = uint64(vi.(float64) * M)
-	default:
-		return value, errors.New("not a number")
-	}
-	return dbus.MakeVariant(sec), nil
-}
-
-func initSystemdProps(spec *specs.Spec) (configs.SdProperties, error) {
-	const keyPrefix = "org.systemd.property."
-	var sp configs.SdProperties
-
-	for k, v := range spec.Annotations {
-		name := strings.TrimPrefix(k, keyPrefix)
-		if len(name) == len(k) { // prefix not there
-			continue
-		}
-		if err := checkPropertyName(name); err != nil {
-			return nil, fmt.Errorf("annotation %s name incorrect: %w", k, err)
-		}
-		value, err := dbus.ParseVariant(v, dbus.Signature{})
-		if err != nil {
-			return nil, fmt.Errorf("annotation %s=%s value parse error: %w", k, v, err)
-		}
-		// Check for Sec suffix.
-		if trimName := strings.TrimSuffix(name, "Sec"); len(trimName) < len(name) {
-			// Check for a lowercase ascii a-z just before Sec.
-			if ch := trimName[len(trimName)-1]; ch >= 'a' && ch <= 'z' {
-				// Convert from Sec to USec.
-				name = trimName + "USec"
-				value, err = convertSecToUSec(value)
-				if err != nil {
-					return nil, fmt.Errorf("annotation %s=%s value parse error: %w", k, v, err)
-				}
-			}
-		}
-		sp = append(sp, configs.SdProperty{Name: name, Value: value})
-	}
-
-	return sp, nil
-}
-
-func createCgroupConfigSystemd(opts *CreateOpts, c *configs.Cgroup) error {
-	spec := opts.Spec
-
-	sp, err := initSystemdProps(spec)
-	if err != nil {
-		return err
-	}
-	c.SystemdProps = sp
-
-	if spec.Linux == nil || spec.Linux.CgroupsPath == "" {
-		// Default for c.Parent is set by systemd cgroup drivers.
-		c.ScopePrefix = "runc"
-		c.Name = opts.CgroupName
-	} else {
-		// Parse the path from expected "slice:prefix:name"
-		// for e.g. "system.slice:docker:1234"
-		parts := strings.Split(spec.Linux.CgroupsPath, ":")
-		if len(parts) != 3 {
-			return fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups, got %q instead", spec.Linux.CgroupsPath)
-		}
-		c.Parent = parts[0]
-		c.ScopePrefix = parts[1]
-		c.Name = parts[2]
-	}
-
-	return nil
 }
 
 func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*configs.Cgroup, error) {

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	dbus "github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -663,9 +662,9 @@ func convertSecToUSec(value dbus.Variant) (dbus.Variant, error) {
 	return dbus.MakeVariant(sec), nil
 }
 
-func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
+func initSystemdProps(spec *specs.Spec) (configs.SdProperties, error) {
 	const keyPrefix = "org.systemd.property."
-	var sp []systemdDbus.Property
+	var sp configs.SdProperties
 
 	for k, v := range spec.Annotations {
 		name := strings.TrimPrefix(k, keyPrefix)
@@ -691,7 +690,7 @@ func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
 				}
 			}
 		}
-		sp = append(sp, systemdDbus.Property{Name: name, Value: value})
+		sp = append(sp, configs.SdProperty{Name: name, Value: value})
 	}
 
 	return sp, nil

--- a/libcontainer/specconv/systemd.go
+++ b/libcontainer/specconv/systemd.go
@@ -1,0 +1,103 @@
+package specconv
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	dbus "github.com/godbus/dbus/v5"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Some systemd properties are documented as having "Sec" suffix
+// (e.g. TimeoutStopSec) but are expected to have "USec" suffix
+// here, so let's provide conversion to improve compatibility.
+func convertSecToUSec(value dbus.Variant) (dbus.Variant, error) {
+	var sec uint64
+	const M = 1000000
+	vi := value.Value()
+	switch value.Signature().String() {
+	case "y":
+		sec = uint64(vi.(byte)) * M
+	case "n":
+		sec = uint64(vi.(int16)) * M
+	case "q":
+		sec = uint64(vi.(uint16)) * M
+	case "i":
+		sec = uint64(vi.(int32)) * M
+	case "u":
+		sec = uint64(vi.(uint32)) * M
+	case "x":
+		sec = uint64(vi.(int64)) * M
+	case "t":
+		sec = vi.(uint64) * M
+	case "d":
+		sec = uint64(vi.(float64) * M)
+	default:
+		return value, errors.New("not a number")
+	}
+	return dbus.MakeVariant(sec), nil
+}
+
+func initSystemdProps(spec *specs.Spec) (configs.SdProperties, error) {
+	const keyPrefix = "org.systemd.property."
+	var sp configs.SdProperties
+
+	for k, v := range spec.Annotations {
+		name := strings.TrimPrefix(k, keyPrefix)
+		if len(name) == len(k) { // prefix not there
+			continue
+		}
+		if err := checkPropertyName(name); err != nil {
+			return nil, fmt.Errorf("annotation %s name incorrect: %w", k, err)
+		}
+		value, err := dbus.ParseVariant(v, dbus.Signature{})
+		if err != nil {
+			return nil, fmt.Errorf("annotation %s=%s value parse error: %w", k, v, err)
+		}
+		// Check for Sec suffix.
+		if trimName := strings.TrimSuffix(name, "Sec"); len(trimName) < len(name) {
+			// Check for a lowercase ascii a-z just before Sec.
+			if ch := trimName[len(trimName)-1]; ch >= 'a' && ch <= 'z' {
+				// Convert from Sec to USec.
+				name = trimName + "USec"
+				value, err = convertSecToUSec(value)
+				if err != nil {
+					return nil, fmt.Errorf("annotation %s=%s value parse error: %w", k, v, err)
+				}
+			}
+		}
+		sp = append(sp, configs.SdProperty{Name: name, Value: value})
+	}
+
+	return sp, nil
+}
+
+func createCgroupConfigSystemd(opts *CreateOpts, c *configs.Cgroup) error {
+	spec := opts.Spec
+
+	sp, err := initSystemdProps(spec)
+	if err != nil {
+		return err
+	}
+	c.SystemdProps = sp
+
+	if spec.Linux == nil || spec.Linux.CgroupsPath == "" {
+		// Default for c.Parent is set by systemd cgroup drivers.
+		c.ScopePrefix = "runc"
+		c.Name = opts.CgroupName
+	} else {
+		// Parse the path from expected "slice:prefix:name"
+		// for e.g. "system.slice:docker:1234"
+		parts := strings.Split(spec.Linux.CgroupsPath, ":")
+		if len(parts) != 3 {
+			return fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups, got %q instead", spec.Linux.CgroupsPath)
+		}
+		c.Parent = parts[0]
+		c.ScopePrefix = parts[1]
+		c.Name = parts[2]
+	}
+
+	return nil
+}

--- a/libcontainer/specconv/systemd.go
+++ b/libcontainer/specconv/systemd.go
@@ -1,3 +1,5 @@
+//go:build linux && !runc_nosd
+
 package specconv
 
 import (

--- a/rootless_linux.go
+++ b/rootless_linux.go
@@ -6,8 +6,6 @@ import (
 	"github.com/moby/sys/userns"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-
-	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 )
 
 func shouldUseRootlessCgroupManager(context *cli.Context) (bool, error) {
@@ -38,7 +36,7 @@ func shouldUseRootlessCgroupManager(context *cli.Context) (bool, error) {
 	// On error, we assume we are root. An error may happen during shelling out to `busctl` CLI,
 	// mostly when $DBUS_SESSION_BUS_ADDRESS is unset.
 	if context.GlobalBool("systemd-cgroup") {
-		ownerUID, err := systemd.DetectUID()
+		ownerUID, err := sdDetectUID()
 		if err != nil {
 			logrus.WithError(err).Debug("failed to get the OwnerUID value, assuming the value to be 0")
 			ownerUID = 0

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
@@ -388,17 +387,11 @@ func startContainer(context *cli.Context, action CtAct, criuOpts *libcontainer.C
 		}
 	}
 
-	// Support on-demand socket activation by passing file descriptors into the container init process.
-	listenFDs := []*os.File{}
-	if os.Getenv("LISTEN_FDS") != "" {
-		listenFDs = activation.Files(false)
-	}
-
 	r := &runner{
 		enableSubreaper: !context.Bool("no-subreaper"),
 		shouldDestroy:   !context.Bool("keep"),
 		container:       container,
-		listenFDs:       listenFDs,
+		listenFDs:       sdGetListenFDs(),
 		notifySocket:    notifySocket,
 		consoleSocket:   context.String("console-socket"),
 		pidfdSocket:     context.String("pidfd-socket"),

--- a/utils_no_systemd_linux.go
+++ b/utils_no_systemd_linux.go
@@ -1,0 +1,16 @@
+//go:build linux && runc_nosd
+
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+func sdGetListenFDs() []*os.File {
+	return nil
+}
+
+func sdDetectUID() (int, error) {
+	return -1, errors.New("no systemd support")
+}

--- a/utils_systemd_linux.go
+++ b/utils_systemd_linux.go
@@ -1,0 +1,23 @@
+//go:build linux && !runc_nosd
+
+package main
+
+import (
+	"os"
+
+	"github.com/coreos/go-systemd/v22/activation"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
+)
+
+func sdGetListenFDs() []*os.File {
+	// Support on-demand socket activation by passing file descriptors into the container init process.
+	listenFDs := []*os.File{}
+	if os.Getenv("LISTEN_FDS") != "" {
+		listenFDs = activation.Files(false)
+	}
+	return listenFDs
+}
+
+func sdDetectUID() (int, error) {
+	return systemd.DetectUID()
+}


### PR DESCRIPTION
This is a carry of #3959, please see details in there.

The changes from #3959 are:
 * all merge conflicts resolved
 * build tag renamed from `no_systemd` to `runc_nosd`
 
Using this makes runc binary size ~10% smaller (of which half is github.com/godbus/dbus/v5).

For the unstripped binary:
```
│ -9.91%  │ runc                                        │ 15 MB    │ 14 MB    │ -1.5 MB │
│         │ runc-nosd                                   │          │          │         │
```

For stripped binary:
```
│ -10.32% │ runc-stripped                               │ 11 MB    │ 9.5 MB   │ -1.1 MB │
│         │ runc-nosd-stripped                          │          │          │         │

```
