### PR TITLE
Make state.json 25% smaller

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -92,69 +92,69 @@ type Syscall struct {
 // Config defines configuration options for executing a process inside a contained environment.
 type Config struct {
 	// NoPivotRoot will use MS_MOVE and a chroot to jail the process into the container's rootfs
-	// This is a common option when the container is running in ramdisk
-	NoPivotRoot bool `json:"no_pivot_root"`
+	// This is a common option when the container is running in ramdisk.
+	NoPivotRoot bool `json:"no_pivot_root,omitempty"`
 
 	// ParentDeathSignal specifies the signal that is sent to the container's process in the case
 	// that the parent process dies.
-	ParentDeathSignal int `json:"parent_death_signal"`
+	ParentDeathSignal int `json:"parent_death_signal,omitempty"`
 
 	// Path to a directory containing the container's root filesystem.
 	Rootfs string `json:"rootfs"`
 
 	// Umask is the umask to use inside of the container.
-	Umask *uint32 `json:"umask"`
+	Umask *uint32 `json:"umask,omitempty"`
 
 	// Readonlyfs will remount the container's rootfs as readonly where only externally mounted
 	// bind mounts are writtable.
-	Readonlyfs bool `json:"readonlyfs"`
+	Readonlyfs bool `json:"readonlyfs,omitempty"`
 
 	// Specifies the mount propagation flags to be applied to /.
-	RootPropagation int `json:"rootPropagation"`
+	RootPropagation int `json:"rootPropagation,omitempty"`
 
 	// Mounts specify additional source and destination paths that will be mounted inside the container's
-	// rootfs and mount namespace if specified
+	// rootfs and mount namespace if specified.
 	Mounts []*Mount `json:"mounts"`
 
 	// The device nodes that should be automatically created within the container upon container start.  Note, make sure that the node is marked as allowed in the cgroup as well!
 	Devices []*devices.Device `json:"devices"`
 
-	MountLabel string `json:"mount_label"`
+	MountLabel string `json:"mount_label,omitempty"`
 
-	// Hostname optionally sets the container's hostname if provided
-	Hostname string `json:"hostname"`
+	// Hostname optionally sets the container's hostname if provided.
+	Hostname string `json:"hostname,omitempty"`
 
-	// Domainname optionally sets the container's domainname if provided
-	Domainname string `json:"domainname"`
+	// Domainname optionally sets the container's domainname if provided.
+	Domainname string `json:"domainname,omitempty"`
 
 	// Namespaces specifies the container's namespaces that it should setup when cloning the init process
-	// If a namespace is not provided that namespace is shared from the container's parent process
+	// If a namespace is not provided that namespace is shared from the container's parent process.
 	Namespaces Namespaces `json:"namespaces"`
 
 	// Capabilities specify the capabilities to keep when executing the process inside the container
-	// All capabilities not specified will be dropped from the processes capability mask
-	Capabilities *Capabilities `json:"capabilities"`
+	// All capabilities not specified will be dropped from the processes capability mask.
+	Capabilities *Capabilities `json:"capabilities,omitempty"`
 
-	// Networks specifies the container's network setup to be created
-	Networks []*Network `json:"networks"`
+	// Networks specifies the container's network setup to be created.
+	Networks []*Network `json:"networks,omitempty"`
 
-	// Routes can be specified to create entries in the route table as the container is started
-	Routes []*Route `json:"routes"`
+	// Routes can be specified to create entries in the route table as the container is started.
+	Routes []*Route `json:"routes,omitempty"`
 
 	// Cgroups specifies specific cgroup settings for the various subsystems that the container is
-	// placed into to limit the resources the container has available
+	// placed into to limit the resources the container has available.
 	Cgroups *Cgroup `json:"cgroups"`
 
 	// AppArmorProfile specifies the profile to apply to the process running in the container and is
-	// change at the time the process is execed
+	// change at the time the process is executed.
 	AppArmorProfile string `json:"apparmor_profile,omitempty"`
 
 	// ProcessLabel specifies the label to apply to the process running in the container.  It is
-	// commonly used by selinux
+	// commonly used by selinux.
 	ProcessLabel string `json:"process_label,omitempty"`
 
 	// Rlimits specifies the resource limits, such as max open files, to set in the container
-	// If Rlimits are not set, the container will inherit rlimits from the parent process
+	// If Rlimits are not set, the container will inherit rlimits from the parent process.
 	Rlimits []Rlimit `json:"rlimits,omitempty"`
 
 	// OomScoreAdj specifies the adjustment to be made by the kernel when calculating oom scores
@@ -164,35 +164,35 @@ type Config struct {
 	// More information about kernel oom score calculation here: https://lwn.net/Articles/317814/
 	OomScoreAdj *int `json:"oom_score_adj,omitempty"`
 
-	// UIDMappings is an array of User ID mappings for User Namespaces
-	UIDMappings []IDMap `json:"uid_mappings"`
+	// UIDMappings is an array of User ID mappings for User Namespaces.
+	UIDMappings []IDMap `json:"uid_mappings,omitempty"`
 
-	// GIDMappings is an array of Group ID mappings for User Namespaces
-	GIDMappings []IDMap `json:"gid_mappings"`
+	// GIDMappings is an array of Group ID mappings for User Namespaces.
+	GIDMappings []IDMap `json:"gid_mappings,omitempty"`
 
 	// MaskPaths specifies paths within the container's rootfs to mask over with a bind
 	// mount pointing to /dev/null as to prevent reads of the file.
-	MaskPaths []string `json:"mask_paths"`
+	MaskPaths []string `json:"mask_paths,omitempty"`
 
 	// ReadonlyPaths specifies paths within the container's rootfs to remount as read-only
 	// so that these files prevent any writes.
-	ReadonlyPaths []string `json:"readonly_paths"`
+	ReadonlyPaths []string `json:"readonly_paths,omitempty"`
 
 	// Sysctl is a map of properties and their values. It is the equivalent of using
 	// sysctl -w my.property.name value in Linux.
-	Sysctl map[string]string `json:"sysctl"`
+	Sysctl map[string]string `json:"sysctl,omitempty"`
 
 	// Seccomp allows actions to be taken whenever a syscall is made within the container.
 	// A number of rules are given, each having an action to be taken if a syscall matches it.
 	// A default action to be taken if no rules match is also given.
-	Seccomp *Seccomp `json:"seccomp"`
+	Seccomp *Seccomp `json:"seccomp,omitempty"`
 
 	// NoNewPrivileges controls whether processes in the container can gain additional privileges.
 	NoNewPrivileges bool `json:"no_new_privileges,omitempty"`
 
 	// Hooks are a collection of actions to perform at various container lifecycle events.
 	// CommandHooks are serialized to JSON, but other hooks are not.
-	Hooks Hooks
+	Hooks Hooks `json:"Hooks,omitempty"`
 
 	// Version is the version of opencontainer specification that is supported.
 	Version string `json:"version"`
@@ -202,7 +202,7 @@ type Config struct {
 
 	// NoNewKeyring will not allocated a new session keyring for the container.  It will use the
 	// callers keyring in this case.
-	NoNewKeyring bool `json:"no_new_keyring"`
+	NoNewKeyring bool `json:"no_new_keyring,omitempty"`
 
 	// IntelRdt specifies settings for Intel RDT group that the container is placed into
 	// to limit the resources (e.g., L3 cache, memory bandwidth) the container has available
@@ -445,15 +445,15 @@ func KnownHookNames() []string {
 
 type Capabilities struct {
 	// Bounding is the set of capabilities checked by the kernel.
-	Bounding []string
+	Bounding []string `json:"Bounding,omitempty"`
 	// Effective is the set of capabilities checked by the kernel.
-	Effective []string
+	Effective []string `json:"Effective,omitempty"`
 	// Inheritable is the capabilities preserved across execve.
-	Inheritable []string
+	Inheritable []string `json:"Inheritable,omitempty"`
 	// Permitted is the limiting superset for effective capabilities.
-	Permitted []string
+	Permitted []string `json:"Permitted,omitempty"`
 	// Ambient is the ambient set of capabilities that are kept.
-	Ambient []string
+	Ambient []string `json:"Ambient,omitempty"`
 }
 
 // Deprecated: use (Hooks).Run instead.

--- a/libcontainer/configs/mount_linux.go
+++ b/libcontainer/configs/mount_linux.go
@@ -4,7 +4,7 @@ import "golang.org/x/sys/unix"
 
 type MountIDMapping struct {
 	// Recursive indicates if the mapping needs to be recursive.
-	Recursive bool `json:"recursive"`
+	Recursive bool `json:"recursive,omitempty"`
 
 	// UserNSPath is a path to a user namespace that indicates the necessary
 	// id-mappings for MOUNT_ATTR_IDMAP. If set to non-"", UIDMappings and
@@ -31,26 +31,26 @@ type Mount struct {
 	Device string `json:"device"`
 
 	// Mount flags.
-	Flags int `json:"flags"`
+	Flags int `json:"flags,omitempty"`
 
 	// Mount flags that were explicitly cleared in the configuration (meaning
 	// the user explicitly requested that these flags *not* be set).
-	ClearedFlags int `json:"cleared_flags"`
+	ClearedFlags int `json:"cleared_flags,omitempty"`
 
-	// Propagation Flags
-	PropagationFlags []int `json:"propagation_flags"`
+	// Propagation flags.
+	PropagationFlags []int `json:"propagation_flags,omitempty"`
 
 	// Mount data applied to the mount.
-	Data string `json:"data"`
+	Data string `json:"data,omitempty"`
 
 	// Relabel source if set, "z" indicates shared, "Z" indicates unshared.
-	Relabel string `json:"relabel"`
+	Relabel string `json:"relabel,omitempty"`
 
 	// RecAttr represents mount properties to be applied recursively (AT_RECURSIVE), see mount_setattr(2).
-	RecAttr *unix.MountAttr `json:"rec_attr"`
+	RecAttr *unix.MountAttr `json:"rec_attr,omitempty"`
 
 	// Extensions are additional flags that are specific to runc.
-	Extensions int `json:"extensions"`
+	Extensions int `json:"extensions,omitempty"`
 
 	// Mapping is the MOUNT_ATTR_IDMAP configuration for the mount. If non-nil,
 	// the mount is configured to use MOUNT_ATTR_IDMAP-style id mappings.

--- a/libcontainer/configs/namespaces_linux.go
+++ b/libcontainer/configs/namespaces_linux.go
@@ -86,7 +86,7 @@ func NamespaceTypes() []NamespaceType {
 // alternate path that is able to be joined via setns.
 type Namespace struct {
 	Type NamespaceType `json:"type"`
-	Path string        `json:"path"`
+	Path string        `json:"path,omitempty"`
 }
 
 func (n *Namespace) GetPath(pid int) string {

--- a/libcontainer/configs/network.go
+++ b/libcontainer/configs/network.go
@@ -5,49 +5,49 @@ package configs
 // The network configuration can be omitted from a container causing the
 // container to be setup with the host's networking stack
 type Network struct {
-	// Type sets the networks type, commonly veth and loopback
+	// Type sets the networks type, commonly veth and loopback.
 	Type string `json:"type"`
 
-	// Name of the network interface
-	Name string `json:"name"`
+	// Name of the network interface.
+	Name string `json:"name,omitempty"`
 
 	// The bridge to use.
-	Bridge string `json:"bridge"`
+	Bridge string `json:"bridge,omitempty"`
 
-	// MacAddress contains the MAC address to set on the network interface
-	MacAddress string `json:"mac_address"`
+	// MacAddress contains the MAC address to set on the network interface.
+	MacAddress string `json:"mac_address,omitempty"`
 
-	// Address contains the IPv4 and mask to set on the network interface
-	Address string `json:"address"`
+	// Address contains the IPv4 and mask to set on the network interface.
+	Address string `json:"address,omitempty"`
 
-	// Gateway sets the gateway address that is used as the default for the interface
-	Gateway string `json:"gateway"`
+	// Gateway sets the gateway address that is used as the default for the interface.
+	Gateway string `json:"gateway,omitempty"`
 
-	// IPv6Address contains the IPv6 and mask to set on the network interface
-	IPv6Address string `json:"ipv6_address"`
+	// IPv6Address contains the IPv6 and mask to set on the network interface.
+	IPv6Address string `json:"ipv6_address,omitempty"`
 
-	// IPv6Gateway sets the ipv6 gateway address that is used as the default for the interface
-	IPv6Gateway string `json:"ipv6_gateway"`
+	// IPv6Gateway sets the ipv6 gateway address that is used as the default for the interface.
+	IPv6Gateway string `json:"ipv6_gateway,omitempty"`
 
 	// Mtu sets the mtu value for the interface and will be mirrored on both the host and
 	// container's interfaces if a pair is created, specifically in the case of type veth
 	// Note: This does not apply to loopback interfaces.
-	Mtu int `json:"mtu"`
+	Mtu int `json:"mtu,omitempty"`
 
 	// TxQueueLen sets the tx_queuelen value for the interface and will be mirrored on both the host and
 	// container's interfaces if a pair is created, specifically in the case of type veth
 	// Note: This does not apply to loopback interfaces.
-	TxQueueLen int `json:"txqueuelen"`
+	TxQueueLen int `json:"txqueuelen,omitempty"`
 
 	// HostInterfaceName is a unique name of a veth pair that resides on in the host interface of the
 	// container.
-	HostInterfaceName string `json:"host_interface_name"`
+	HostInterfaceName string `json:"host_interface_name,omitempty"`
 
 	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
 	// bridge port in the case of type veth
 	// Note: This is unsupported on some systems.
 	// Note: This does not apply to loopback interfaces.
-	HairpinMode bool `json:"hairpin_mode"`
+	HairpinMode bool `json:"hairpin_mode,omitempty"`
 }
 
 // Route defines a routing table entry.
@@ -62,14 +62,14 @@ type Network struct {
 // destination of 0.0.0.0(or *) when viewed in the route table.
 type Route struct {
 	// Destination specifies the destination IP address and mask in the CIDR form.
-	Destination string `json:"destination"`
+	Destination string `json:"destination,omitempty"`
 
 	// Source specifies the source IP address and mask in the CIDR form.
-	Source string `json:"source"`
+	Source string `json:"source,omitempty"`
 
 	// Gateway specifies the gateway IP address.
-	Gateway string `json:"gateway"`
+	Gateway string `json:"gateway,omitempty"`
 
 	// InterfaceName specifies the device to set this route up for, for example eth0.
-	InterfaceName string `json:"interface_name"`
+	InterfaceName string `json:"interface_name,omitempty"`
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -50,11 +50,11 @@ type Container struct {
 type State struct {
 	BaseState
 
-	// Platform specific fields below here
+	// Platform specific fields below.
 
 	// Specified if the container was started under the rootless mode.
 	// Set to true if BaseState.Config.RootlessEUID && BaseState.Config.RootlessCgroups
-	Rootless bool `json:"rootless"`
+	Rootless bool `json:"rootless,omitempty"`
 
 	// Paths to all the container's cgroups, as returned by (*cgroups.Manager).GetPaths
 	//
@@ -62,17 +62,17 @@ type State struct {
 	// to the cgroup for this subsystem.
 	//
 	// For cgroup v2 unified hierarchy, a key is "", and the value is the unified path.
-	CgroupPaths map[string]string `json:"cgroup_paths"`
+	CgroupPaths map[string]string `json:"cgroup_paths,omitempty"`
 
 	// NamespacePaths are filepaths to the container's namespaces. Key is the namespace type
 	// with the value as the path.
 	NamespacePaths map[configs.NamespaceType]string `json:"namespace_paths"`
 
-	// Container's standard descriptors (std{in,out,err}), needed for checkpoint and restore
+	// Container's standard descriptors (std{in,out,err}), needed for checkpoint and restore.
 	ExternalDescriptors []string `json:"external_descriptors,omitempty"`
 
-	// Intel RDT "resource control" filesystem path
-	IntelRdtPath string `json:"intel_rdt_path"`
+	// Intel RDT "resource control" filesystem path.
+	IntelRdtPath string `json:"intel_rdt_path,omitempty"`
 }
 
 // ID returns the container's unique ID


### PR DESCRIPTION
This makes the state.json file 1303 bytes or almost 25% smaller (when using the default spec, YMMV) by omitting default values.

Before: 5496 bytes
After: 4193 bytes

(With opencontainers/cgroups#9 applied on top, the new size is 3424, which is almost 40% savings, compared to the original).