### PR TITLE
runc update: don't lose intelRdt state

### DIFF
--- a/update.go
+++ b/update.go
@@ -387,8 +387,12 @@ other options are ignored.
 					return err
 				}
 			}
-			config.IntelRdt.L3CacheSchema = l3CacheSchema
-			config.IntelRdt.MemBwSchema = memBwSchema
+			if l3CacheSchema != "" {
+				config.IntelRdt.L3CacheSchema = l3CacheSchema
+			}
+			if memBwSchema != "" {
+				config.IntelRdt.MemBwSchema = memBwSchema
+			}
 		}
 
 		// XXX(kolyshkin@): currently "runc update" is unable to change


### PR DESCRIPTION
Prevent --l3-cache-schema from clearing the intel_rdt.memBwSchema state and --mem-bw-schema clearing l3_cache_schema, respectively.