### PR TITLE
criu: Add time namespace to container config after checkpoint/restore

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -1151,6 +1151,13 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 		}
 		// create a timestamp indicating when the restored checkpoint was started
 		c.created = time.Now().UTC()
+		if !c.config.Namespaces.Contains(configs.NEWTIME) &&
+			configs.IsNamespaceSupported(configs.NEWTIME) &&
+			c.checkCriuVersion(31400) == nil {
+			// CRIU restores processes into a time namespace.
+			c.config.Namespaces = append(c.config.Namespaces,
+				configs.Namespace{Type: configs.NEWTIME})
+		}
 		if _, err := c.updateState(r); err != nil {
 			return err
 		}


### PR DESCRIPTION
CRIU always restores processes into a time namespace to prevent backward jumps of monotonic and boottime clocks. This change updates the container config to ensure that `runc exec` launches new processes within the container's time namespace.

Fixes https://github.com/checkpoint-restore/criu/issues/2610