### PR TITLE
[1.2] Retry direct unix package calls if observing EINTR

### DIFF
--- a/libcontainer/notify_v2_linux.go
+++ b/libcontainer/notify_v2_linux.go
@@ -2,6 +2,7 @@ package libcontainer
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"unsafe"
 
@@ -40,7 +41,11 @@ func registerMemoryEventV2(cgDir, evName, cgEvName string) (<-chan struct{}, err
 
 		for {
 			n, err := unix.Read(fd, buffer[:])
+			if err == unix.EINTR { //nolint:errorlint // unix errors are bare
+				continue
+			}
 			if err != nil {
+				err = os.NewSyscallError("read", err)
 				logrus.Warnf("unable to read event data from inotify, got error: %v", err)
 				return
 			}


### PR DESCRIPTION
_This is a backport of #4637 to release-1.2._

----

Retry Recvfrom, Sendmsg, Readmsg, and Read as they can return EINTR.

(cherry picked from commit 28475f12e3eeebdf5923bcf7e41bd25a80ea3af7)