### PR TITLE
add timens to default generated config.json

### DIFF
--- a/libcontainer/specconv/example.go
+++ b/libcontainer/specconv/example.go
@@ -144,6 +144,9 @@ func Example() *specs.Spec {
 				{
 					Type: specs.MountNamespace,
 				},
+				{
+					Type: specs.TimeNamespace,
+				},
 			},
 		},
 	}

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -142,16 +142,14 @@ function teardown() {
 	requires timens
 
 	# Create a detached container with the namespaces we want. We notably want
-	# to include both userns and timens, which require config-related
-	# configuration.
+	# to include userns, which require config-related configuration.
 	if [ $EUID -eq 0 ]; then
 		update_config '.linux.namespaces += [{"type": "user"}]
 			| .linux.uidMappings += [{"containerID": 0, "hostID": 100000, "size": 100}]
 			| .linux.gidMappings += [{"containerID": 0, "hostID": 200000, "size": 200}]'
 		remap_rootfs
 	fi
-	update_config '.linux.namespaces += [{"type": "time"}]
-		| .linux.timeOffsets = {
+	update_config '.linux.timeOffsets = {
 			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'

--- a/tests/integration/timens.bats
+++ b/tests/integration/timens.bats
@@ -28,8 +28,7 @@ function teardown() {
 	requires timens
 
 	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
-	update_config '.linux.namespaces += [{"type": "time"}]
-		| .linux.timeOffsets = null'
+	update_config '.linux.timeOffsets = null'
 
 	runc run test_busybox
 	[ "$status" -eq 0 ]
@@ -42,8 +41,7 @@ function teardown() {
 	requires timens
 
 	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
-	update_config '.linux.namespaces += [{"type": "time"}]
-		| .linux.timeOffsets = {
+	update_config '.linux.timeOffsets = {
 			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
@@ -64,8 +62,7 @@ function teardown() {
 	remap_rootfs
 
 	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
-	update_config '.linux.namespaces += [{"type": "time"}]
-		| .linux.timeOffsets = {
+	update_config '.linux.timeOffsets = {
 			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'


### PR DESCRIPTION
- add timens to generated config.json
- fix tests to account for timens present in default config.json