### PR TITLE
[1.2] Refactor/improve prepareCriuRestoreMounts

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -568,9 +568,6 @@ func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
 			tmpfs = append(tmpfs, m.Destination)
 		}
 	}
-	// Now go through all mounts and create the mountpoints
-	// if the mountpoints are not on a tmpfs, as CRIU will
-	// restore the complete tmpfs content from its checkpoint.
 	umounts := []string{}
 	defer func() {
 		for _, u := range umounts {
@@ -586,28 +583,32 @@ func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
 			})
 		}
 	}()
+	// Now go through all mounts and create the required mountpoints.
 	for _, m := range mounts {
-		if !isPathInPrefixList(m.Destination, tmpfs) {
-			if err := c.makeCriuRestoreMountpoints(m); err != nil {
+		// If the mountpoint is on a tmpfs, skip it as CRIU will
+		// restore the complete tmpfs content from its checkpoint.
+		if isPathInPrefixList(m.Destination, tmpfs) {
+			continue
+		}
+		if err := c.makeCriuRestoreMountpoints(m); err != nil {
+			return err
+		}
+		// If the mount point is a bind mount, we need to mount
+		// it now so that runc can create the necessary mount
+		// points for mounts in bind mounts.
+		// This also happens during initial container creation.
+		// Without this CRIU restore will fail
+		// See: https://github.com/opencontainers/runc/issues/2748
+		// It is also not necessary to order the mount points
+		// because during initial container creation mounts are
+		// set up in the order they are configured.
+		if m.Device == "bind" {
+			if err := utils.WithProcfd(c.config.Rootfs, m.Destination, func(dstFd string) error {
+				return mountViaFds(m.Source, nil, m.Destination, dstFd, "", unix.MS_BIND|unix.MS_REC, "")
+			}); err != nil {
 				return err
 			}
-			// If the mount point is a bind mount, we need to mount
-			// it now so that runc can create the necessary mount
-			// points for mounts in bind mounts.
-			// This also happens during initial container creation.
-			// Without this CRIU restore will fail
-			// See: https://github.com/opencontainers/runc/issues/2748
-			// It is also not necessary to order the mount points
-			// because during initial container creation mounts are
-			// set up in the order they are configured.
-			if m.Device == "bind" {
-				if err := utils.WithProcfd(c.config.Rootfs, m.Destination, func(dstFd string) error {
-					return mountViaFds(m.Source, nil, m.Destination, dstFd, "", unix.MS_BIND|unix.MS_REC, "")
-				}); err != nil {
-					return err
-				}
-				umounts = append(umounts, m.Destination)
-			}
+			umounts = append(umounts, m.Destination)
 		}
 	}
 	return nil

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -523,19 +523,8 @@ func (c *Container) restoreNetwork(req *criurpc.CriuReq, criuOpts *CriuOpts) {
 // restore using CRIU. This function is inspired from the code in
 // rootfs_linux.go.
 func (c *Container) makeCriuRestoreMountpoints(m *configs.Mount) error {
-	if m.Device == "cgroup" {
-		// No mount point(s) need to be created:
-		//
-		// * for v1, mount points are saved by CRIU because
-		//   /sys/fs/cgroup is a tmpfs mount
-		//
-		// * for v2, /sys/fs/cgroup is a real mount, but
-		//   the mountpoint appears as soon as /sys is mounted
-		return nil
-	}
 	// TODO: pass srcFD? Not sure if criu is impacted by issue #2484.
 	me := mountEntry{Mount: m}
-	// For all other filesystems, just make the target.
 	if _, err := createMountpoint(c.config.Rootfs, me); err != nil {
 		return fmt.Errorf("create criu restore mountpoint for %s mount: %w", me.Destination, err)
 	}
@@ -585,6 +574,14 @@ func (c *Container) prepareCriuRestoreMounts(mounts []*configs.Mount) error {
 	}()
 	// Now go through all mounts and create the required mountpoints.
 	for _, m := range mounts {
+		// No cgroup mount point(s) need to be created:
+		// * for v1, mount points are saved by CRIU because
+		//   /sys/fs/cgroup is a tmpfs mount;
+		// * for v2, /sys/fs/cgroup is a real mount, but
+		//   the mountpoint appears as soon as /sys is mounted.
+		if m.Device == "cgroup" {
+			continue
+		}
 		// If the mountpoint is on a tmpfs, skip it as CRIU will
 		// restore the complete tmpfs content from its checkpoint.
 		if isPathInPrefixList(m.Destination, tmpfs) {


### PR DESCRIPTION
Backport of https://github.com/opencontainers/runc/pull/4765 to release-1.2. Original description follows.

----

This makes `prepareCriuRestoreMounts` more readable, smaller, and slightly faster.

Split to 4 commits for easier review.

Should not change behavior in any way.

Covered by existing tests in `tests/integration/checkpoint.bats`.