### PR TITLE
libcontainer/configs/validate: check that intelrdt is enabled

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -283,6 +283,10 @@ func sysctl(config *configs.Config) error {
 
 func intelrdtCheck(config *configs.Config) error {
 	if config.IntelRdt != nil {
+		if !intelrdt.IsEnabled() {
+			return fmt.Errorf("intelRdt is specified in config, but Intel RDT is not enabled")
+		}
+
 		if config.IntelRdt.ClosID == "." || config.IntelRdt.ClosID == ".." || strings.Contains(config.IntelRdt.ClosID, "/") {
 			return fmt.Errorf("invalid intelRdt.ClosID %q", config.IntelRdt.ClosID)
 		}

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -416,6 +416,12 @@ func WriteIntelRdtTasks(dir string, pid int) error {
 	return nil
 }
 
+// IsEnabled checks if Intel RDT is enabled.
+func IsEnabled() bool {
+	fsroot, err := Root()
+	return err == nil && fsroot != ""
+}
+
 // IsCATEnabled checks if Intel RDT/CAT is enabled.
 func IsCATEnabled() bool {
 	featuresInit()


### PR DESCRIPTION
If intelRdt is specified in the spec, check that the resctrl fs is actually mounted. Fixes e.g. the case where "intelRdt.closID" is specified but runc silently ignores this if resctrl is not mounted.