### PR TITLE
util_linux: add connection close in setupIO

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -117,9 +117,9 @@ func setupIO(process *libcontainer.Process, container *libcontainer.Container, c
 			}()
 		} else {
 			// the caller of runc will handle receiving the console master
-			conn, Err := net.Dial("unix", sockpath)
-			if Err != nil {
-				return nil, Err
+			conn, err := net.Dial("unix", sockpath)
+			if err != nil {
+				return nil, err
 			}
 			defer func() {
 				if Err != nil {
@@ -131,9 +131,9 @@ func setupIO(process *libcontainer.Process, container *libcontainer.Container, c
 				return nil, errors.New("casting to UnixConn failed")
 			}
 			t.postStart = append(t.postStart, uc)
-			socket, Err := uc.File()
-			if Err != nil {
-				return nil, Err
+			socket, err := uc.File()
+			if err != nil {
+				return nil, err
 			}
 			t.postStart = append(t.postStart, socket)
 			process.ConsoleSocket = socket

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -123,11 +123,13 @@ func setupIO(process *libcontainer.Process, container *libcontainer.Container, c
 			}
 			uc, ok := conn.(*net.UnixConn)
 			if !ok {
+				conn.Close()
 				return nil, errors.New("casting to UnixConn failed")
 			}
 			t.postStart = append(t.postStart, uc)
 			socket, err := uc.File()
 			if err != nil {
+				conn.Close()
 				return nil, err
 			}
 			t.postStart = append(t.postStart, socket)


### PR DESCRIPTION
If an error occurs while creating a file descriptor using socket, err := uc.File(), this error is returned to the calling runner.run function. The runner.run function also simply returns this error, and, as a result, the connection created in the line conn, err := net.Dial("unix", sockpath) remains open.

Found by Linux Verification Center (linuxtesting.org) with SVACE.