### PR TITLE
[1.3] go.mod: Delete exclude directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,13 +26,6 @@ require (
 	google.golang.org/protobuf v1.36.5
 )
 
-// https://github.com/opencontainers/runc/issues/4594
-exclude (
-	github.com/cilium/ebpf v0.17.0
-	github.com/cilium/ebpf v0.17.1
-	github.com/cilium/ebpf v0.17.2
-)
-
 require (
 	github.com/cilium/ebpf v0.17.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect


### PR DESCRIPTION
This is a backport of #4748 for the 1.3 branch.