### PR TITLE
[1.3] libcontainer: close seccomp agent connection to prevent resource leaks

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -872,6 +872,7 @@ func sendContainerProcessState(listenerPath string, state *specs.ContainerProces
 	if err != nil {
 		return fmt.Errorf("failed to connect with seccomp agent specified in the seccomp profile: %w", err)
 	}
+	defer conn.Close()
 
 	socket, err := conn.(*net.UnixConn).File()
 	if err != nil {


### PR DESCRIPTION
Backport of https://github.com/opencontainers/runc/pull/4796 to release-1.3 branch. Original description follows.

---

Add missing defer conn.Close().

Signed-off-by: Liubimov Pavel prlyubimov@gmail.com