### PR TITLE
[1.3] .cirrus.yml: install less dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
     CIRRUS_WORKING_DIR: /home/runc
     GO_VER_PREFIX: "1.24."
     BATS_VERSION: "v1.9.0"
-    RPMS: gcc git iptables jq glibc-static libseccomp-devel make criu fuse-sshfs container-selinux
+    RPMS: gcc git-core iptables jq glibc-static libseccomp-devel make criu fuse-sshfs container-selinux
     # yamllint disable rule:key-duplicates
     matrix:
       DISTRO: almalinux-8
@@ -46,7 +46,7 @@ task:
     # Work around dnf mirror failures by retrying a few times.
     for i in $(seq 0 2); do
       sleep $i
-      yum install -y $RPMS && break
+      yum install -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs $RPMS && break
     done
     [ $? -eq 0 ] # fail if yum failed
 


### PR DESCRIPTION
_Backport of #4671 to release-1.3 branch._

----

In a nutshell:
 - use git-core instead of git;
 - do not install weak deps;
 - do not install docs.

This results in less packages to install:
 - 25 instead of 72 for almalinux-8
 - 24 instead of 90 for almalinux-9


(cherry picked from commit 1d9bea537812e3a1ac18b072bd3ef5faab5f17fb)