### PR TITLE
Add audit support for loong64

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -58,6 +58,14 @@ const uintptr_t C_FILTER_FLAG_NEW_LISTENER = SECCOMP_FILTER_FLAG_NEW_LISTENER;
 #define AUDIT_ARCH_RISCV64	(EM_RISCV|__AUDIT_ARCH_64BIT|__AUDIT_ARCH_LE)
 #endif
 
+// TODO: If loongarch support is not fully merged, at some point we will want to remove this.
+#ifndef AUDIT_ARCH_LOONGARCH64
+#ifndef EM_LOONGARCH
+#define EM_LOONGARCH		258
+#endif
+#define AUDIT_ARCH_LOONGARCH64	(EM_LOONGARCH|__AUDIT_ARCH_64BIT|__AUDIT_ARCH_LE)
+#endif
+
 // We use the AUDIT_ARCH_* values because those are the ones used by the kernel
 // and SCMP_ARCH_* sometimes has fake values (such as SCMP_ARCH_X32). But we
 // use <seccomp.h> so we get libseccomp's fallback definitions of AUDIT_ARCH_*.
@@ -78,6 +86,7 @@ const uint32_t C_AUDIT_ARCH_PPC64LE      = AUDIT_ARCH_PPC64LE;
 const uint32_t C_AUDIT_ARCH_S390         = AUDIT_ARCH_S390;
 const uint32_t C_AUDIT_ARCH_S390X        = AUDIT_ARCH_S390X;
 const uint32_t C_AUDIT_ARCH_RISCV64      = AUDIT_ARCH_RISCV64;
+const uint32_t C_AUDIT_ARCH_LOONGARCH64  = AUDIT_ARCH_LOONGARCH64; //nolint:godot // C code, not Go comment.
 */
 import "C"
 
@@ -217,6 +226,8 @@ func scmpArchToAuditArch(arch libseccomp.ScmpArch) (linuxAuditArch, error) {
 		return linuxAuditArch(C.C_AUDIT_ARCH_S390X), nil
 	case libseccomp.ArchRISCV64:
 		return linuxAuditArch(C.C_AUDIT_ARCH_RISCV64), nil
+	case libseccomp.ArchLOONGARCH64:
+		return linuxAuditArch(C.C_AUDIT_ARCH_LOONGARCH64), nil
 	default:
 		return invalidArch, fmt.Errorf("unknown architecture: %v", arch)
 	}


### PR DESCRIPTION
I want to support runc compilation on loogarch64, this is the first step.