### PR TITLE
[1.3] rootfs: remove /proc/net/dev from allowed overmount list

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -839,7 +839,6 @@ func checkProcMount(rootfs, dest string, m mountEntry) error {
 		"/proc/uptime",
 		"/proc/loadavg",
 		"/proc/slabinfo",
-		"/proc/net/dev",
 		"/proc/sys/kernel/ns_last_pid",
 		"/proc/sys/crypto/fips_enabled",
 	}


### PR DESCRIPTION
This is a backport of #4817.

<hr>

This was added in 2ee9cbb ("It's /proc/stat, not /proc/stats") with
no actual justification, and doesn't really make much sense on further
inspection:

 * /proc/net is a symlink to "self/net", which means that /proc/net/dev
   is a per-process file, and so overmounting it would only affect pid1.
   Any other program that cares about /proc/net/dev would see their own
   process's configuration, and unprivileged processes wouldn't be able
   to see /proc/1/... data anyway.

   In addition, the fact that this is a symlink means that runc will
   deny the overmount because /proc/1/net/dev is not in the proc
   overmount allowlist. This means that this has not worked for many
   years, and probably never worked in the first place.

 * /proc/self/net is already namespaced with network namespaces, so the
   primary argument for allowing /proc overmounts (lxcfs-like masking of
   procfs files to emulate namespacing for files that are not properly
   namespaced for containers -- such as /proc/cpuinfo) is moot.

   It goes without saying that lxcfs has never overmounted
   /proc/self/net/... files, so the general "because lxcfs"
   justification doesn't hold water either.

 * The kernel has slowly been moving towards blocking overmounts in
   /proc/self/. Linux 6.12 blocked overmounts for fd, fdinfo, and
   map_files; future Linux versions will probably end up blocking
   everything under /proc/self/.

Fixes #4771 
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>