### PR TITLE
[1.3] doc: update spec-conformance.md

### DIFF
--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -1,6 +1,6 @@
 # Spec conformance
 
-This branch of runc implements the [OCI Runtime Spec v1.2.0](https://github.com/opencontainers/runtime-spec/tree/v1.2.0)
+This branch of runc implements the [OCI Runtime Spec v1.2.1](https://github.com/opencontainers/runtime-spec/tree/v1.2.1)
 for the `linux` platform.
 
 The following features are not implemented yet:


### PR DESCRIPTION
Backport #4660 
----
Update runtime-spec version from `v1.2.0` to `v1.2.1`.

(cherry picked from commit 79e9cf53e0e4ad723005e1b8c4cfd6a0a829e168)