### PR TITLE
[1.2] ci fixes (ssh-keygen and criu version bumps for almalinux 8 and fedora)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,14 +71,8 @@ task:
     git checkout $BATS_VERSION
     ./install.sh /usr/local
     cd -
-    # Add a user for rootless tests
-    useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
-    # Allow root and rootless itself to execute `ssh rootless@localhost` in tests/rootless.sh
-    ssh-keygen -t ecdsa -N "" -f /root/rootless.key
-    mkdir -m 0700 -p /home/rootless/.ssh
-    cp /root/rootless.key /home/rootless/.ssh/id_ecdsa
-    cat /root/rootless.key.pub >> /home/rootless/.ssh/authorized_keys
-    chown -R rootless.rootless /home/rootless
+    # Setup rootless tests.
+    /home/runc/script/setup_rootless.sh
     # set PATH
     echo 'export PATH=/usr/local/go/bin:/usr/local/bin:$PATH' >> /root/.bashrc
     # Setup ssh localhost for terminal emulation (script -e did not work)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ task:
   install_dependencies_script: |
     case $DISTRO in
     *-8)
-      yum config-manager --set-enabled powertools # for glibc-static
+      dnf config-manager --set-enabled powertools # for glibc-static
       ;;
     *-9)
       dnf config-manager --set-enabled crb # for glibc-static
@@ -49,6 +49,15 @@ task:
       yum install -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs $RPMS && break
     done
     [ $? -eq 0 ] # fail if yum failed
+
+    case $DISTRO in
+    *-8)
+      # Use newer criu (with https://github.com/checkpoint-restore/criu/pull/2545).
+      # Alas we have to disable container-tools for that.
+      dnf -y module disable container-tools
+      dnf -y copr enable adrian/criu-el8
+      dnf -y install criu
+    esac
 
     # Install Go.
     PREFIX="https://go.dev/dl/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,13 +163,7 @@ jobs:
     - name: add rootless user
       if: matrix.rootless == 'rootless'
       run: |
-        sudo useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
-        # Allow root and rootless itself to execute `ssh rootless@localhost` in tests/rootless.sh
-        ssh-keygen -t ecdsa -N "" -f $HOME/rootless.key
-        sudo mkdir -m 0700 -p /home/rootless/.ssh
-        sudo cp $HOME/rootless.key /home/rootless/.ssh/id_ecdsa
-        sudo cp $HOME/rootless.key.pub /home/rootless/.ssh/authorized_keys
-        sudo chown -R rootless.rootless /home/rootless
+        ./script/setup_rootless.sh
         sudo chmod a+X $HOME # for Ubuntu 22.04 and later
 
     - name: integration test (fs driver)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,9 +102,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: install shellcheck
         env:
-          VERSION: v0.9.0
+          VERSION: v0.10.0
           BASEURL: https://github.com/koalaman/shellcheck/releases/download
-          SHA256: 7087178d54de6652b404c306233264463cb9e7a9afeb259bb663cc4dbfd64149
+          SHA256: f35ae15a4677945428bdfe61ccc297490d89dd1e544cc06317102637638c6deb
         run: |
           mkdir ~/bin
           curl -sSfL --retry 5 $BASEURL/$VERSION/shellcheck-$VERSION.linux.x86_64.tar.xz |

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ shellcheck:
 shfmt:
 	$(CONTAINER_ENGINE) run $(CONTAINER_ENGINE_RUN_FLAGS) \
 		--rm -v $(CURDIR):/src -w /src \
-		mvdan/shfmt:v3.5.1 -d -w .
+		mvdan/shfmt:v3.11.0 -d -w .
 
 .PHONY: localshfmt
 localshfmt:

--- a/script/setup_host_fedora.sh
+++ b/script/setup_host_fedora.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -eux -o pipefail
-DNF_OPTS="-y --setopt=install_weak_deps=False --setopt=tsflags=nodocs --exclude=kernel,kernel-core"
-RPMS="bats git-core glibc-static golang jq libseccomp-devel make"
+DNF=(dnf -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs --exclude="kernel,kernel-core")
+RPMS=(bats git-core glibc-static golang jq libseccomp-devel make)
 # Work around dnf mirror failures by retrying a few times.
 for i in $(seq 0 2); do
 	sleep "$i"
-	# shellcheck disable=SC2086
-	dnf $DNF_OPTS update && dnf $DNF_OPTS install $RPMS && break
+	"${DNF[@]}" update && "${DNF[@]}" install "${RPMS[@]}" && break
 done
 dnf clean all
 

--- a/script/setup_host_fedora.sh
+++ b/script/setup_host_fedora.sh
@@ -12,15 +12,8 @@ dnf clean all
 # To avoid "avc: denied { nosuid_transition }" from SELinux as we run tests on /tmp.
 mount -o remount,suid /tmp
 
-# Add a user for rootless tests
-useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
-
-# Allow root and rootless itself to execute `ssh rootless@localhost` in tests/rootless.sh
-ssh-keygen -t ecdsa -N "" -f /root/rootless.key
-mkdir -m 0700 /home/rootless/.ssh
-cp /root/rootless.key /home/rootless/.ssh/id_ecdsa
-cat /root/rootless.key.pub >>/home/rootless/.ssh/authorized_keys
-chown -R rootless.rootless /home/rootless
+# Setup rootless user.
+"$(dirname "${BASH_SOURCE[0]}")"/setup_rootless.sh
 
 # Delegate cgroup v2 controllers to rootless user via --systemd-cgroup
 mkdir -p /etc/systemd/system/user@.service.d

--- a/script/setup_host_fedora.sh
+++ b/script/setup_host_fedora.sh
@@ -7,6 +7,13 @@ for i in $(seq 0 2); do
 	sleep "$i"
 	"${DNF[@]}" update && "${DNF[@]}" install "${RPMS[@]}" && break
 done
+
+# criu-4.1-1 has a known bug (https://github.com/checkpoint-restore/criu/issues/2650)
+# which is fixed in criu-4.1-2 (currently in updates-testing). TODO: remove this later.
+if [[ $(rpm -q criu) == "criu-4.1-1.fc"* ]]; then
+	"${DNF[@]}" --enablerepo=updates-testing update criu
+fi
+
 dnf clean all
 
 # To avoid "avc: denied { nosuid_transition }" from SELinux as we run tests on /tmp.

--- a/script/setup_host_fedora.sh
+++ b/script/setup_host_fedora.sh
@@ -18,8 +18,7 @@ useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
 
 # Allow root and rootless itself to execute `ssh rootless@localhost` in tests/rootless.sh
 ssh-keygen -t ecdsa -N "" -f /root/rootless.key
-# shellcheck disable=SC2174
-mkdir -m 0700 -p /home/rootless/.ssh
+mkdir -m 0700 /home/rootless/.ssh
 cp /root/rootless.key /home/rootless/.ssh/id_ecdsa
 cat /root/rootless.key.pub >>/home/rootless/.ssh/authorized_keys
 chown -R rootless.rootless /home/rootless

--- a/script/setup_rootless.sh
+++ b/script/setup_rootless.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux -o pipefail
+
+# Add a user for rootless tests.
+sudo useradd -u2000 -m -d/home/rootless -s/bin/bash rootless
+
+# Allow both the current user and rootless itself to use
+# ssh rootless@localhost in tests/rootless.sh.
+# shellcheck disable=SC2174 # Silence "-m only applies to the deepest directory".
+mkdir -p -m 0700 "$HOME/.ssh"
+ssh-keygen -t ecdsa -N "" -f "$HOME/.ssh/rootless.key"
+sudo mkdir -p -m 0700 /home/rootless/.ssh
+sudo cp "$HOME/.ssh/rootless.key" /home/rootless/.ssh/id_ecdsa
+sudo cp "$HOME/.ssh/rootless.key.pub" /home/rootless/.ssh/authorized_keys
+sudo chown -R rootless.rootless /home/rootless

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -21,7 +21,6 @@ function teardown() {
 @test "runc create [hook fails]" {
 	for hook in prestart createRuntime createContainer; do
 		echo "testing hook $hook"
-		# shellcheck disable=SC2016
 		update_config '.hooks |= {"'$hook'": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
 		runc create --console-socket "$CONSOLE_SOCKET" test_hooks
 		[ "$status" -ne 0 ]
@@ -34,7 +33,6 @@ function teardown() {
 	# All hooks except Poststop.
 	for hook in prestart createRuntime createContainer startContainer poststart; do
 		echo "testing hook $hook"
-		# shellcheck disable=SC2016
 		update_config '.hooks |= {"'$hook'": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
 		runc run "test_hook-$hook"
 		[[ "$output" != "Hello World" ]]

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -84,7 +84,6 @@ function teardown() {
 	chmod 'a=rwx,ug+s,+t' rootfs/tmp # set all bits
 	mode=$(stat -c %A rootfs/tmp)
 
-	# shellcheck disable=SC2016
 	update_config '.process.args = ["sh", "-c", "stat -c %A /tmp"]'
 	update_config '.mounts += [{"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options":["noexec","nosuid","nodev","rprivate"]}]'
 
@@ -94,7 +93,6 @@ function teardown() {
 }
 
 @test "runc run with tmpfs perms" {
-	# shellcheck disable=SC2016
 	update_config '.process.args = ["sh", "-c", "stat -c %a /tmp/test"]'
 	update_config '.mounts += [{"destination": "/tmp/test", "type": "tmpfs", "source": "tmpfs", "options": ["mode=0444"]}]'
 
@@ -113,14 +111,12 @@ function teardown() {
 	# so it should use the directory's perms.
 	update_config '.mounts[-1].options = []'
 	chmod 0710 rootfs/tmp/test
-	# shellcheck disable=SC2016
 	runc run test_tmpfs
 	[ "$status" -eq 0 ]
 	[ "${lines[0]}" = "710" ]
 
 	# Add back the mode on the mount, and it should use that instead.
 	# Just for fun, use different perms than was used earlier.
-	# shellcheck disable=SC2016
 	update_config '.mounts[-1].options = ["mode=0410"]'
 	runc run test_tmpfs
 	[ "$status" -eq 0 ]

--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -183,7 +183,7 @@ function scmp_act_notify_template() {
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY startContainer hook)" {
 	# shellcheck disable=SC2016
 	# We use single quotes to properly delimit the $1 param to
-	# update_config(), but this shellshcheck is quite silly and fails if the
+	# update_config(), but shellcheck is quite silly and fails if the
 	# multi-line string includes some $var (even when it is properly outside of the
 	# single quotes) or when we use this syntax to execute commands in the
 	# string: $(command).

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -123,7 +123,6 @@ function teardown() {
 
 	# replace "uid": 0 with "uid": 1000
 	# and do a similar thing for gid.
-	# shellcheck disable=SC2016
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 			| (.. | select(.gid? == 0)) .gid |= 100'
 

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -185,7 +185,7 @@ for enabled_features in $features_powerset; do
 		# We use `ssh rootless@localhost` instead of `sudo -u rootless` for creating systemd user session.
 		# Alternatively we could use `machinectl shell`, but it is known not to work well on SELinux-enabled hosts as of April 2020:
 		# https://bugzilla.redhat.com/show_bug.cgi?id=1788616
-		ssh -t -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$HOME/rootless.key" rootless@localhost -- PATH="$PATH" RUNC_USE_SYSTEMD="$RUNC_USE_SYSTEMD" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
+		ssh -t -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$HOME/.ssh/rootless.key" rootless@localhost -- PATH="$PATH" RUNC_USE_SYSTEMD="$RUNC_USE_SYSTEMD" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	else
 		sudo -HE -u rootless PATH="$PATH" "$(which bats)" -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	fi


### PR DESCRIPTION
This is a backport of
 - #4670 (except the last commit)
 - #4728
 - #4736 

to release-1.2 branch. Original description follows.

----

(from #4670)

High level overview:

- bump shfmt and shellcheck;
- get rid of some "shellcheck disable" annotations;
~~- bump bats to v0.11.0 so we use the same version everywhere.~~ (not applied)

----

(from #4728) 

We are seeing a ton on flakes on almalinux-8 CI job, all caused by criu inability to freeze a cgroup. This was worked around in criu (Freeze fixes and v1 kludges checkpoint-restore/criu#2545), but obviously we can't rely on a distro vendor to update the package.
Let's use a copr (thanks to @adrianreber!)

Fixes: #4273

ssh-keygen stopped working in AlmaLinux 8, fix this as well (see commit for details).

Fixes: #4731

----

(from #4736)

Package criu-4.1-1 has a known bug [1] which is fixed in criu-4.1-2 [2],
which is currently only available in updates-testing. Add a kludge to
install newer criu if necessary to fix CI.
    
This will not be needed in ~2 weeks once the new package is promoted to
updates. 

[1]: https://github.com/checkpoint-restore/criu/issues/2650
[2]: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d374d8ce17