### PR TITLE
runc exec: use CLONE_INTO_CGROUP

### DIFF
--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -282,7 +282,7 @@ function check_exec_debug() {
 	# Check we can't join non-existing subcgroup.
 	runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
 	[ "$status" -ne 0 ]
-	[[ "$output" == *" adding pid "*"o such file or directory"* ]]
+	[[ "$output" == *" cgroup"*"o such file or directory"* ]]
 
 	# Check we can join top-level cgroup (implicit).
 	runc exec test_busybox grep '^0::/$' /proc/self/cgroup


### PR DESCRIPTION
~~_Requires (and currently includes) PR #4822; draft until that one is merged._~~

It makes sense to make runc exec benefit from `clone2(CLONE_INTO_CGROUP)`, when
available. Since it requires a recent kernel and might not work, implement a fallback.

Based on:
 - https://go-review.googlesource.com/c/go/+/417695
 - https://github.com/coreos/go-systemd/pull/458
 - https://github.com/opencontainers/cgroups/pull/26
 - https://github.com/opencontainers/runc/pull/4822
 
Closes: #4782.