### PR TITLE
[release-1.3] allow scheduled CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - main
       - release-*
   pull_request:
+  workflow_dispatch: # Allow it to be triggered via scheduled.yml
 permissions:
   contents: read
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,7 @@ on:
       - main
       - release-*
   pull_request:
+  workflow_dispatch: # Allow it to be triggered via scheduled.yml
 env:
   GO_VERSION: 1.24
 permissions:


### PR DESCRIPTION
This is needed by https://github.com/opencontainers/runc/pull/4760.