### PR TITLE
CI: switch to packaged criu on arm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,11 @@ jobs:
           # (need to compile criu) and don't add much value/coverage.
           - criu: criu-dev
             go-version: 1.23.x
-            os: ubuntu-24.04
           - criu: criu-dev
             rootless: rootless
-            os: ubuntu-24.04
           # Do race detection only on latest Go.
           - race: -race
             go-version: 1.23.x
-          # CRIU package 4.1-1 from opensuse build farm doesn't work on arm.
-          - os: ubuntu-24.04-arm
-            criu: ""
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The issue on arm (https://github.com/checkpoint-restore/criu/issues/2709) is now fixed, so
let's get back to using the packaged criu version for most of the CI matrix.

This reverts commit 105674844eaaf24bf14135ef0c64703e511882ab ("ci: use criu built from source on gha arm").