### PR TITLE
[1.2] CI: fix criu-dev compile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
       if: ${{ matrix.criu != '' }}
       run: |
         sudo apt -qy install \
-          libcap-dev libnet1-dev libnl-3-dev \
+          libcap-dev libnet1-dev libnl-3-dev uuid-dev \
           libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
         git clone https://github.com/checkpoint-restore/criu.git ~/criu
         (cd ~/criu && git checkout ${{ matrix.criu }} && sudo make install-criu)


### PR DESCRIPTION
As of [1], criu requires uuid library.

[1]: https://github.com/checkpoint-restore/criu/pull/2550/commits/9a2b7d6b3baa2b3183489ed9cebece039f9f488f

Cherry picked from commit bccaab89aea826e2d4c495d45b4665b53ccca0f2 / PR #4609. ~~Draft until that one is merged.~~