### PR TITLE
Allow shared mounts by default

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1016,7 +1016,18 @@ func prepareRoot(config *configs.Config) error {
 	flag := unix.MS_SLAVE | unix.MS_REC
 	if config.RootPropagation != 0 {
 		flag = config.RootPropagation
+	} else {
+		for _, m := range config.Mounts {
+			if m.Flags&unix.MS_SHARED != 0 {
+				// if a mount is using shared, then we don't lock down access with
+				// slave, instead we just use private so that the submounts can be
+				// configured shared correctly.
+				flag = unix.MS_PRIVATE
+				break
+			}
+		}
 	}
+
 	if err := mount("", "/", "", uintptr(flag), ""); err != nil {
 		return err
 	}


### PR DESCRIPTION
The current behavior disallows any mount having (r)shared on it because by default, the root is set with MS_SLAVE|MS_REC, which disallows sub-dirs from having a different propagation.

Projects have been working around this by setting the RootfsPropogation to "shared", to override the default
(https://github.com/containerd/nerdctl/blob/main/pkg/mountutil/mountutil_linux.go#L185-L193).

This patch makes a reasonable attempt to make the functionality work without touching RootfsPropogation.