### PR TITLE
ci: stop using go cache for lint job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: false
       - name: install deps
         run: |
           sudo apt -q update


### PR DESCRIPTION
Not sure if this will work, but this will prevent the lint job from using go cache, trying to workaround the false positives issue reported in https://github.com/golangci/golangci-lint/issues/5979.

Should not result in a slower CI overall (as lint is not the slowest job).