### PR TITLE
release: explicitly set --keyserver in release signing scripts

### DIFF
--- a/script/release_sign.sh
+++ b/script/release_sign.sh
@@ -108,7 +108,7 @@ trap 'rm -r "$tmp_gpgdir"' EXIT
 tmp_runc_gpgflags=("--homedir=$tmp_gpgdir" "--no-default-keyring" "--keyring=$project.keyring")
 gpg "${tmp_runc_gpgflags[@]}" --import <"$root/$project.keyring"
 
-tmp_seccomp_gpgflags=("--homedir=$tmp_gpgdir" "--no-default-keyring" "--keyring=seccomp.keyring")
+tmp_seccomp_gpgflags=("--homedir=$tmp_gpgdir" "--no-default-keyring" "--keyring=seccomp.keyring" "--keyserver=keys.openpgp.org")
 gpg "${tmp_seccomp_gpgflags[@]}" --recv-keys 0x47A68FCE37C7D7024FD65E11356CE62C2B524099
 gpg "${tmp_seccomp_gpgflags[@]}" --recv-keys 0x7100AADFAE6E6E940D2E0AD655E45A5AE8CA7C8A
 


### PR DESCRIPTION
On my machine, the --recv-keys steps to get upstream keys started
producing errors recently, and even setting a default keyserver in the
global gpg configuration doesn't seem to help:

  + gpg --homedir=/tmp/runc-sign-tmpkeyring.qm0IP6
        --no-default-keyring --keyring=seccomp.keyring
        --recv-keys 0x47A68FCE37C7D7024FD65E11356CE62C2B524099
  gpg: keybox '/tmp/runc-sign-tmpkeyring.qm0IP6/seccomp.keyring' created
  gpg: keyserver receive failed: No keyserver available

So just explicitly specify a reputable keyserver. Ideally we would use
an .onion-address keyserver to avoid potential targeted attacks but not
everybody runs a Tor proxy on their machine.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>