### PR TITLE
ci: only run lint-extra job on PRs to main

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,9 +42,9 @@ jobs:
       - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.5
-      # Extra linters, only checking new code from a pull request.
+      # Extra linters, only checking new code from a pull request to main.
       - name: lint-extra
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
         run: |
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 


### PR DESCRIPTION
All the new code appears in main (not in the release branches), and we only want extra linter rules to apply to new code.

Disable lint-extra job if the PR is not to the main branch.

Inspired by lint-extra warnings in release-1.x PRs.