### PR TITLE
[1.3] CI: swithc to GHA for arm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,16 @@ jobs:
           # (need to compile criu) and don't add much value/coverage.
           - criu: criu-dev
             go-version: 1.23.x
+            os: ubuntu-24.04
           - criu: criu-dev
             rootless: rootless
+            os: ubuntu-24.04
           # Do race detection only on latest Go.
           - race: -race
             go-version: 1.23.x
+          # CRIU package 4.1-1 from opensuse build farm doesn't work on arm.
+          - os: ubuntu-24.04-arm
+            criu: ""
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,11 @@ jobs:
           # (need to compile criu) and don't add much value/coverage.
           - criu: criu-dev
             go-version: 1.23.x
-            os: ubuntu-24.04
           - criu: criu-dev
             rootless: rootless
-            os: ubuntu-24.04
           # Do race detection only on latest Go.
           - race: -race
             go-version: 1.23.x
-          # CRIU package 4.1-1 from opensuse build farm doesn't work on arm.
-          - os: ubuntu-24.04-arm
-            criu: ""
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, actuated-arm64-6cpu-8gb]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
         go-version: [1.23.x, 1.24.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
@@ -36,37 +36,13 @@ jobs:
             go-version: 1.23.x
           - criu: criu-dev
             rootless: rootless
-          - criu: criu-dev
-            race: -race
-          - go-version: 1.23.x
-            os: actuated-arm64-6cpu-8gb
-          - race: "-race"
-            os: actuated-arm64-6cpu-8gb
-          - criu: criu-dev
-            os: actuated-arm64-6cpu-8gb
+          # Do race detection only on latest Go.
+          - race: -race
+            go-version: 1.23.x
 
     runs-on: ${{ matrix.os }}
 
     steps:
-# https://gist.github.com/alexellis/1f33e581c75e11e161fe613c46180771#file-metering-gha-md
-# vmmeter start
-    - name: Prepare arkade
-      uses: alexellis/arkade-get@master
-      if: matrix.os == 'actuated-arm64-6cpu-8gb'
-      with:
-        crane: latest
-        print-summary: false
-
-    - name: Install vmmeter
-      if: matrix.os == 'actuated-arm64-6cpu-8gb'
-      run: |
-        crane export --platform linux/arm64 ghcr.io/openfaasltd/vmmeter:latest | sudo tar -xvf - -C /usr/local/bin
-
-    - name: Run vmmeter
-      uses: self-actuated/vmmeter-action@master
-      if: matrix.os == 'actuated-arm64-6cpu-8gb'
-# vmmeter end
-
     - name: checkout
       uses: actions/checkout@v4
 
@@ -92,17 +68,6 @@ jobs:
         # kernel config
         script/check-config.sh
 
-    - name: start sshd (used for testing rootless with systemd user session)
-      if: ${{ matrix.os == 'actuated-arm64-6cpu-8gb' && matrix.rootless == 'rootless' }}
-      run: |
-        # Generate new keys to fix "sshd: no hostkeys available -- exiting."
-        sudo ssh-keygen -A
-        if ! sudo systemctl start ssh.service; then
-          sudo journalctl -xeu ssh.service
-          exit 1
-        fi
-        ps auxw | grep sshd
-
     - name: install deps
       run: |
         sudo apt update
@@ -119,7 +84,7 @@ jobs:
         sudo apt update
         sudo apt -y install criu
 
-    - name: install CRIU (criu ${{ matrix.criu }})
+    - name: install CRIU (${{ matrix.criu }})
       if: ${{ matrix.criu != '' }}
       run: |
         sudo apt -qy install \
@@ -149,7 +114,7 @@ jobs:
 
     - name: Allow userns for runc
       # https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15
-      if: matrix.os == 'ubuntu-24.04'
+      if: startsWith(matrix.os, 'ubuntu-24.04')
       run: |
         sed "s;^profile runc /usr/sbin/;profile runc-test $PWD/;" < /etc/apparmor.d/runc | sudo apparmor_parser
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![gha/validate](https://github.com/opencontainers/runc/workflows/validate/badge.svg)](https://github.com/opencontainers/runc/actions?query=workflow%3Avalidate)
 [![gha/ci](https://github.com/opencontainers/runc/workflows/ci/badge.svg)](https://github.com/opencontainers/runc/actions?query=workflow%3Aci)
 [![CirrusCI](https://api.cirrus-ci.com/github/opencontainers/runc.svg)](https://cirrus-ci.com/github/opencontainers/runc)
-<a href="https://actuated.dev"><img alt="Arm CI sponsored by Actuated" src="https://docs.actuated.dev/images/actuated-badge.png" width="120px"></img></a>
 
 ## Introduction
 


### PR DESCRIPTION
Backport of #4844 and #4856.

<hr>

Since GHA now provides ARM, we can switch away from actuated.

Many thanks to @alexellis (https://github.com/self-actuated) for supporting this project.