### PR TITLE
[1.3] criu: Add time namespace to container config after checkpoint/restore

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -1151,6 +1151,13 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 		}
 		// create a timestamp indicating when the restored checkpoint was started
 		c.created = time.Now().UTC()
+		if !c.config.Namespaces.Contains(configs.NEWTIME) &&
+			configs.IsNamespaceSupported(configs.NEWTIME) &&
+			c.checkCriuVersion(31400) == nil {
+			// CRIU restores processes into a time namespace.
+			c.config.Namespaces = append(c.config.Namespaces,
+				configs.Namespace{Type: configs.NEWTIME})
+		}
 		if _, err := c.updateState(r); err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport of #4696 to release-1.3.

----

Since v3.14, CRIU always restores processes into a time namespace to prevent backward jumps of monotonic and boottime clocks. This change updates the container configuration to ensure that `runc exec` launches new processes within the container's time namespace.

Fixes #2610

(cherry picked from commit b68cbdff345fc196e8619164ebf40f1ebaeb6561)