### PR TITLE
[1.3] tests/int/cgroups.bats: exclude dmem controller

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -50,7 +50,7 @@ function setup() {
 				check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/machine.slice/cgroup.controllers)"
 			else
 				# Filter out controllers that systemd is unable to delegate.
-				check_cgroup_value "cgroup.controllers" "$(sed 's/ \(hugetlb\|misc\|rdma\)//g' </sys/fs/cgroup/user.slice/user-${EUID}.slice/cgroup.controllers)"
+				check_cgroup_value "cgroup.controllers" "$(sed 's/ \(dmem\|hugetlb\|misc\|rdma\)//g' </sys/fs/cgroup/user.slice/user-${EUID}.slice/cgroup.controllers)"
 			fi
 		else
 			check_cgroup_value "cgroup.controllers" "$(cat /sys/fs/cgroup/cgroup.controllers)"


### PR DESCRIPTION
Backport of #4806 to release-1.3 branch. Original description follows.

----

The dmem controller is added into kernel v6.13 and is now enabled in Fedora 42 kernels. Yet, systemd is not aware of dmem.

This fixes the test case failure on Fedora.

For the initial test case, see commit 27515719.

For earlier commits similar to this one, see
commits 601cf582, 05272718, e83ca519.


(cherry picked from commit b3432118edfd9b600a68ed1a01c0ae98fb195871)