### PR TITLE
libct: log a warning on join session keyring failure

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -39,10 +39,9 @@ func (l *linuxSetnsInit) Init() error {
 		defer selinux.SetKeyLabel("") //nolint: errcheck
 		// Do not inherit the parent's session keyring.
 		if _, err := keys.JoinSessionKeyring(l.getSessionRingName()); err != nil {
-			// Same justification as in standart_init_linux.go as to why we
+			logrus.Warnf("KeyctlJoinSessionKeyring: %v", err)
+			// Same justification as in standard_init_linux.go as to why we
 			// don't bail on ENOSYS.
-			//
-			// TODO(cyphar): And we should have logging here too.
 			if !errors.Is(err, unix.ENOSYS) {
 				return fmt.Errorf("unable to join session keyring: %w", err)
 			}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -55,14 +55,12 @@ func (l *linuxStandardInit) Init() error {
 
 		// Do not inherit the parent's session keyring.
 		if sessKeyId, err := keys.JoinSessionKeyring(ringname); err != nil {
+			logrus.Warnf("KeyctlJoinSessionKeyring: %v", err)
 			// If keyrings aren't supported then it is likely we are on an
 			// older kernel (or inside an LXC container). While we could bail,
 			// the security feature we are using here is best-effort (it only
 			// really provides marginal protection since VFS credentials are
 			// the only significant protection of keyrings).
-			//
-			// TODO(cyphar): Log this so people know what's going on, once we
-			//               have proper logging in 'runc init'.
 			if !errors.Is(err, unix.ENOSYS) {
 				return fmt.Errorf("unable to join session keyring: %w", err)
 			}


### PR DESCRIPTION
This addresses a TODO item added by commit 40f146841 / PR #1893,
as we do have runc init logging working fine for quite some time.

While at it, fix a typo in a comment (standart -> standard).