### PR TITLE
libc/utils: simplify CleanPath

### DIFF
--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -50,19 +50,19 @@ func CleanPath(path string) string {
 
 	// Ensure that all paths are cleaned (especially problematic ones like
 	// "/../../../../../" which can cause lots of issues).
-	path = filepath.Clean(path)
+
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
 
 	// If the path isn't absolute, we need to do more processing to fix paths
 	// such as "../../../../<etc>/some/path". We also shouldn't convert absolute
 	// paths to relative ones.
-	if !filepath.IsAbs(path) {
-		path = filepath.Clean(string(os.PathSeparator) + path)
-		// This can't fail, as (by definition) all paths are relative to root.
-		path, _ = filepath.Rel(string(os.PathSeparator), path)
-	}
+	path = filepath.Clean(string(os.PathSeparator) + path)
+	// This can't fail, as (by definition) all paths are relative to root.
+	path, _ = filepath.Rel(string(os.PathSeparator), path)
 
-	// Clean the path again for good measure.
-	return filepath.Clean(path)
+	return path
 }
 
 // stripRoot returns the passed path, stripping the root path if it was


### PR DESCRIPTION
This simplifies the code flow and basically removes the last `filepath.Clean`, which is not necessary in either case:
 - for absolute path, single `filepath.Clean` is sufficient (as it is guaranteed to remove all dot and dot-dot elements);
 - for relative path, `filepath.Rel` already calls `Clean` at the end (which is even documented).