### PR TITLE
ci/cross-i386: retry adding ppa

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,8 +192,8 @@ jobs:
     - name: install deps
       run: |
         sudo dpkg --add-architecture i386
-        # add criu repo
-        sudo add-apt-repository -y ppa:criu/ppa
+        # Add criu repo. The web server returns gateway timeout, thus the retry.
+        sudo add-apt-repository -y ppa:criu/ppa || sudo add-apt-repository -y ppa:criu/ppa
         # apt-add-repository runs apt update so we don't have to.
 
         sudo apt -qy install libseccomp-dev libseccomp-dev:i386 gcc-multilib libgcc-s1:i386 criu


### PR DESCRIPTION
For some reason, launchpad.net is frequently giving us Gateway Timeout. Let's retry adding the ppa once to mitigate that.

(The alternative is not to install criu and thus run criu-related unit tests on i386 -- this might actually be better).