### PR TITLE
CI: gha: rm ubuntu-20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04, actuated-arm64-6cpu-8gb]
+        os: [ubuntu-24.04, actuated-arm64-6cpu-8gb]
         go-version: [1.23.x, 1.24.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
@@ -172,8 +172,6 @@ jobs:
       run: sudo -E PATH="$PATH" script -e -c 'make local${{ matrix.rootless }}integration'
 
     - name: integration test (systemd driver)
-      # Skip rootless+systemd for ubuntu 20.04 because of cgroup v1.
-      if: ${{ !(matrix.os == 'ubuntu-20.04' && matrix.rootless == 'rootless') }}
       run: |
         # Delegate all cgroup v2 controllers to rootless user via --systemd-cgroup.
         # The default (since systemd v252) is "pids memory cpu".


### PR DESCRIPTION
There is an [announce] that Ubuntu 20.04 will be removed in April, and in March there will be a few "brown-out" dates/times when it won't work.

This leaves us with no other options than to remove ubuntu-20.04 from the testing matrix.

As a result, cgroup v1 testing will only be done on AlmaLinux 8 running on CirrusCI. It is probably going to be sufficient for the time being (until we deprecate cgroup v1).

If not, our options are
 - run Ubuntu 20.04 (or other cgroup v1 distro) in a VM on GHA;
 - switch to cirrus-ci.

[announce]: https://github.com/actions/runner-images/issues/11101