### PR TITLE
libc/int/userns: add build tag to C file

### DIFF
--- a/libcontainer/internal/userns/userns_maps_linux.c
+++ b/libcontainer/internal/userns/userns_maps_linux.c
@@ -1,3 +1,5 @@
+//go:build linux
+
 #define _GNU_SOURCE
 #include <fcntl.h>
 #include <sched.h>


### PR DESCRIPTION
This fixes k3s cross-compilation on Windows, broken by commit 1912d5988bbb37918 ("*: actually support joining a userns with a new container").

[@kolyshkin: commit message]

Fixes: 1912d5988bbb37918

----

As far as I can see, this is first mentioned in https://github.com/k3s-io/k3s/pull/9332 a year ago but was never reported to runc 😞 

Indeed, Go recognizes `//go:build` in C files, and also matches GOOS and GOARCH in file names even for `.c` files.

Also, I don't know how to reproduce it here (`GOOS=windows CGO_ENABLED=1 go build ./libcontainer/...` gives too many errors).