### PR TITLE
utils: Handle close_range more gracefully

### DIFF
--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -103,7 +103,13 @@ func CloseExecFrom(minFd int) error {
 	// Use close_range(CLOSE_RANGE_CLOEXEC) if possible.
 	if haveCloseRangeCloexec() {
 		err := unix.CloseRange(uint(minFd), math.MaxInt32, unix.CLOSE_RANGE_CLOEXEC)
-		return os.NewSyscallError("close_range", err)
+		if err == nil {
+			return nil
+		}
+
+		logrus.Debugf("close_range failed, closing range one at a time (error: %v)", err)
+
+		// If close_range fails, we fall back to the standard loop.
 	}
 	// Otherwise, fall back to the standard loop.
 	return fdRangeFrom(minFd, unix.CloseOnExec)

--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -102,7 +102,7 @@ func fdRangeFrom(minFd int, fn fdFunc) error {
 func CloseExecFrom(minFd int) error {
 	// Use close_range(CLOSE_RANGE_CLOEXEC) if possible.
 	if haveCloseRangeCloexec() {
-		err := unix.CloseRange(uint(minFd), math.MaxUint, unix.CLOSE_RANGE_CLOEXEC)
+		err := unix.CloseRange(uint(minFd), math.MaxInt32, unix.CLOSE_RANGE_CLOEXEC)
 		return os.NewSyscallError("close_range", err)
 	}
 	// Otherwise, fall back to the standard loop.


### PR DESCRIPTION
This fixes 2 things:

1. The last argument needs to be at most a int32, so be sure to pass only that as the max (discovered under gvisor)
2. If close_range fails, don't error out, instead just close the fds the long way.