### PR TITLE
Use pidfd_send_signal under the hood

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -116,11 +116,7 @@ func (p *containerProcess) startTime() (uint64, error) {
 }
 
 func (p *containerProcess) signal(sig os.Signal) error {
-	s, ok := sig.(unix.Signal)
-	if !ok {
-		return errors.New("os: unsupported signal type")
-	}
-	return unix.Kill(p.pid(), s)
+	return p.cmd.Process.Signal(sig)
 }
 
 func (p *containerProcess) externalDescriptors() []string {

--- a/signals.go
+++ b/signals.go
@@ -114,7 +114,7 @@ func (h *signalHandler) forward(process *libcontainer.Process, tty *tty, detach 
 		default:
 			us := s.(unix.Signal)
 			logrus.Debugf("forwarding signal %d (%s) to %d", int(us), unix.SignalName(us), pid1)
-			if err := unix.Kill(pid1, us); err != nil {
+			if err := process.Signal(s); err != nil {
 				logrus.Error(err)
 			}
 		}


### PR DESCRIPTION
This carries the first commit from #4517, and adds another patch on top of it.

The sole reason is to use pidfd_send_signal under the hood, if that's available.