### PR TITLE
libct: setup personality before initializing seccomp

### DIFF
--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -80,6 +80,14 @@ func (l *linuxSetnsInit) Init() error {
 	if err := setupIOPriority(l.config); err != nil {
 		return err
 	}
+
+	// Set personality if specified.
+	if l.config.Config.Personality != nil {
+		if err := setupPersonality(l.config.Config); err != nil {
+			return err
+		}
+	}
+
 	// Tell our parent that we're ready to exec. This must be done before the
 	// Seccomp rules have been applied, because we need to be able to read and
 	// write to a socket.
@@ -109,11 +117,6 @@ func (l *linuxSetnsInit) Init() error {
 	}
 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
 		return err
-	}
-	if l.config.Config.Personality != nil {
-		if err := setupPersonality(l.config.Config); err != nil {
-			return err
-		}
 	}
 	// Check for the arg early to make sure it exists.
 	name, err := exec.LookPath(l.config.Args[0])

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -164,6 +164,13 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
+	// Set personality if specified.
+	if l.config.Config.Personality != nil {
+		if err := setupPersonality(l.config.Config); err != nil {
+			return err
+		}
+	}
+
 	// Tell our parent that we're ready to exec. This must be done before the
 	// Seccomp rules have been applied, because we need to be able to read and
 	// write to a socket.
@@ -234,13 +241,6 @@ func (l *linuxStandardInit) Init() error {
 		}
 
 		if err := syncParentSeccomp(l.pipe, seccompFd); err != nil {
-			return err
-		}
-	}
-
-	// Set personality if specified.
-	if l.config.Config.Personality != nil {
-		if err := setupPersonality(l.config.Config); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Set the process personality early to ensure it takes effect before
seccomp is initialized. If seccomp filters are applied first and they
block personality-related system calls (e.g., `personality(2)`),
subsequent attempts to set the personality will fail.

Please see:
https://github.com/opencontainers/runc/pull/4726#discussion_r2317775814