### PR TITLE
Refactor/improve prepareCriuRestoreMounts

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -523,11 +523,9 @@ func (c *Container) restoreNetwork(req *criurpc.CriuReq, criuOpts *CriuOpts) {
 	}
 }
 
-// isPathInPrefixList is a small function for CRIU restore to make sure
-// mountpoints, which are on a tmpfs, are not created in the roofs.
-func isPathInPrefixList(path string, prefix []string) bool {
-	for _, p := range prefix {
-		if strings.HasPrefix(path, p+"/") {
+func isOnTmpfs(path string, mounts []*configs.Mount) bool {
+	for _, m := range mounts {
+		if m.Device == "tmpfs" && strings.HasPrefix(path, m.Destination+"/") {
 			return true
 		}
 	}
@@ -541,14 +539,6 @@ func isPathInPrefixList(path string, prefix []string) bool {
 // This function also creates missing mountpoints as long as they
 // are not on top of a tmpfs, as CRIU will restore tmpfs content anyway.
 func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
-	// First get a list of a all tmpfs mounts
-	tmpfs := []string{}
-	for _, m := range mounts {
-		switch m.Device {
-		case "tmpfs":
-			tmpfs = append(tmpfs, m.Destination)
-		}
-	}
 	umounts := []string{}
 	defer func() {
 		for _, u := range umounts {
@@ -576,7 +566,7 @@ func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
 		}
 		// If the mountpoint is on a tmpfs, skip it as CRIU will
 		// restore the complete tmpfs content from its checkpoint.
-		if isPathInPrefixList(m.Destination, tmpfs) {
+		if isOnTmpfs(m.Destination, mounts) {
 			continue
 		}
 		if _, err := createMountpoint(c.config.Rootfs, mountEntry{Mount: m}); err != nil {

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -523,18 +523,6 @@ func (c *Container) restoreNetwork(req *criurpc.CriuReq, criuOpts *CriuOpts) {
 	}
 }
 
-// makeCriuRestoreMountpoints makes the actual mountpoints for the
-// restore using CRIU. This function is inspired from the code in
-// rootfs_linux.go.
-func (c *Container) makeCriuRestoreMountpoints(m *configs.Mount) error {
-	// TODO: pass srcFD? Not sure if criu is impacted by issue #2484.
-	me := mountEntry{Mount: m}
-	if _, err := createMountpoint(c.config.Rootfs, me); err != nil {
-		return fmt.Errorf("create criu restore mountpoint for %s mount: %w", me.Destination, err)
-	}
-	return nil
-}
-
 // isPathInPrefixList is a small function for CRIU restore to make sure
 // mountpoints, which are on a tmpfs, are not created in the roofs.
 func isPathInPrefixList(path string, prefix []string) bool {
@@ -591,8 +579,8 @@ func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
 		if isPathInPrefixList(m.Destination, tmpfs) {
 			continue
 		}
-		if err := c.makeCriuRestoreMountpoints(m); err != nil {
-			return err
+		if _, err := createMountpoint(c.config.Rootfs, mountEntry{Mount: m}); err != nil {
+			return fmt.Errorf("create criu restore mountpoint for %s mount: %w", m.Destination, err)
 		}
 		// If the mount point is a bind mount, we need to mount
 		// it now so that runc can create the necessary mount


### PR DESCRIPTION
This makes `prepareCriuRestoreMounts` more readable, smaller, and slightly faster.

Split to 4 commits for easier review.

Should not change behavior in any way.

Covered by existing tests in `tests/integration/checkpoint.bats`.