### PR TITLE
[1.2] libc/int/userns: add build tag to C file

### DIFF
--- a/libcontainer/internal/userns/userns_maps_linux.c
+++ b/libcontainer/internal/userns/userns_maps_linux.c
@@ -1,3 +1,5 @@
+//go:build linux
+
 #define _GNU_SOURCE
 #include <fcntl.h>
 #include <sched.h>


### PR DESCRIPTION
Backport of #4616 to release-1.2.

----

This fixes k3s cross-compilation on Windows, broken by commit 1912d5988bbb37918 ("*: actually support joining a userns with a new container").

[@kolyshkin: commit message]

Fixes: 1912d5988bbb37918

(cherry picked from commit ccb589bd7de3be12ca81e3f903f9e7bea1107eb2)