### PR TITLE
libcontainer/intelrdt: refactor path handling

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/moby/sys/mountinfo"
 	"golang.org/x/sys/unix"
 
@@ -173,7 +174,9 @@ func NewManager(config *configs.Config, id string, path string) *Manager {
 		if config.IntelRdt.ClosID != "" {
 			clos = config.IntelRdt.ClosID
 		}
-		path = filepath.Join(rootPath, clos)
+		if path, err = securejoin.SecureJoin(rootPath, clos); err != nil {
+			return nil
+		}
 	}
 
 	return newManager(config, id, path)

--- a/libcontainer/intelrdt/intelrdt_test.go
+++ b/libcontainer/intelrdt/intelrdt_test.go
@@ -101,13 +101,14 @@ func TestApply(t *testing.T) {
 	helper := NewIntelRdtTestUtil(t)
 
 	const closID = "test-clos"
+	closPath := filepath.Join(helper.IntelRdtPath, closID)
 
 	helper.config.IntelRdt.ClosID = closID
-	intelrdt := newManager(helper.config, "", helper.IntelRdtPath)
+	intelrdt := newManager(helper.config, "container-1", closPath)
 	if err := intelrdt.Apply(1234); err == nil {
 		t.Fatal("unexpected success when applying pid")
 	}
-	if _, err := os.Stat(filepath.Join(helper.IntelRdtPath, closID)); err == nil {
+	if _, err := os.Stat(closPath); err == nil {
 		t.Fatal("closid dir should not exist")
 	}
 


### PR DESCRIPTION
Also, use GetPath() in Apply to get the resctrl group path, similar to other methods of intelRdtManager.