### PR TITLE
runc update: refuse to create new rdt group

### DIFF
--- a/update.go
+++ b/update.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/docker/go-units"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
@@ -377,15 +376,7 @@ other options are ignored.
 			// In update command, we could re-enable through IntelRdtManager.Apply()
 			// and then update intelrdt constraint.
 			if config.IntelRdt == nil {
-				state, err := container.State()
-				if err != nil {
-					return err
-				}
-				config.IntelRdt = &configs.IntelRdt{}
-				intelRdtManager := intelrdt.NewManager(&config, container.ID(), state.IntelRdtPath)
-				if err := intelRdtManager.Apply(state.InitProcessPid); err != nil {
-					return err
-				}
+				return errors.New("updating a non-existent Intel RDT configuration is not supported")
 			}
 			if l3CacheSchema != "" {
 				config.IntelRdt.L3CacheSchema = l3CacheSchema


### PR DESCRIPTION
Error out --l3-cache-schema and --mem-bw-schema if the original spec didn't specify intelRdt which also means that no CLOS (resctrl group) was created for the container.

This prevents serious issues in this corner case.

First, a CLOS was created but the schemata of the CLOS was not correctly updated. Confusingly, calling runc update twice did the job: the first call created the resctrl group and the seccond call was able to update the schemata. This issue would be relatively easily fixable, though.

Second, more severe issue is that creating new CLOSes this way caused them to be orphaned, not being removed when the container exists. This is caused by runc not capturing the updated state (original spec was intelRdt=nil -> no CLOS but after update this is not the case).

The most severe problem is that the update only move (or tried to move) the original init process pid but all children escaped the update. Doing this (i.e. migrating all processes of a container from CLOS to another CLOS) reliably, race-free, would probably require freezing the container.