### PR TITLE
Use Go 1.22+ features

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -15,7 +15,7 @@ import (
 
 func killContainer(container *libcontainer.Container) error {
 	_ = container.Signal(unix.SIGKILL)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		time.Sleep(100 * time.Millisecond)
 		if err := container.Signal(unix.Signal(0)); err != nil {
 			return container.Destroy()

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -503,7 +503,7 @@ func (hooks *Hooks) MarshalJSON() ([]byte, error) {
 		return serializableHooks
 	}
 
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"prestart":        serialize((*hooks)[Prestart]),
 		"createRuntime":   serialize((*hooks)[CreateRuntime]),
 		"createContainer": serialize((*hooks)[CreateContainer]),

--- a/libcontainer/configs/namespaces_linux.go
+++ b/libcontainer/configs/namespaces_linux.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 )
 
@@ -98,7 +99,7 @@ func (n *Namespaces) Remove(t NamespaceType) bool {
 	if i == -1 {
 		return false
 	}
-	*n = append((*n)[:i], (*n)[i+1:]...)
+	*n = slices.Delete((*n), i, i+1)
 	return true
 }
 

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -832,7 +832,7 @@ func logCriuErrors(dir, file string) {
 			logrus.Warn("...")
 		}
 		// Print the last lines.
-		for add := 0; add < max; add++ {
+		for add := range max {
 			i := (idx + add) % max
 			s := lines[i]
 			actLineNo := lineNo + add - max + 1
@@ -961,7 +961,7 @@ func (c *Container) criuSwrk(process *Process, req *criurpc.CriuReq, opts *CriuO
 
 		val := reflect.ValueOf(req.GetOpts())
 		v := reflect.Indirect(val)
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			st := v.Type()
 			name := st.Field(i).Name
 			if 'A' <= name[0] && name[0] <= 'Z' {

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -191,7 +191,7 @@ func validateID(id string) error {
 	}
 
 	// Allowed characters: 0-9 A-Z a-z _ + - .
-	for i := 0; i < len(id); i++ {
+	for i := range len(id) {
 		c := id[i]
 		switch {
 		case c >= 'a' && c <= 'z':

--- a/libcontainer/factory_linux_test.go
+++ b/libcontainer/factory_linux_test.go
@@ -81,7 +81,7 @@ func TestFactoryLoadContainer(t *testing.T) {
 	}
 }
 
-func marshal(path string, v interface{}) error {
+func marshal(path string, v any) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return err

--- a/libcontainer/integration/bench_test.go
+++ b/libcontainer/integration/bench_test.go
@@ -60,7 +60,7 @@ func genBigEnv(count int) []string {
 	}
 
 	envs := make([]string, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		key := strings.ToUpper(randStr(10))
 		value := randStr(20)
 		envs[i] = key + "=" + value

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -209,7 +209,7 @@ func TestExecInError(t *testing.T) {
 	}()
 	ok(t, err)
 
-	for i := 0; i < 42; i++ {
+	for range 42 {
 		unexistent := &libcontainer.Process{
 			Cwd:  "/",
 			Args: []string{"unexistent"},
@@ -263,7 +263,7 @@ func TestExecInTTY(t *testing.T) {
 
 	// Repeat to increase chances to catch a race; see
 	// https://github.com/opencontainers/runc/issues/2425.
-	for i := 0; i < 300; i++ {
+	for range 300 {
 		var stdout bytes.Buffer
 
 		parent, child, err := utils.NewSockPair("console")

--- a/libcontainer/integration/update_test.go
+++ b/libcontainer/integration/update_test.go
@@ -60,7 +60,7 @@ func testUpdateDevices(t *testing.T, systemd bool) {
 	}
 	defaultDevices := config.Cgroups.Resources.Devices
 
-	for i := 0; i < 300; i++ {
+	for i := range 300 {
 		// Check the access
 		buf.Reset()
 		err = container.Run(devCheck)

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -877,7 +877,7 @@ func getPipeFds(pid int) ([]string, error) {
 	fds := make([]string, 3)
 
 	dirPath := filepath.Join("/proc", strconv.Itoa(pid), "/fd")
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		// XXX: This breaks if the path is not a valid symlink (which can
 		//      happen in certain particularly unlucky mount namespace setups).
 		f := filepath.Join(dirPath, strconv.Itoa(i))

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -878,7 +878,7 @@ func reOpenDevNull() error {
 	if err := unix.Fstat(int(file.Fd()), &devNullStat); err != nil {
 		return &os.PathError{Op: "fstat", Path: file.Name(), Err: err}
 	}
-	for fd := 0; fd < 3; fd++ {
+	for fd := range 3 {
 		if err := unix.Fstat(fd, &stat); err != nil {
 			return &os.PathError{Op: "fstat", Path: "fd " + strconv.Itoa(fd), Err: err}
 		}
@@ -1211,7 +1211,7 @@ func remountReadonly(m *configs.Mount) error {
 		dest  = m.Destination
 		flags = m.Flags
 	)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		// There is a special case in the kernel for
 		// MS_REMOUNT | MS_BIND, which allows us to change only the
 		// flags even as an unprivileged user (i.e. user namespace)

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -626,7 +626,7 @@ func checkPropertyName(s string) error {
 	}
 	// Check ASCII characters rather than Unicode runes,
 	// so we have to use indexes rather than range.
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		ch := s[i]
 		if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
 			continue

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -5,6 +5,7 @@ package specconv
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -916,11 +917,7 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*cgrou
 				}
 			}
 			if len(r.Unified) > 0 {
-				// copy the map
-				c.Resources.Unified = make(map[string]string, len(r.Unified))
-				for k, v := range r.Unified {
-					c.Resources.Unified[k] = v
-				}
+				c.Resources.Unified = maps.Clone(r.Unified)
 			}
 		}
 	}

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -676,7 +676,7 @@ func TestInitSystemdProps(t *testing.T) {
 	type expT struct {
 		isErr bool
 		name  string
-		value interface{}
+		value any
 	}
 
 	testCases := []struct {

--- a/libcontainer/state_linux_test.go
+++ b/libcontainer/state_linux_test.go
@@ -24,7 +24,7 @@ func TestStateStatus(t *testing.T) {
 }
 
 func testTransitions(t *testing.T, initialState containerState, valid []containerState) {
-	validMap := map[reflect.Type]interface{}{}
+	validMap := map[reflect.Type]any{}
 	for _, validState := range valid {
 		validMap[reflect.TypeOf(validState)] = nil
 		t.Run(validState.status().String(), func(t *testing.T) {

--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -113,7 +113,7 @@ func writeSync(pipe *syncSocket, sync syncType) error {
 	return doWriteSync(pipe, syncT{Type: sync})
 }
 
-func writeSyncArg(pipe *syncSocket, sync syncType, arg interface{}) error {
+func writeSyncArg(pipe *syncSocket, sync syncType, arg any) error {
 	argJSON, err := json.Marshal(arg)
 	if err != nil {
 		return fmt.Errorf("writing sync %v: marshal argument failed: %w", sync, err)

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -27,7 +27,7 @@ func ExitStatus(status unix.WaitStatus) int {
 // without a trailing newline. This is used instead of json.Encoder because
 // there might be a problem in json decoder in some cases, see:
 // https://github.com/docker/docker/issues/14203#issuecomment-174177790
-func WriteJSON(w io.Writer, v interface{}) error {
+func WriteJSON(w io.Writer, v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return err

--- a/ps.go
+++ b/ps.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"slices"
 )
 
 var psCommand = cli.Command{
@@ -86,11 +87,8 @@ var psCommand = cli.Command{
 				return fmt.Errorf("unable to parse pid: %w", err)
 			}
 
-			for _, pid := range pids {
-				if pid == p {
-					fmt.Println(line)
-					break
-				}
+			if slices.Contains(pids, p) {
+				fmt.Println(line)
 			}
 		}
 		return nil

--- a/tty.go
+++ b/tty.go
@@ -44,7 +44,7 @@ func setupProcessPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, err
 		},
 	}
 	// add the process's io to the post start closers if they support close
-	for _, cc := range []interface{}{
+	for _, cc := range []any{
 		p.Stdin,
 		p.Stdout,
 		p.Stderr,

--- a/types/events.go
+++ b/types/events.go
@@ -7,9 +7,9 @@ import (
 
 // Event struct for encoding the event data to json.
 type Event struct {
-	Type string      `json:"type"`
-	ID   string      `json:"id"`
-	Data interface{} `json:"data,omitempty"`
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Data any    `json:"data,omitempty"`
 }
 
 // stats is the runc specific stats structure for stability when encoding and decoding stats.


### PR DESCRIPTION
This applies various code modifications based on gopls "modernize" linter; in particular:
 - use new functions from `maps` and `slices` pkg where it makes sense;
 - use for range over integers;
 - use `any` instead of `interface`.

Should not result in any change in functionality.