### PR TITLE
ci: update to criu-4.1-2 on Fedora

### DIFF
--- a/script/setup_host_fedora.sh
+++ b/script/setup_host_fedora.sh
@@ -7,6 +7,13 @@ for i in $(seq 0 2); do
 	sleep "$i"
 	"${DNF[@]}" update && "${DNF[@]}" install "${RPMS[@]}" && break
 done
+
+# criu-4.1-1 has a known bug (https://github.com/checkpoint-restore/criu/issues/2650)
+# which is fixed in criu-4.1-2 (currently in updates-testing). TODO: remove this later.
+if [[ $(rpm -q criu) == "criu-4.1-1.fc"* ]]; then
+	"${DNF[@]}" --enablerepo=updates-testing update criu
+fi
+
 dnf clean all
 
 # To avoid "avc: denied { nosuid_transition }" from SELinux as we run tests on /tmp.


### PR DESCRIPTION
Package criu-4.1-1 has a known bug [1] which is fixed in criu-4.1-2 [2],
which is currently only available in updates-testing. Add a kludge to
install newer criu if necessary to fix CI.
    
This will not be needed in ~2 weeks once the new package is promoted to
updates. 

~~OK, we need to wait until criu-4.1-2 is available from all fedora mirrors. Draft until then.~~

[1]: https://github.com/checkpoint-restore/criu/issues/2650
[2]: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d374d8ce17