### PR TITLE
tests/cmd/remap-rootfs: fix mips builds

### DIFF
--- a/tests/cmd/remap-rootfs/remap-rootfs.go
+++ b/tests/cmd/remap-rootfs/remap-rootfs.go
@@ -49,7 +49,7 @@ type inodeID struct {
 }
 
 func toInodeID(st *syscall.Stat_t) inodeID {
-	return inodeID{Dev: st.Dev, Ino: st.Ino}
+	return inodeID{Dev: uint64(st.Dev), Ino: st.Ino} //nolint:unconvert // Dev is uint32 on e.g. MIPS.
 }
 
 func remapRootfs(root string, uidMap, gidMap []specs.LinuxIDMapping) error {


### PR DESCRIPTION
Similar to #1824, we need to convert the device number to uint64 for mips.

Signed-off-by: Henry Chen <henry.chen@oss.cipunited.com>