### PR TITLE
[1.3] rootfs: only set mode= for tmpfs mount if target already existed

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -512,6 +512,18 @@ func (m *mountEntry) createOpenMountpoint(rootfs string) (Err error) {
 			_ = dstFile.Close()
 		}
 	}()
+	if err == nil && m.Device == "tmpfs" {
+		// If the original target exists, copy the mode for the tmpfs mount.
+		stat, err := dstFile.Stat()
+		if err != nil {
+			return fmt.Errorf("check tmpfs source mode: %w", err)
+		}
+		dt := fmt.Sprintf("mode=%04o", syscallMode(stat.Mode()))
+		if m.Data != "" {
+			dt = dt + "," + m.Data
+		}
+		m.Data = dt
+	}
 	if err != nil {
 		if !errors.Is(err, unix.ENOENT) {
 			return fmt.Errorf("lookup mountpoint target: %w", err)
@@ -550,19 +562,6 @@ func (m *mountEntry) createOpenMountpoint(rootfs string) (Err error) {
 		if err != nil {
 			return fmt.Errorf("make mountpoint %q: %w", m.Destination, err)
 		}
-	}
-
-	if m.Device == "tmpfs" {
-		// If the original target exists, copy the mode for the tmpfs mount.
-		stat, err := dstFile.Stat()
-		if err != nil {
-			return fmt.Errorf("check tmpfs source mode: %w", err)
-		}
-		dt := fmt.Sprintf("mode=%04o", syscallMode(stat.Mode()))
-		if m.Data != "" {
-			dt = dt + "," + m.Data
-		}
-		m.Data = dt
 	}
 
 	dstFullPath, err := procfs.ProcSelfFdReadlink(dstFile)


### PR DESCRIPTION
Backport of #4973. ~~(Draft until merged.)~~

<hr>

This was always the intended behaviour but commit 72fbb34 ("rootfs:
switch to fd-based handling of mountpoint targets") regressed it when
adding a mechanism to create a file handle to the target if it didn't
already exist (causing the later stat to always succeed).

A lot of people depend on this functionality, so add some tests to make
sure we don't break it in the future.

Fixes #4971
Fixes: 72fbb34f5006 ("rootfs: switch to fd-based handling of mountpoint targets")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>