### PR TITLE
ci: add scheduled run of GHA CI

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,35 @@
+# This enables periodical execution of CI jobs in branches we maintain.
+#
+# CI jobs are triggered through here (instead of adding "schedule:" to the
+# appropriate files) because scheduled jobs are only run on the main branch.
+# In other words, it's a way to run periodical CI for other branches.
+
+name: scheduled
+on:
+  schedule:
+    # Runs at 00:00 UTC every Sunday, Tuesday, Thursday.
+    - cron: '0 0 * * 0,2,4'
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  trigger-workflow:
+    strategy:
+      matrix:
+        branch: ["main", "release-1.3"]
+        wf_id: ["validate.yml", "test.yml"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger ${{ matrix.wf_id }} workflow on ${{ matrix.branch}} branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '${{ matrix.wf_id }}',
+              ref: '${{ matrix.branch }}'
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - main
       - release-*
   pull_request:
+  workflow_dispatch:
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,12 @@ jobs:
           # Disable most of criu-dev jobs, as they are expensive
           # (need to compile criu) and don't add much value/coverage.
           - criu: criu-dev
-            go-version: 1.22.x
+            go-version: 1.23.x
           - criu: criu-dev
             rootless: rootless
           - criu: criu-dev
             race: -race
-          - go-version: 1.22.x
+          - go-version: 1.23.x
             os: actuated-arm64-6cpu-8gb
           - race: "-race"
             os: actuated-arm64-6cpu-8gb

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,7 @@ on:
       - main
       - release-*
   pull_request:
+  workflow_dispatch:
 env:
   GO_VERSION: 1.24
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -157,21 +157,25 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-24.04
-    # Only check commits on pull requests.
-    if: github.event_name == 'pull_request'
     steps:
       - name: get pr commits
+        if: github.event_name == 'pull_request' # Only check commits on pull requests.
         id: 'get-pr-commits'
         uses: tim-actions/get-pr-commits@v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check subject line length
+        if: github.event_name == 'pull_request' # Only check commits on pull requests.
         uses: tim-actions/commit-message-checker-with-regex@v0.3.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,72}(\n.*)*$'
           error: 'Subject too long (max 72)'
+
+      - name: succeed (not a PR) # Allow all-done to succeed for non-PRs.
+        if: github.event_name != 'pull_request'
+        run: echo "Nothing to check here."
 
   cfmt:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This is to ensure that our CI is not rotting away even if there are no new PRs or merges. This is especially useful for release branches which tend to cease working over time due to some external reasons.

**Update:** I was not sure it's possible, but it appears to work on my fork now, but here it needs #4763 to be merged first, ~~thus the draft status (until #4763 is merged).~~ **Update2**: dep PR is merged so this one is ready, too.