### PR TITLE
fix: close conn in setupIO

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -123,11 +123,13 @@ func setupIO(process *libcontainer.Process, container *libcontainer.Container, c
 			}
 			uc, ok := conn.(*net.UnixConn)
 			if !ok {
+				conn.Close()
 				return nil, errors.New("casting to UnixConn failed")
 			}
 			t.postStart = append(t.postStart, uc)
 			socket, err := uc.File()
 			if err != nil {
+				conn.Close()
 				return nil, err
 			}
 			t.postStart = append(t.postStart, socket)


### PR DESCRIPTION
Hello!

I've noticed that in `utils_linux.go/setupIO` connection `conn` may not be closed in some scenarios. I'm not sure how likely these scenarios are in practice but still want to highlight it and add explicit close.

Manually close conn in setupIO in cases when
1) *net.UnixConn type assertion failed;
2) fd wasn't created.