### PR TITLE
ci fixes (ssh-keygen and criu version bump for almalinux 8)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ task:
   install_dependencies_script: |
     case $DISTRO in
     *-8)
-      yum config-manager --set-enabled powertools # for glibc-static
+      dnf config-manager --set-enabled powertools # for glibc-static
       ;;
     *-9)
       dnf config-manager --set-enabled crb # for glibc-static
@@ -49,6 +49,15 @@ task:
       yum install -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs $RPMS && break
     done
     [ $? -eq 0 ] # fail if yum failed
+
+    case $DISTRO in
+    *-8)
+      # Use newer criu (with https://github.com/checkpoint-restore/criu/pull/2545).
+      # Alas we have to disable container-tools for that.
+      dnf -y module disable container-tools
+      dnf -y copr enable adrian/criu-el8
+      dnf -y install criu
+    esac
 
     # Install Go.
     URL_PREFIX="https://go.dev/dl/"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,14 +71,8 @@ task:
     git checkout $BATS_VERSION
     ./install.sh /usr/local
     cd -
-    # Add a user for rootless tests
-    useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
-    # Allow root and rootless itself to execute `ssh rootless@localhost` in tests/rootless.sh
-    ssh-keygen -t ecdsa -N "" -f /root/rootless.key
-    mkdir -m 0700 -p /home/rootless/.ssh
-    cp /root/rootless.key /home/rootless/.ssh/id_ecdsa
-    cat /root/rootless.key.pub >> /home/rootless/.ssh/authorized_keys
-    chown -R rootless.rootless /home/rootless
+    # Setup rootless tests.
+    /home/runc/script/setup_rootless.sh
     # set PATH
     echo 'export PATH=/usr/local/go/bin:/usr/local/bin:$PATH' >> /root/.bashrc
     # Setup ssh localhost for terminal emulation (script -e did not work)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,13 +159,7 @@ jobs:
     - name: add rootless user
       if: matrix.rootless == 'rootless'
       run: |
-        sudo useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
-        # Allow root and rootless itself to execute `ssh rootless@localhost` in tests/rootless.sh
-        ssh-keygen -t ecdsa -N "" -f $HOME/rootless.key
-        sudo mkdir -m 0700 -p /home/rootless/.ssh
-        sudo cp $HOME/rootless.key /home/rootless/.ssh/id_ecdsa
-        sudo cp $HOME/rootless.key.pub /home/rootless/.ssh/authorized_keys
-        sudo chown -R rootless.rootless /home/rootless
+        ./script/setup_rootless.sh
         sudo chmod a+X $HOME # for Ubuntu 22.04 and later
 
     - name: integration test (fs driver)

--- a/script/setup_host_fedora.sh
+++ b/script/setup_host_fedora.sh
@@ -12,15 +12,8 @@ dnf clean all
 # To avoid "avc: denied { nosuid_transition }" from SELinux as we run tests on /tmp.
 mount -o remount,suid /tmp
 
-# Add a user for rootless tests
-useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
-
-# Allow root and rootless itself to execute `ssh rootless@localhost` in tests/rootless.sh
-ssh-keygen -t ecdsa -N "" -f /root/rootless.key
-mkdir -m 0700 /home/rootless/.ssh
-cp /root/rootless.key /home/rootless/.ssh/id_ecdsa
-cat /root/rootless.key.pub >>/home/rootless/.ssh/authorized_keys
-chown -R rootless.rootless /home/rootless
+# Setup rootless user.
+"$(dirname "${BASH_SOURCE[0]}")"/setup_rootless.sh
 
 # Delegate cgroup v2 controllers to rootless user via --systemd-cgroup
 mkdir -p /etc/systemd/system/user@.service.d

--- a/script/setup_rootless.sh
+++ b/script/setup_rootless.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux -o pipefail
+
+# Add a user for rootless tests.
+sudo useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
+
+# Allow both the current user and rootless itself to use
+# ssh rootless@localhost in tests/rootless.sh.
+# shellcheck disable=SC2174 # Silence "-m only applies to the deepest directory".
+mkdir -p -m 0700 "$HOME/.ssh"
+ssh-keygen -t ecdsa -N "" -f "$HOME/.ssh/rootless.key"
+sudo mkdir -p -m 0700 /home/rootless/.ssh
+sudo cp "$HOME/.ssh/rootless.key" /home/rootless/.ssh/id_ecdsa
+sudo cp "$HOME/.ssh/rootless.key.pub" /home/rootless/.ssh/authorized_keys
+sudo chown -R rootless.rootless /home/rootless

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -185,7 +185,7 @@ for enabled_features in $features_powerset; do
 		# We use `ssh rootless@localhost` instead of `sudo -u rootless` for creating systemd user session.
 		# Alternatively we could use `machinectl shell`, but it is known not to work well on SELinux-enabled hosts as of April 2020:
 		# https://bugzilla.redhat.com/show_bug.cgi?id=1788616
-		ssh -t -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$HOME/rootless.key" rootless@localhost -- PATH="$PATH" RUNC_USE_SYSTEMD="$RUNC_USE_SYSTEMD" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
+		ssh -t -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$HOME/.ssh/rootless.key" rootless@localhost -- PATH="$PATH" RUNC_USE_SYSTEMD="$RUNC_USE_SYSTEMD" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	else
 		sudo -HE -u rootless PATH="$PATH" "$(which bats)" -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	fi


### PR DESCRIPTION
1. We are seeing a ton on flakes on almalinux-8 CI job, all caused by criu inability to freeze a cgroup. This was worked around in criu (https://github.com/checkpoint-restore/criu/pull/2545), but obviously we can't rely on a distro vendor to update the package.

Let's use a copr (thanks to @adrianreber!)

Fixes: https://github.com/opencontainers/runc/issues/4273

2. ssh-keygen stopped working in AlmaLinux 8, fix this as well (see commit for details).

Fixes: #4731