### PR TITLE
[1.3] cgroup separation followup

### DIFF
--- a/libcontainer/configs/cgroup_deprecated.go
+++ b/libcontainer/configs/cgroup_deprecated.go
@@ -1,7 +1,8 @@
-package configs // Deprecated: use [github.com/opencontainers/cgroups].
+package configs
 
 import "github.com/opencontainers/cgroups"
 
+// Deprecated: use [github.com/opencontainers/cgroups].
 type (
 	Cgroup         = cgroups.Cgroup
 	Resources      = cgroups.Resources
@@ -14,12 +15,14 @@ type (
 	IfPrioMap      = cgroups.IfPrioMap
 )
 
+// Deprecated: use [github.com/opencontainers/cgroups].
 const (
 	Undefined = cgroups.Undefined
 	Frozen    = cgroups.Frozen
 	Thawed    = cgroups.Thawed
 )
 
+// Deprecated: use [github.com/opencontainers/cgroups].
 var (
 	NewWeightDevice   = cgroups.NewWeightDevice
 	NewThrottleDevice = cgroups.NewThrottleDevice

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -1,3 +1,5 @@
+// Package configs provides various container-related configuration types
+// used by libcontainer.
 package configs
 
 import (

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
+	"github.com/opencontainers/cgroups"
 	devices "github.com/opencontainers/cgroups/devices/config"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -144,8 +145,8 @@ type Config struct {
 	Routes []*Route `json:"routes"`
 
 	// Cgroups specifies specific cgroup settings for the various subsystems that the container is
-	// placed into to limit the resources the container has available
-	Cgroups *Cgroup `json:"cgroups"`
+	// placed into to limit the resources the container has available.
+	Cgroups *cgroups.Cgroup `json:"cgroups"`
 
 	// AppArmorProfile specifies the profile to apply to the process running in the container and is
 	// change at the time the process is execed

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -458,7 +458,7 @@ type Capabilities struct {
 	Ambient []string
 }
 
-// Deprecated: use (Hooks).Run instead.
+// Deprecated: use [Hooks.Run] instead.
 func (hooks HookList) RunHooks(state *specs.State) error {
 	for i, h := range hooks {
 		if err := h.Run(state); err != nil {


### PR DESCRIPTION
Backport of #4784 to release-1.3.

Needed in 1.3 because deprecation notice for stuff in libcontainer/configs was not effective, thus users won't know they have to switch.

Original description follows.

----

This is a followup to #4638, fixing a few minor issues I found just now.

See individual commits for details.