### PR TITLE
ci: disable golangci-lint cache to fix false positives

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.5
+          version: v2.6
           skip-cache: true
       # Extra linters, only checking new code from a pull request to main.
       - name: lint-extra


### PR DESCRIPTION
This will result in slower runs but we are having issues with
golangci-lint (false positives) that are most probably related
to caching.

While at it, bump golangci-lint to latest version. 

Related to https://github.com/golangci/golangci-lint/issues/5979
