### PR TITLE
tests: Only sleep on suse

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -162,7 +162,9 @@ function setup() {
 	# usually triggered by the "change" event from losetup, we can wait for a
 	# little bit before continuing the test. For more details, see
 	# <https://github.com/opencontainers/runc/issues/4781>.
-	sleep 2s
+	if host_is_os ".*suse.*"; then
+		sleep 2s
+	fi
 
 	# See if BFQ scheduler is available.
 	if ! { grep -qw bfq "/sys/block/${dev#/dev/}/queue/scheduler" &&

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -673,13 +673,23 @@ function requires() {
 # variables in /etc/os-release. The arguments are regular expressions, and any
 # match will cause the test to be skipped.
 function exclude_os() {
+	if host_is_os "$@"; then
+		skip "test doesn't work on these OSes: $*"
+	fi
+}
+
+# Similar to exclude_os, but it doesn't skip the test and just returns 0 if it
+# matches, 1 if it doesn't.
+function host_is_os() {
 	local host
 	host="$(sh -c '. /etc/os-release ; echo "$ID-$VERSION_ID"')"
-	for bad_os in "$@"; do
-		if [[ "$host" =~ ^$bad_os$ ]]; then
-			skip "test doesn't work on $bad_os"
+	for os in "$@"; do
+		if [[ "$host" =~ ^$os$ ]]; then
+			echo "host is $os" >&2
+			return 0
 		fi
 	done
+	return 1
 }
 
 # Retry a command $1 times until it succeeds. Wait $2 seconds between retries.


### PR DESCRIPTION
This way we don't affect github actions and if other platforms need this in the future (unlikely), we can decide to add them on a case-by-case basis.

Follow-up for: #4825.

@cyphar @kolyshkin PTAL

---

As I said in the PR, it looks fine to me without this too. I won't complain if you don't want to merge this