### PR TITLE
libcontainer: close seccomp agent connection to prevent resource leaks

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -854,6 +854,7 @@ func sendContainerProcessState(listenerPath string, state *specs.ContainerProces
 	if err != nil {
 		return fmt.Errorf("failed to connect with seccomp agent specified in the seccomp profile: %w", err)
 	}
+	defer conn.Close()
 
 	socket, err := conn.(*net.UnixConn).File()
 	if err != nil {


### PR DESCRIPTION
Add missing defer conn.Close().