### PR TITLE
libct/cg/sd: set the DeviceAllow property before DevicePolicy

### DIFF
--- a/libcontainer/cgroups/devices/systemd.go
+++ b/libcontainer/cgroups/devices/systemd.go
@@ -23,10 +23,9 @@ func systemdProperties(r *cgroups.Resources, sdVer int) ([]systemdDbus.Property,
 	}
 
 	properties := []systemdDbus.Property{
+		newProp("DeviceAllow", []deviceAllowEntry{}),
 		// Always run in the strictest white-list mode.
 		newProp("DevicePolicy", "strict"),
-		// Empty the DeviceAllow array before filling it.
-		newProp("DeviceAllow", []deviceAllowEntry{}),
 	}
 
 	// Figure out the set of rules.
@@ -239,7 +238,7 @@ func allowAllDevices() []systemdDbus.Property {
 	// Setting mode to auto and removing all DeviceAllow rules
 	// results in allowing access to all devices.
 	return []systemdDbus.Property{
-		newProp("DevicePolicy", "auto"),
 		newProp("DeviceAllow", []deviceAllowEntry{}),
+		newProp("DevicePolicy", "auto"),
 	}
 }


### PR DESCRIPTION
Every unit created by runc need daemon reload since systemd v230. This breaks support for NVIDIA GPUs, see
https://github.com/opencontainers/runc/issues/3708#issuecomment-2216967210

Add a workaround for the below systemd issue.
https://github.com/systemd/systemd/issues/35710

Instead of filling the empty DeviceAllow array, a new array is created with allowed devices. Remove the comment about it, since it's misleading.

Closes #4568