### PR TITLE
libct: we should set envs after we are in the jail of the container

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -234,12 +234,6 @@ func startInitialization() (retErr error) {
 }
 
 func containerInit(t initType, config *initConfig, pipe *syncSocket, consoleSocket, pidfdSocket, fifoFile, logPipe *os.File) error {
-	env, err := prepareEnv(config.Env, config.UID)
-	if err != nil {
-		return err
-	}
-	config.Env = env
-
 	// Clean the RLIMIT_NOFILE cache in go runtime.
 	// Issue: https://github.com/opencontainers/runc/issues/4195
 	maybeClearRlimitNofileCache(config.Rlimits)
@@ -325,6 +319,14 @@ func finalizeNamespace(config *initConfig) error {
 			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %w", config.Cwd, err)
 		}
 	}
+
+	// We should set envs after we are in the jail of the container.
+	// Please see https://github.com/opencontainers/runc/issues/4688
+	env, err := prepareEnv(config.Env, config.UID)
+	if err != nil {
+		return err
+	}
+	config.Env = env
 
 	w, err := capabilities.New(config.Capabilities)
 	if err != nil {

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -219,3 +219,19 @@ EOF
 	[ ${#lines[@]} -eq 1 ]
 	[[ ${lines[0]} = "exec /run.sh: no such file or directory" ]]
 }
+
+# https://github.com/opencontainers/runc/issues/4688
+@test "runc run check default home" {
+	# cannot start containers as another user in rootless setup without idmap
+	[ $EUID -ne 0 ] && requires rootless_idmap
+	echo 'tempuser:x:2000:2000:tempuser:/home/tempuser:/bin/sh' >>rootfs/etc/passwd
+
+	# shellcheck disable=SC2016
+	update_config '	  .process.cwd = "/root"
+			| .process.user.uid = 2000
+			| .process.args |= ["sh", "-c", "echo $HOME"]'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "/home/tempuser" ]
+}


### PR DESCRIPTION
Because we have to set a default HOME env for the current container user, so we should set it after we are in the jail of the container, or else we'll use host's `/etc/passwd` to get a wrong HOME value.

Fixes #4688.