### PR TITLE
remove broken fuzzer from oss-fuzz build script

### DIFF
--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -8,6 +8,5 @@
 # OSS-fuzz environment.
 # More info about compile_go_fuzzer() can be found here:
 #     https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
-compile_go_fuzzer github.com/opencontainers/runc/libcontainer/userns FuzzUIDMap id_map_fuzzer linux,gofuzz
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/user FuzzUser user_fuzzer
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/configs FuzzUnmarshalJSON configs_fuzzer


### PR DESCRIPTION
The fuzzer has been removed, so this line should be removed too.