### PR TITLE
[1.3] ci fixes + support for scheduled ci jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - main
       - release-*
   pull_request:
+  workflow_dispatch:
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,12 @@ jobs:
           # Disable most of criu-dev jobs, as they are expensive
           # (need to compile criu) and don't add much value/coverage.
           - criu: criu-dev
-            go-version: 1.22.x
+            go-version: 1.23.x
           - criu: criu-dev
             rootless: rootless
           - criu: criu-dev
             race: -race
-          - go-version: 1.22.x
+          - go-version: 1.23.x
             os: actuated-arm64-6cpu-8gb
           - race: "-race"
             os: actuated-arm64-6cpu-8gb

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,7 @@ on:
       - main
       - release-*
   pull_request:
+  workflow_dispatch:
 env:
   GO_VERSION: 1.24
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -152,21 +152,24 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-24.04
-    # Only check commits on pull requests.
-    if: github.event_name == 'pull_request'
     steps:
       - name: get pr commits
+        if: github.event_name == 'pull_request' # Only check commits on pull requests.
         id: 'get-pr-commits'
         uses: tim-actions/get-pr-commits@v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check subject line length
+        if: github.event_name == 'pull_request' # Only check commits on pull requests.
         uses: tim-actions/commit-message-checker-with-regex@v0.3.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,72}(\n.*)*$'
           error: 'Subject too long (max 72)'
+      - name: succeed (not a PR)
+        if: github.event_name != 'pull_request'
+        run: echo "Nothing to check here."
 
   cfmt:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This is a partial backport of #4760 to release-1.3 branch, fixing some issues and allowing the scheduled jobs to be run on release-1.3 branch.