### PR TITLE
[1.2] libct: fix mips compilation

### DIFF
--- a/libcontainer/console_linux.go
+++ b/libcontainer/console_linux.go
@@ -33,9 +33,10 @@ func checkPtmxHandle(ptmx *os.File) error {
 		if stat.Ino != PTMX_INO {
 			return fmt.Errorf("ptmx handle has wrong inode number: %v", stat.Ino)
 		}
-		if stat.Mode&unix.S_IFMT != unix.S_IFCHR || stat.Rdev != unix.Mkdev(PTMX_MAJOR, PTMX_MINOR) {
+		rdev := uint64(stat.Rdev) //nolint:unconvert // Rdev is uint32 on MIPS.
+		if stat.Mode&unix.S_IFMT != unix.S_IFCHR || rdev != unix.Mkdev(PTMX_MAJOR, PTMX_MINOR) {
 			return fmt.Errorf("ptmx handle is not a real char ptmx device: ftype %#x %d:%d",
-				stat.Mode&unix.S_IFMT, unix.Major(stat.Rdev), unix.Minor(stat.Rdev))
+				stat.Mode&unix.S_IFMT, unix.Major(rdev), unix.Minor(rdev))
 		}
 		return nil
 	})
@@ -79,9 +80,10 @@ func getPtyPeer(pty console.Console, unsafePeerPath string, flags int) (*os.File
 		if statfs.Type != unix.DEVPTS_SUPER_MAGIC {
 			return fmt.Errorf("pty peer handle is not on a real devpts mount: super magic is %#x", statfs.Type)
 		}
-		if stat.Mode&unix.S_IFMT != unix.S_IFCHR || stat.Rdev != wantPeerDev {
+		rdev := uint64(stat.Rdev) //nolint:unconvert // Rdev is uint32 on MIPS.
+		if stat.Mode&unix.S_IFMT != unix.S_IFCHR || rdev != wantPeerDev {
 			return fmt.Errorf("pty peer handle is not the real char device for pty %d: ftype %#x %d:%d",
-				peerNum, stat.Mode&unix.S_IFMT, unix.Major(stat.Rdev), unix.Minor(stat.Rdev))
+				peerNum, stat.Mode&unix.S_IFMT, unix.Major(rdev), unix.Minor(rdev))
 		}
 		return nil
 	}); err != nil {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1046,10 +1046,10 @@ func mknodDevice(destDir *os.File, destName string, node *devices.Device) error 
 				node.Type, node.Path,
 				stat.Mode&unix.S_IFMT, fileMode&unix.S_IFMT)
 		}
-		if stat.Rdev != dev {
+		if rdev := uint64(stat.Rdev); rdev != dev { //nolint:unconvert // Rdev is uint32 on MIPS.
 			return fmt.Errorf("new %c device inode %s has incorrect major:minor: %d:%d doesn't match expected %d:%d",
 				node.Type, node.Path,
-				unix.Major(stat.Rdev), unix.Minor(stat.Rdev),
+				unix.Major(rdev), unix.Minor(rdev),
 				unix.Major(dev), unix.Minor(dev))
 		}
 		return nil
@@ -1320,7 +1320,8 @@ func remountReadonly(m *configs.Mount) error {
 }
 
 func isDevNull(st *unix.Stat_t) bool {
-	return st.Mode&unix.S_IFMT == unix.S_IFCHR && st.Rdev == unix.Mkdev(1, 3)
+	//nolint:unconvert // Rdev is uint32 on MIPS.
+	return st.Mode&unix.S_IFMT == unix.S_IFCHR && uint64(st.Rdev) == unix.Mkdev(1, 3)
 }
 
 func verifyDevNull(f *os.File) error {


### PR DESCRIPTION
Backport of #4964.

<hr>

On MIPS arches, Rdev is uint32 so we have to convert it.

Can't test this for mips in CI (adding mips compile which is not easy as distros drop mips support).

Tested locally with:
```
GOARCH=mips64le go build -tags "seccomp urfave_cli_no_docs" -o runc .
```
(which still errors out but it's not related).

Fixes: #4962.

Fixes: 8476df83 ("libct: add/use isDevNull, verifyDevNull")
Fixes: de87203e ("console: verify /dev/pts/ptmx before use")
Fixes: 398955bc ("console: add fallback for pre-TIOCGPTPEER kernels")
Reported-by: @tianon 