### PR TITLE
[1.4] fix(seccompagent): close received FDs, not loop index

### DIFF
--- a/tests/cmd/seccompagent/seccompagent.go
+++ b/tests/cmd/seccompagent/seccompagent.go
@@ -27,8 +27,8 @@ var (
 )
 
 func closeStateFds(recvFds []int) {
-	for i := range recvFds {
-		unix.Close(i)
+	for _, fd := range recvFds {
+		_ = unix.Close(fd)
 	}
 }
 


### PR DESCRIPTION
Backport of #4913 to release-1.4 branch.

----

Prevents accidentally closing 0/1/2 on error paths.

(cherry picked from commit 8c1b3f9608736a326532d81a4ca84d2b264adf10)