### PR TITLE
[1.2] cgroups: ebpf: use link.Anchor to check for BPF_F_REPLACE support

### DIFF
--- a/libcontainer/cgroups/devices/ebpf_linux.go
+++ b/libcontainer/cgroups/devices/ebpf_linux.go
@@ -107,14 +107,14 @@ func haveBpfProgReplace() bool {
 			},
 		})
 		if err != nil {
-			logrus.Debugf("checking for BPF_F_REPLACE support: ebpf.NewProgram failed: %v", err)
+			logrus.Warnf("checking for BPF_F_REPLACE support: ebpf.NewProgram failed: %v", err)
 			return
 		}
 		defer prog.Close()
 
 		devnull, err := os.Open("/dev/null")
 		if err != nil {
-			logrus.Debugf("checking for BPF_F_REPLACE support: open dummy target fd: %v", err)
+			logrus.Warnf("checking for BPF_F_REPLACE support: open dummy target fd: %v", err)
 			return
 		}
 		defer devnull.Close()
@@ -138,7 +138,11 @@ func haveBpfProgReplace() bool {
 			return
 		}
 		if !errors.Is(err, unix.EBADF) {
-			logrus.Debugf("checking for BPF_F_REPLACE: got unexpected (not EBADF or EINVAL) error: %v", err)
+			// If we see any new errors here, it's possible that there is a
+			// regression due to a cilium/ebpf update and the above EINVAL
+			// checks are not working. So, be loud about it so someone notices
+			// and we can get the issue fixed quicker.
+			logrus.Warnf("checking for BPF_F_REPLACE: got unexpected (not EBADF or EINVAL) error: %v", err)
 		}
 		haveBpfProgReplaceBool = true
 	})

--- a/libcontainer/cgroups/devices/ebpf_linux.go
+++ b/libcontainer/cgroups/devices/ebpf_linux.go
@@ -133,11 +133,10 @@ func haveBpfProgReplace() bool {
 			Attach:  ebpf.AttachCGroupDevice,
 			Flags:   unix.BPF_F_ALLOW_MULTI,
 		})
-		if errors.Is(err, unix.EINVAL) {
+		if errors.Is(err, ebpf.ErrNotSupported) || errors.Is(err, unix.EINVAL) {
 			// not supported
 			return
 		}
-		// attach_flags test succeeded.
 		if !errors.Is(err, unix.EBADF) {
 			logrus.Debugf("checking for BPF_F_REPLACE: got unexpected (not EBADF or EINVAL) error: %v", err)
 		}

--- a/libcontainer/cgroups/devices/ebpf_linux.go
+++ b/libcontainer/cgroups/devices/ebpf_linux.go
@@ -123,12 +123,15 @@ func haveBpfProgReplace() bool {
 		// BPF_CGROUP_DEVICE programs. If passing BPF_F_REPLACE gives us EINVAL
 		// we know that the feature isn't present.
 		err = link.RawAttachProgram(link.RawAttachProgramOptions{
-			// We rely on this fd being checked after attachFlags.
+			// We rely on this fd being checked after attachFlags in the kernel.
 			Target: int(devnull.Fd()),
-			// Attempt to "replace" bad fds with this program.
+			// Attempt to "replace" our BPF program with itself. This will
+			// always fail, but we should get -EINVAL if BPF_F_REPLACE is not
+			// supported.
+			Anchor:  link.ReplaceProgram(prog),
 			Program: prog,
 			Attach:  ebpf.AttachCGroupDevice,
-			Flags:   unix.BPF_F_ALLOW_MULTI | unix.BPF_F_REPLACE,
+			Flags:   unix.BPF_F_ALLOW_MULTI,
 		})
 		if errors.Is(err, unix.EINVAL) {
 			// not supported


### PR DESCRIPTION
Backport of #4548. ~~(Draft until merged.)~~

<hr>

In v0.13.0, cilium/ebpf stopped supporting setting BPF_F_REPLACE as an
explicit flag and instead requires us to use link.Anchor to specify
where the program should be attached.

Commit https://github.com/opencontainers/runc/commit/216175a9ca84cac30a570049a98e948f60c5f1a4 ("Upgrade Cilium's eBPF library version to 0.16")
did update this correctly for the actual attaching logic, but when
checking for kernel support we still passed BPF_F_REPLACE. This would
result in a generic error being returned, which our feature-support
checking logic would treat as being an error the indicates that
BPF_F_REPLACE *is* supported, resulting in a regression on pre-5.6
kernels.

It turns out that our debug logging saying that this unexpected error
was happening was being output as a result of this change, but nobody
noticed...

Fixes: https://github.com/opencontainers/runc/commit/216175a9ca84cac30a570049a98e948f60c5f1a4 ("Upgrade Cilium's eBPF library version to 0.16")
Fixes #3008
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>