### PR TITLE
Completely remove --criu option

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,11 +101,6 @@ func main() {
 			Value: root,
 			Usage: "root directory for storage of container state (this should be located in tmpfs)",
 		},
-		cli.StringFlag{
-			Name:   "criu",
-			Usage:  "(obsoleted; do not use)",
-			Hidden: true,
-		},
 		cli.BoolFlag{
 			Name:  "systemd-cgroup",
 			Usage: "enable systemd cgroup support, expects cgroupsPath to be of form \"slice:prefix:name\" for e.g. \"system.slice:runc:434234\"",
@@ -151,10 +146,6 @@ func main() {
 		}
 		if err := reviseRootDir(context); err != nil {
 			return err
-		}
-		// TODO: remove this in runc 1.3.0.
-		if context.IsSet("criu") {
-			fmt.Fprintln(os.Stderr, "WARNING: --criu ignored (criu binary from $PATH is used); do not use")
 		}
 
 		return configLogrus(context)


### PR DESCRIPTION
This option is unusable since commit 6e1d476a / PR #3353, it's now time to actually remove it.

NO NEED TO BACKPORT TO release-1.3, we want to have it for v1.4 only.