### PR TITLE
Add RetryOnEINTR() helpers and handle more cases that can return EINTR

### DIFF
--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -3,6 +3,7 @@ package libcontainer
 import (
 	"os"
 
+	unixutils "github.com/opencontainers/runc/libcontainer/internal/unix-utils"
 	"golang.org/x/sys/unix"
 )
 
@@ -26,7 +27,9 @@ func mountConsole(slavePath string) error {
 // dupStdio opens the slavePath for the console and dups the fds to the current
 // processes stdio, fd 0,1,2.
 func dupStdio(slavePath string) error {
-	fd, err := unix.Open(slavePath, unix.O_RDWR, 0)
+	fd, err := unixutils.RetryOnEINTR2(func() (int, error) {
+		return unix.Open(slavePath, unix.O_RDWR, 0)
+	})
 	if err != nil {
 		return &os.PathError{
 			Op:   "open",

--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -38,7 +38,10 @@ func dupStdio(slavePath string) error {
 		}
 	}
 	for _, i := range []int{0, 1, 2} {
-		if err := unix.Dup3(fd, i, 0); err != nil {
+		err := unixutils.RetryOnEINTR(func() error {
+			return unix.Dup3(fd, i, 0)
+		})
+		if err != nil {
 			return err
 		}
 	}

--- a/libcontainer/internal/unix-utils/unix.go
+++ b/libcontainer/internal/unix-utils/unix.go
@@ -1,0 +1,29 @@
+package unixutils
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// RetryOnEINTR takes a function that returns an error and calls it until it the error returned is
+// not EINTR.
+func RetryOnEINTR(fn func() error) error {
+	var err error
+	for {
+		err = fn()
+		if !errors.Is(err, unix.EINTR) {
+			return err
+		}
+	}
+}
+
+// RetryOnEINTR2 is like RetryOnEINTR, but it returns 2 values.
+func RetryOnEINTR2[T any](fn func() (T, error)) (val T, err error) {
+	for {
+		val, err = fn()
+		if !errors.Is(err, unix.EINTR) {
+			return val, err
+		}
+	}
+}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -884,7 +884,10 @@ func reOpenDevNull() error {
 		}
 		if stat.Rdev == devNullStat.Rdev {
 			// Close and re-open the fd.
-			if err := unix.Dup3(int(file.Fd()), fd, 0); err != nil {
+			err := unixutils.RetryOnEINTR(func() error {
+				return unix.Dup3(int(file.Fd()), fd, 0)
+			})
+			if err != nil {
 				return &os.PathError{
 					Op:   "dup3",
 					Path: "fd " + strconv.Itoa(int(file.Fd())),

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/cgroups"
 	devices "github.com/opencontainers/cgroups/devices/config"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	unixutils "github.com/opencontainers/runc/libcontainer/internal/unix-utils"
 	"github.com/opencontainers/runc/libcontainer/internal/userns"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
@@ -348,12 +349,7 @@ type CreateOpts struct {
 // the value from the kernel, which guarantees the returned value
 // to be absolute and clean.
 func getwd() (wd string, err error) {
-	for {
-		wd, err = unix.Getwd()
-		if err != unix.EINTR {
-			break
-		}
-	}
+	wd, err = unixutils.RetryOnEINTR2(unix.Getwd)
 	return wd, os.NewSyscallError("getwd", err)
 }
 

--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -14,6 +14,7 @@ import (
 	_ "unsafe" // for go:linkname
 
 	securejoin "github.com/cyphar/filepath-securejoin"
+	unixutils "github.com/opencontainers/runc/libcontainer/internal/unix-utils"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -358,7 +359,9 @@ func Openat(dir *os.File, path string, flags int, mode uint32) (*os.File, error)
 	}
 	flags |= unix.O_CLOEXEC
 
-	fd, err := unix.Openat(dirFd, path, flags, mode)
+	fd, err := unixutils.RetryOnEINTR2(func() (int, error) {
+		return unix.Openat(dirFd, path, flags, mode)
+	})
 	if err != nil {
 		return nil, &os.PathError{Op: "openat", Path: path, Err: err}
 	}


### PR DESCRIPTION
This PR adds two helpers:
 * `RetryOnEINTR()`: This helper takes a function that returns an error and retries until that error is not EINTR
 * `RetryOnEINTR2()`: This helper returns an int and an error. This is useful for functions like unix.Open(). While we could handle them with the previous helper using go closures, when coding that it doesn't look nice:  we need to declar the vars before and it gets kind of long. With this helper, we can just use the synta: `fd, err := utils.RetryOnEINTR2()...` and declare the vars on assignment, which is much nicer.

Then, the rest of the commits use them for unix.Open and unix.Dup*(), that were not properly handled and switches the existing code with open-coded versions to use the helpers.

Please note the comment on the commit about unix.Open on why I didn't try to switch some cases to os.OpenFile(). I'd like to tackle that later, on another PR.