### PR TITLE
go.mod: Delete exclude directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,13 +26,6 @@ require (
 	google.golang.org/protobuf v1.36.6
 )
 
-// https://github.com/opencontainers/runc/issues/4594
-exclude (
-	github.com/cilium/ebpf v0.17.0
-	github.com/cilium/ebpf v0.17.1
-	github.com/cilium/ebpf v0.17.2
-)
-
 require (
 	github.com/cilium/ebpf v0.17.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect


### PR DESCRIPTION
We already have the indirect require for 1.17.3, that comes opencontainers/cgroups[1]. That module requires that version as min, so go can't use older versions. We can just remove the excludes.

There might be cases where people can use runc as a dependency and use replace to override it (not sure, but probably). We were clear on what our dependencies are, so we can sleep fine. In the unlikely case that some project uses runc as a dependency and:

 * Uses a replace for cilium v0.17.x but not the latest patch release (0.17.3 is fixed)
 * they run with 32bits
 * and hit this (that didn't happen always on CI)
 * Ignore the changelog for 0.17.3 that mentions the buffer overflow on 32 bits platforms[2].

In that case, if we have a bug report, we can point them to the right place. But 0.17.3 was released for some months now (most people probably update) and 0.18.0 was released recently. I wouldn't worry about someone hitting this in real life.

Also, the excludes directives prevent go install from working, so let's just remove them.

[1]: https://github.com/opencontainers/cgroups/blob/9657f5a18b8d60a0f39fbb34d0cb7771e28e6278/go.mod#L6
[2]: https://github.com/cilium/ebpf/releases/tag/v0.17.3