### PR TITLE
[DNM] ci: try criu 4.1 on Fedora 41

### DIFF
--- a/script/setup_host_fedora.sh
+++ b/script/setup_host_fedora.sh
@@ -7,6 +7,9 @@ for i in $(seq 0 2); do
 	sleep "$i"
 	"${DNF[@]}" update && "${DNF[@]}" install "${RPMS[@]}" && break
 done
+
+# Bump criu to v4.1 for testing.
+dnf -y --enablerepo=updates-testing update criu
 dnf clean all
 
 # To avoid "avc: denied { nosuid_transition }" from SELinux as we run tests on /tmp.


### PR DESCRIPTION
For the sake of https://github.com/opencontainers/runc/issues/4729 / https://github.com/checkpoint-restore/criu/issues/2649 debugging.