### PR TITLE
CI: remove deprecated lima-vm/lima-actions/ssh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,8 +218,6 @@ jobs:
 
     # NOTE the execution environment lacks a terminal, needed for
     # some integration tests. So we use `ssh -tt` command to fake a terminal.
-    - uses: lima-vm/lima-actions/ssh@v1
-
     - name: "Run unit tests"
       run: ssh -tt lima-default sudo -i make -C /tmp/runc localunittest
 


### PR DESCRIPTION
`lima-vm/lima-actions/ssh` is now merged into `lima-vm/lima-actions/setup`.

https://github.com/lima-vm/lima-actions/releases/tag/v1.1.0