### PR TITLE
libcontainer: rename dmz -> exeseal

### DIFF
--- a/contrib/cmd/memfd-bind/memfd-bind.go
+++ b/contrib/cmd/memfd-bind/memfd-bind.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opencontainers/runc/libcontainer/dmz"
+	"github.com/opencontainers/runc/libcontainer/exeseal"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -101,7 +101,7 @@ func cleanup(path string) error {
 	return nil
 }
 
-// memfdClone is a memfd-only implementation of dmz.CloneBinary.
+// memfdClone is a memfd-only implementation of exeseal.CloneBinary.
 func memfdClone(path string) (*os.File, error) {
 	binFile, err := os.Open(path)
 	if err != nil {
@@ -113,7 +113,7 @@ func memfdClone(path string) (*os.File, error) {
 		return nil, fmt.Errorf("checking %s size: %w", path, err)
 	}
 	size := stat.Size()
-	memfd, sealFn, err := dmz.Memfd("/proc/self/exe")
+	memfd, sealFn, err := exeseal.Memfd("/proc/self/exe")
 	if err != nil {
 		return nil, fmt.Errorf("creating memfd failed: %w", err)
 	}
@@ -126,7 +126,7 @@ func memfdClone(path string) (*os.File, error) {
 	if err := sealFn(&memfd); err != nil {
 		return nil, fmt.Errorf("could not seal fd: %w", err)
 	}
-	if !dmz.IsCloned(memfd) {
+	if !exeseal.IsCloned(memfd) {
 		return nil, fmt.Errorf("cloned memfd is not properly sealed")
 	}
 	return memfd, nil

--- a/libcontainer/exeseal/cloned_binary_linux.go
+++ b/libcontainer/exeseal/cloned_binary_linux.go
@@ -1,4 +1,4 @@
-package dmz
+package exeseal
 
 import (
 	"errors"
@@ -224,7 +224,7 @@ func CloneSelfExe(tmpDir string) (*os.File, error) {
 	// around ~60% overhead during container startup.
 	overlayFile, err := sealedOverlayfs("/proc/self/exe", tmpDir)
 	if err == nil {
-		logrus.Debug("runc-dmz: using overlayfs for sealed /proc/self/exe") // used for tests
+		logrus.Debug("runc exeseal: using overlayfs for sealed /proc/self/exe") // used for tests
 		return overlayFile, nil
 	}
 	logrus.WithError(err).Debugf("could not use overlayfs for /proc/self/exe sealing -- falling back to making a temporary copy")

--- a/libcontainer/exeseal/overlayfs_linux.go
+++ b/libcontainer/exeseal/overlayfs_linux.go
@@ -1,4 +1,4 @@
-package dmz
+package exeseal
 
 import (
 	"fmt"

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -52,7 +52,7 @@ type Process struct {
 	// ExtraFiles specifies additional open files to be inherited by the process.
 	ExtraFiles []*os.File
 
-	// Open handles to cloned binaries -- see dmz.CloneSelfExe for more details.
+	// Open handles to cloned binaries -- see exeseal.CloneSelfExe for more details.
 	clonedExes []*os.File
 
 	// Initial size for the console.

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -131,10 +131,10 @@ function teardown() {
 	runc --debug run test_hello
 	[ "$status" -eq 0 ]
 	[[ "$output" = *"Hello World"* ]]
-	[[ "$output" = *"runc-dmz: using /proc/self/exe clone"* ]]
+	[[ "$output" = *"runc exeseal: using /proc/self/exe clone"* ]]
 	# runc will use fsopen("overlay") if it can.
 	if can_fsopen overlay; then
-		[[ "$output" = *"runc-dmz: using overlayfs for sealed /proc/self/exe"* ]]
+		[[ "$output" = *"runc exeseal: using overlayfs for sealed /proc/self/exe"* ]]
 	fi
 }
 


### PR DESCRIPTION
The "dmz" name was originally used because the libcontainer/dmz package
housed the runc-dmz binary, but since we removed it in commit
871057d863e8("drop runc-dmz solution according to overlay solution")
the name is an anachronism and we should just give it a more
self-explanatory name.

So, call it libcontainer/exeseal because the purpose of the package is
to provide tools to seal /proc/self/exe against attackers.

Closes #4516
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>