### PR TITLE
tests/int/events.bats: don't require root

### DIFF
--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -13,9 +13,8 @@ function teardown() {
 # This needs to be placed at the top of the bats file to work around
 # a shellcheck bug. See <https://github.com/koalaman/shellcheck/issues/2873>.
 function test_events() {
-	# XXX: currently cgroups require root containers.
-	requires root
-	init_cgroup_paths
+	[ $EUID -ne 0 ] && requires rootless_cgroup
+	set_cgroups_path
 
 	local status interval retry_every=1
 	if [ $# -eq 2 ]; then
@@ -45,8 +44,7 @@ function test_events() {
 }
 
 @test "events --stats" {
-	# XXX: currently cgroups require root containers.
-	requires root
+	[ $EUID -ne 0 ] && requires rootless_cgroup
 	init_cgroup_paths
 
 	# run busybox detached
@@ -61,6 +59,7 @@ function test_events() {
 }
 
 @test "events --stats with psi data" {
+	# XXX: CPU PSI avg data only available to root.
 	requires root cgroups_v2 psi
 	init_cgroup_paths
 
@@ -101,7 +100,7 @@ function test_events() {
 }
 
 @test "events oom" {
-	# XXX: currently cgroups require root containers.
+	# XXX: oom is not triggered for rootless containers.
 	requires root cgroups_swap
 	init_cgroup_paths
 


### PR DESCRIPTION
These tests should work as rootless as long as cgroup access works.