### PR TITLE
fix rootfs propagation mode to shared / unbindable

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -215,6 +215,18 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 		return fmt.Errorf("error jailing process inside rootfs: %w", err)
 	}
 
+	// Apply root mount propagation flags.
+	// This must be done after pivot_root/chroot because the mount propagation flag is applied
+	// to the current root ("/"), and not to the old rootfs before it becomes "/". Applying the
+	// flag in prepareRoot would affect the host mount namespace if the container's
+	// root mount is shared.
+	// MS_PRIVATE is skipped as rootfsParentMountPrivate() is already called.
+	if config.RootPropagation != 0 && config.RootPropagation&unix.MS_PRIVATE == 0 {
+		if err := mount("", "/", "", uintptr(config.RootPropagation), ""); err != nil {
+			return fmt.Errorf("unable to apply root propagation flags: %w", err)
+		}
+	}
+
 	if setupDev {
 		if err := reOpenDevNull(); err != nil {
 			return fmt.Errorf("error reopening /dev/null inside container: %w", err)

--- a/tests/integration/mounts_propagation.bats
+++ b/tests/integration/mounts_propagation.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	requires root
+	setup_debian
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+@test "runc run [rootfsPropagation shared]" {
+	update_config ' .linux.rootfsPropagation = "shared" '
+
+	update_config ' .process.args = ["findmnt", "--noheadings", "-o", "PROPAGATION", "/"] '
+
+	runc run test_shared_rootfs
+	[ "$status" -eq 0 ]
+	[ "$output" = "shared" ]
+}


### PR DESCRIPTION
This PR adds support for applying mount propagation settings (MS_SHARED or MS_UNBINDABLE) to the container root based on the value of config.RootPropagation. 
We apply mount propagation after executing pivot_root and rootfsParentMountPrivate

Fixes https://github.com/opencontainers/runc/issues/1755

Related:
https://github.com/opencontainers/runc/pull/1815 
https://github.com/youki-dev/youki/issues/3141

Signed-off-by: Yusuke Sakurai <yusuke.sakurai@3-shake.com>