### PR TITLE
[1.3] runc pause/unpause/ps: get rid of excessive warning

### DIFF
--- a/pause.go
+++ b/pause.go
@@ -30,7 +30,11 @@ Use runc list to identify instances of containers and their current status.`,
 		if err != nil {
 			return err
 		}
-		return container.Pause()
+		err = container.Pause()
+		if err != nil {
+			return err
+		}
+		return nil
 	},
 }
 
@@ -59,6 +63,10 @@ Use runc list to identify instances of containers and their current status.`,
 		if err != nil {
 			return err
 		}
-		return container.Resume()
+		err = container.Resume()
+		if err != nil {
+			return err
+		}
+		return nil
 	},
 }

--- a/pause.go
+++ b/pause.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -19,19 +18,13 @@ Use runc list to identify instances of containers and their current status.`,
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}
-		rootlessCg, err := shouldUseRootlessCgroupManager(context)
-		if err != nil {
-			return err
-		}
-		if rootlessCg {
-			logrus.Warnf("runc pause may fail if you don't have the full access to cgroups")
-		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err
 		}
 		err = container.Pause()
 		if err != nil {
+			maybeLogCgroupWarning("pause", err)
 			return err
 		}
 		return nil
@@ -52,19 +45,13 @@ Use runc list to identify instances of containers and their current status.`,
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}
-		rootlessCg, err := shouldUseRootlessCgroupManager(context)
-		if err != nil {
-			return err
-		}
-		if rootlessCg {
-			logrus.Warn("runc resume may fail if you don't have the full access to cgroups")
-		}
 		container, err := getContainer(context)
 		if err != nil {
 			return err
 		}
 		err = container.Resume()
 		if err != nil {
+			maybeLogCgroupWarning("resume", err)
 			return err
 		}
 		return nil

--- a/ps.go
+++ b/ps.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -28,13 +27,6 @@ var psCommand = cli.Command{
 		if err := checkArgs(context, 1, minArgs); err != nil {
 			return err
 		}
-		rootlessCg, err := shouldUseRootlessCgroupManager(context)
-		if err != nil {
-			return err
-		}
-		if rootlessCg {
-			logrus.Warn("runc ps may fail if you don't have the full access to cgroups")
-		}
 
 		container, err := getContainer(context)
 		if err != nil {
@@ -43,6 +35,7 @@ var psCommand = cli.Command{
 
 		pids, err := container.Processes()
 		if err != nil {
+			maybeLogCgroupWarning("ps", err)
 			return err
 		}
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -447,4 +448,10 @@ func setupPidfdSocket(process *libcontainer.Process, sockpath string) (_clean fu
 	return func() {
 		conn.Close()
 	}, nil
+}
+
+func maybeLogCgroupWarning(op string, err error) {
+	if errors.Is(err, fs.ErrPermission) {
+		logrus.Warn("runc " + op + " failure might be caused by lack of full access to cgroups")
+	}
 }


### PR DESCRIPTION
This is a backport of #4709 to release-1.3.

----

This issue was originally reported in podman PR 25792 (https://github.com/containers/podman/pull/25792).

When calling runc pause/unpause for an ordinary user, podman do not provide --systemd-cgroups option, and shouldUseRootlessCgroupManager returns true. This results in a warning:

	$ podman pause sleeper
	WARN[0000] runc pause may fail if you don't have the full access to cgroups
	sleeper

Actually, it does not make sense to call shouldUseRootlessCgroupManager at this point, because we already know if we're rootless or not, from the container state.json (same for systemd).

Also, busctl binary is not available either in this context, so shouldUseRootlessCgroupManager would not work properly.

Finally, it doesn't really matter if we use systemd or not, because we use fs/fs2 manager to freeze/unfreeze, and it will return something like EPERM (or tell that cgroups is not configured, for a true rootless container).

So, let's only print the warning after pause/unpause failed, if the error returned looks like a permission error.

Same logic applies to `runc ps`.