### PR TITLE
[RFC] libcontainer/intelrdt: support explicit assignment to root CLOS

### DIFF
--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -287,7 +287,7 @@ func intelrdtCheck(config *configs.Config) error {
 			return fmt.Errorf("intelRdt is specified in config, but Intel RDT is not enabled")
 		}
 
-		if config.IntelRdt.ClosID == "." || config.IntelRdt.ClosID == ".." || strings.Contains(config.IntelRdt.ClosID, "/") {
+		if config.IntelRdt.ClosID == "." || config.IntelRdt.ClosID == ".." || (config.IntelRdt.ClosID != "/" && strings.Contains(config.IntelRdt.ClosID, "/")) {
 			return fmt.Errorf("invalid intelRdt.ClosID %q", config.IntelRdt.ClosID)
 		}
 


### PR DESCRIPTION
Makes it possible e.g. to enable monitoring
(linux.intelRdt.enableMonitoring) without creating a CLOS (resctrl group) for the container.

Implements https://github.com/opencontainers/runtime-spec/pull/1289.