### PR TITLE
libcontainer: logs: safely close channel and ensure error propagation in ForwardLogs in logs.go

### DIFF
--- a/libcontainer/logs/logs.go
+++ b/libcontainer/logs/logs.go
@@ -23,6 +23,7 @@ func ForwardLogs(logPipe io.ReadCloser) chan error {
 	}
 
 	go func() {
+		defer close(done)
 		for s.Scan() {
 			processEntry(s.Bytes(), logger)
 		}
@@ -32,7 +33,6 @@ func ForwardLogs(logPipe io.ReadCloser) chan error {
 		// The only error we want to return is when reading from
 		// logPipe has failed.
 		done <- s.Err()
-		close(done)
 	}()
 
 	return done


### PR DESCRIPTION
Static analyzer reported:
Use of value 'done' at logs.go:38 after release at logs.go:35 by calling function 'logs.ForwardLogs$1' at logs.go:25.

Corrections explained:
- Added `defer close(done)` to ensure the channel is closed after the goroutine finishes.
- Removed explicit `close(done)` after sending the error to avoid potential panics.
- Ensured that errors from `s.Scan()` are properly propagated to the `done` channel.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>