### PR TITLE
fix(seccompagent): close received FDs, not loop index

### DIFF
--- a/tests/cmd/seccompagent/seccompagent.go
+++ b/tests/cmd/seccompagent/seccompagent.go
@@ -32,8 +32,8 @@ var (
 )
 
 func closeStateFds(recvFds []int) {
-	for i := range recvFds {
-		unix.Close(i)
+	for _, fd := range recvFds {
+		_ = unix.Close(fd)
 	}
 }
 


### PR DESCRIPTION
Prevents accidentally closing 0/1/2 on error paths.