### PR TITLE
Simplify getting net.UnixConn

### DIFF
--- a/tests/cmd/pidfd-kill/pidfd-kill.go
+++ b/tests/cmd/pidfd-kill/pidfd-kill.go
@@ -99,12 +99,7 @@ func recvPidfd(socketFile string) (*os.File, error) {
 	}
 	defer conn.Close()
 
-	unixconn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return nil, errors.New("failed to cast to unixconn")
-	}
-
-	socket, err := unixconn.File()
+	socket, err := conn.(*net.UnixConn).File()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cmd/recvtty/recvtty.go
+++ b/tests/cmd/recvtty/recvtty.go
@@ -85,13 +85,7 @@ func handleSingle(path string, noStdin bool) error {
 	// Close ln, to allow for other instances to take over.
 	ln.Close()
 
-	// Get the fd of the connection.
-	unixconn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return errors.New("failed to cast to unixconn")
-	}
-
-	socket, err := unixconn.File()
+	socket, err := conn.(*net.UnixConn).File()
 	if err != nil {
 		return err
 	}
@@ -158,13 +152,7 @@ func handleNull(path string) error {
 			// Don't leave references lying around.
 			defer conn.Close()
 
-			// Get the fd of the connection.
-			unixconn, ok := conn.(*net.UnixConn)
-			if !ok {
-				return
-			}
-
-			socket, err := unixconn.File()
+			socket, err := conn.(*net.UnixConn).File()
 			if err != nil {
 				return
 			}

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -95,7 +95,7 @@ func newProcess(p *specs.Process) (*libcontainer.Process, error) {
 }
 
 // setupIO modifies the given process config according to the options.
-func setupIO(process *libcontainer.Process, container *libcontainer.Container, createTTY, detach bool, sockpath string) (*tty, error) {
+func setupIO(process *libcontainer.Process, container *libcontainer.Container, createTTY, detach bool, sockpath string) (_ *tty, Err error) {
 	if createTTY {
 		process.Stdin = nil
 		process.Stdout = nil
@@ -121,6 +121,11 @@ func setupIO(process *libcontainer.Process, container *libcontainer.Container, c
 			if err != nil {
 				return nil, err
 			}
+			defer func() {
+				if Err != nil {
+					conn.Close()
+				}
+			}()
 			t.postStart = append(t.postStart, conn)
 			socket, err := conn.(*net.UnixConn).File()
 			if err != nil {

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -121,12 +121,8 @@ func setupIO(process *libcontainer.Process, container *libcontainer.Container, c
 			if err != nil {
 				return nil, err
 			}
-			uc, ok := conn.(*net.UnixConn)
-			if !ok {
-				return nil, errors.New("casting to UnixConn failed")
-			}
-			t.postStart = append(t.postStart, uc)
-			socket, err := uc.File()
+			t.postStart = append(t.postStart, conn)
+			socket, err := conn.(*net.UnixConn).File()
 			if err != nil {
 				return nil, err
 			}
@@ -432,13 +428,7 @@ func setupPidfdSocket(process *libcontainer.Process, sockpath string) (_clean fu
 		return nil, fmt.Errorf("failed to dail %s: %w", sockpath, err)
 	}
 
-	uc, ok := conn.(*net.UnixConn)
-	if !ok {
-		conn.Close()
-		return nil, errors.New("failed to cast to UnixConn")
-	}
-
-	socket, err := uc.File()
+	socket, err := conn.(*net.UnixConn).File()
 	if err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("failed to dup socket: %w", err)


### PR DESCRIPTION
These typecasts can't fail, so it doesn't make sense checking for errors.
This also simplifies the cleanup logic.

Closes: #4821
Closes: #4780

(Authors of both PRs, i.e. @grey3228 and @mi4r, are credited in the second commit)