### PR TITLE
GHA CI bumps

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.62
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,7 +127,7 @@ jobs:
         run : ./script/check-config.sh
 
   space-at-eol:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: rm -fr vendor


### PR DESCRIPTION
1. golangci-lint v1.60 --> v1.62
2. ubuntu-latest -> ubuntu-24.04