### PR TITLE
tests/int/cgroups: Use 64K aligned limits for memory.max

### DIFF
--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -362,7 +362,7 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 	update_config ' .linux.resources.unified |= {
-				"memory.max": "20484096",
+				"memory.max": "20512768",
 				"memory.swap.max": "20971520"
 			}'
 
@@ -373,10 +373,10 @@ convert_hugetlb_size() {
 	[ "$status" -eq 0 ]
 	echo "$output"
 
-	echo "$output" | grep -q '^memory.max:20484096$'
+	echo "$output" | grep -q '^memory.max:20512768$'
 	echo "$output" | grep -q '^memory.swap.max:20971520$'
 
-	check_systemd_value "MemoryMax" 20484096
+	check_systemd_value "MemoryMax" 20512768
 	check_systemd_value "MemorySwapMax" 20971520
 }
 


### PR DESCRIPTION
When a non–page-aligned value is written to memory.max, the kernel aligns it down to the nearest page boundary. On systems with a page size greater than 4K (e.g., 64K), this caused failures because the configured memory.max value was not 64K aligned.

This patch fixes the issue by explicitly aligning the memory.max value to 64K. Since 64K is also a multiple of 4K, the value is correctly aligned on both 4K and 64K page size systems.

However, this approach will still fail on systems where the hardcoded memory.max value is not aligned to the system page size.

Fixes: https://github.com/opencontainers/runc/issues/4841