### PR TITLE
test: add missed use of for range over integers

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux_test.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux_test.go
@@ -299,8 +299,8 @@ func TestEnosysStub_SingleArch(t *testing.T) {
 }
 
 func TestEnosysStub_MultiArch(t *testing.T) {
-	for end := 0; end < len(testArches); end++ {
-		for start := 0; start < end; start++ {
+	for end := range len(testArches) {
+		for start := range end {
 			var arches []string
 			for _, arch := range testArches[start:end] {
 				// "native" indicates a blank architecture field for seccomp, to test


### PR DESCRIPTION
The commit mentioned below has missed these changes.

Fixes: 17570625 ("Use for range over integers")
Signed-off-by: Ariel Otilibili <otilibil@eurecom.fr>