### PR TITLE
linux: compute array size for SetMempolicy more robustly

### DIFF
--- a/internal/linux/linux.go
+++ b/internal/linux/linux.go
@@ -76,8 +76,12 @@ func Sendmsg(fd int, p, oob []byte, to unix.Sockaddr, flags int) error {
 
 // SetMempolicy wraps set_mempolicy.
 func SetMempolicy(mode uint, mask *unix.CPUSet) error {
+	var maskSize uintptr
+	if mask != nil {
+		maskSize = unsafe.Sizeof(*mask) * uintptr(len(*mask))
+	}
 	err := retryOnEINTR(func() error {
-		_, _, errno := unix.Syscall(unix.SYS_SET_MEMPOLICY, uintptr(mode), uintptr(unsafe.Pointer(mask)), unsafe.Sizeof(*mask)*8)
+		_, _, errno := unix.Syscall(unix.SYS_SET_MEMPOLICY, uintptr(mode), uintptr(unsafe.Pointer(mask)), maskSize)
 		if errno != 0 {
 			return errno
 		}


### PR DESCRIPTION
This is a minor fix -- use len() to make sure that golang.org/x/sys/unix
changing the size of CPUSet doesn't break anything, and avoid a possible
nil deref.

Fixes: eda7bdf80cca ("Add memory policy support")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>