### PR TITLE
go.mod: Use 1.22.0 instead of 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/runc
 
-go 1.22
+go 1.22.0
 
 // Suggest toolchain 1.22.4 due to a fix in golang for libcontainer/nsenter/.
 // For more info, see: #4233


### PR DESCRIPTION
Before go 1.21, using "go 1.20" meant 1.20.0 and all patch releases, excluding rc releases of 1.20. However, since go 1.21, it means truncating everything after the 21: 1.21, 1.21rc2, and 1.21.3 all are accepted. See more info here:

* https://go.dev/doc/toolchain#version

Let's keep doing the same we always did and add the .0 for that. Other projects, like containerd and kubernetes, are also using the .0 now.