### PR TITLE
.github: Improve issue template description

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -25,6 +25,8 @@ body:
   - type: textarea
     attributes:
       label: Steps to reproduce the issue
+      description: |
+        As much as possible, try to make steps that would work in a script. This makes the repro unambiguous and easy to follow.
       value: |
         1.
         2.


### PR DESCRIPTION
We received several times issues that the repro steps are human readable text with ambiguous instructions. That usually ends up in maintainers asking questions so people provide clear steps.

Let's just make the issue template more clear in that regard.