### PR TITLE
Fix process/config properties merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    IDs before calling libcontainer; it is recommended to use Go package
    github.com/moby/sys/user for that. (#3999)
 
+### Fixed
+ * `runc exec -p` no longer ignores specified `ioPriority` setting.
+   Similarly, libcontainer's `Container.Start` and `Container.Run`
+   methods no longer ignore `Process.IOPriority` setting. (#4585)
+
 ## [1.2.0] - 2024-10-22
 
 > できるときにできることをやるんだ。それが今だ。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    github.com/moby/sys/user for that. (#3999)
 
 ### Fixed
- * `runc exec -p` no longer ignores specified `ioPriority` setting.
-   Similarly, libcontainer's `Container.Start` and `Container.Run`
-   methods no longer ignore `Process.IOPriority` setting. (#4585)
+ * `runc exec -p` no longer ignores specified `ioPriority` and `scheduler`
+   settings. Similarly, libcontainer's `Container.Start` and `Container.Run`
+   methods no longer ignore `Process.IOPriority` and `Process.Scheduler`
+   settings. (#4585)
 
 ## [1.2.0] - 2024-10-22
 

--- a/libcontainer/capabilities/capabilities.go
+++ b/libcontainer/capabilities/capabilities.go
@@ -47,6 +47,9 @@ func KnownCapabilities() []string {
 // printing a warning instead.
 func New(capConfig *configs.Capabilities) (*Caps, error) {
 	var c Caps
+	if capConfig == nil {
+		return &c, nil
+	}
 
 	_, err := capMap()
 	if err != nil {
@@ -103,6 +106,9 @@ type Caps struct {
 
 // ApplyBoundingSet sets the capability bounding set to those specified in the whitelist.
 func (c *Caps) ApplyBoundingSet() error {
+	if c.pid == nil {
+		return nil
+	}
 	c.pid.Clear(capability.BOUNDING)
 	c.pid.Set(capability.BOUNDING, c.caps[capability.BOUNDING]...)
 	return c.pid.Apply(capability.BOUNDING)
@@ -110,6 +116,9 @@ func (c *Caps) ApplyBoundingSet() error {
 
 // Apply sets all the capabilities for the current process in the config.
 func (c *Caps) ApplyCaps() error {
+	if c.pid == nil {
+		return nil
+	}
 	c.pid.Clear(capability.CAPS | capability.BOUNDS)
 	for _, g := range []capability.CapType{
 		capability.EFFECTIVE,

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -704,8 +704,6 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 		PassedFilesCount: len(process.ExtraFiles),
 		ContainerID:      c.ID(),
 		NoNewPrivileges:  c.config.NoNewPrivileges,
-		RootlessEUID:     c.config.RootlessEUID,
-		RootlessCgroups:  c.config.RootlessCgroups,
 		AppArmorProfile:  c.config.AppArmorProfile,
 		ProcessLabel:     c.config.ProcessLabel,
 		Rlimits:          c.config.Rlimits,

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -689,6 +689,9 @@ func (c *Container) newSetnsProcess(p *Process, cmd *exec.Cmd, comm *processComm
 }
 
 func (c *Container) newInitConfig(process *Process) *initConfig {
+	// Set initial properties. For those properties that exist
+	// both in the container config and the process, use the ones
+	// from the container config first, and override them later.
 	cfg := &initConfig{
 		Config:           c.config,
 		Args:             process.Args,
@@ -710,6 +713,9 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 		ConsoleWidth:     process.ConsoleWidth,
 		ConsoleHeight:    process.ConsoleHeight,
 	}
+
+	// Overwrite config properties with ones from process.
+
 	if process.NoNewPrivileges != nil {
 		cfg.NoNewPrivileges = *process.NoNewPrivileges
 	}
@@ -722,6 +728,9 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 	if len(process.Rlimits) > 0 {
 		cfg.Rlimits = process.Rlimits
 	}
+
+	// Set misc properties.
+
 	if cgroups.IsCgroup2UnifiedMode() {
 		cfg.Cgroup2Path = c.cgroupManager.Path("")
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -700,7 +700,7 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 		GID:              process.GID,
 		AdditionalGroups: process.AdditionalGroups,
 		Cwd:              process.Cwd,
-		Capabilities:     process.Capabilities,
+		Capabilities:     c.config.Capabilities,
 		PassedFilesCount: len(process.ExtraFiles),
 		ContainerID:      c.ID(),
 		NoNewPrivileges:  c.config.NoNewPrivileges,
@@ -714,6 +714,9 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 
 	// Overwrite config properties with ones from process.
 
+	if process.Capabilities != nil {
+		cfg.Capabilities = process.Capabilities
+	}
 	if process.NoNewPrivileges != nil {
 		cfg.NoNewPrivileges = *process.NoNewPrivileges
 	}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -708,6 +708,7 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 		ProcessLabel:     c.config.ProcessLabel,
 		Rlimits:          c.config.Rlimits,
 		IOPriority:       c.config.IOPriority,
+		Scheduler:        c.config.Scheduler,
 		CreateConsole:    process.ConsoleSocket != nil,
 		ConsoleWidth:     process.ConsoleWidth,
 		ConsoleHeight:    process.ConsoleHeight,
@@ -732,6 +733,9 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 	}
 	if process.IOPriority != nil {
 		cfg.IOPriority = process.IOPriority
+	}
+	if process.Scheduler != nil {
+		cfg.Scheduler = process.Scheduler
 	}
 
 	// Set misc properties.

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -707,6 +707,7 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 		AppArmorProfile:  c.config.AppArmorProfile,
 		ProcessLabel:     c.config.ProcessLabel,
 		Rlimits:          c.config.Rlimits,
+		IOPriority:       c.config.IOPriority,
 		CreateConsole:    process.ConsoleSocket != nil,
 		ConsoleWidth:     process.ConsoleWidth,
 		ConsoleHeight:    process.ConsoleHeight,
@@ -728,6 +729,9 @@ func (c *Container) newInitConfig(process *Process) *initConfig {
 	}
 	if len(process.Rlimits) > 0 {
 		cfg.Rlimits = process.Rlimits
+	}
+	if process.IOPriority != nil {
+		cfg.IOPriority = process.IOPriority
 	}
 
 	// Set misc properties.

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -322,13 +322,7 @@ func finalizeNamespace(config *initConfig) error {
 		}
 	}
 
-	caps := &configs.Capabilities{}
-	if config.Capabilities != nil {
-		caps = config.Capabilities
-	} else if config.Config.Capabilities != nil {
-		caps = config.Config.Capabilities
-	}
-	w, err := capabilities.New(caps)
+	w, err := capabilities.New(config.Capabilities)
 	if err != nil {
 		return err
 	}

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -81,6 +81,7 @@ type initConfig struct {
 	NoNewPrivileges bool                  `json:"no_new_privileges"`
 	ProcessLabel    string                `json:"process_label"`
 	Rlimits         []configs.Rlimit      `json:"rlimits"`
+	IOPriority      *configs.IOPriority   `json:"io_priority,omitempty"`
 
 	// Miscellaneous properties, filled in by [Container.newInitConfig]
 	// unless documented otherwise.
@@ -623,7 +624,7 @@ func setupScheduler(config *configs.Config) error {
 	return nil
 }
 
-func setupIOPriority(config *configs.Config) error {
+func setupIOPriority(config *initConfig) error {
 	const ioprioWhoPgrp = 1
 
 	ioprio := config.IOPriority

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -82,6 +82,7 @@ type initConfig struct {
 	ProcessLabel    string                `json:"process_label"`
 	Rlimits         []configs.Rlimit      `json:"rlimits"`
 	IOPriority      *configs.IOPriority   `json:"io_priority,omitempty"`
+	Scheduler       *configs.Scheduler    `json:"scheduler,omitempty"`
 
 	// Miscellaneous properties, filled in by [Container.newInitConfig]
 	// unless documented otherwise.
@@ -607,7 +608,7 @@ func setupRlimits(limits []configs.Rlimit, pid int) error {
 	return nil
 }
 
-func setupScheduler(config *configs.Config) error {
+func setupScheduler(config *initConfig) error {
 	if config.Scheduler == nil {
 		return nil
 	}
@@ -616,7 +617,7 @@ func setupScheduler(config *configs.Config) error {
 		return err
 	}
 	if err := unix.SchedSetAttr(0, attr, 0); err != nil {
-		if errors.Is(err, unix.EPERM) && config.Cgroups.CpusetCpus != "" {
+		if errors.Is(err, unix.EPERM) && config.Config.Cgroups.CpusetCpus != "" {
 			return errors.New("process scheduler can't be used together with AllowedCPUs")
 		}
 		return fmt.Errorf("error setting scheduler: %w", err)

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -82,12 +82,6 @@ type initConfig struct {
 	ProcessLabel    string                `json:"process_label"`
 	Rlimits         []configs.Rlimit      `json:"rlimits"`
 
-	// Properties that only exist in container config.
-	// FIXME: they are also passed in Config above.
-
-	RootlessEUID    bool `json:"rootless_euid,omitempty"`
-	RootlessCgroups bool `json:"rootless_cgroups,omitempty"`
-
 	// Miscellaneous properties, filled in by [Container.newInitConfig]
 	// unless documented otherwise.
 
@@ -484,7 +478,7 @@ func setupUser(config *initConfig) error {
 	// There's nothing we can do about /etc/group entries, so we silently
 	// ignore setting groups here (since the user didn't explicitly ask us to
 	// set the group).
-	allowSupGroups := !config.RootlessEUID && string(bytes.TrimSpace(setgroups)) != "deny"
+	allowSupGroups := !config.Config.RootlessEUID && string(bytes.TrimSpace(setgroups)) != "deny"
 
 	if allowSupGroups {
 		if err := unix.Setgroups(config.AdditionalGroups); err != nil {

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -17,8 +17,11 @@ type processOperations interface {
 	pid() int
 }
 
-// Process specifies the configuration and IO for a process inside
-// a container.
+// Process defines the configuration and IO for a process inside a container.
+//
+// Note that some Process properties are also present in container configuration
+// ([configs.Config]). In all such cases, Process properties take precedence
+// over container configuration ones.
 type Process struct {
 	// The command to be run followed by any arguments.
 	Args []string
@@ -34,44 +37,54 @@ type Process struct {
 	// in addition to those that the user belongs to.
 	AdditionalGroups []int
 
-	// Cwd will change the processes current working directory inside the container's rootfs.
+	// Cwd will change the process's current working directory inside the container's rootfs.
 	Cwd string
 
-	// Stdin is a pointer to a reader which provides the standard input stream.
+	// Stdin is a reader which provides the standard input stream.
 	Stdin io.Reader
 
-	// Stdout is a pointer to a writer which receives the standard output stream.
+	// Stdout is a writer which receives the standard output stream.
 	Stdout io.Writer
 
-	// Stderr is a pointer to a writer which receives the standard error stream.
+	// Stderr is a writer which receives the standard error stream.
 	Stderr io.Writer
 
-	// ExtraFiles specifies additional open files to be inherited by the container
+	// ExtraFiles specifies additional open files to be inherited by the process.
 	ExtraFiles []*os.File
 
-	// open handles to cloned binaries -- see dmz.CloneSelfExe for more details
+	// Open handles to cloned binaries -- see dmz.CloneSelfExe for more details.
 	clonedExes []*os.File
 
-	// Initial sizings for the console
+	// Initial size for the console.
 	ConsoleWidth  uint16
 	ConsoleHeight uint16
 
-	// Capabilities specify the capabilities to keep when executing the process inside the container
-	// All capabilities not specified will be dropped from the processes capability mask
+	// Capabilities specify the capabilities to keep when executing the process.
+	// All capabilities not specified will be dropped from the processes capability mask.
+	//
+	// If not nil, takes precedence over container's [configs.Config.Capabilities].
 	Capabilities *configs.Capabilities
 
 	// AppArmorProfile specifies the profile to apply to the process and is
-	// changed at the time the process is execed
+	// changed at the time the process is executed.
+	//
+	// If not empty, takes precedence over container's [configs.Config.AppArmorProfile].
 	AppArmorProfile string
 
-	// Label specifies the label to apply to the process.  It is commonly used by selinux
+	// Label specifies the label to apply to the process. It is commonly used by selinux.
+	//
+	// If not empty, takes precedence over container's [configs.Config.ProcessLabel].
 	Label string
 
 	// NoNewPrivileges controls whether processes can gain additional privileges.
+	//
+	// If not nil, takes precedence over container's [configs.Config.NoNewPrivileges].
 	NoNewPrivileges *bool
 
-	// Rlimits specifies the resource limits, such as max open files, to set in the container
-	// If Rlimits are not set, the container will inherit rlimits from the parent process
+	// Rlimits specifies the resource limits, such as max open files, to set for the process.
+	// If unset, the process will inherit rlimits from the parent process.
+	//
+	// If not empty, takes precedence over container's [configs.Config.Rlimit].
 	Rlimits []configs.Rlimit
 
 	// ConsoleSocket provides the masterfd console.

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -114,6 +114,9 @@ type Process struct {
 
 	Scheduler *configs.Scheduler
 
+	// IOPriority is a process I/O priority.
+	//
+	// If not empty, takes precedence over container's [configs.Config.IOPriority].
 	IOPriority *configs.IOPriority
 }
 

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -112,6 +112,9 @@ type Process struct {
 	// For cgroup v2, the only key allowed is "".
 	SubCgroupPaths map[string]string
 
+	// Scheduler represents the scheduling attributes for a process.
+	//
+	// If not empty, takes precedence over container's [configs.Config.Scheduler].
 	Scheduler *configs.Scheduler
 
 	// IOPriority is a process I/O priority.

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -106,7 +106,7 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 		root:            config.Rootfs,
 		label:           config.MountLabel,
 		cgroup2Path:     iConfig.Cgroup2Path,
-		rootlessCgroups: iConfig.RootlessCgroups,
+		rootlessCgroups: config.RootlessCgroups,
 		cgroupns:        config.Namespaces.Contains(configs.NEWCGROUP),
 	}
 	for _, m := range config.Mounts {

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -71,7 +71,7 @@ func (l *linuxSetnsInit) Init() error {
 		unix.Umask(int(*l.config.Config.Umask))
 	}
 
-	if err := setupScheduler(l.config.Config); err != nil {
+	if err := setupScheduler(l.config); err != nil {
 		return err
 	}
 

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -75,7 +75,7 @@ func (l *linuxSetnsInit) Init() error {
 		return err
 	}
 
-	if err := setupIOPriority(l.config.Config); err != nil {
+	if err := setupIOPriority(l.config); err != nil {
 		return err
 	}
 	// Tell our parent that we're ready to exec. This must be done before the

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -155,7 +155,7 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 
-	if err := setupScheduler(l.config.Config); err != nil {
+	if err := setupScheduler(l.config); err != nil {
 		return err
 	}
 

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -159,7 +159,7 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	if err := setupIOPriority(l.config.Config); err != nil {
+	if err := setupIOPriority(l.config); err != nil {
 		return err
 	}
 

--- a/tests/integration/ioprio.bats
+++ b/tests/integration/ioprio.bats
@@ -20,11 +20,25 @@ function teardown() {
 	# Check the init process.
 	runc exec test_ioprio ionice -p 1
 	[ "$status" -eq 0 ]
-	[[ "$output" = *'best-effort: prio 4'* ]]
+	[ "${lines[0]}" = 'best-effort: prio 4' ]
 
-	# Check the process made from the exec command.
+	# Check an exec process, which should derive ioprio from config.json.
 	runc exec test_ioprio ionice
 	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = 'best-effort: prio 4' ]
 
-	[[ "$output" = *'best-effort: prio 4'* ]]
+	# Check an exec with a priority taken from process.json,
+	# which should override the ioprio in config.json.
+	proc='
+{
+	"terminal": false,
+	"ioPriority": {
+		"class": "IOPRIO_CLASS_IDLE"
+	},
+	"args": [ "/usr/bin/ionice" ],
+	"cwd": "/"
+}'
+	runc exec --process <(echo "$proc") test_ioprio
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = 'idle' ]
 }

--- a/tests/integration/scheduler.bats
+++ b/tests/integration/scheduler.bats
@@ -12,17 +12,49 @@ function teardown() {
 }
 
 @test "scheduler is applied" {
-	update_config ' .process.scheduler = {"policy": "SCHED_DEADLINE", "nice": 19, "priority": 0, "runtime": 42000, "deadline": 1000000, "period": 1000000, }'
+	update_config ' .process.scheduler = {
+		"policy": "SCHED_BATCH",
+		"priority": 0,
+		"nice": 19
+	}'
 
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
 	[ "$status" -eq 0 ]
 
+	# Check init settings.
 	runc exec test_scheduler chrt -p 1
 	[ "$status" -eq 0 ]
-
-	[[ "${lines[0]}" == *"scheduling policy: SCHED_DEADLINE" ]]
+	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
 	[[ "${lines[1]}" == *"priority: 0" ]]
-	[[ "${lines[2]}" == *"runtime/deadline/period parameters: 42000/1000000/1000000" ]]
+
+	# Check exec settings derived from config.json.
+	runc exec test_scheduler sh -c 'chrt -p $$'
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
+	[[ "${lines[1]}" == *"priority: 0" ]]
+
+	# Another exec, with different scheduler settings.
+	proc='
+{
+	"terminal": false,
+	"args": [ "/bin/sleep", "600" ],
+	"cwd": "/",
+	"scheduler": {
+		"policy": "SCHED_DEADLINE",
+		"flags": [ "SCHED_FLAG_RESET_ON_FORK" ],
+		"nice": 19,
+		"priority": 0,
+		"runtime": 42000,
+		"deadline": 100000,
+		"period": 1000000
+	}
+}'
+	__runc exec -d --pid-file pid.txt --process <(echo "$proc") test_scheduler
+
+	run chrt -p "$(cat pid.txt)"
+	[[ "${lines[0]}" == *"scheduling policy: SCHED_DEADLINE|SCHED_RESET_ON_FORK" ]]
+	[[ "${lines[1]}" == *"priority: 0" ]]
+	[[ "${lines[2]}" == *"runtime/deadline/period parameters: 42000/100000/1000000" ]]
 }
 
 # Checks that runc emits a specific error when scheduling policy is used


### PR DESCRIPTION
runc exec (as well as libcontainer's `container.Run`/`container.Start`) has an interesting feature of deriving various process' properties from the runtime spec for container init (the `Process` entry in `config.json` aka spec).

This is mostly implemented via merging `Config` and `Process` properties into `initConfig`, which happens in [libcontainer/container_linux.go, func newInitConfig](https://github.com/opencontainers/runc/blob/610aa88ab201f289c05c2e262912d0630f46eb35/libcontainer/container_linux.go#L683-L721). Note how `initConfig` fields are taken from `c.config` first (they are there from spec's `Process`) and then are overwritten by properties of a particular process being run. These `initConfig` fields are then used to set up various process attributes.

Alas, this functionality (of merging process and config properties) is
 - spread over the libcontainer code;
 - not well documented;
 - have a few bugs.
 
 This PR is an attempt to improve the situation,
 - documenting the related data structures (first commit);
 - simplifying, unifying and documenting some of the merging code (intermediate commits);
 - fixing two actual bugs, related to process' IOPriority and Scheduler properties (last two commits).