### PR TITLE
Retry direct unix package calls if observing EINTR

### DIFF
--- a/libcontainer/notify_v2_linux.go
+++ b/libcontainer/notify_v2_linux.go
@@ -2,6 +2,7 @@ package libcontainer
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"unsafe"
 
@@ -40,7 +41,11 @@ func registerMemoryEventV2(cgDir, evName, cgEvName string) (<-chan struct{}, err
 
 		for {
 			n, err := unix.Read(fd, buffer[:])
+			if err == unix.EINTR { //nolint:errorlint // unix errors are bare
+				continue
+			}
 			if err != nil {
+				err = os.NewSyscallError("read", err)
 				logrus.Warnf("unable to read event data from inotify, got error: %v", err)
 				return
 			}


### PR DESCRIPTION
It appears this similar pattern is done elsewhere in libcontainer. Unsure if it needs to be do everywhere unix. is used directly or not.

This was observed during a buildkit run, with this output:

```
runc run failed: unable to start container process: error during container init: reading from parent failed: fetch packet length from socket: interrupted system call
```