### PR TITLE
[1.3] Embed version from VERSION file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ BUILDTAGS += $(EXTRA_BUILDTAGS)
 
 COMMIT := $(shell git describe --dirty --long --always)
 EXTRA_VERSION :=
-VERSION := $(shell cat ./VERSION)$(EXTRA_VERSION)
-LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
+LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) \
+		  $(if $(strip $(EXTRA_VERSION)),-X main.extraVersion=$(EXTRA_VERSION),)
 
 GOARCH := $(shell $(GO) env GOARCH)
 
@@ -118,11 +118,11 @@ release: runcimage
 		--rm -v $(CURDIR):/go/src/$(PROJECT) \
 		-e RELEASE_ARGS=$(RELEASE_ARGS) \
 		$(RUNC_IMAGE) make localrelease
-	script/release_sign.sh -S $(GPG_KEYID) -r release/$(VERSION) -v $(VERSION)
+	script/release_sign.sh -S $(GPG_KEYID)
 
 .PHONY: localrelease
 localrelease: verify-changelog
-	script/release_build.sh -r release/$(VERSION) -v $(VERSION) $(RELEASE_ARGS)
+	script/release_build.sh $(RELEASE_ARGS)
 
 .PHONY: dbuild
 dbuild: runcimage

--- a/main.go
+++ b/main.go
@@ -27,6 +27,22 @@ var version = "unknown"
 // and will be populated by the Makefile
 var gitCommit = ""
 
+func printVersion(c *cli.Context) {
+	w := c.App.Writer
+
+	fmt.Fprintln(w, "runc version", c.App.Version)
+	if gitCommit != "" {
+		fmt.Fprintln(w, "commit:", gitCommit)
+	}
+	fmt.Fprintln(w, "spec:", specs.Version)
+	fmt.Fprintln(w, "go:", runtime.Version())
+
+	major, minor, micro := seccomp.Version()
+	if major+minor+micro > 0 {
+		fmt.Fprintf(w, "libseccomp: %d.%d.%d\n", major, minor, micro)
+	}
+}
+
 const (
 	specConfig = "config.json"
 	usage      = `Open Container Initiative runtime
@@ -57,21 +73,10 @@ value for "bundle" is the current directory.`
 func main() {
 	app := cli.NewApp()
 	app.Name = "runc"
+	app.Version = version
 	app.Usage = usage
 
-	v := []string{version}
-
-	if gitCommit != "" {
-		v = append(v, "commit: "+gitCommit)
-	}
-	v = append(v, "spec: "+specs.Version)
-	v = append(v, "go: "+runtime.Version())
-
-	major, minor, micro := seccomp.Version()
-	if major+minor+micro > 0 {
-		v = append(v, fmt.Sprintf("libseccomp: %d.%d.%d", major, minor, micro))
-	}
-	app.Version = strings.Join(v, "\n")
+	cli.VersionPrinter = printVersion
 
 	root := "/run/runc"
 	xdgDirUsed := false

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -19,12 +20,18 @@ import (
 	"github.com/urfave/cli"
 )
 
-// version must be set from the contents of VERSION file by go build's
-// -X main.version= option in the Makefile.
-var version = "unknown"
+// version is set from the contents of VERSION file.
+//
+//go:embed VERSION
+var version string
+
+// extraVersion is an optional suffix appended to runc version.
+// It can be set via Makefile ("make EXTRA_VERSION=xxx") or by
+// adding -X main.extraVersion=xxx option to the go build command.
+var extraVersion = ""
 
 // gitCommit will be the hash that the binary was built from
-// and will be populated by the Makefile
+// and will be populated by the Makefile.
 var gitCommit = ""
 
 func printVersion(c *cli.Context) {
@@ -73,7 +80,7 @@ value for "bundle" is the current directory.`
 func main() {
 	app := cli.NewApp()
 	app.Name = "runc"
-	app.Version = version
+	app.Version = strings.TrimSpace(version) + extraVersion
 	app.Usage = usage
 
 	cli.VersionPrinter = printVersion


### PR DESCRIPTION
This is a backport of #4718 to release-1.3 branch. Original description follows.

----

This is a carry/rework of #3163.

See individual commits for details.

Aside from embedding VERSION file into the binary, it simplifies the output of `runc help`.

Before:
```console
$ runc help
 ...
USAGE:
   runc [global options] command [command options] [arguments...]

VERSION:
   1.3.0-rc.1+dev
commit: v1.3.0-rc.1-93-g932e8342
spec: 1.2.1
go: go1.24.2
libseccomp: 2.5.5

COMMANDS:
   checkpoint  checkpoint a running container
...
```

After:
```console
$ runc help
 ...
USAGE:
   runc [global options] command [command options] [arguments...]
   
VERSION:
   1.3.0-rc.1+dev

COMMANDS:
   checkpoint  checkpoint a running container
...
```

The full version info is still shown by `runc --version` exactly as before:
```console
$ runc --version
runc version 1.3.0-rc.1+dev
commit: v1.3.0-rc.1-93-g932e8342
spec: 1.2.1
go: go1.24.2
libseccomp: 2.5.5
```

The EXTRA_VERSION kludge, added by #4370, also works exactly as before:

```console
$ make EXTRA_VERSION="+build-1"
go build -trimpath "-buildmode=pie"  -tags "seccomp urfave_cli_no_docs" -ldflags "-X main.gitCommit=v1.3.0-rc.1-95-gd84aaa38 -X main.extraVersion=+build-1 " -o runc .
[kir@kir-tp1 runc]$ ./runc --version
runc version 1.3.0-rc.1+dev+build-1
commit: v1.3.0-rc.1-95-gd84aaa38
spec: 1.2.1
go: go1.24.2
libseccomp: 2.5.5
```