### PR TITLE
libct: don't send config to nsexec when joining an existing timens

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1146,8 +1146,9 @@ func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Namespa
 		Value: c.config.RootlessEUID,
 	})
 
-	// write boottime and monotonic time ns offsets.
-	if c.config.TimeOffsets != nil {
+	// write boottime and monotonic time ns offsets only when we are not joining an existing time ns
+	_, joinExistingTime := nsMaps[configs.NEWTIME]
+	if !joinExistingTime && c.config.TimeOffsets != nil {
 		var offsetSpec bytes.Buffer
 		for clock, offset := range c.config.TimeOffsets {
 			fmt.Fprintf(&offsetSpec, "%s %d %d\n", clock, offset.Secs, offset.Nanosecs)


### PR DESCRIPTION
Fix #4635 

When we exec a process in a container has private timens, we need to
join the init process's timens path, so, we should not send the timens
config to nsexec, otherwise, runc will try to update the process's time
ns configuration when joining the timens path.
We should configure the process's timens offset only when we need to
create new time namespace, we shouldn't do it if we are joining an
existing time namespace.