### PR TITLE
[1.3][ci]: switch to golangci-lint v2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,9 +38,9 @@ jobs:
         run: |
           sudo apt -q update
           sudo apt -qy install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -3,13 +3,19 @@
 #
 # For the default linter config, see .golangci.yml. This config should
 # only enable additional linters not enabled in the default config.
+version: "2"
 
 run:
   build-tags:
     - seccomp
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - godot
     - revive
+    - staticcheck
+  settings:
+    staticcheck:
+      checks:
+        - all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,29 @@
-# For documentation, see https://golangci-lint.run/usage/configuration/
+version: "2"
 
 run:
   build-tags:
     - seccomp
 
-linters:
+formatters:
   enable:
     - gofumpt
+
+linters:
+  enable:
     - errorlint
     - unconvert
     - unparam
-
-linters-settings:
-  govet:
-    enable:
-      - nilness
+  settings:
+    govet:
+      enable:
+        - nilness
+    staticcheck:
+      checks:
+        - all
+        - -ST1000 # https://staticcheck.dev/docs/checks/#ST1000 Incorrect or missing package comment.
+        - -ST1003 # https://staticcheck.dev/docs/checks/#ST1003 Poorly chosen identifier.
+        - -ST1005 # https://staticcheck.dev/docs/checks/#ST1005 Incorrectly formatted error string.
+        - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
+  exclusions:
+    presets:
+      - std-error-handling

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -70,7 +70,7 @@ checkpointed.`,
 		}
 
 		err = container.Checkpoint(options)
-		if err == nil && !(options.LeaveRunning || options.PreDump) {
+		if err == nil && !options.LeaveRunning && !options.PreDump {
 			// Destroy the container unless we tell CRIU to keep it.
 			if err := container.Destroy(); err != nil {
 				logrus.Warn(err)

--- a/libcontainer/capabilities/capabilities.go
+++ b/libcontainer/capabilities/capabilities.go
@@ -114,7 +114,7 @@ func (c *Caps) ApplyBoundingSet() error {
 	return c.pid.Apply(capability.BOUNDING)
 }
 
-// Apply sets all the capabilities for the current process in the config.
+// ApplyCaps sets all the capabilities for the current process in the config.
 func (c *Caps) ApplyCaps() error {
 	if c.pid == nil {
 		return nil

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -956,8 +956,8 @@ func (c *Container) criuSwrk(process *Process, req *criurpc.CriuReq, opts *CriuO
 	// available but empty. criurpc.CriuReqType_VERSION actually
 	// has no req.GetOpts().
 	if logrus.GetLevel() >= logrus.DebugLevel &&
-		!(req.GetType() == criurpc.CriuReqType_FEATURE_CHECK ||
-			req.GetType() == criurpc.CriuReqType_VERSION) {
+		(req.GetType() != criurpc.CriuReqType_FEATURE_CHECK &&
+			req.GetType() != criurpc.CriuReqType_VERSION) {
 
 		val := reflect.ValueOf(req.GetOpts())
 		v := reflect.Indirect(val)

--- a/libcontainer/intelrdt/cmt.go
+++ b/libcontainer/intelrdt/cmt.go
@@ -2,7 +2,7 @@ package intelrdt
 
 var cmtEnabled bool
 
-// Check if Intel RDT/CMT is enabled.
+// IsCMTEnabled checks if Intel RDT/CMT is enabled.
 func IsCMTEnabled() bool {
 	featuresInit()
 	return cmtEnabled

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -416,13 +416,13 @@ func WriteIntelRdtTasks(dir string, pid int) error {
 	return nil
 }
 
-// Check if Intel RDT/CAT is enabled
+// IsCATEnabled checks if Intel RDT/CAT is enabled.
 func IsCATEnabled() bool {
 	featuresInit()
 	return catEnabled
 }
 
-// Check if Intel RDT/MBA is enabled
+// IsMBAEnabled checks if Intel RDT/MBA is enabled.
 func IsMBAEnabled() bool {
 	featuresInit()
 	return mbaEnabled
@@ -443,7 +443,7 @@ func (m *Manager) getIntelRdtPath() (string, error) {
 	return filepath.Join(rootPath, clos), nil
 }
 
-// Applies Intel RDT configuration to the process with the specified pid
+// Apply applies Intel RDT configuration to the process with the specified pid.
 func (m *Manager) Apply(pid int) (err error) {
 	// If intelRdt is not specified in config, we do nothing
 	if m.config.IntelRdt == nil {
@@ -478,7 +478,7 @@ func (m *Manager) Apply(pid int) (err error) {
 	return nil
 }
 
-// Destroys the Intel RDT container-specific 'container_id' group
+// Destroy destroys the Intel RDT container-specific container_id group.
 func (m *Manager) Destroy() error {
 	// Don't remove resctrl group if closid has been explicitly specified. The
 	// group is likely externally managed, i.e. by some other entity than us.
@@ -494,8 +494,8 @@ func (m *Manager) Destroy() error {
 	return nil
 }
 
-// Returns Intel RDT path to save in a state file and to be able to
-// restore the object later
+// GetPath returns Intel RDT path to save in a state file and to be able to
+// restore the object later.
 func (m *Manager) GetPath() string {
 	if m.path == "" {
 		m.path, _ = m.getIntelRdtPath()
@@ -503,7 +503,7 @@ func (m *Manager) GetPath() string {
 	return m.path
 }
 
-// Returns statistics for Intel RDT
+// GetStats returns statistics for Intel RDT.
 func (m *Manager) GetStats() (*Stats, error) {
 	// If intelRdt is not specified in config
 	if m.config.IntelRdt == nil {

--- a/libcontainer/intelrdt/mbm.go
+++ b/libcontainer/intelrdt/mbm.go
@@ -3,7 +3,7 @@ package intelrdt
 // The flag to indicate if Intel RDT/MBM is enabled
 var mbmEnabled bool
 
-// Check if Intel RDT/MBM is enabled.
+// IsMBMEnabled checks if Intel RDT/MBM is enabled.
 func IsMBMEnabled() bool {
 	featuresInit()
 	return mbmEnabled

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -357,7 +357,7 @@ func mountCgroupV2(m *configs.Mount, c *mountConfig) error {
 	err := utils.WithProcfd(c.root, m.Destination, func(dstFd string) error {
 		return mountViaFds(m.Source, nil, m.Destination, dstFd, "cgroup2", uintptr(m.Flags), m.Data)
 	})
-	if err == nil || !(errors.Is(err, unix.EPERM) || errors.Is(err, unix.EBUSY)) {
+	if err == nil || (!errors.Is(err, unix.EPERM) && !errors.Is(err, unix.EBUSY)) {
 		return err
 	}
 

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1260,7 +1260,7 @@ func maskPath(path string, mountLabel string) error {
 // writeSystemProperty writes the value to a path under /proc/sys as determined from the key.
 // For e.g. net.ipv4.ip_forward translated to /proc/sys/net/ipv4/ip_forward.
 func writeSystemProperty(key, value string) error {
-	keyPath := strings.Replace(key, ".", "/", -1)
+	keyPath := strings.ReplaceAll(key, ".", "/")
 	return os.WriteFile(path.Join("/proc/sys", keyPath), []byte(value), 0o644)
 }
 

--- a/notify_socket.go
+++ b/notify_socket.go
@@ -103,11 +103,11 @@ func (s *notifySocket) waitForContainer(container *libcontainer.Container) error
 	return s.run(state.InitProcessPid)
 }
 
-func (n *notifySocket) run(pid1 int) error {
-	if n.socket == nil {
+func (s *notifySocket) run(pid1 int) error {
+	if s.socket == nil {
 		return nil
 	}
-	notifySocketHostAddr := net.UnixAddr{Name: n.host, Net: "unixgram"}
+	notifySocketHostAddr := net.UnixAddr{Name: s.host, Net: "unixgram"}
 	client, err := net.DialUnix("unixgram", nil, &notifySocketHostAddr)
 	if err != nil {
 		return err
@@ -120,7 +120,7 @@ func (n *notifySocket) run(pid1 int) error {
 	go func() {
 		for {
 			buf := make([]byte, 4096)
-			r, err := n.socket.Read(buf)
+			r, err := s.socket.Read(buf)
 			if err != nil {
 				return
 			}

--- a/types/events.go
+++ b/types/events.go
@@ -12,7 +12,7 @@ type Event struct {
 	Data interface{} `json:"data,omitempty"`
 }
 
-// stats is the runc specific stats structure for stability when encoding and decoding stats.
+// Stats is the runc specific stats structure for stability when encoding and decoding stats.
 type Stats struct {
 	CPU               Cpu                 `json:"cpu"`
 	CPUSet            CPUSet              `json:"cpuset"`


### PR DESCRIPTION
Backport #4692 
----
Switch to golangci v2.0.

The new configuration file was initially generated by golangci-lint
migrate, when tweaked to minimize and simplify.
    
golangci-lint v2 switches to a new version of staticcheck which shows
much more warnings. Some of them were fixed by a few previous commits,
and the rest of them are disabled.
    
In particular, ST1005 had to be disabled (an attempt to fix it was made
in https://github.com/opencontainers/runc/pull/3857 but it wasn't merged).