### PR TITLE
Switch `busybox` in integration tests from `glibc` to `musl`

### DIFF
--- a/libcontainer/integration/seccomp_test.go
+++ b/libcontainer/integration/seccomp_test.go
@@ -335,10 +335,23 @@ func TestSeccompMultipleConditionSameArgDeniesStdout(t *testing.T) {
 		},
 	}
 
-	buffers := runContainerOk(t, config, "ls", "/")
+	buffers, exitCode, err := runContainer(t, config, "echo", "hey")
 	// Verify that nothing was printed
-	if len(buffers.Stdout.String()) != 0 {
-		t.Fatalf("Something was written to stdout, write call succeeded!\n")
+	if out := buffers.Stdout.String(); out != "" {
+		t.Fatalf("want empty stdout, got %q", out)
+	}
+	if outErr := buffers.Stderr.String(); outErr != "" {
+		t.Fatalf("want empty stderr, got %q", outErr)
+	}
+	if exitCode == 0 {
+		t.Fatalf("want non-zero exit code, got 0")
+	}
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	// TODO for some reason, exitCode from "runContainer" is -1 when it should probably be 1?
+	if errStr := err.Error(); errStr != "exit status 1" {
+		t.Fatalf("want exit status 1, got %q", errStr)
 	}
 }
 

--- a/tests/integration/bootstrap-get-images.sh
+++ b/tests/integration/bootstrap-get-images.sh
@@ -9,8 +9,8 @@ set -Eeuo pipefail
 # https://github.com/docker-library/bashbrew/releases
 
 images=(
-	# pinned to an older BusyBox (prior to 1.36 becoming "latest") because 1.36.0 has some unresolved bugs, especially around sha256sum
-	'https://github.com/docker-library/official-images/raw/eaed422a86b43c885a0f980d48f4bbf346086a4a/library/busybox:glibc'
+	# https://github.com/docker-library/official-images/commits/HEAD/library/busybox
+	'https://github.com/docker-library/official-images/raw/1702810da520102b52d89977e025c64a24ddd95e/library/busybox:musl'
 
 	# pinned to an older Debian Buster which has more architectures than the latest does (Buster transitioned from the Debian Security Team to the LTS Team which supports a smaller set)
 	'https://github.com/docker-library/official-images/raw/ce10f6b60289c0c0b5de6f785528b8725f225a58/library/debian:buster-slim'
@@ -76,7 +76,7 @@ bashbrew cat --format '
 		{{- $branch := $.TagEntry.ArchGitFetch . | trimPrefixes "refs/heads/" -}}
 		{{- $commit := $.TagEntry.ArchGitCommit . -}}
 		{{- $dir := $.TagEntry.ArchDirectory . -}}
-		{{- $tarball := eq $.RepoName "debian" | ternary "rootfs.tar.xz" "busybox.tar.xz" -}}
+		{{- $tarball := eq $.RepoName "debian" | ternary "rootfs.tar.xz" "rootfs.tar.gz" -}}
 
 		{{ . | replace "arm64v8" "arm64" "arm32" "arm" "i386" "386" }} {{- ")\n" -}}
 		{{- "\t" -}}# {{ $repo }}/tree/{{ $branch }}{{- "\n" -}}

--- a/tests/integration/get-images.sh
+++ b/tests/integration/get-images.sh
@@ -49,50 +49,50 @@ fi
 case $arch in
 amd64)
 	# https://github.com/docker-library/busybox/tree/dist-amd64
-	# https://github.com/docker-library/busybox/tree/31d342ad033e27c18723a516a2274ab39547be27/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/31d342ad033e27c18723a516a2274ab39547be27/stable/glibc/busybox.tar.xz"
+	# https://github.com/docker-library/busybox/tree/3fe52725c149a6966493eefe94d32a2704b6b7bf/latest/musl/amd64
+	url="https://github.com/docker-library/busybox/raw/3fe52725c149a6966493eefe94d32a2704b6b7bf/latest/musl/amd64/rootfs.tar.gz"
 	;;
 
-armv5)
-	# https://github.com/docker-library/busybox/tree/dist-arm32v5
-	# https://github.com/docker-library/busybox/tree/96ea82ea25565f78b50bd032d5768d64985d6e11/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/96ea82ea25565f78b50bd032d5768d64985d6e11/stable/glibc/busybox.tar.xz"
+armv6)
+	# https://github.com/docker-library/busybox/tree/dist-arm32v6
+	# https://github.com/docker-library/busybox/tree/248607b93b215b4e7c8c6b3cd141f23de2e740ac/latest/musl/arm32v6
+	url="https://github.com/docker-library/busybox/raw/248607b93b215b4e7c8c6b3cd141f23de2e740ac/latest/musl/arm32v6/rootfs.tar.gz"
 	;;
 
 armv7)
 	# https://github.com/docker-library/busybox/tree/dist-arm32v7
-	# https://github.com/docker-library/busybox/tree/5cb6c347469e86e4468e5e248de751b3598bb577/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/5cb6c347469e86e4468e5e248de751b3598bb577/stable/glibc/busybox.tar.xz"
+	# https://github.com/docker-library/busybox/tree/5f7f7ef50c73b07d9822c08b5ba0d7fb98b7b43a/latest/musl/arm32v7
+	url="https://github.com/docker-library/busybox/raw/5f7f7ef50c73b07d9822c08b5ba0d7fb98b7b43a/latest/musl/arm32v7/rootfs.tar.gz"
 	;;
 
 arm64)
 	# https://github.com/docker-library/busybox/tree/dist-arm64v8
-	# https://github.com/docker-library/busybox/tree/94c664b5ca464546266bce54be0082874a44c7b2/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/94c664b5ca464546266bce54be0082874a44c7b2/stable/glibc/busybox.tar.xz"
+	# https://github.com/docker-library/busybox/tree/ab49e875ac9a27b182e49d70672530d6ec71d5d7/latest/musl/arm64v8
+	url="https://github.com/docker-library/busybox/raw/ab49e875ac9a27b182e49d70672530d6ec71d5d7/latest/musl/arm64v8/rootfs.tar.gz"
 	;;
 
 386)
 	# https://github.com/docker-library/busybox/tree/dist-i386
-	# https://github.com/docker-library/busybox/tree/461a473aef31b7726ea99909a24551bf44565c05/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/461a473aef31b7726ea99909a24551bf44565c05/stable/glibc/busybox.tar.xz"
-	;;
-
-mips64le)
-	# https://github.com/docker-library/busybox/tree/dist-mips64le
-	# https://github.com/docker-library/busybox/tree/47f73f7c735dcd6760a976bfe0012d251b6ef0a9/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/47f73f7c735dcd6760a976bfe0012d251b6ef0a9/stable/glibc/busybox.tar.xz"
+	# https://github.com/docker-library/busybox/tree/a3bd0b33cc571a394668621670d67886da930223/latest/musl/i386
+	url="https://github.com/docker-library/busybox/raw/a3bd0b33cc571a394668621670d67886da930223/latest/musl/i386/rootfs.tar.gz"
 	;;
 
 ppc64le)
 	# https://github.com/docker-library/busybox/tree/dist-ppc64le
-	# https://github.com/docker-library/busybox/tree/9ca13bc214717966383cf97e08606b444b7300e4/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/9ca13bc214717966383cf97e08606b444b7300e4/stable/glibc/busybox.tar.xz"
+	# https://github.com/docker-library/busybox/tree/fe3c277a9485182093b8b471d428ce9c9574a056/latest/musl/ppc64le
+	url="https://github.com/docker-library/busybox/raw/fe3c277a9485182093b8b471d428ce9c9574a056/latest/musl/ppc64le/rootfs.tar.gz"
+	;;
+
+riscv64)
+	# https://github.com/docker-library/busybox/tree/dist-riscv64
+	# https://github.com/docker-library/busybox/tree/57a6af974cdd6e8859cb2c76927765872426c39b/latest/musl/riscv64
+	url="https://github.com/docker-library/busybox/raw/57a6af974cdd6e8859cb2c76927765872426c39b/latest/musl/riscv64/rootfs.tar.gz"
 	;;
 
 s390x)
 	# https://github.com/docker-library/busybox/tree/dist-s390x
-	# https://github.com/docker-library/busybox/tree/a03814d21bcf97767121bb9422a742ec237a09e2/stable/glibc
-	url="https://github.com/docker-library/busybox/raw/a03814d21bcf97767121bb9422a742ec237a09e2/stable/glibc/busybox.tar.xz"
+	# https://github.com/docker-library/busybox/tree/53c1b0b8d9fff46e5ada0e5816fb5fd0281ef246/latest/musl/s390x
+	url="https://github.com/docker-library/busybox/raw/53c1b0b8d9fff46e5ada0e5816fb5fd0281ef246/latest/musl/s390x/rootfs.tar.gz"
 	;;
 
 *)


### PR DESCRIPTION
Also, update to the latest version/builds.

See also:
- (alternative to) https://github.com/opencontainers/runc/pull/4842
- https://github.com/opencontainers/runc/issues/4836

cc @kolyshkin @cyphar @ricardobranco777

The comment from @tshah14 in https://github.com/opencontainers/runc/issues/4836#issuecomment-3264739956 about static vs dynamic made me realize we have a `uclibc` variant in DOI that _is_ statically compiled and might get us a "free pass" in `runc` (so chasing the bugfix in BusyBox upstream can be fully independent), but unfortunately the architecture support on `uclibc` is a significantly smaller set (we lose `ppc64le`, for example, which is the one we're trying to fix :joy:), so I figured maybe it's worth trying the `musl` variant to see if perhaps it has enough of a simpler `libc` implementation as to avoid the segfault?

Notably this loses `mips64le` and `armv5`, but I don't think either of those are actively tested in `runc` anyhow so maybe that's an acceptable compromise, assuming this works? :bow: