### PR TITLE
fix(libcontainer):enhance the detail of error printing

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -241,7 +241,7 @@ func (c *Container) exec() error {
 				// could be because process started, ran, and completed between our 100ms timeout and our system.Stat() check.
 				// see if the fifo exists and has data (with a non-blocking open, which will succeed if the writing process is complete).
 				if err := handleFifoResult(fifoOpen(path, false)); err != nil {
-					return errors.New("container process is already dead")
+					return fmt.Errorf("container process is already dead, because %w", err)
 				}
 				return nil
 			}
@@ -283,12 +283,12 @@ func fifoOpen(path string, block bool) openResult {
 
 func handleFifoResult(result openResult) error {
 	if result.err != nil {
-		return result.err
+		return fmt.Errorf("openResult err: %w", result.err)
 	}
 	f := result.file
 	defer f.Close()
 	if err := readFromExecFifo(f); err != nil {
-		return err
+		return fmt.Errorf("read from exec fifo err: %w", err)
 	}
 	return os.Remove(f.Name())
 }


### PR DESCRIPTION
While I meet some exec fifo's problem , Not friendly enough for my positioning problem. So I want more detailed printing.

it will be like this
ERRO[0016] containerd: start init process                error="exit status 1: \"start for 13179ebcb85b085b588613c99c154405148eb552b4565d0e6268d6ba242d015a failed: container process is already dead,because openResult err: container_linux.go:275: open exec fifo for reading caused \\\"open /run/runc/13179ebcb85b085b588613c99c154405148eb552b4565d0e6268d6ba242d015a/exec.fifo: no such file or directory\\\"\\none or more of container start failed\\n\""

I have identified this issue and may initiate a discussion in the future.