### PR TITLE
libcontainer/intelrdt: add support for EnableMonitoring field

### DIFF
--- a/features.go
+++ b/features.go
@@ -56,8 +56,9 @@ var featuresCommand = cli.Command{
 					Enabled: &t,
 				},
 				IntelRdt: &features.IntelRdt{
-					Enabled:  &t,
-					Schemata: &t,
+					Enabled:    &t,
+					Schemata:   &t,
+					Monitoring: &t,
 				},
 				MountExtensions: &features.MountExtensions{
 					IDMap: &features.IDMap{

--- a/libcontainer/configs/intelrdt.go
+++ b/libcontainer/configs/intelrdt.go
@@ -17,4 +17,7 @@ type IntelRdt struct {
 	// The unit of memory bandwidth is specified in "percentages" by
 	// default, and in "MBps" if MBA Software Controller is enabled.
 	MemBwSchema string `json:"memBwSchema,omitempty"`
+
+	// Create a monitoring group for the container.
+	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
 }

--- a/libcontainer/configs/validate/intelrdt_test.go
+++ b/libcontainer/configs/validate/intelrdt_test.go
@@ -19,22 +19,17 @@ func TestValidateIntelRdt(t *testing.T) {
 		isErr      bool
 	}{
 		{
-			name:       "rdt not supported, no config",
-			rdtEnabled: false,
-			config:     nil,
-			isErr:      false,
+			name: "rdt not supported, no config",
 		},
 		{
-			name:       "rdt not supported, with config",
-			rdtEnabled: false,
-			config:     &configs.IntelRdt{},
-			isErr:      true,
+			name:   "rdt not supported, with config",
+			config: &configs.IntelRdt{},
+			isErr:  true,
 		},
 		{
 			name:       "empty config",
 			rdtEnabled: true,
 			config:     &configs.IntelRdt{},
-			isErr:      false,
 		},
 		{
 			name:       "root clos",
@@ -42,7 +37,6 @@ func TestValidateIntelRdt(t *testing.T) {
 			config: &configs.IntelRdt{
 				ClosID: "/",
 			},
-			isErr: false,
 		},
 		{
 			name:       "invalid ClosID (.)",
@@ -71,7 +65,6 @@ func TestValidateIntelRdt(t *testing.T) {
 		{
 			name:       "cat not supported",
 			rdtEnabled: true,
-			catEnabled: false,
 			config: &configs.IntelRdt{
 				L3CacheSchema: "0=ff",
 			},
@@ -80,7 +73,6 @@ func TestValidateIntelRdt(t *testing.T) {
 		{
 			name:       "mba not supported",
 			rdtEnabled: true,
-			mbaEnabled: false,
 			config: &configs.IntelRdt{
 				MemBwSchema: "0=100",
 			},
@@ -96,7 +88,6 @@ func TestValidateIntelRdt(t *testing.T) {
 				L3CacheSchema: "0=ff",
 				MemBwSchema:   "0=100",
 			},
-			isErr: false,
 		},
 	}
 	for _, tc := range testCases {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -73,6 +73,11 @@ type State struct {
 
 	// Intel RDT "resource control" filesystem path.
 	IntelRdtPath string `json:"intel_rdt_path,omitempty"`
+
+	// Path of the container specific monitoring group in resctrl filesystem.
+	// Empty if the container does not have aindividual dedicated monitoring
+	// group.
+	IntelRdtMonPath string `json:"intel_rdt_mon_path,omitempty"`
 }
 
 // ID returns the container's unique ID
@@ -942,8 +947,10 @@ func (c *Container) currentState() *State {
 	}
 
 	intelRdtPath := ""
+	intelRdtMonPath := ""
 	if c.intelRdtManager != nil {
 		intelRdtPath = c.intelRdtManager.GetPath()
+		intelRdtMonPath = c.intelRdtManager.GetMonPath()
 	}
 	state := &State{
 		BaseState: BaseState{
@@ -956,6 +963,7 @@ func (c *Container) currentState() *State {
 		Rootless:            c.config.RootlessEUID && c.config.RootlessCgroups,
 		CgroupPaths:         c.cgroupManager.GetPaths(),
 		IntelRdtPath:        intelRdtPath,
+		IntelRdtMonPath:     intelRdtMonPath,
 		NamespacePaths:      make(map[configs.NamespaceType]string),
 		ExternalDescriptors: externalDescriptors,
 	}

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -462,10 +462,11 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		}
 		if spec.Linux.IntelRdt != nil {
 			config.IntelRdt = &configs.IntelRdt{
-				ClosID:        spec.Linux.IntelRdt.ClosID,
-				Schemata:      spec.Linux.IntelRdt.Schemata,
-				L3CacheSchema: spec.Linux.IntelRdt.L3CacheSchema,
-				MemBwSchema:   spec.Linux.IntelRdt.MemBwSchema,
+				ClosID:           spec.Linux.IntelRdt.ClosID,
+				Schemata:         spec.Linux.IntelRdt.Schemata,
+				L3CacheSchema:    spec.Linux.IntelRdt.L3CacheSchema,
+				MemBwSchema:      spec.Linux.IntelRdt.MemBwSchema,
+				EnableMonitoring: spec.Linux.IntelRdt.EnableMonitoring,
 			}
 		}
 		if spec.Linux.Personality != nil {


### PR DESCRIPTION
The linux.intelRdt.enableMonitoring field enables the creation of a per-container monitoring group. The monitoring group is removed when the container is destroyed.

Refs: https://github.com/opencontainers/runtime-spec/pull/1287