### PR TITLE
[1.2] libct/system: rm Fexecve

### DIFF
--- a/libcontainer/system/linux.go
+++ b/libcontainer/system/linux.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
-	"syscall"
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
@@ -41,49 +39,6 @@ func Exec(cmd string, args []string, env []string) error {
 			return &os.PathError{Op: "exec", Path: cmd, Err: err}
 		}
 	}
-}
-
-func execveat(fd uintptr, pathname string, args []string, env []string, flags int) error {
-	pathnamep, err := syscall.BytePtrFromString(pathname)
-	if err != nil {
-		return err
-	}
-
-	argvp, err := syscall.SlicePtrFromStrings(args)
-	if err != nil {
-		return err
-	}
-
-	envp, err := syscall.SlicePtrFromStrings(env)
-	if err != nil {
-		return err
-	}
-
-	_, _, errno := syscall.Syscall6(
-		unix.SYS_EXECVEAT,
-		fd,
-		uintptr(unsafe.Pointer(pathnamep)),
-		uintptr(unsafe.Pointer(&argvp[0])),
-		uintptr(unsafe.Pointer(&envp[0])),
-		uintptr(flags),
-		0,
-	)
-	return errno
-}
-
-func Fexecve(fd uintptr, args []string, env []string) error {
-	var err error
-	for {
-		err = execveat(fd, "", args, env, unix.AT_EMPTY_PATH)
-		if err != unix.EINTR { // nolint:errorlint // unix errors are bare
-			break
-		}
-	}
-	if err == unix.ENOSYS { // nolint:errorlint // unix errors are bare
-		// Fallback to classic /proc/self/fd/... exec.
-		return Exec("/proc/self/fd/"+strconv.Itoa(int(fd)), args, env)
-	}
-	return os.NewSyscallError("execveat", err)
 }
 
 func SetParentDeathSignal(sig uintptr) error {


### PR DESCRIPTION
_This is a backport of #4576 to release-1.2. The sense of this backport is to make sure no one starts using this function._

This helper was added for runc-dmz in commit dac417174, but runc-dmz was later removed in commit 871057d, which forgot to remove the helper.

(cherry picked from commit 83350c24a979d9982f9c35a9311ef41180d7c4bd)