### PR TITLE
tests/int/selinux: test keyring security label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ TESTBINDIR := tests/cmd/_bin
 $(TESTBINDIR):
 	mkdir $(TESTBINDIR)
 
-TESTBINS := recvtty sd-helper seccompagent fs-idmap pidfd-kill remap-rootfs
+TESTBINS := recvtty sd-helper seccompagent fs-idmap pidfd-kill remap-rootfs key_label
 .PHONY: test-binaries $(TESTBINS)
 test-binaries: $(TESTBINS)
 $(TESTBINS): $(TESTBINDIR)

--- a/tests/cmd/key_label/key_label.go
+++ b/tests/cmd/key_label/key_label.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// This is a simple program to print the current session keyring name and its
+// security label, to be run inside container (see selinux.bats). Can be
+// thought of poor man's keyctl. Written in Go so we can have a static binary
+// (a program in C would require libkeyutils which is usually provided only as
+// a dynamic library).
+func main() {
+	id, err := unix.KeyctlGetKeyringID(unix.KEY_SPEC_SESSION_KEYRING, false)
+	if err != nil {
+		log.Fatalf("GetKeyringID: %v", err)
+	}
+
+	desc, err := unix.KeyctlString(unix.KEYCTL_DESCRIBE, id)
+	if err != nil {
+		log.Fatalf("KeyctlDescribe: %v", err)
+	}
+	// keyring;1000;1000;3f030000;_ses
+	name := desc[strings.LastIndexByte(desc, ';')+1:]
+
+	label, err := unix.KeyctlString(unix.KEYCTL_GET_SECURITY, id)
+	if err != nil {
+		log.Fatalf("KeyctlGetSecurity: %v", err)
+	}
+
+	println(name, label)
+}

--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -27,7 +27,7 @@ function teardown() {
 	teardown_bundle
 	# Show any avc denials.
 	if [[ -v AU_DD && -v AU_TT ]] && command -v ausearch &>/dev/null; then
-		ausearch -ts "$AU_DD" "$AU_TT" -i -m avc || true
+		ausearch -ts "$AU_DD" "$AU_TT" -i -m avc,user_avc || true
 	fi
 }
 

--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -31,6 +31,48 @@ function teardown() {
 	fi
 }
 
+# This needs to be placed at the top of the bats file to work around
+# a shellcheck bug. See <https://github.com/koalaman/shellcheck/issues/2873>.
+function run_check_label() {
+	HELPER="key_label"
+	cp "${TESTBINDIR}/${HELPER}" rootfs/bin/
+
+	LABEL="system_u:system_r:container_t:s0:c4,c5"
+	update_config '	  .process.selinuxLabel |= "'"$LABEL"'"
+			| .process.args = ["/bin/'"$HELPER"'"]'
+	runc run tst
+	[ "$status" -eq 0 ]
+	# Key name is _ses.$CONTAINER_NAME.
+	KEY=_ses.tst
+	[ "$output" == "$KEY $LABEL" ]
+}
+
+# This needs to be placed at the top of the bats file to work around
+# a shellcheck bug. See <https://github.com/koalaman/shellcheck/issues/2873>.
+function exec_check_label() {
+	HELPER="key_label"
+	cp "${TESTBINDIR}/${HELPER}" rootfs/bin/
+
+	LABEL="system_u:system_r:container_t:s0:c4,c5"
+	update_config '	  .process.selinuxLabel |= "'"$LABEL"'"
+			| .process.args = ["/bin/sh"]'
+	runc run -d --console-socket "$CONSOLE_SOCKET" tst
+	[ "$status" -eq 0 ]
+
+	runc exec tst "/bin/$HELPER"
+	[ "$status" -eq 0 ]
+	# Key name is _ses.$CONTAINER_NAME.
+	KEY=_ses.tst
+	[ "$output" == "$KEY $LABEL" ]
+}
+
+function enable_userns() {
+	update_config '	  .linux.namespaces += [{"type": "user"}]
+			| .linux.uidMappings += [{"hostID": 100000, "containerID": 0, "size": 65534}]
+			| .linux.gidMappings += [{"hostID": 200000, "containerID": 0, "size": 65534}]'
+	remap_rootfs
+}
+
 # Baseline test, to check that runc works with selinux enabled.
 @test "runc run (no selinux label)" {
 	update_config '	  .process.args = ["/bin/true"]'
@@ -43,4 +85,22 @@ function teardown() {
 			| .process.args = ["/bin/true"]'
 	runc run tst
 	[ "$status" -eq 0 ]
+}
+
+@test "runc run (session keyring security label)" {
+	run_check_label
+}
+
+@test "runc exec (session keyring security label)" {
+	exec_check_label
+}
+
+@test "runc run (session keyring security label + userns)" {
+	enable_userns
+	run_check_label
+}
+
+@test "runc exec (session keyring security label + userns)" {
+	enable_userns
+	exec_check_label
 }


### PR DESCRIPTION
This tests the functionality added by commit cd96170c1
("Need to setup labeling of kernel keyrings.", PR #2012), for both
runc run and runc exec, with and without user namespace.

Related to https://github.com/opencontainers/selinux/issues/222
