### PR TITLE
ci: add check for toolchain in go.mod

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -144,6 +144,8 @@ jobs:
         check-latest: true
     - name: verify deps
       run: make verify-dependencies
+    - name: no toolchain in go.mod # See https://github.com/opencontainers/runc/pull/4717, https://github.com/dependabot/dependabot-core/issues/11933.
+      run: if grep -q '^toolchain ' go.mod; then echo "Error: go.mod must not have toolchain directive, please fix"; exit 1; fi
 
 
   commit:


### PR DESCRIPTION
This is a followup to #4717, adding a CI check that `toolchain` is not present in go.mod.