### PR TITLE
[1.4] libct: close child fds on prepareCgroupFD error

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -353,22 +353,21 @@ func (p *setnsProcess) prepareCgroupFD() (*os.File, error) {
 	return fd, nil
 }
 
-func (p *setnsProcess) start() (retErr error) {
-	defer p.comm.closeParent()
+// startWithCgroupFD starts a process via clone3 with CLONE_INTO_CGROUP,
+// with a fallback if it fails (e.g. not available).
+func (p *setnsProcess) startWithCgroupFD() error {
+	// Close the child side of the pipes.
+	defer p.comm.closeChild()
 
 	fd, err := p.prepareCgroupFD()
 	if err != nil {
-		p.comm.closeChild()
 		return err
 	}
-
-	// Get the "before" value of oom kill count.
-	oom, _ := p.manager.OOMKillCount()
+	if fd != nil {
+		defer fd.Close()
+	}
 
 	err = p.startWithCPUAffinity()
-	if fd != nil {
-		fd.Close()
-	}
 	if err != nil && p.cmd.SysProcAttr.UseCgroupFD {
 		logrus.Debugf("exec with CLONE_INTO_CGROUP failed: %v; retrying without", err)
 		// SysProcAttr.CgroupFD is never used when UseCgroupFD is unset.
@@ -376,9 +375,16 @@ func (p *setnsProcess) start() (retErr error) {
 		err = p.startWithCPUAffinity()
 	}
 
-	// Close the child-side of the pipes (controlled by child).
-	p.comm.closeChild()
-	if err != nil {
+	return err
+}
+
+func (p *setnsProcess) start() (retErr error) {
+	defer p.comm.closeParent()
+
+	// Get the "before" value of oom kill count.
+	oom, _ := p.manager.OOMKillCount()
+
+	if err := p.startWithCgroupFD(); err != nil {
 		return fmt.Errorf("error starting setns process: %w", err)
 	}
 


### PR DESCRIPTION
Backport of #4930

<hr>

The `(*setns).start` is supposed to close child fds once the child has started, or upon returning an error.
There was no code to return an error before calling start, but commit 5af4dd4e6 added it, together with
a bug -- child fds are not closed if prepareCgroupFD fails.

I'm not sure ifhow to add a good test case for it. Found when working on PR #4928 (which modified the code
to read the child logs even when start() fails).

Fixes: 5af4dd4e6 / PR #4812.

----

This PR also includes the refactoring of start to avoid similar problems in the future.