### PR TITLE
libct/apparmor: don't use vars for public functions

### DIFF
--- a/libcontainer/apparmor/apparmor.go
+++ b/libcontainer/apparmor/apparmor.go
@@ -2,15 +2,17 @@ package apparmor
 
 import "errors"
 
-var (
-	// IsEnabled returns true if apparmor is enabled for the host.
-	IsEnabled = isEnabled
+// IsEnabled returns true if apparmor is enabled for the host.
+func IsEnabled() bool {
+	return isEnabled()
+}
 
-	// ApplyProfile will apply the profile with the specified name to the process after
-	// the next exec. It is only supported on Linux and produces an ErrApparmorNotEnabled
-	// on other platforms.
-	ApplyProfile = applyProfile
+// ApplyProfile will apply the profile with the specified name to the process
+// after the next exec. It is only supported on Linux and produces an
+// [ErrApparmorNotEnabled] on other platforms.
+func ApplyProfile(name string) error {
+	return applyProfile(name)
+}
 
-	// ErrApparmorNotEnabled indicates that AppArmor is not enabled or not supported.
-	ErrApparmorNotEnabled = errors.New("apparmor: config provided but apparmor not supported")
-)
+// ErrApparmorNotEnabled indicates that AppArmor is not enabled or not supported.
+var ErrApparmorNotEnabled = errors.New("apparmor: config provided but apparmor not supported")

--- a/libcontainer/apparmor/apparmor_linux.go
+++ b/libcontainer/apparmor/apparmor_linux.go
@@ -53,7 +53,7 @@ func setProcAttr(attr, value string) error {
 	return err
 }
 
-// changeOnExec reimplements aa_change_onexec from libapparmor in Go
+// changeOnExec reimplements aa_change_onexec from libapparmor in Go.
 func changeOnExec(name string) error {
 	if err := setProcAttr("exec", "exec "+name); err != nil {
 		return fmt.Errorf("apparmor failed to apply profile: %w", err)
@@ -61,9 +61,8 @@ func changeOnExec(name string) error {
 	return nil
 }
 
-// applyProfile will apply the profile with the specified name to the process after
-// the next exec. It is only supported on Linux and produces an error on other
-// platforms.
+// applyProfile will apply the profile with the specified name to the process
+// after the next exec.
 func applyProfile(name string) error {
 	if name == "" {
 		return nil


### PR DESCRIPTION
Unfortunately, Go documentation formatter does a sloppy job formatting documentation for variables -- it is rendered as comments (see [1]).

Switch to using wrapper functions, solely for the sake of better documentation formatting.

[1]: https://pkg.go.dev/github.com/opencontainers/runc@v1.3.0-rc.2/libcontainer/apparmor