### PR TITLE
ci: bump codespell to v2.4.1, fix some typos

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
-      run: pip install --break-system-packages codespell==v2.3.0
+      run: pip install --break-system-packages codespell==v2.4.1
     - name: run codespell
       run: codespell
 

--- a/libcontainer/exeseal/cloned_binary_linux.go
+++ b/libcontainer/exeseal/cloned_binary_linux.go
@@ -48,7 +48,7 @@ func sealMemfd(f **os.File) error {
 	// to work on older kernels.
 	fd := (*f).Fd()
 
-	// Skip F_SEAL_FUTURE_WRITE, it is not needed because we alreadu use the
+	// Skip F_SEAL_FUTURE_WRITE, it is not needed because we already use the
 	// stronger F_SEAL_WRITE (and is buggy on Linux <5.5 -- see kernel commit
 	// 05d351102dbe and <https://github.com/opencontainers/runc/pull/4640>).
 

--- a/libcontainer/internal/userns/usernsfd_linux.go
+++ b/libcontainer/internal/userns/usernsfd_linux.go
@@ -61,7 +61,7 @@ type Handles struct {
 
 // Release all resources associated with this Handle. All existing files
 // returned from Get() will continue to work even after calling Release(). The
-// same Handles can be re-used after calling Release().
+// same Handles can be reused after calling Release().
 func (hs *Handles) Release() {
 	hs.m.Lock()
 	defer hs.m.Unlock()

--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -130,7 +130,7 @@ func runtime_IsPollDescriptor(fd uintptr) bool //nolint:revive
 //
 // NOTE: That this function is incredibly dangerous to use in most Go code, as
 // closing file descriptors from underneath *os.File handles can lead to very
-// bad behaviour (the closed file descriptor can be re-used and then any
+// bad behaviour (the closed file descriptor can be reused and then any
 // *os.File operations would apply to the wrong file). This function is only
 // intended to be called from the last stage of runc init.
 func UnsafeCloseFrom(minFd int) error {

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -217,7 +217,7 @@ function teardown() {
 	# Also create a network namespace that *is not owned* by the above userns.
 	# NOTE: Having no permissions in a namespaces makes it necessary to modify
 	# the config so that we don't get mount errors (for reference: no netns
-	# permissions == no sysfs mounts, no pidns permissoins == no procfs mounts,
+	# permissions == no sysfs mounts, no pidns permissions == no procfs mounts,
 	# no utsns permissions == no sethostname(2), no ipc permissions == no
 	# mqueue mounts, etc).
 	netns_path="$(mktemp "$BATS_RUN_TMPDIR/netns.XXXXXX")"


### PR DESCRIPTION
All but one were found by codespell.