### PR TITLE
ci: Check for exclude/replace directives

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -147,6 +147,9 @@ jobs:
     - name: no toolchain in go.mod # See https://github.com/opencontainers/runc/pull/4717, https://github.com/dependabot/dependabot-core/issues/11933.
       run: |
         if grep -q '^toolchain ' go.mod; then echo "Error: go.mod must not have toolchain directive, please fix"; exit 1; fi
+    - name: no exclude nor replace in go.mod
+      run: |
+        if grep -Eq '^\s*(exclude|replace) ' go.mod; then echo "Error: go.mod must not have exclude/replace directive, it breaks go install. Please fix"; exit 1; fi
 
 
   commit:


### PR DESCRIPTION
To not accidentally break `go install`, let's add CI to check it. If in the future we need those directives, we can remove the CI check.

This should only be merged after #4748, as we are currently using an exclude directive.