### PR TITLE
tests/int: use `run -N|!` for runc

### DIFF
--- a/tests/integration/capabilities.bats
+++ b/tests/integration/capabilities.bats
@@ -12,8 +12,7 @@ function teardown() {
 }
 
 @test "runc run no capability" {
-	runc run test_no_caps
-	[ "$status" -eq 0 ]
+	runc -0 run test_no_caps
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
@@ -22,8 +21,7 @@ function teardown() {
 
 @test "runc run with unknown capability" {
 	update_config '.process.capabilities.bounding = ["CAP_UNKNOWN", "UNKNOWN_CAP"]'
-	runc run test_unknown_caps
-	[ "$status" -eq 0 ]
+	runc -0 run test_unknown_caps
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
@@ -32,8 +30,7 @@ function teardown() {
 
 @test "runc run with new privileges" {
 	update_config '.process.noNewPrivileges = false'
-	runc run test_new_privileges
-	[ "$status" -eq 0 ]
+	runc -0 run test_new_privileges
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
@@ -44,8 +41,7 @@ function teardown() {
 	update_config '.process.user = {"uid":0}'
 	update_config '.process.capabilities.bounding = ["CAP_SYS_ADMIN"]'
 	update_config '.process.capabilities.permitted = ["CAP_SYS_ADMIN", "CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"]'
-	runc run test_some_caps
-	[ "$status" -eq 0 ]
+	runc -0 run test_some_caps
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapBnd:	0000000000200000"* ]]
@@ -57,11 +53,9 @@ function teardown() {
 @test "runc exec --cap" {
 	update_config '	  .process.args = ["/bin/sh"]
 			| .process.capabilities = {}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_exec_cap
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_exec_cap
 
-	runc exec test_exec_cap cat /proc/self/status
-	[ "$status" -eq 0 ]
+	runc -0 exec test_exec_cap cat /proc/self/status
 	# Check no capabilities are set.
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapPrm:	0000000000000000"* ]]
@@ -69,8 +63,7 @@ function teardown() {
 	[[ "${output}" == *"CapBnd:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
 
-	runc exec --cap CAP_KILL --cap CAP_AUDIT_WRITE test_exec_cap cat /proc/self/status
-	[ "$status" -eq 0 ]
+	runc -0 exec --cap CAP_KILL --cap CAP_AUDIT_WRITE test_exec_cap cat /proc/self/status
 	# Check capabilities are added into bounding/effective/permitted only,
 	# but not to inheritable or ambient.
 	#
@@ -90,11 +83,9 @@ function teardown() {
 			| .process.capabilities.effective = ["CAP_KILL"]
 			| .process.capabilities.bounding = ["CAP_KILL", "CAP_CHOWN", "CAP_SYSLOG"]
 			| .process.capabilities.ambient = ["CAP_CHOWN"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_some_caps
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_some_caps
 
-	runc exec test_some_caps cat /proc/self/status
-	[ "$status" -eq 0 ]
+	runc -0 exec test_some_caps cat /proc/self/status
 	# Check that capabilities are as set in spec.
 	#
 	# CAP_CHOWN is 0, the bit mask is 0x1 (1 << 0)
@@ -108,8 +99,7 @@ function teardown() {
 
 	# Check that if config.json has an inheritable capability set,
 	# runc exec --cap adds ambient capabilities.
-	runc exec --cap CAP_SYSLOG test_some_caps cat /proc/self/status
-	[ "$status" -eq 0 ]
+	runc -0 exec --cap CAP_SYSLOG test_some_caps cat /proc/self/status
 	[[ "${output}" == *"CapInh:	0000000400000001"* ]]
 	[[ "${output}" == *"CapPrm:	0000000400000021"* ]]
 	[[ "${output}" == *"CapEff:	0000000400000021"* ]]
@@ -120,8 +110,7 @@ function teardown() {
 @test "runc run [ambient caps not set in inheritable result in a warning]" {
 	update_config '   .process.capabilities.inheritable = ["CAP_KILL"]
                        | .process.capabilities.ambient = ["CAP_KILL", "CAP_CHOWN"]'
-	runc run test_amb
-	[ "$status" -eq 0 ]
+	runc -0 run test_amb
 	# This should result in CAP_KILL set in ambient,
 	# and a warning about inability to set CAP_CHOWN.
 	#

--- a/tests/integration/cgroup_delegation.bats
+++ b/tests/integration/cgroup_delegation.bats
@@ -27,11 +27,9 @@ function setup() {
 }
 
 @test "runc exec (cgroup v2, ro cgroupfs, new cgroupns) does not chown cgroup" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
-	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
 	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
 }
 
@@ -41,21 +39,17 @@ function setup() {
 	# inherit cgroup namespace (remove cgroup from namespaces list)
 	update_config '.linux.namespaces |= map(select(.type != "cgroup"))'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
-	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
 	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
 }
 
 @test "runc exec (cgroup v2, rw cgroupfs, new cgroupns) does chown cgroup" {
 	set_cgroup_mount_writable
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
-	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
 	[ "$output" = "root" ] # /sys/fs/cgroup owned by root (of user namespace)
 }

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -12,8 +12,7 @@ function setup() {
 }
 
 @test "runc create (no limits + no cgrouppath + no permission) succeeds" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 }
 
 @test "runc create (rootless + no limits + cgrouppath + no permission) fails with permission error" {
@@ -21,8 +20,7 @@ function setup() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 1 ]
+	runc -1 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[[ "$output" == *"unable to apply cgroup configuration"*"permission denied"* ]]
 }
 
@@ -31,8 +29,7 @@ function setup() {
 
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 1 ]
+	runc -1 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[[ "$output" == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] ||
 		[[ "$output" == *"cannot set pids limit: container could not join or create cgroup"* ]]
 }
@@ -43,8 +40,7 @@ function setup() {
 	set_cgroups_path
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	if [ -v CGROUP_V2 ]; then
 		if [ -v RUNC_USE_SYSTEMD ]; then
 			if [ $EUID -eq 0 ]; then
@@ -65,11 +61,9 @@ function setup() {
 	set_cgroups_path
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 
-	runc exec test_cgroups_permissions echo "cgroups_exec"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_permissions echo "cgroups_exec"
 	[[ ${lines[0]} == *"cgroups_exec"* ]]
 }
 
@@ -79,37 +73,29 @@ function setup() {
 	set_cgroups_path
 	set_cgroup_mount_writable
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
 
-	runc exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers
 	[[ ${lines[0]} == *"memory"* ]]
 
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group cat /proc/self/cgroup
 	[[ ${lines[0]} = "0::/" ]]
 
-	runc exec test_cgroups_group mkdir /sys/fs/cgroup/foo
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group mkdir /sys/fs/cgroup/foo
 
-	runc exec test_cgroups_group sh -c "echo 1 > /sys/fs/cgroup/foo/cgroup.procs"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group sh -c "echo 1 > /sys/fs/cgroup/foo/cgroup.procs"
 
 	# the init process is now in "/foo", but an exec process can still join "/"
 	# because we haven't enabled any domain controller.
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group cat /proc/self/cgroup
 	[[ ${lines[0]} = "0::/" ]]
 
 	# turn on a domain controller (memory)
-	runc exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
 
 	# an exec process can no longer join "/" after turning on a domain controller.
 	# falls back to "/foo".
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group cat /proc/self/cgroup
 	[[ ${lines[0]} = "0::/foo" ]]
 
 	# teardown: remove "/foo"
@@ -120,8 +106,7 @@ for pid in $(cat /sys/fs/cgroup/foo/cgroup.procs); do
 done
 rmdir /sys/fs/cgroup/foo
 EOF
-	runc exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
 }
 
 @test "runc run (cgroup v1 + unified resources should fail)" {
@@ -131,8 +116,7 @@ EOF
 	set_resources_limit
 	update_config '.linux.resources.unified |= {"memory.min": "131072"}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -ne 0 ]
+	runc ! run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	[[ "$output" == *'invalid configuration'* ]]
 }
 
@@ -143,8 +127,7 @@ EOF
 	set_cgroups_path
 	update_config '.linux.resources.blockIO |= {"weight": 750}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
 	runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.bfq.weight'
 	if [[ "$status" -eq 0 ]]; then
@@ -188,8 +171,7 @@ EOF
 			| .linux.resources.blockIO.weightDevice |= [
 				{ major: '"$major"', minor: '"$minor"', weight: 444 }
 			]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
 
 	if [ -v CGROUP_V2 ]; then
 		file="io.bfq.weight"
@@ -240,8 +222,7 @@ EOF
 			   ]
 			| .linux.resources.unified |=
 				{"io.max": "'"$major1"':'"$minor1"' riops=333 wiops=444\n'"$major2"':'"$minor2"' riops=555 wiops=666\n"}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
 
 	weights=$(get_cgroup_value "io.max")
 	grep "^$major1:$minor1 .* riops=333 wiops=444$" <<<"$weights"
@@ -255,8 +236,7 @@ EOF
 	set_cgroups_path
 	update_config '.linux.resources.cpu.idle = 1'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	check_cgroup_value "cpu.idle" "1"
 }
 
@@ -300,8 +280,7 @@ convert_hugetlb_size() {
 	done
 
 	set_cgroups_path
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_hugetlb
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_hugetlb
 
 	lim="max"
 	[ -v CGROUP_V1 ] && lim="limit_in_bytes"
@@ -369,11 +348,9 @@ convert_hugetlb_size() {
 				"cpu.weight": "42"
 			}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
-	runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.min *.max *.low *.high'
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.min *.max *.low *.high'
 	echo "$output"
 
 	echo "$output" | grep -q '^memory.min:131072$'
@@ -401,11 +378,9 @@ convert_hugetlb_size() {
 				"memory.swap.max": "20971520"
 			}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
-	runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.max'
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.max'
 	echo "$output"
 
 	echo "$output" | grep -q '^memory.max:20512768$'
@@ -434,19 +409,15 @@ convert_hugetlb_size() {
 				"cpu.weight": "42"
 			}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
-	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
 	[ "$output" = '131072' ]
 
-	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
 	[ "$output" = '10485760' ]
 
-	runc exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
 	[ "$output" = '42' ]
 	check_systemd_value "TasksMax" 42
 
@@ -461,12 +432,10 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
 	# Make sure we don't have any extra cgroups inside
-	runc exec test_cgroups_unified find /sys/fs/cgroup/ -type d
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_unified find /sys/fs/cgroup/ -type d
 	[ "$(wc -l <<<"$output")" -eq 1 ]
 }
 
@@ -475,15 +444,13 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
-	[ "$status" -eq 0 ]
+	runc -0 run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
 
 	pid=$(cat pid.txt)
 	run_cgroup=$(tail -1 </proc/"$pid"/cgroup)
 	[[ "$run_cgroup" == *"runc-cgroups-integration-test"* ]]
 
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec test_cgroups_group cat /proc/self/cgroup
 	exec_cgroup=${lines[-1]}
 	[[ $exec_cgroup == *"runc-cgroups-integration-test"* ]]
 
@@ -497,14 +464,11 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
-	runc pause ct1
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" ct1
+	runc -0 pause ct1
 
 	# Exec should not timeout or succeed.
-	runc exec ct1 echo ok
-	[ "$status" -eq 255 ]
+	runc -255 exec ct1 echo ok
 	[[ "$output" == *"cannot exec in a paused container"* ]]
 }
 
@@ -514,10 +478,8 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
-	runc pause ct1
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" ct1
+	runc -0 pause ct1
 
 	# Resume the container a bit later.
 	(
@@ -526,8 +488,7 @@ convert_hugetlb_size() {
 	) &
 
 	# Exec should succeed (once the container is resumed).
-	runc exec --ignore-paused ct1 echo ok
-	[ "$status" -eq 0 ]
+	runc -0 exec --ignore-paused ct1 echo ok
 	[ "$output" = "ok" ]
 }
 
@@ -536,17 +497,14 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" ct1
 
 	# Run a second container sharing the cgroup with the first one.
-	runc --debug run -d --console-socket "$CONSOLE_SOCKET" ct2
-	[ "$status" -ne 0 ]
+	runc ! --debug run -d --console-socket "$CONSOLE_SOCKET" ct2
 	[[ "$output" == *"container's cgroup is not empty"* ]]
 
 	# Same but using runc create.
-	runc create --console-socket "$CONSOLE_SOCKET" ct3
-	[ "$status" -ne 0 ]
+	runc ! create --console-socket "$CONSOLE_SOCKET" ct3
 	[[ "$output" == *"container's cgroup is not empty"* ]]
 }
 
@@ -571,14 +529,12 @@ convert_hugetlb_size() {
 	echo "$STATE" >"$FREEZER"
 
 	# Start a container.
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 1 ]
+	runc -1 run -d --console-socket "$CONSOLE_SOCKET" ct1
 	# A warning should be printed.
 	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
 
 	# Same check for runc create.
-	runc create --console-socket "$CONSOLE_SOCKET" ct2
-	[ "$status" -eq 1 ]
+	runc -1 create --console-socket "$CONSOLE_SOCKET" ct2
 	# A warning should be printed.
 	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -99,7 +99,7 @@ function setup() {
 	[[ ${lines[0]} = "0::/foo" ]]
 
 	# teardown: remove "/foo"
-	cat <<'EOF' | runc exec test_cgroups_group sh -eux
+	cat <<'EOF' | runc -0 exec test_cgroups_group sh -eux
 echo -memory > /sys/fs/cgroup/cgroup.subtree_control
 for pid in $(cat /sys/fs/cgroup/foo/cgroup.procs); do
 	echo $pid > /sys/fs/cgroup/cgroup.procs || true
@@ -133,7 +133,7 @@ EOF
 	if [[ "$status" -eq 0 ]]; then
 		[ "$output" = 'default 750' ]
 	else
-		runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
+		runc -0 exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
 		[ "$output" = 'default 7475' ]
 	fi
 }
@@ -181,7 +181,7 @@ EOF
 	weights1=$(get_cgroup_value $file)
 
 	# Check that runc update works.
-	runc update -r - test_dev_weight <<EOF
+	runc -0 update -r - test_dev_weight <<EOF
 {
   "blockIO": {
     "weight": 111,
@@ -484,7 +484,7 @@ convert_hugetlb_size() {
 	# Resume the container a bit later.
 	(
 		sleep 2
-		runc resume ct1
+		runc -0 resume ct1
 	) &
 
 	# Exec should succeed (once the container is resumed).

--- a/tests/integration/cpu_affinity.bats
+++ b/tests/integration/cpu_affinity.bats
@@ -41,8 +41,7 @@ function cpus_to_mask() {
 	first="$(first_cpu)"
 	second=$((first + 1)) # Hacky; might not work in all environments.
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" ct1
 
 	for cpus in "$second" "$first-$second" "$first,$second" "$first"; do
 		proc='
@@ -65,8 +64,7 @@ function cpus_to_mask() {
 	first="$(first_cpu)"
 	second=$((first + 1)) # Hacky; might not work in all environments.
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" ct1
 
 	for cpus in "$second" "$first-$second" "$first,$second" "$first"; do
 		proc='
@@ -95,11 +93,9 @@ function cpus_to_mask() {
 	update_config "	  .process.execCPUAffinity.initial = \"$initial\"
 			| .process.execCPUAffinity.final = \"$final\""
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" ct1
 
-	runc --debug exec ct1 grep "Cpus_allowed_list:" /proc/self/status
-	[ "$status" -eq 0 ]
+	runc -0 --debug exec ct1 grep "Cpus_allowed_list:" /proc/self/status
 	mask=$(cpus_to_mask "$initial")
 	[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
 	[[ "$output" == *"Cpus_allowed_list:	$final"* ]] # Mind the literal tab.
@@ -171,8 +167,7 @@ function cpus_to_mask() {
 	[ -v RUNC_USE_SYSTEMD ] || [[ "$output" == $'Cpus_allowed_list:\t'"$first-$second" ]]
 
 	# Stop the container so we can reconfigure it.
-	runc delete -f ctr
-	[ "$status" -eq 0 ]
+	runc -0 delete -f ctr
 
 	# Ditto for a cpuset that has no overlap with the original cpumask.
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$second"'"}'

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -75,45 +75,38 @@ is_allowed_fdtarget() {
 }
 
 @test "runc create" {
-	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 create --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 start test_busybox
 
 	testcontainer test_busybox running
 }
 
 @test "runc create exec" {
-	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 create --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
-	runc exec test_busybox true
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox true
 
 	testcontainer test_busybox created
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 start test_busybox
 
 	testcontainer test_busybox running
 }
 
 @test "runc create --pid-file" {
-	runc create --pid-file pid.txt --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 create --pid-file pid.txt --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
 	[ -e pid.txt ]
 	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 start test_busybox
 
 	testcontainer test_busybox running
 }
@@ -123,16 +116,14 @@ is_allowed_fdtarget() {
 	mkdir pid_file
 	cd pid_file
 
-	runc create --pid-file pid.txt -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 create --pid-file pid.txt -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
 	[ -e pid.txt ]
 	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 start test_busybox
 
 	testcontainer test_busybox running
 }
@@ -156,8 +147,7 @@ is_allowed_fdtarget() {
 	fi
 
 	exp="Such configuration is strongly discouraged"
-	runc create --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	runc -0 create --console-socket "$CONSOLE_SOCKET" test
 	if [ $EUID -ne 0 ] && ! rootless_cgroup; then
 		[[ "$output" = *"$exp"* ]]
 	else

--- a/tests/integration/cwd.bats
+++ b/tests/integration/cwd.bats
@@ -21,11 +21,9 @@ function teardown() {
 			| .process.user.uid = 42
 			| .process.args |= ["sleep", "1h"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --user 0 test_busybox true
-	[ "$status" -eq 0 ]
+	runc -0 exec --user 0 test_busybox true
 }
 
 # Verify a cwd owned by the container user can be chdir'd to,
@@ -53,8 +51,7 @@ function teardown() {
 			| .process.cwd = "'"$AUX_DIR"'"
 			| .process.args |= ["ls", "'"$AUX_DIR"'"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 }
 
 # Verify a cwd not owned by the container user can be chdir'd to,
@@ -69,6 +66,5 @@ function teardown() {
 			| .process.user.uid = 42
 			| .process.args |= ["ls", "/tmp"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 }

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -18,8 +18,7 @@ function check_debug() {
 }
 
 @test "global --debug" {
-	runc --debug run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 --debug run test_hello
 
 	# check expected debug output was sent to stderr
 	[[ "${output}" == *"level=debug"* ]]
@@ -27,8 +26,7 @@ function check_debug() {
 }
 
 @test "global --debug to --log" {
-	runc --log log.out --debug run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 --log log.out --debug run test_hello
 
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]
@@ -41,8 +39,7 @@ function check_debug() {
 }
 
 @test "global --debug to --log --log-format 'text'" {
-	runc --log log.out --log-format "text" --debug run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 --log log.out --log-format "text" --debug run test_hello
 
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]
@@ -55,8 +52,7 @@ function check_debug() {
 }
 
 @test "global --debug to --log --log-format 'json'" {
-	runc --log log.out --log-format "json" --debug run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 --log log.out --log-format "json" --debug run test_hello
 
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -113,7 +113,7 @@ function test_runc_delete_host_pidns() {
 
 	testcontainer test_busybox running
 
-	runc delete --force test_busybox
+	runc -0 delete --force test_busybox
 
 	runc ! state test_busybox
 }
@@ -186,7 +186,7 @@ EOF
 		[ -d "${path}" ] || fail "test failed to create memory sub-cgroup ($path not found)"
 	done
 
-	runc delete --force test_busybox
+	runc -0 delete --force test_busybox
 
 	runc ! state test_busybox
 
@@ -228,7 +228,7 @@ EOF
 	[ -d "$CGROUP_V2_PATH"/foo ]
 
 	# force delete test_busybox
-	runc delete --force test_busybox
+	runc -0 delete --force test_busybox
 
 	runc ! state test_busybox
 
@@ -256,7 +256,7 @@ EOF
 	# Expect "unit is not active" exit code.
 	run -3 systemctl status $user "$SD_UNIT_NAME"
 
-	runc delete test-failed-unit
+	runc -0 delete test-failed-unit
 	# Expect "no such unit" exit code.
 	run -4 systemctl status $user "$SD_UNIT_NAME"
 }

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -40,8 +40,7 @@ function test_runc_delete_host_pidns() {
 				  ) // .)'
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	cgpath=$(get_cgroup_path "pids")
 	init_pid=$(cat "$cgpath"/cgroup.procs)
 
@@ -65,11 +64,10 @@ function test_runc_delete_host_pidns() {
 	done
 
 	# Must kill those processes and remove container.
-	runc delete "$@" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 delete "$@" test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ] # "Container does not exist"
+	runc ! state test_busybox
+	[[ "$output" == *"container does not exist"* ]]
 
 	# Wait and check that all the processes are gone.
 	wait_pids_gone 10 0.2 "${pids[@]}"
@@ -90,8 +88,7 @@ function test_runc_delete_host_pidns() {
 	[ $EUID -ne 0 ] && requires systemd
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
 
 	testcontainer testbusyboxdelete running
 	# Ensure the find statement used later is correct.
@@ -100,35 +97,29 @@ function test_runc_delete_host_pidns() {
 		fail "expected cgroup not found"
 	fi
 
-	runc kill testbusyboxdelete KILL
-	[ "$status" -eq 0 ]
+	runc -0 kill testbusyboxdelete KILL
 	wait_for_container 10 1 testbusyboxdelete stopped
 
-	runc delete testbusyboxdelete
-	[ "$status" -eq 0 ]
+	runc -0 delete testbusyboxdelete
 
-	runc state testbusyboxdelete
-	[ "$status" -ne 0 ]
+	runc ! state testbusyboxdelete
 
 	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 
 @test "runc delete --force" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 }
 
 @test "runc delete --force ignore not exist" {
-	runc delete --force notexists
-	[ "$status" -eq 0 ]
+	runc -0 delete --force notexists
 }
 
 # Issue 4047, case "runc delete".
@@ -149,14 +140,11 @@ function test_runc_delete_host_pidns() {
 		set_cgroups_path
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" ct1
 	testcontainer ct1 running
 
-	runc pause ct1
-	[ "$status" -eq 0 ]
-	runc delete --force ct1
-	[ "$status" -eq 0 ]
+	runc -0 pause ct1
+	runc -0 delete --force ct1
 }
 
 @test "runc delete --force in cgroupv1 with subcgroups" {
@@ -168,8 +156,7 @@ function test_runc_delete_host_pidns() {
 
 	local subsystems="memory freezer"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
@@ -180,7 +167,7 @@ function test_runc_delete_host_pidns() {
 	[[ ${pid} =~ [0-9]+ ]]
 
 	# create a sub-cgroup
-	cat <<EOF | runc exec test_busybox sh
+	cat <<EOF | runc -0 exec test_busybox sh
 set -e -u -x
 for s in ${subsystems}; do
   cd /sys/fs/cgroup/\$s
@@ -190,7 +177,6 @@ for s in ${subsystems}; do
   cat tasks
 done
 EOF
-	[ "$status" -eq 0 ]
 	[[ "$output" =~ [0-9]+ ]]
 
 	for s in ${subsystems}; do
@@ -202,8 +188,7 @@ EOF
 
 	runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 
 	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
@@ -214,8 +199,7 @@ EOF
 	set_cgroups_path
 	set_cgroup_mount_writable
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
@@ -237,8 +221,7 @@ EOF
   echo ${pid} > cgroup.threads
   cat cgroup.threads
 EOF
-	runc exec test_busybox sh <nest.sh
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox sh <nest.sh
 	[[ "$output" =~ [0-9]+ ]]
 
 	# check create subcgroups success
@@ -247,8 +230,7 @@ EOF
 	# force delete test_busybox
 	runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 
 	# check delete subcgroups success
 	[ ! -d "$CGROUP_V2_PATH"/foo ]
@@ -264,8 +246,7 @@ EOF
 			   }
 			| .process.args |= ["/bin/sleep", "10"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test-failed-unit
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test-failed-unit
 
 	wait_for_container 10 1 test-failed-unit stopped
 

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -14,8 +14,7 @@ function teardown() {
 	update_config ' .linux.devices += [{"path": "/dev/tty", "type": "c", "major": 5, "minor": 0}]
 		      | .process.args |= ["ls", "-lLn", "/dev/tty"]'
 
-	runc run test_dev
-	[ "$status" -eq 0 ]
+	runc -0 run test_dev
 
 	if [ $EUID -ne 0 ]; then
 		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"65534".+"65534".+"5,".+"0".+"/dev/tty" ]]
@@ -28,8 +27,7 @@ function teardown() {
 	update_config ' .linux.devices += [{"path": "/dev/ptmx", "type": "c", "major": 5, "minor": 2}]
 		      | .process.args |= ["ls", "-lLn", "/dev/ptmx"]'
 
-	runc run test_dev
-	[ "$status" -eq 0 ]
+	runc -0 run test_dev
 	[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"0".+"0".+"5,".+"2".+"/dev/ptmx" ]]
 }
 
@@ -43,29 +41,24 @@ function teardown() {
 			| .process.capabilities.permitted += ["CAP_SYSLOG"]
 			| .process.args |= ["sh"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_deny
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_deny
 
 	# test write
-	runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
-	[ "$status" -eq 1 ]
+	runc -1 exec test_deny sh -c 'hostname | tee /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
 	# test read
-	runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
-	[ "$status" -eq 1 ]
+	runc -1 exec test_deny sh -c 'head -n 1 /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
 	runc update test_deny --pids-limit 42
 
 	# test write
-	runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
-	[ "$status" -eq 1 ]
+	runc -1 exec test_deny sh -c 'hostname | tee /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
 	# test read
-	runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
-	[ "$status" -eq 1 ]
+	runc -1 exec test_deny sh -c 'head -n 1 /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 }
 
@@ -80,23 +73,19 @@ function teardown() {
 			| .process.capabilities.permitted += ["CAP_SYSLOG"]
 			| .hostname = "myhostname"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_allow_char
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_allow_char
 
 	# test write
-	runc exec test_allow_char sh -c 'hostname | tee /dev/kmsg'
-	[ "$status" -eq 0 ]
+	runc -0 exec test_allow_char sh -c 'hostname | tee /dev/kmsg'
 	[[ "${lines[0]}" == *'myhostname'* ]]
 
 	# test read
-	runc exec test_allow_char sh -c 'head -n 1 /dev/kmsg'
-	[ "$status" -eq 0 ]
+	runc -0 exec test_allow_char sh -c 'head -n 1 /dev/kmsg'
 
 	# test access
 	TEST_NAME="dev_access_test"
 	gcc -static -o "rootfs/bin/${TEST_NAME}" "${TESTDATA}/${TEST_NAME}.c"
-	runc exec test_allow_char sh -c "${TEST_NAME} /dev/kmsg"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_allow_char sh -c "${TEST_NAME} /dev/kmsg"
 }
 
 @test "runc run [device cgroup allow rm block device]" {
@@ -114,32 +103,26 @@ function teardown() {
 			| .process.capabilities.effective += ["CAP_MKNOD"]
 			| .process.capabilities.permitted += ["CAP_MKNOD"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_allow_block
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_allow_block
 
 	# test mknod
-	runc exec test_allow_block sh -c 'mknod /dev/fooblock b '"$major"' '"$minor"''
-	[ "$status" -eq 0 ]
+	runc -0 exec test_allow_block sh -c 'mknod /dev/fooblock b '"$major"' '"$minor"''
 
 	# test read
-	runc exec test_allow_block sh -c 'fdisk -l '"$device"''
-	[ "$status" -eq 0 ]
+	runc -0 exec test_allow_block sh -c 'fdisk -l '"$device"''
 }
 
 # https://github.com/opencontainers/runc/issues/3551
 @test "runc exec vs systemctl daemon-reload" {
 	requires systemd root
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_exec
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_exec
 
-	runc exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
-	[ "$status" -eq 0 ]
+	runc -0 exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
 
 	systemctl daemon-reload
 
-	runc exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
-	[ "$status" -eq 0 ]
+	runc -0 exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
 }
 
 # https://github.com/opencontainers/runc/issues/4568

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -51,7 +51,7 @@ function teardown() {
 	runc -1 exec test_deny sh -c 'head -n 1 /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
-	runc update test_deny --pids-limit 42
+	runc -0 update test_deny --pids-limit 42
 
 	# test write
 	runc -1 exec test_deny sh -c 'hostname | tee /dev/kmsg'
@@ -133,6 +133,6 @@ function teardown() {
 	requires systemd_v230
 
 	set_cgroups_path
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_need_reload
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_need_reload
 	check_systemd_value "NeedDaemonReload" "no"
 }

--- a/tests/integration/env.bats
+++ b/tests/integration/env.bats
@@ -23,8 +23,7 @@ function teardown() {
 	update_config ' .process.env += ["HOME=/override"]'
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == '/override' ]]
 }
 
@@ -32,8 +31,7 @@ function teardown() {
 	update_config ' .process.env += ["HOME="]'
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == '/root' ]]
 }
 
@@ -41,8 +39,7 @@ function teardown() {
 	update_config ' .process.env += ["HOME=/override", "HOME="]'
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == '/root' ]]
 }
 
@@ -51,8 +48,7 @@ function teardown() {
 	update_config ' .process.args = ["env"]'
 	update_config ' .process.env = ["HOME=", "PATH=/usr/bin:/bin"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 
 	# There should be 2 words/env-vars: HOME and PATH.
 	[ "$(wc -w <<<"$output")" -eq 2 ]
@@ -63,8 +59,7 @@ function teardown() {
 	update_config ' .process.args = ["env"]'
 	update_config ' .process.env = ["ONE=two", "ONE=", "PATH=/usr/bin:/bin"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 
 	# There should be 3 words/env-vars: ONE, PATH and HOME.
 	[ "$(wc -w <<<"$output")" -eq 3 ]
@@ -74,8 +69,7 @@ function teardown() {
 	update_config ' .process.env += ["ONE=two", "ONE=three"]'
 	update_config ' .process.args += ["-c", "echo ONE=\"$ONE\""]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == "ONE=three" ]]
 }
 
@@ -83,8 +77,7 @@ function teardown() {
 	update_config ' .process.env = ["NEW_LINE_ENV=\n", "PATH=/usr/bin:/bin"]'
 	update_config ' .process.args = ["env"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 
 	# There should be 4 lines
 	# NEW_LINE is a \n and when printed, it takes another line:

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -66,7 +66,7 @@ function test_events() {
 	# Stress the CPU a bit. Need something that runs for more than 10s.
 	runc -0 exec test_busybox dd if=/dev/zero bs=1 count=128K of=/dev/null
 
-	runc exec test_busybox sh -c 'tail /sys/fs/cgroup/*.pressure'
+	runc -0 exec test_busybox sh -c 'tail /sys/fs/cgroup/*.pressure'
 
 	runc -0 events --stats test_busybox
 

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -22,8 +22,7 @@ function test_events() {
 		retry_every="$2"
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# Spawn two subshels:
 	# 1. Event logger that sends stats events to events.log.
@@ -47,12 +46,10 @@ function test_events() {
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	init_cgroup_paths
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# generate stats
-	runc events --stats test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 events --stats test_busybox
 	[[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
 	[[ "${lines[0]}" == *"data"* ]]
 }
@@ -64,17 +61,14 @@ function test_events() {
 
 	update_config '.linux.resources.cpu |= { "quota": 1000 }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# Stress the CPU a bit. Need something that runs for more than 10s.
-	runc exec test_busybox dd if=/dev/zero bs=1 count=128K of=/dev/null
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox dd if=/dev/zero bs=1 count=128K of=/dev/null
 
 	runc exec test_busybox sh -c 'tail /sys/fs/cgroup/*.pressure'
 
-	runc events --stats test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 events --stats test_busybox
 
 	# Check PSI metrics.
 	jq '.data.cpu.psi' <<<"${lines[0]}"
@@ -91,11 +85,9 @@ function test_events() {
 	requires cgroups_v2 cgroups_hugetlb
 	init_cgroup_paths
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc events --stats test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 events --stats test_busybox
 	# Ensure hugetlb node is present.
 	jq -e '.data.hugetlb // empty' <<<"${lines[0]}"
 }
@@ -120,8 +112,7 @@ function test_events() {
 	# we need the container to hit OOM, so disable swap
 	update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# spawn two sub processes (shells)
 	# the first sub process is an event logger that sends stats events to events.log

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -11,42 +11,25 @@ function teardown() {
 }
 
 @test "runc exec" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox echo Hello from exec
-	[ "$status" -eq 0 ]
-	echo text echoed = "'""${output}""'"
+	runc -0 exec test_busybox echo Hello from exec
 	[[ "${output}" == *"Hello from exec"* ]]
 }
 
 @test "runc exec [exit codes]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-
-	runc exec test_busybox false
-	[ "$status" -eq 1 ]
-
-	runc exec test_busybox sh -c "exit 42"
-	[ "$status" -eq 42 ]
-
-	runc exec --pid-file /non-existent/directory test_busybox true
-	[ "$status" -eq 255 ]
-
-	runc exec test_busybox no-such-binary
-	[ "$status" -eq 255 ]
-
-	runc exec no_such_container true
-	[ "$status" -eq 255 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc -1 exec test_busybox false
+	runc -42 exec test_busybox sh -c "exit 42"
+	runc -255 exec --pid-file /non-existent/directory test_busybox true
+	runc -255 exec test_busybox no-such-binary
+	runc -255 exec no_such_container true
 }
 
 @test "runc exec --pid-file" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --pid-file pid.txt test_busybox echo Hello from exec
-	[ "$status" -eq 0 ]
-	echo text echoed = "'""${output}""'"
+	runc -0 exec --pid-file pid.txt test_busybox echo Hello from exec
 	[[ "${output}" == *"Hello from exec"* ]]
 
 	[ -e pid.txt ]
@@ -60,11 +43,9 @@ function teardown() {
 	mkdir pid_file
 	cd pid_file
 
-	runc run -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --pid-file pid.txt test_busybox echo Hello from exec
-	[ "$status" -eq 0 ]
+	runc -0 exec --pid-file pid.txt test_busybox echo Hello from exec
 	echo text echoed = "'""${output}""'"
 	[[ "${output}" == *"Hello from exec"* ]]
 
@@ -75,32 +56,23 @@ function teardown() {
 }
 
 @test "runc exec ls -la" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox ls -la
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox ls -la
 	[[ ${lines[0]} == *"total"* ]]
 	[[ ${lines[1]} == *"."* ]]
 	[[ ${lines[2]} == *".."* ]]
 }
 
 @test "runc exec ls -la with --cwd" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-
-	runc exec --cwd /bin test_busybox pwd
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc -0 exec --cwd /bin test_busybox pwd
 	[[ ${output} == "/bin"* ]]
 }
 
 @test "runc exec --env" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-
-	runc exec --env RUNC_EXEC_TEST=true test_busybox env
-	[ "$status" -eq 0 ]
-
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc -0 exec --env RUNC_EXEC_TEST=true test_busybox env
 	[[ ${output} == *"RUNC_EXEC_TEST=true"* ]]
 }
 
@@ -108,11 +80,9 @@ function teardown() {
 	# --user can't work in rootless containers that don't have idmap.
 	[ $EUID -ne 0 ] && requires rootless_idmap
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --user 1000:1000 test_busybox id
-	[ "$status" -eq 0 ]
+	runc -0 exec --user 1000:1000 test_busybox id
 	[[ "${output}" == "uid=1000 gid=1000"* ]]
 
 	# Check the default value of HOME ("/") is set even in case when
@@ -123,8 +93,7 @@ function teardown() {
 	# a historical de facto behavior we're afraid to change.
 
 	# shellcheck disable=SC2016
-	runc exec --user 1000 test_busybox sh -u -c 'echo $HOME'
-	[ "$status" -eq 0 ]
+	runc -0 exec --user 1000 test_busybox sh -u -c 'echo $HOME'
 	[[ "$output" = "/" ]]
 }
 
@@ -132,8 +101,7 @@ function teardown() {
 @test "runc exec --user vs /dev/null ownership" {
 	requires root
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	ls -l /dev/null
 	__runc exec -d --user 1000:1000 test_busybox id </dev/null
@@ -147,25 +115,21 @@ function teardown() {
 @test "runc exec --additional-gids" {
 	requires root
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	wait_for_container 15 1 test_busybox
 
-	runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
-	[ "$status" -eq 0 ]
+	runc -0 exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
 	[ "$output" = "1000 100 65534" ]
 }
 
 @test "runc exec --preserve-fds" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	echo hello >preserve-fds.test
 	# fd 3 is used by bats, so we use 4
 	exec 4<preserve-fds.test
-	runc exec --preserve-fds=2 test_busybox cat /proc/self/fd/4
-	[ "$status" -eq 0 ]
+	runc -0 exec --preserve-fds=2 test_busybox cat /proc/self/fd/4
 	[ "${output}" = "hello" ]
 }
 
@@ -176,20 +140,17 @@ function check_exec_debug() {
 }
 
 @test "runc --debug exec" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test
 
-	runc --debug exec test true
-	[ "$status" -eq 0 ]
+	runc -0 --debug exec test true
 	[[ "${output}" == *"level=debug"* ]]
 	check_exec_debug "$output"
 }
 
 @test "runc --debug --log exec" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test
 
-	runc --debug --log log.out exec test true
+	runc -0 --debug --log log.out exec test true
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]
 
@@ -210,43 +171,35 @@ function check_exec_debug() {
 	testcontainer test_busybox running
 
 	# Check we can't join parent cgroup.
-	runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	runc ! exec --cgroup ".." test_busybox cat /proc/self/cgroup
 	[[ "$output" == *"bad sub cgroup path"* ]]
 
 	# Check we can't join non-existing subcgroup.
-	runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	runc ! exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
 	[[ "$output" == *" adding pid "*"o such file or directory"* ]]
 
 	# Check we can't join non-existing subcgroup (for a particular controller).
-	runc exec --cgroup cpu:nonexistent test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	runc ! exec --cgroup cpu:nonexistent test_busybox cat /proc/self/cgroup
 	[[ "$output" == *" adding pid "*"o such file or directory"* ]]
 
 	# Check we can't specify non-existent controller.
-	runc exec --cgroup whaaat:/ test_busybox true
-	[ "$status" -ne 0 ]
+	runc ! exec --cgroup whaaat:/ test_busybox true
 	[[ "$output" == *"unknown controller "* ]]
 
 	# Check we can join top-level cgroup (implicit).
-	runc exec test_busybox cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox cat /proc/self/cgroup
 	run ! grep -v ":$REL_CGROUPS_PATH\$" <<<"$output"
 
 	# Check we can join top-level cgroup (explicit).
-	runc exec --cgroup / test_busybox cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec --cgroup / test_busybox cat /proc/self/cgroup
 	run ! grep -v ":$REL_CGROUPS_PATH\$" <<<"$output"
 
 	# Create a few subcgroups.
 	# Note that cpu,cpuacct may be mounted together or separate.
-	runc exec test_busybox sh -euc "mkdir -p /sys/fs/cgroup/memory/submem /sys/fs/cgroup/cpu/subcpu /sys/fs/cgroup/cpuacct/subcpu"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox sh -euc "mkdir -p /sys/fs/cgroup/memory/submem /sys/fs/cgroup/cpu/subcpu /sys/fs/cgroup/cpuacct/subcpu"
 
 	# Check that explicit --cgroup works.
-	runc exec --cgroup memory:submem --cgroup cpu,cpuacct:subcpu test_busybox cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec --cgroup memory:submem --cgroup cpu,cpuacct:subcpu test_busybox cat /proc/self/cgroup
 	[[ "$output" == *":memory:$REL_CGROUPS_PATH/submem"* ]]
 	[[ "$output" == *":cpu"*":$REL_CGROUPS_PATH/subcpu"* ]]
 }
@@ -261,64 +214,51 @@ function check_exec_debug() {
 	testcontainer test_busybox running
 
 	# Check we can't join parent cgroup.
-	runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	runc ! exec --cgroup ".." test_busybox cat /proc/self/cgroup
 	[[ "$output" == *"bad sub cgroup path"* ]]
 
 	# Check we can't join non-existing subcgroup.
-	runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	runc ! exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
 	[[ "$output" == *" cgroup"*"o such file or directory"* ]]
 
 	# Check we can join top-level cgroup (implicit).
-	runc exec test_busybox grep '^0::/$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox grep '^0::/$' /proc/self/cgroup
 
 	# Check we can join top-level cgroup (explicit).
-	runc exec --cgroup / test_busybox grep '^0::/$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec --cgroup / test_busybox grep '^0::/$' /proc/self/cgroup
 
 	# Now move "init" to a subcgroup, and check it was moved.
-	runc exec test_busybox sh -euc "mkdir /sys/fs/cgroup/foobar \
+	runc -0 exec test_busybox sh -euc "mkdir /sys/fs/cgroup/foobar \
 		&& echo 1 > /sys/fs/cgroup/foobar/cgroup.procs \
 		&& grep -w foobar /proc/1/cgroup"
-	[ "$status" -eq 0 ]
 
 	# The following part is taken from
 	# @test "runc exec (cgroup v2 + init process in non-root cgroup) succeeds"
 
 	# The init process is now in "/foo", but an exec process can still
 	# join "/" because we haven't enabled any domain controller yet.
-	runc exec test_busybox grep '^0::/$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox grep '^0::/$' /proc/self/cgroup
 
 	# Turn on a domain controller (memory).
-	runc exec test_busybox sh -euc 'echo $$ > /sys/fs/cgroup/foobar/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox sh -euc 'echo $$ > /sys/fs/cgroup/foobar/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
 
 	# An exec process can no longer join "/" after turning on a domain
 	# controller.  Check that cgroup v2 fallback to init cgroup works.
-	runc exec test_busybox sh -euc "cat /proc/self/cgroup && grep '^0::/foobar$' /proc/self/cgroup"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox sh -euc "cat /proc/self/cgroup && grep '^0::/foobar$' /proc/self/cgroup"
 
 	# Check that --cgroup / disables the init cgroup fallback.
-	runc exec --cgroup / test_busybox true
-	[ "$status" -ne 0 ]
+	runc ! exec --cgroup / test_busybox true
 	[[ "$output" == *" adding pid "*" to cgroups"*"evice or resource busy"* ]]
 
 	# Check that explicit --cgroup foobar works.
-	runc exec --cgroup foobar test_busybox grep '^0::/foobar$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec --cgroup foobar test_busybox grep '^0::/foobar$' /proc/self/cgroup
 
 	# Check all processes is in foobar (this check is redundant).
-	runc exec --cgroup foobar test_busybox sh -euc '! grep -vwH foobar /proc/*/cgroup'
-	[ "$status" -eq 0 ]
+	runc -0 exec --cgroup foobar test_busybox sh -euc '! grep -vwH foobar /proc/*/cgroup'
 
 	# Add a second subcgroup, check we're in it.
-	runc exec --cgroup foobar test_busybox mkdir /sys/fs/cgroup/second
-	[ "$status" -eq 0 ]
-	runc exec --cgroup second test_busybox grep -w second /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	runc -0 exec --cgroup foobar test_busybox mkdir /sys/fs/cgroup/second
+	runc -0 exec --cgroup second test_busybox grep -w second /proc/self/cgroup
 }
 
 @test "runc exec [execve error]" {
@@ -327,9 +267,8 @@ function check_exec_debug() {
 sh
 EOF
 	chmod +x rootfs/run.sh
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	runc exec -t test_busybox /run.sh
-	[ "$status" -ne 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc ! exec -t test_busybox /run.sh
 
 	# After the sync socket closed, we should not send error to parent
 	# process, or else we will get a unnecessary error log(#4171).
@@ -345,10 +284,8 @@ EOF
 	[ $EUID -ne 0 ] && requires rootless_idmap
 	echo 'tempuser:x:2000:2000:tempuser:/home/tempuser:/bin/sh' >>rootfs/etc/passwd
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test
 
-	runc exec -u 2000 test sh -c "echo \$HOME"
-	[ "$status" -eq 0 ]
+	runc -0 exec -u 2000 test sh -c "echo \$HOME"
 	[ "${lines[0]}" = "/home/tempuser" ]
 }

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -10,13 +10,11 @@ function setup() {
 }
 
 @test "runc -h" {
-	runc -h
-	[ "$status" -eq 0 ]
+	runc -0 -h
 	[[ ${lines[0]} =~ NAME:+ ]]
 	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 
-	runc --help
-	[ "$status" -eq 0 ]
+	runc -0 --help
 	[[ ${lines[0]} =~ NAME:+ ]]
 	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 }
@@ -47,8 +45,7 @@ function setup() {
 
 	for cmd in "${cmds[@]}"; do
 		for arg in "-h" "--help"; do
-			runc "$cmd" "$arg"
-			[ "$status" -eq 0 ]
+			runc -0 "$cmd" "$arg"
 			[[ ${lines[0]} =~ NAME:+ ]]
 			[[ ${lines[1]} =~ $runc\ $cmd+ ]]
 		done
@@ -56,7 +53,6 @@ function setup() {
 }
 
 @test "runc foo -h" {
-	runc foo -h
-	[ "$status" -ne 0 ]
+	runc ! foo -h
 	[[ "${output}" == *"No help topic for 'foo'"* ]]
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -85,7 +85,7 @@ function runc_spec() {
 	local rootless=""
 	[ $EUID -ne 0 ] && rootless="--rootless"
 
-	runc spec $rootless
+	runc -0 spec $rootless
 
 	# Always add additional mappings if we have idmaps.
 	if [[ $EUID -ne 0 && "$ROOTLESS_FEATURES" == *"idmap"* ]]; then

--- a/tests/integration/hooks_so.bats
+++ b/tests/integration/hooks_so.bats
@@ -43,8 +43,7 @@ function teardown() {
 		.root.readonly |= false |
 		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 
 	echo "Checking create-runtime library"
 	echo "$output" | grep "$HOOKLIBCR"

--- a/tests/integration/host-mntns.bats
+++ b/tests/integration/host-mntns.bats
@@ -23,8 +23,7 @@ function teardown() {
 			| .linux.namespaces -= [{"type": "mount"}]
 			| .linux.maskedPaths = []
 			| .linux.readonlyPaths = []'
-	runc run test_host_mntns
-	[ "$status" -eq 0 ]
+	runc -0 run test_host_mntns
 	runc delete -f test_host_mntns
 
 	# There should be one such file.

--- a/tests/integration/host-mntns.bats
+++ b/tests/integration/host-mntns.bats
@@ -24,7 +24,7 @@ function teardown() {
 			| .linux.maskedPaths = []
 			| .linux.readonlyPaths = []'
 	runc -0 run test_host_mntns
-	runc delete -f test_host_mntns
+	runc -0 delete -f test_host_mntns
 
 	# There should be one such file.
 	run -0 ls createRuntimeHook.*

--- a/tests/integration/idmap.bats
+++ b/tests/integration/idmap.bats
@@ -113,8 +113,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=0=0="* ]]
 }
 
@@ -123,8 +122,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=100000=100000="* ]]
 }
 
@@ -134,8 +132,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "touch /tmp/mount-1/bar && stat -c =%u=%g= /tmp/mount-1/bar"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=0=0="* ]]
 }
 
@@ -144,9 +141,8 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "touch /tmp/mount-1/bar && stat -c =%u=%g= /tmp/mount-1/bar"]'
 
-	runc run test_debian
+	runc ! run test_debian
 	# The write must fail because the user is unmapped.
-	[ "$status" -ne 0 ]
 	[[ "$output" == *"Value too large for defined data type"* ]] # ERANGE
 }
 
@@ -158,8 +154,7 @@ function setup_idmap_basic_mount() {
 	# Add the shared option to the idmap mount.
 	update_config '.mounts |= map((select(.source == "source-1/") | .options += ["shared"]) // .)'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"shared"* ]]
 }
 
@@ -171,8 +166,7 @@ function setup_idmap_basic_mount() {
 	# Switch the mount to have a relative mount destination.
 	update_config '.mounts |= map((select(.source == "source-1/") | .destination = "tmp/mount-1") // .)'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=0=0="* ]]
 }
 
@@ -183,8 +177,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/{,bind-}mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-1/foo.txt:0=0="* ]]
 	[[ "$output" == *"=/tmp/bind-mount-1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
 }
@@ -195,8 +188,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/{,bind-}mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-1/foo.txt:100000=100000="* ]]
 	[[ "$output" == *"=/tmp/bind-mount-1/foo.txt:0=0="* ]]
 }
@@ -211,8 +203,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-[12]/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-1/foo.txt:0=0="* ]]
 	[[ "$output" == *"=/tmp/mount-2/foo.txt:1=1="* ]]
 }
@@ -228,8 +219,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1{,-alt{,-sym}}/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:0=11="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1=22="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:2=33="* ]]
@@ -250,8 +240,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1{,-alt{,-sym}}/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:100000=100011="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:100001=100022="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:100002=100033="* ]]
@@ -273,8 +262,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi[123]/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1100=1911="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1101=1922="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:1102=1933="* ]]
@@ -294,8 +282,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi[123]/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1100=1911="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1101=1922="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:1102=1933="* ]]
@@ -329,8 +316,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:3000=3303="* ]]
@@ -356,8 +342,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:3000=3303="* ]]
@@ -388,8 +373,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
@@ -425,8 +409,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
@@ -464,8 +447,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
@@ -501,8 +483,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
@@ -540,8 +521,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
@@ -577,8 +557,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
@@ -606,8 +585,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]
@@ -635,8 +613,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]
@@ -657,8 +634,7 @@ function setup_idmap_basic_mount() {
 		| .linux.gidMappings += [{"containerID": 0, "hostID": 100000, "size": 65536}]'
 	update_config '.process.args = ["sleep", "infinity"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" target_userns
 
 	# Configure our container to attach to the first container's userns.
 	target_pid="$(__runc state target_userns | jq .pid)"
@@ -677,8 +653,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	runc -0 run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]

--- a/tests/integration/ioprio.bats
+++ b/tests/integration/ioprio.bats
@@ -14,17 +14,14 @@ function teardown() {
 	# Create a container with a specific I/O priority.
 	update_config '.process.ioPriority = {"class": "IOPRIO_CLASS_BE", "priority": 4}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_ioprio
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_ioprio
 
 	# Check the init process.
-	runc exec test_ioprio ionice -p 1
-	[ "$status" -eq 0 ]
+	runc -0 exec test_ioprio ionice -p 1
 	[ "${lines[0]}" = 'best-effort: prio 4' ]
 
 	# Check an exec process, which should derive ioprio from config.json.
-	runc exec test_ioprio ionice
-	[ "$status" -eq 0 ]
+	runc -0 exec test_ioprio ionice
 	[ "${lines[0]}" = 'best-effort: prio 4' ]
 
 	# Check an exec with a priority taken from process.json,
@@ -38,7 +35,6 @@ function teardown() {
 	"args": [ "/usr/bin/ionice" ],
 	"cwd": "/"
 }'
-	runc exec --process <(echo "$proc") test_ioprio
-	[ "$status" -eq 0 ]
+	runc -0 exec --process <(echo "$proc") test_ioprio
 	[ "${lines[0]}" = 'idle' ]
 }

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -16,37 +16,30 @@ function teardown() {
 
 @test "list" {
 	bundle=$(pwd)
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_box1
 
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_box2
 
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_box3
 
-	ROOT=$ALT_ROOT runc list
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 list
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
 	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
 
-	ROOT=$ALT_ROOT runc list -q
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 list -q
 	[ "${lines[0]}" = "test_box1" ]
 	[ "${lines[1]}" = "test_box2" ]
 	[ "${lines[2]}" = "test_box3" ]
 
-	ROOT=$ALT_ROOT runc list --format table
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 list --format table
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
 	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
 
-	ROOT=$ALT_ROOT runc list --format json
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 list --format json
 	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -18,47 +18,37 @@ function teardown() {
 }
 
 @test "mask paths [file]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox cat /testfile
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox cat /testfile
 	[ -z "$output" ]
 
-	runc exec test_busybox rm -f /testfile
-	[ "$status" -eq 1 ]
+	runc -1 exec test_busybox rm -f /testfile
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_busybox umount /testfile
-	[ "$status" -eq 1 ]
+	runc -1 exec test_busybox umount /testfile
 	[[ "${output}" == *"Operation not permitted"* ]]
 }
 
 @test "mask paths [directory]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox ls /testdir
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox ls /testdir
 	[ -z "$output" ]
 
-	runc exec test_busybox touch /testdir/foo
-	[ "$status" -eq 1 ]
+	runc -1 exec test_busybox touch /testdir/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_busybox rm -rf /testdir
-	[ "$status" -eq 1 ]
+	runc -1 exec test_busybox rm -rf /testdir
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_busybox umount /testdir
-	[ "$status" -eq 1 ]
+	runc -1 exec test_busybox umount /testdir
 	[[ "${output}" == *"Operation not permitted"* ]]
 }
 
 @test "mask paths [prohibit symlink /proc]" {
 	ln -s /symlink rootfs/proc
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[[ "${output}" == *"must be mounted on ordinary directory"* ]]
 }
 
@@ -67,8 +57,7 @@ function teardown() {
 	requires root
 
 	ln -s /symlink rootfs/sys
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	# On cgroup v1, this may fail before checking if /sys is a symlink,
 	# so we merely check that it fails, and do not check the exact error
 	# message like for /proc above.

--- a/tests/integration/memorypolicy.bats
+++ b/tests/integration/memorypolicy.bats
@@ -17,8 +17,7 @@ function teardown() {
 		"mode": "MPOL_INTERLEAVE",
 		"nodes": "0"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == "interleave:0" ]]
 }
 
@@ -30,8 +29,7 @@ function teardown() {
 		"nodes": "0",
 		"flags": ["MPOL_F_STATIC_NODES"]
 	}'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == "bind"*"static"*"0" ]]
 }
 
@@ -42,11 +40,9 @@ function teardown() {
 		"nodes": "0",
 		"flags": ["MPOL_F_RELATIVE_NODES"]
 	}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox /bin/sh -c "head -n 1 /proc/self/numa_maps | cut -d \" \" -f 2"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox /bin/sh -c "head -n 1 /proc/self/numa_maps | cut -d \" \" -f 2"
 	[[ "${lines[0]}" == "prefer"*"relative"*"0" ]]
 }
 
@@ -55,8 +51,7 @@ function teardown() {
 	.process.args = ["/bin/sh", "-c", "head -n 1 /proc/self/numa_maps | cut -d \" \" -f 2"]
 	| .linux.memoryPolicy = {
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy"* ]]
 }
 
@@ -67,8 +62,7 @@ function teardown() {
 		"mode": "INTERLEAVE",
 		"nodes": "0"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy"* ]]
 }
 
@@ -80,8 +74,7 @@ function teardown() {
 		"nodes": "0",
 		"flags": ["MPOL_F_RELATIVE_NODES", "badflag"]
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy flag"* ]]
 }
 
@@ -91,8 +84,7 @@ function teardown() {
 	| .linux.memoryPolicy = {
 		"mode": "MPOL_DEFAULT"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == *"default"* ]]
 }
 
@@ -102,8 +94,7 @@ function teardown() {
 	| .linux.memoryPolicy = {
 		"nodes": "0-7"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy mode"* ]]
 }
 
@@ -114,8 +105,7 @@ function teardown() {
 		"mode": "MPOL_DEFAULT",
 		"nodes": "0-7",
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run test_busybox
 	[[ "${lines[*]}" == *"mode requires 0 nodes but got 8"* ]]
 }
 
@@ -127,7 +117,6 @@ function teardown() {
 		"nodes": "0-9876543210",
 		"flags": []
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	runc -1 run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy node"* ]]
 }

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -18,8 +18,7 @@ function test_ro_cgroup_mount() {
 	local lines status
 	# shellcheck disable=SC2016
 	update_config '.process.args |= ["sh", "-euc", "for f in `grep /sys/fs/cgroup /proc/mounts | awk \"{print \\\\$2}\"| uniq`; do test -e $f && grep -w $f /proc/mounts | tail -n1; done"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[ "${#lines[@]}" -ne 0 ]
 	for line in "${lines[@]}"; do [[ "${line}" == *'ro,'* ]]; done
 }
@@ -122,8 +121,7 @@ function test_mount_order() {
 	# Check that the entire tree was copied and the mounts were done in the
 	# expected order.
 	update_config '.process.args = ["cat", "/final/x/y/z/z/x/y/z/x/file"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" == *"a/x"* ]] # the final "file" was from a/x.
 }
 
@@ -176,8 +174,7 @@ test_mount_target() {
 			| .process.args |= ["ls", "-ld", "/dir1/dir2"]'
 
 	umask 022
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == *'drwxrwxrwx'* ]]
 }
 
@@ -189,8 +186,7 @@ test_mount_target() {
 				}]
 			| .process.args |= ["ls", "/tmp/bind/config.json"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
 }
 
@@ -204,8 +200,7 @@ test_mount_target() {
 				}]
 			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == *'ro,'* ]]
 }
 
@@ -214,8 +209,7 @@ test_mount_target() {
 	update_config '   .mounts |= map((select(.destination == "/dev") | .options += ["ro"]) // .)
 			| .process.args |= ["grep", "^tmpfs /dev", "/proc/mounts"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "${lines[0]}" == *'ro,'* ]]
 }
 
@@ -231,8 +225,7 @@ test_mount_target() {
 					options: ["ro", "nodev", "nosuid"]
 				}]
 			| .process.args |= ["true"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 }
 
 # CVE-2023-27561 CVE-2019-19921
@@ -242,8 +235,7 @@ test_mount_target() {
 	mkdir -p rootfs/bad-proc
 	ln -sf /bad-proc rootfs/proc
 	# This should fail.
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 	[[ "$output" == *"must be mounted on ordinary directory"* ]]
 }
 
@@ -260,8 +252,7 @@ test_mount_target() {
 	}]'
 	update_config '.process.args |= ["true"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 
 	# Verify that the setgid bit is inherited.
 	[[ "$(stat -c %a rootfs/setgid)" == 7755 ]]

--- a/tests/integration/mounts_propagation.bats
+++ b/tests/integration/mounts_propagation.bats
@@ -16,7 +16,6 @@ function teardown() {
 
 	update_config ' .process.args = ["findmnt", "--noheadings", "-o", "PROPAGATION", "/"] '
 
-	runc run test_shared_rootfs
-	[ "$status" -eq 0 ]
+	runc -0 run test_shared_rootfs
 	[ "$output" = "shared" ]
 }

--- a/tests/integration/mounts_recursive.bats
+++ b/tests/integration/mounts_recursive.bats
@@ -34,30 +34,24 @@ function teardown() {
 @test "runc run [rbind,ro mount is read-only but not recursively]" {
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt\", options: [\"rbind\",\"ro\"]}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro
 
-	runc exec test_rbind_ro touch /mnt/foo
-	[ "$status" -eq 1 ]
+	runc -1 exec test_rbind_ro touch /mnt/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_rbind_ro touch /mnt/subvol/bar
-	[ "$status" -eq 0 ]
+	runc -0 exec test_rbind_ro touch /mnt/subvol/bar
 }
 
 @test "runc run [rbind,rro mount is recursively read-only]" {
 	requires_kernel 5.12
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt\", options: [\"rbind\",\"rro\"]}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_rro
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_rbind_rro
 
-	runc exec test_rbind_rro touch /mnt/foo
-	[ "$status" -eq 1 ]
+	runc -1 exec test_rbind_rro touch /mnt/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_rbind_rro touch /mnt/subvol/bar
-	[ "$status" -eq 1 ]
+	runc -1 exec test_rbind_rro touch /mnt/subvol/bar
 	[[ "${output}" == *"Read-only file system"* ]]
 }
 
@@ -65,14 +59,11 @@ function teardown() {
 	requires_kernel 5.12
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt\", options: [\"rbind\",\"ro\",\"rro\"]}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro_rro
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro_rro
 
-	runc exec test_rbind_ro_rro touch /mnt/foo
-	[ "$status" -eq 1 ]
+	runc -1 exec test_rbind_ro_rro touch /mnt/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_rbind_ro_rro touch /mnt/subvol/bar
-	[ "$status" -eq 1 ]
+	runc -1 exec test_rbind_ro_rro touch /mnt/subvol/bar
 	[[ "${output}" == *"Read-only file system"* ]]
 }

--- a/tests/integration/mounts_sshfs.bats
+++ b/tests/integration/mounts_sshfs.bats
@@ -78,16 +78,14 @@ function setup_sshfs_bind_flags() {
 function pass_sshfs_bind_flags() {
 	setup_sshfs_bind_flags "$@"
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	mnt_flags="$output"
 }
 
 function fail_sshfs_bind_flags() {
 	setup_sshfs_bind_flags "$@"
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 	[[ "$output" == *"runc run failed: unable to start container process: error during container init: error mounting"*"operation not permitted"* ]]
 }
 

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -51,7 +51,7 @@ function teardown() {
 
 	# The network namespace owner controls the lifecycle of the interface.
 	# The interface should remain on the namespace after the container was killed.
-	runc delete --force test_busybox
+	runc -0 delete --force test_busybox
 
 	# Move back the interface to the root namespace (pid 1).
 	ip netns exec "$ns_name" ip link set dev dummy0 netns 1

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -40,16 +40,14 @@ function teardown() {
 	update_config ' .linux.netDevices |= {"dummy0": {} }
       		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 }
 
 @test "move network device to container network namespace and restore it back" {
 	setup_netns
 	update_config ' .linux.netDevices |= {"dummy0": {} }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# The network namespace owner controls the lifecycle of the interface.
 	# The interface should remain on the namespace after the container was killed.
@@ -67,8 +65,7 @@ function teardown() {
 	update_config ' .linux.netDevices |= {"dummy0": {} }
       		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 
 	# Verify the interface is still present in the network namespace.
 	ip netns exec "$ns_name" ip address show dev dummy0
@@ -86,8 +83,7 @@ function teardown() {
 	ip link set down dev dummy0
 	ip address add "$global_ip" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" == *"$global_ip "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -107,8 +103,7 @@ function teardown() {
 	ip link set down dev dummy0
 	ip address add "$non_global_ip" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" != *" $non_global_ip "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -124,8 +119,7 @@ function teardown() {
 	# Set a custom mtu to the interface.
 	ip link set mtu "$mtu_value" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" == *"mtu $mtu_value "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -142,8 +136,7 @@ function teardown() {
 	# set a custom mac address to the interface
 	ip link set address "$mac_address" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" == *"ether $mac_address "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -156,8 +149,7 @@ function teardown() {
 	update_config ' .linux.netDevices |= { "dummy0": { "name" : "ctr_dummy0" } }
       		| .process.args |= ["ip", "address", "show", "dev", "ctr_dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 
 	# Verify the interface is still present in the network namespace.
 	ip netns exec "$ns_name" ip address show dev ctr_dummy0
@@ -179,8 +171,7 @@ function teardown() {
 	# Set a custom ip address to the interface.
 	ip address add "$global_ip" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" == *" $global_ip "* ]]
 	[[ "$output" == *"ether $mac_address "* ]]
 	[[ "$output" == *"mtu $mtu_value "* ]]

--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -17,7 +17,6 @@ function teardown() {
 			| .process.capabilities.bounding += ["CAP_SETFCAP"]
 			| .process.capabilities.permitted += ["CAP_SETFCAP"]'
 
-	runc run --no-pivot test_no_pivot
-	[ "$status" -eq 1 ]
+	runc -1 run --no-pivot test_no_pivot
 	[[ "$output" == *"mount: permission denied"* ]]
 }

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -51,7 +51,7 @@ function teardown() {
 
 	testcontainer test_busybox running
 
-	runc delete --force test_busybox
+	runc -0 delete --force test_busybox
 
 	runc ! state test_busybox
 }

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -17,18 +17,15 @@ function teardown() {
 		set_cgroups_path
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc pause test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 pause test_busybox
 
 	testcontainer test_busybox paused
 
-	runc resume test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 resume test_busybox
 
 	testcontainer test_busybox running
 }
@@ -40,27 +37,21 @@ function teardown() {
 		set_cgroups_path
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc pause test_busybox
-	[ "$status" -eq 0 ]
-	runc pause nonexistent
-	[ "$status" -ne 0 ]
+	runc -0 pause test_busybox
+	runc ! pause nonexistent
 
 	testcontainer test_busybox paused
 
-	runc resume test_busybox
-	[ "$status" -eq 0 ]
-	runc resume nonexistent
-	[ "$status" -ne 0 ]
+	runc -0 resume test_busybox
+	runc ! resume nonexistent
 
 	testcontainer test_busybox running
 
 	runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 }

--- a/tests/integration/personality.bats
+++ b/tests/integration/personality.bats
@@ -19,8 +19,7 @@ function teardown() {
                 "flags": []
 			}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" == *"i686"* ]]
 }
 
@@ -30,10 +29,8 @@ function teardown() {
                 "domain": "LINUX32",
       }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-	runc exec test_busybox /bin/sh -c "uname -a"
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc -0 exec test_busybox /bin/sh -c "uname -a"
 	[[ "$output" == *"i686"* ]]
 }
 
@@ -45,8 +42,7 @@ function teardown() {
                 "flags": []
 			}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[[ "$output" == *"x86_64"* ]]
 }
 
@@ -56,10 +52,8 @@ function teardown() {
                 "domain": "LINUX",
       }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-	runc exec test_busybox /bin/sh -c "uname -a"
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc -0 exec test_busybox /bin/sh -c "uname -a"
 	[[ "$output" == *"x86_64"* ]]
 }
 
@@ -74,9 +68,7 @@ function teardown() {
                 "syscalls":[{"names":["personality"], "action":"SCMP_ACT_ERRNO"}]
 	  }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-	runc exec test_busybox /bin/sh -c "uname -a"
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc -0 exec test_busybox /bin/sh -c "uname -a"
 	[[ "$output" == *"x86_64"* ]]
 }

--- a/tests/integration/pidfd-socket.bats
+++ b/tests/integration/pidfd-socket.bats
@@ -17,8 +17,7 @@ function teardown() {
 @test "runc create [ --pidfd-socket ] " {
 	setup_pidfd_kill "SIGTERM"
 
-	runc create --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
-	[ "$status" -eq 0 ]
+	runc -0 create --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
 	testcontainer test_pidfd created
 
 	pidfd_kill
@@ -28,8 +27,7 @@ function teardown() {
 @test "runc run [ --pidfd-socket ] " {
 	setup_pidfd_kill "SIGKILL"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
 	testcontainer test_pidfd running
 
 	pidfd_kill
@@ -41,8 +39,7 @@ function teardown() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
 	testcontainer test_pidfd running
 
 	# Use sub-cgroup to ensure that exec process has been killed
@@ -70,8 +67,7 @@ function teardown() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
 	testcontainer test_pidfd running
 
 	# Use sub-cgroup to ensure that exec process has been killed

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -11,8 +11,7 @@ function setup() {
 	# Rootless does not have default cgroup path.
 	[ $EUID -ne 0 ] && set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 }
 
@@ -21,33 +20,27 @@ function teardown() {
 }
 
 @test "ps" {
-	runc ps test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 ps test_busybox
 	[[ "$output" =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
 	[[ "$output" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
 }
 
 @test "ps -f json" {
-	runc ps -f json test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 ps -f json test_busybox
 	[[ "$output" =~ [0-9]+ ]]
 }
 
 @test "ps -e -x" {
-	runc ps test_busybox -e -x
-	[ "$status" -eq 0 ]
+	runc -0 ps test_busybox -e -x
 	[[ "$output" =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
 	[[ "$output" =~ [0-9]+ ]]
 }
 
 @test "ps after the container stopped" {
-	runc ps test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 ps test_busybox
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	runc -0 kill test_busybox KILL
 	wait_for_container 10 1 test_busybox stopped
 
-	runc ps test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 ps test_busybox
 }

--- a/tests/integration/rlimits.bats
+++ b/tests/integration/rlimits.bats
@@ -22,8 +22,7 @@ function run_check_nofile() {
 	update_config ".process.rlimits = [{\"type\": \"RLIMIT_NOFILE\", \"soft\": ${soft}, \"hard\": ${hard}}]"
 	update_config '.process.args = ["/bin/sh", "-c", "ulimit -n; ulimit -H -n"]'
 
-	runc run test_rlimit
-	[ "$status" -eq 0 ]
+	runc -0 run test_rlimit
 	[[ "${lines[0]}" == "${soft}" ]]
 	[[ "${lines[1]}" == "${hard}" ]]
 }
@@ -36,11 +35,9 @@ function exec_check_nofile() {
 	hard="$2"
 	update_config ".process.rlimits = [{\"type\": \"RLIMIT_NOFILE\", \"soft\": ${soft}, \"hard\": ${hard}}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rlimit
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_rlimit
 
-	runc exec test_rlimit /bin/sh -c "ulimit -n; ulimit -H -n"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_rlimit /bin/sh -c "ulimit -n; ulimit -H -n"
 	[[ "${lines[0]}" == "${soft}" ]]
 	[[ "${lines[1]}" == "${hard}" ]]
 }

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -16,36 +16,26 @@ function teardown() {
 
 @test "global --root" {
 	# run busybox detached using $ALT_ROOT for state
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_dotbox
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_dotbox
 
 	# run busybox detached in default root
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc state test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 state test_busybox
 	[[ "${output}" == *"running"* ]]
 
-	ROOT=$ALT_ROOT runc state test_dotbox
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 state test_dotbox
 	[[ "${output}" == *"running"* ]]
 
-	ROOT=$ALT_ROOT runc state test_busybox
-	[ "$status" -ne 0 ]
+	ROOT=$ALT_ROOT runc ! state test_busybox
 
-	runc state test_dotbox
-	[ "$status" -ne 0 ]
+	runc ! state test_dotbox
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	runc -0 kill test_busybox KILL
 	wait_for_container 10 1 test_busybox stopped
-	runc delete test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 delete test_busybox
 
-	ROOT=$ALT_ROOT runc kill test_dotbox KILL
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 kill test_dotbox KILL
 	ROOT=$ALT_ROOT wait_for_container 10 1 test_dotbox stopped
-	ROOT=$ALT_ROOT runc delete test_dotbox
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT runc -0 delete test_dotbox
 }

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -12,26 +12,21 @@ function teardown() {
 }
 
 @test "runc run" {
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run test_hello
 
-	runc state test_hello
-	[ "$status" -ne 0 ]
+	runc ! state test_hello
 }
 
 @test "runc run --keep" {
-	runc run --keep test_run_keep
-	[ "$status" -eq 0 ]
+	runc -0 run --keep test_run_keep
 
 	testcontainer test_run_keep stopped
 
-	runc state test_run_keep
-	[ "$status" -eq 0 ]
+	runc -0 state test_run_keep
 
 	runc delete test_run_keep
 
-	runc state test_run_keep
-	[ "$status" -ne 0 ]
+	runc ! state test_run_keep
 }
 
 @test "runc run --keep (check cgroup exists)" {
@@ -41,21 +36,18 @@ function teardown() {
 
 	set_cgroups_path
 
-	runc run --keep test_run_keep
-	[ "$status" -eq 0 ]
+	runc -0 run --keep test_run_keep
 
 	testcontainer test_run_keep stopped
 
-	runc state test_run_keep
-	[ "$status" -eq 0 ]
+	runc -0 state test_run_keep
 
 	# check that cgroup exists
 	check_cgroup_value "pids.max" "max"
 
 	runc delete test_run_keep
 
-	runc state test_run_keep
-	[ "$status" -ne 0 ]
+	runc ! state test_run_keep
 }
 
 @test "runc run [hostname domainname]" {
@@ -63,17 +55,14 @@ function teardown() {
 			| .hostname = "myhostname"
 			| .domainname= "mydomainname"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_utc
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_utc
 
 	# test hostname
-	runc exec test_utc hostname
-	[ "$status" -eq 0 ]
+	runc -0 exec test_utc hostname
 	[[ "${lines[0]}" == *'myhostname'* ]]
 
 	# test domainname
-	runc exec test_utc cat /proc/sys/kernel/domainname
-	[ "$status" -eq 0 ]
+	runc -0 exec test_utc cat /proc/sys/kernel/domainname
 	[[ "${lines[0]}" == *'mydomainname'* ]]
 }
 
@@ -87,8 +76,7 @@ function teardown() {
 	update_config '.process.args = ["sh", "-c", "stat -c %A /tmp"]'
 	update_config '.mounts += [{"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options":["noexec","nosuid","nodev","rprivate"]}]'
 
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	runc -0 run test_tmpfs
 	[ "${lines[0]}" = "$mode" ]
 }
 
@@ -97,35 +85,30 @@ function teardown() {
 	update_config '.mounts += [{"destination": "/tmp/test", "type": "tmpfs", "source": "tmpfs", "options": ["mode=0444"]}]'
 
 	# Directory is to be created by runc.
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	runc -0 run test_tmpfs
 	[ "${lines[0]}" = "444" ]
 
 	# Run a 2nd time with the pre-existing directory.
 	# Ref: https://github.com/opencontainers/runc/issues/3911
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	runc -0 run test_tmpfs
 	[ "${lines[0]}" = "444" ]
 
 	# Existing directory, custom perms, no mode on the mount,
 	# so it should use the directory's perms.
 	update_config '.mounts[-1].options = []'
 	chmod 0710 rootfs/tmp/test
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	runc -0 run test_tmpfs
 	[ "${lines[0]}" = "710" ]
 
 	# Add back the mode on the mount, and it should use that instead.
 	# Just for fun, use different perms than was used earlier.
 	update_config '.mounts[-1].options = ["mode=0410"]'
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	runc -0 run test_tmpfs
 	[ "${lines[0]}" = "410" ]
 }
 
 @test "runc run [/proc/self/exe clone]" {
-	runc --debug run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 --debug run test_hello
 	[[ "$output" = *"Hello World"* ]]
 	[[ "$output" = *"runc exeseal: using /proc/self/exe clone"* ]]
 	# runc will use fsopen("overlay") if it can.
@@ -153,8 +136,7 @@ function teardown() {
 		}'
 	update_config '.process.args = ["sleep", "infinity"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_ctr
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" target_ctr
 
 	# Modify our container's configuration such that it is just going to
 	# inherit all of the namespaces of the target container.
@@ -173,25 +155,21 @@ function teardown() {
 	# Remove the userns and timens configuration (they cannot be changed).
 	update_config '.linux |= (del(.uidMappings) | del(.gidMappings) | del(.timeOffsets))'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" attached_ctr
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" attached_ctr
 
 	# Make sure there are two sleep processes in our container.
-	runc exec attached_ctr ps aux
-	[ "$status" -eq 0 ]
+	runc -0 exec attached_ctr ps aux
 	run -0 grep "sleep infinity" <<<"$output"
 	[ "${#lines[@]}" -eq 2 ]
 
 	# ... that the userns mappings are the same...
-	runc exec attached_ctr cat /proc/self/uid_map
-	[ "$status" -eq 0 ]
+	runc -0 exec attached_ctr cat /proc/self/uid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+100000\s+100$' <<<"$output"
 	else
 		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
 	fi
-	runc exec attached_ctr cat /proc/self/gid_map
-	[ "$status" -eq 0 ]
+	runc -0 exec attached_ctr cat /proc/self/gid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+200000\s+200$' <<<"$output"
 	else
@@ -211,8 +189,7 @@ sh
 EOF
 	chmod +x rootfs/run.sh
 	update_config '.process.args = [ "/run.sh" ]'
-	runc run test_hello
-	[ "$status" -ne 0 ]
+	runc ! run test_hello
 
 	# After the sync socket closed, we should not send error to parent
 	# process, or else we will get a unnecessary error log(#4171).
@@ -231,7 +208,6 @@ EOF
 			| .process.user.uid = 2000
 			| .process.args |= ["sh", "-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	[ "${lines[0]}" = "/home/tempuser" ]
 }

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -24,7 +24,7 @@ function teardown() {
 
 	runc -0 state test_run_keep
 
-	runc delete test_run_keep
+	runc -0 delete test_run_keep
 
 	runc ! state test_run_keep
 }
@@ -45,7 +45,7 @@ function teardown() {
 	# check that cgroup exists
 	check_cgroup_value "pids.max" "max"
 
-	runc delete test_run_keep
+	runc -0 delete test_run_keep
 
 	runc ! state test_run_keep
 }
@@ -177,7 +177,7 @@ function teardown() {
 	fi
 
 	# ... as well as the timens offsets.
-	runc exec attached_ctr cat /proc/self/timens_offsets
+	runc -0 exec attached_ctr cat /proc/self/timens_offsets
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }

--- a/tests/integration/scheduler.bats
+++ b/tests/integration/scheduler.bats
@@ -18,18 +18,15 @@ function teardown() {
 		"nice": 19
 	}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
 
 	# Check init settings.
-	runc exec test_scheduler chrt -p 1
-	[ "$status" -eq 0 ]
+	runc -0 exec test_scheduler chrt -p 1
 	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
 	[[ "${lines[1]}" == *"priority: 0" ]]
 
 	# Check exec settings derived from config.json.
-	runc exec test_scheduler sh -c 'chrt -p $$'
-	[ "$status" -eq 0 ]
+	runc -0 exec test_scheduler sh -c 'chrt -p $$'
 	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
 	[[ "${lines[1]}" == *"priority: 0" ]]
 
@@ -71,7 +68,6 @@ function teardown() {
 	update_config ' .linux.resources.cpu.cpus = "0"
 		| .process.scheduler = {"policy": "SCHED_DEADLINE", "nice": 19, "runtime": 42000, "deadline": 1000000, "period": 1000000, }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
-	[ "$status" -eq 1 ]
+	runc -1 run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
 	[[ "$output" == *"process scheduler can't be used together with AllowedCPUs"* ]]
 }

--- a/tests/integration/seccomp-notify-compat.bats
+++ b/tests/integration/seccomp-notify-compat.bats
@@ -29,7 +29,6 @@ function teardown() {
 				"syscalls": [{ "names": [ "mkdir" ], "action": "SCMP_ACT_NOTIFY" }]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 	[[ "$output" == *"seccomp notify unsupported:"* ]]
 }

--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -73,7 +73,7 @@ function scmp_act_notify_template() {
 
 	scmp_act_notify_template "sleep infinity" true '"mkdir"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	runc -0 exec test_busybox /bin/sh -c "mkdir /dev/shm/foo && stat /dev/shm/foo-bar"
 }
 

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -18,8 +18,7 @@ function teardown() {
 	update_config ".linux.seccomp = $(<"${TESTDATA}/${TEST_NAME}.json")"
 	update_config '.process.args = ["/seccomp_test"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 }
 
 @test "runc run [seccomp defaultErrnoRet=ENXIO]" {
@@ -30,8 +29,7 @@ function teardown() {
 	update_config ".linux.seccomp = $(<"${TESTDATA}/${TEST_NAME}.json")"
 	update_config '.process.args = ["/seccomp_test2"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 }
 
 # TODO:
@@ -47,8 +45,7 @@ function teardown() {
 				"syscalls":[{"names":["mkdir","mkdirat"], "action":"SCMP_ACT_ERRNO"}]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 	[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Operation not permitted"* ]]
 }
 
@@ -61,8 +58,7 @@ function teardown() {
 				"syscalls":[{"names":["mkdir","mkdirat"], "action":"SCMP_ACT_ERRNO", "errnoRet": 100}]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 	[[ "$output" == *"Network is down"* ]]
 }
 
@@ -141,8 +137,7 @@ function flags_value() {
 			;;
 		esac
 
-		runc --debug run test_busybox
-		[ "$status" -ne 0 ]
+		runc ! --debug run test_busybox
 		[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Operation not permitted"* ]]
 
 		# Check the numeric flags value, as printed in the debug log, is as expected.
@@ -161,8 +156,7 @@ function flags_value() {
 				"syscalls":[{"names":["mkdir","mkdirat"], "action":"SCMP_ACT_KILL"}]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 }
 
 # check that a startContainer hook is run with the seccomp filters applied
@@ -180,8 +174,7 @@ function flags_value() {
 				} ]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 	[[ "$output" == *"error running startContainer hook"* ]]
 	[[ "$output" == *"bad system call"* ]]
 }

--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -40,8 +40,7 @@ function run_check_label() {
 	LABEL="system_u:system_r:container_t:s0:c4,c5"
 	update_config '	  .process.selinuxLabel |= "'"$LABEL"'"
 			| .process.args = ["/bin/'"$HELPER"'"]'
-	runc run tst
-	[ "$status" -eq 0 ]
+	runc -0 run tst
 	# Key name is _ses.$CONTAINER_NAME.
 	KEY=_ses.tst
 	[ "$output" == "$KEY $LABEL" ]
@@ -56,11 +55,9 @@ function exec_check_label() {
 	LABEL="system_u:system_r:container_t:s0:c4,c5"
 	update_config '	  .process.selinuxLabel |= "'"$LABEL"'"
 			| .process.args = ["/bin/sh"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" tst
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" tst
 
-	runc exec tst "/bin/$HELPER"
-	[ "$status" -eq 0 ]
+	runc -0 exec tst "/bin/$HELPER"
 	# Key name is _ses.$CONTAINER_NAME.
 	KEY=_ses.tst
 	[ "$output" == "$KEY $LABEL" ]
@@ -76,15 +73,13 @@ function enable_userns() {
 # Baseline test, to check that runc works with selinux enabled.
 @test "runc run (no selinux label)" {
 	update_config '	  .process.args = ["/bin/true"]'
-	runc run tst
-	[ "$status" -eq 0 ]
+	runc -0 run tst
 }
 
 @test "runc run (custom selinux label)" {
 	update_config '	  .process.selinuxLabel |= "system_u:system_r:container_t:s0:c4,c5"
 			| .process.args = ["/bin/true"]'
-	runc run tst
-	[ "$status" -eq 0 ]
+	runc -0 run tst
 }
 
 @test "runc run (session keyring security label)" {

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -12,13 +12,11 @@ function teardown() {
 }
 
 @test "spec generation cwd" {
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run test_hello
 }
 
 @test "spec generation --bundle" {
-	runc run --bundle "$(pwd)" test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run --bundle "$(pwd)" test_hello
 }
 
 @test "spec validator" {

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -11,18 +11,15 @@ function teardown() {
 }
 
 @test "runc start" {
-	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 create --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 start test_busybox
 
 	testcontainer test_busybox running
 
 	runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 }

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -19,7 +19,7 @@ function teardown() {
 
 	testcontainer test_busybox running
 
-	runc delete --force test_busybox
+	runc -0 delete --force test_busybox
 
 	runc ! state test_busybox
 }

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -11,8 +11,7 @@ function teardown() {
 }
 
 @test "runc run detached" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 }
 
@@ -25,15 +24,13 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 }
 
 @test "runc run detached --pid-file" {
-	runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
@@ -46,8 +43,7 @@ function teardown() {
 	mkdir pid_file
 	cd pid_file
 
-	runc run --pid-file pid.txt -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run --pid-file pid.txt -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -12,8 +12,7 @@ function teardown() {
 }
 
 @test "runc run" {
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run test_hello
 	[[ "${output}" == *"Hello"* ]]
 }
 
@@ -26,8 +25,7 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run test_hello
 	[[ "${output}" == *"Hello"* ]]
 }
 
@@ -46,8 +44,7 @@ function teardown() {
 			| (.. | select(.gid? == 0)) .gid |= 100'
 
 	# Sanity check: make sure we can't run the container w/o CAP_DAC_OVERRIDE.
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 
 	# Enable CAP_DAC_OVERRIDE.
 	update_config '	  .process.capabilities.bounding += ["CAP_DAC_OVERRIDE"]
@@ -56,8 +53,7 @@ function teardown() {
 			| .process.capabilities.ambient += ["CAP_DAC_OVERRIDE"]
 			| .process.capabilities.permitted += ["CAP_DAC_OVERRIDE"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 }
 
 @test "runc run with rootfs set to ." {
@@ -66,14 +62,12 @@ function teardown() {
 	cd rootfs
 	update_config '(.. | select(. == "rootfs")) |= "."'
 
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run test_hello
 	[[ "${output}" == *"Hello"* ]]
 }
 
 @test "runc run --pid-file" {
-	runc run --pid-file pid.txt test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run --pid-file pid.txt test_hello
 	[[ "${output}" == *"Hello"* ]]
 
 	[ -e pid.txt ]
@@ -93,8 +87,7 @@ function teardown() {
 				| .options = ["rbind", "nosuid", "nodev", "noexec"]
 			  ) // .)'
 
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run test_hello
 }
 
 @test "runc run [redundant seccomp rules]" {
@@ -105,6 +98,5 @@ function teardown() {
 					"action": "SCMP_ACT_ALLOW",
 				}]
 			    }'
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	runc -0 run test_hello
 }

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -11,44 +11,35 @@ function teardown() {
 }
 
 @test "state (kill + delete)" {
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	runc -0 kill test_busybox KILL
 	wait_for_container 10 1 test_busybox stopped
 
-	runc delete test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 delete test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 }
 
 @test "state (pause + resume)" {
 	# XXX: pause and resume require cgroups.
 	requires root
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	runc ! state test_busybox
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc pause test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 pause test_busybox
 
 	testcontainer test_busybox paused
 
-	runc resume test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 resume test_busybox
 
 	testcontainer test_busybox running
 }

--- a/tests/integration/timens.bats
+++ b/tests/integration/timens.bats
@@ -20,8 +20,7 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	runc ! run test_busybox
 }
 
 @test "runc run [timens with no offsets]" {
@@ -31,8 +30,7 @@ function teardown() {
 	update_config '.linux.namespaces += [{"type": "time"}]
 		| .linux.timeOffsets = null'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	# Default offsets are 0.
 	grep -E '^monotonic\s+0\s+0$' <<<"$output"
 	grep -E '^boottime\s+0\s+0$' <<<"$output"
@@ -48,8 +46,7 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }
@@ -65,11 +62,9 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox cat /proc/self/timens_offsets
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox cat /proc/self/timens_offsets
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }
@@ -90,8 +85,7 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run test_busybox
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }

--- a/tests/integration/umask.bats
+++ b/tests/integration/umask.bats
@@ -13,16 +13,13 @@ function teardown() {
 @test "umask" {
 	update_config '.process.user += {"umask":63}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	runc -0 run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox grep '^Umask:' "/proc/1/status"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox grep '^Umask:' "/proc/1/status"
 	# umask 63 decimal = umask 77 octal
 	[[ "${output}" == *"77"* ]]
 
-	runc exec test_busybox grep '^Umask:' "/proc/self/status"
-	[ "$status" -eq 0 ]
+	runc -0 exec test_busybox grep '^Umask:' "/proc/self/status"
 	# umask 63 decimal = umask 77 octal
 	[[ "${output}" == *"77"* ]]
 }

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -487,18 +487,18 @@ EOF
 	check_cgroup_value "cpu.idle" "0"
 
 	# If cpu-idle is set, cpu-share (converted to CPUWeight) can't be set via systemd.
-	runc update --cpu-share 200 --cpu-idle 1 test_update
+	runc -1 update --cpu-share 200 --cpu-idle 1 test_update
 	[[ "$output" == *"unable to apply both"* ]]
 	check_cgroup_value "cpu.idle" "1"
 
 	# Changing cpu-shares (converted to CPU weight) resets cpu.idle to 0.
-	runc update --cpu-share 200 test_update
+	runc -0 update --cpu-share 200 test_update
 	check_cgroup_value "cpu.idle" "0"
 
 	# Setting values via unified map.
 
 	# If cpu.idle is set, cpu.weight is ignored.
-	runc update -r - test_update <<EOF
+	runc -1 update -r - test_update <<EOF
 {
   "unified": {
     "cpu.idle": "1",
@@ -510,7 +510,7 @@ EOF
 	check_cgroup_value "cpu.idle" "1"
 
 	# Setting any cpu.weight should reset cpu.idle to 0.
-	runc update -r - test_update <<EOF
+	runc -0 update -r - test_update <<EOF
 {
   "unified": {
     "cpu.weight": "8"
@@ -531,7 +531,7 @@ EOF
 	check_cpu_shares 100
 	check_systemd_value "TasksMax" 20
 
-	runc update -r - test_update <<EOF
+	runc -0 update -r - test_update <<EOF
 {
   "unified": {
     "cpu.max": "max 100000",
@@ -717,7 +717,7 @@ EOF
 	check_cgroup_value "cpu.rt_period_us" "$root_period"
 	check_cgroup_value "cpu.rt_runtime_us" 500001
 
-	runc update -r - test_update_rt <<EOF
+	runc -0 update -r - test_update_rt <<EOF
 {
   "cpu": {
     "realtimePeriod": 800001,

--- a/tests/integration/version.bats
+++ b/tests/integration/version.bats
@@ -3,8 +3,7 @@
 load helpers
 
 @test "runc version" {
-	runc -v
-	[ "$status" -eq 0 ]
+	runc -0 -v
 	[[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
 	[[ ${lines[1]} =~ commit:+ ]]
 	[[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]


### PR DESCRIPTION
This is the second part of tests/integration cleanup I wanted to do for quite some time.
For the first part, see #4945.

1. Improve runc wrapper

    1. Add status check support (same as in bats' run helper).
    
    2. Add PRE_CMD support (so we can use commands like taskset or timeout).
    
    3. Drop sane_helper since the output of the command is shown in case of
       an error, and we show the command itself in runc wrapper (unless -N
       or ! is provided -- in this case the command is shown by bats,
       together with the error). This does not show the output of successful
       commands which IMO is a net positive since we are almost always
       interested in failed command output only.
    
    4. Use the new functionality in cpu_affinity.bats and start.bats as a
       showcase (the test of refactoring is in a separate commit).

2. refactor to use runc status checks
3. add missing runc status checks