### PR TITLE
go.mod: rm toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/opencontainers/runc
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containerd/console v1.0.4


### PR DESCRIPTION
This was added by dependabot in commit 0b536265. Seems there is a bug about it: https://github.com/dependabot/dependabot-core/issues/11933.

Having "toolchain" means instead of using installed go version to build/test, the version specified in toolchain is [downloaded and] used, which might not be what we actually want.

For more details on toolchain directive, see
https://go.dev/doc/toolchain.