### PR TITLE
ci: bump golangci-lint to v2.1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0
+          version: v2.1
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
(The current v2.1 release is v2.1.5 as of today).