### PR TITLE
Improvements to how `runc exec` is handled

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -432,11 +432,11 @@ func (c *Container) signal(s os.Signal) error {
 }
 
 func (c *Container) createExecFifo() (retErr error) {
-	rootuid, err := c.Config().HostRootUID()
+	rootuid, err := c.config.HostRootUID()
 	if err != nil {
 		return err
 	}
-	rootgid, err := c.Config().HostRootGID()
+	rootgid, err := c.config.HostRootGID()
 	if err != nil {
 		return err
 	}

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -43,9 +43,8 @@ func getDefaultImagePath() string {
 	return filepath.Join(cwd, "checkpoint")
 }
 
-// newProcess returns a new libcontainer Process with the arguments from the
-// spec and stdio from the current process.
-func newProcess(p specs.Process) (*libcontainer.Process, error) {
+// newProcess converts [specs.Process] to [libcontainer.Process].
+func newProcess(p *specs.Process) (*libcontainer.Process, error) {
 	lp := &libcontainer.Process{
 		Args:            p.Args,
 		Env:             p.Env,
@@ -221,7 +220,7 @@ func (r *runner) run(config *specs.Process) (int, error) {
 	if err = r.checkTerminal(config); err != nil {
 		return -1, err
 	}
-	process, err := newProcess(*config)
+	process, err := newProcess(config)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
A few small and specific patches around how `runc exec` is being set up.

No changes to functionality, relatively easy to review.

Please see individual commit descriptions for details.