### PR TITLE
Enable gofumpt extra rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,9 @@ run:
 formatters:
   enable:
     - gofumpt
+  settings:
+    gofumpt:
+      extra-rules: true
 
 linters:
   enable:

--- a/internal/linux/linux.go
+++ b/internal/linux/linux.go
@@ -15,7 +15,7 @@ func Dup3(oldfd, newfd, flags int) error {
 }
 
 // Exec wraps [unix.Exec].
-func Exec(cmd string, args []string, env []string) error {
+func Exec(cmd string, args, env []string) error {
 	err := retryOnEINTR(func() error {
 		return unix.Exec(cmd, args, env)
 	})

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -79,7 +79,7 @@ func (c *Container) checkCriuFeatures(criuOpts *CriuOpts, criuFeat *criurpc.Criu
 	return nil
 }
 
-func compareCriuVersion(criuVersion int, minVersion int) error {
+func compareCriuVersion(criuVersion, minVersion int) error {
 	// simple function to perform the actual version compare
 	if criuVersion < minVersion {
 		return fmt.Errorf("CRIU version %d must be %d or higher", criuVersion, minVersion)

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -434,7 +434,7 @@ func TestFreeze(t *testing.T) {
 	}
 }
 
-func testFreeze(t *testing.T, withSystemd bool, useSet bool) {
+func testFreeze(t *testing.T, withSystemd, useSet bool) {
 	if testing.Short() {
 		return
 	}

--- a/libcontainer/intelrdt/cmt_test.go
+++ b/libcontainer/intelrdt/cmt_test.go
@@ -35,7 +35,7 @@ func TestGetCMTNumaNodeStats(t *testing.T) {
 	})
 }
 
-func checkCMTStatCorrection(got CMTNumaNodeStats, expected CMTNumaNodeStats, t *testing.T) {
+func checkCMTStatCorrection(got, expected CMTNumaNodeStats, t *testing.T) {
 	if got.LLCOccupancy != expected.LLCOccupancy {
 		t.Fatalf("Wrong value of `llc_occupancy`. Expected: %v but got: %v",
 			expected.LLCOccupancy,

--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -156,7 +156,7 @@ type Manager struct {
 // NewManager returns a new instance of Manager, or nil if the Intel RDT
 // functionality is not specified in the config, available from hardware or
 // enabled in the kernel.
-func NewManager(config *configs.Config, id string, path string) *Manager {
+func NewManager(config *configs.Config, id, path string) *Manager {
 	if config.IntelRdt == nil {
 		return nil
 	}
@@ -184,7 +184,7 @@ func NewManager(config *configs.Config, id string, path string) *Manager {
 
 // newManager is the same as NewManager, except it does not check if the feature
 // is actually available. Used by unit tests that mock intelrdt paths.
-func newManager(config *configs.Config, id string, path string) *Manager {
+func newManager(config *configs.Config, id, path string) *Manager {
 	return &Manager{
 		config: config,
 		id:     id,

--- a/libcontainer/intelrdt/mbm_test.go
+++ b/libcontainer/intelrdt/mbm_test.go
@@ -38,7 +38,7 @@ func TestGetMBMNumaNodeStats(t *testing.T) {
 	})
 }
 
-func checkMBMStatCorrection(got MBMNumaNodeStats, expected MBMNumaNodeStats, t *testing.T) {
+func checkMBMStatCorrection(got, expected MBMNumaNodeStats, t *testing.T) {
 	if got.MBMTotalBytes != expected.MBMTotalBytes {
 		t.Fatalf("Wrong value of mbm_total_bytes. Expected: %v but got: %v",
 			expected.MBMTotalBytes,

--- a/libcontainer/internal/userns/userns_maps_linux.go
+++ b/libcontainer/internal/userns/userns_maps_linux.go
@@ -39,7 +39,7 @@ func parseIdmapData(data []byte) (ms []configs.IDMap, err error) {
 // Do something equivalent to nsenter --user=<nsPath> cat <path>, but more
 // efficiently. Returns the contents of the requested file from within the user
 // namespace.
-func spawnUserNamespaceCat(nsPath string, path string) ([]byte, error) {
+func spawnUserNamespaceCat(nsPath, path string) ([]byte, error) {
 	rdr, wtr, err := os.Pipe()
 	if err != nil {
 		return nil, fmt.Errorf("create pipe for userns spawn failed: %w", err)

--- a/libcontainer/logs/logs_linux_test.go
+++ b/libcontainer/logs/logs_linux_test.go
@@ -142,7 +142,7 @@ func check(t *testing.T, l *log, txt, notxt string) {
 
 // checkWait is like check, but if the file is empty,
 // it waits until it's not.
-func checkWait(t *testing.T, l *log, txt string, notxt string) {
+func checkWait(t *testing.T, l *log, txt, notxt string) {
 	t.Helper()
 	const (
 		delay = 100 * time.Millisecond

--- a/libcontainer/network_linux.go
+++ b/libcontainer/network_linux.go
@@ -110,7 +110,7 @@ func (l *loopback) detach(n *configs.Network) (err error) {
 // The device name will be kept the same if device.Name is the zero value.
 // This function ensures that the move and rename operations occur atomically.
 // It preserves existing interface attributes, including global IP addresses.
-func devChangeNetNamespace(name string, nsPath string, device configs.LinuxNetDevice) error {
+func devChangeNetNamespace(name, nsPath string, device configs.LinuxNetDevice) error {
 	logrus.Debugf("attaching network device %s with attrs %+v to network namespace %s", name, device, nsPath)
 	link, err := netlink.LinkByName(name)
 	// recover same behavior on vishvananda/netlink@1.2.1 and do not fail when the kernel returns NLM_F_DUMP_INTR.

--- a/libcontainer/notify_linux.go
+++ b/libcontainer/notify_linux.go
@@ -17,7 +17,7 @@ const (
 	CriticalPressure
 )
 
-func registerMemoryEvent(cgDir string, evName string, arg string) (<-chan struct{}, error) {
+func registerMemoryEvent(cgDir, evName, arg string) (<-chan struct{}, error) {
 	evFile, err := os.Open(filepath.Join(cgDir, evName))
 	if err != nil {
 		return nil, err

--- a/libcontainer/nsenter/nsenter_test.go
+++ b/libcontainer/nsenter/nsenter_test.go
@@ -187,7 +187,7 @@ func init() {
 	}
 }
 
-func newPipe(t *testing.T) (parent *os.File, child *os.File) {
+func newPipe(t *testing.T) (parent, child *os.File) {
 	t.Helper()
 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1421,7 +1421,7 @@ func reopenAfterMount(rootfs string, f *os.File, flags int) (_ *os.File, Err err
 
 // Do the mount operation followed by additional mounts required to take care
 // of propagation flags. This will always be scoped inside the container rootfs.
-func (m *mountEntry) mountPropagate(rootfs string, mountLabel string) error {
+func (m *mountEntry) mountPropagate(rootfs, mountLabel string) error {
 	var (
 		data  = label.FormatMountLabel(m.Data, mountLabel)
 		flags = m.Flags

--- a/libcontainer/seccomp/patchbpf/enosys_linux_test.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux_test.go
@@ -68,7 +68,7 @@ func mockFilter(t *testing.T, config *configs.Seccomp) (*bpf.VM, []bpf.Instructi
 
 // fakeConfig generates a fake libcontainer seccomp configuration. The syscalls
 // are added with an action distinct from the default action.
-func fakeConfig(defaultAction configs.Action, explicitSyscalls []string, arches []string) *configs.Seccomp {
+func fakeConfig(defaultAction configs.Action, explicitSyscalls, arches []string) *configs.Seccomp {
 	config := configs.Seccomp{
 		DefaultAction: defaultAction,
 		Architectures: arches,

--- a/libcontainer/utils/cmsg.go
+++ b/libcontainer/utils/cmsg.go
@@ -114,7 +114,7 @@ func RecvFile(socket *os.File) (_ *os.File, Err error) {
 // SendFile sends a file over the given AF_UNIX socket. file.Name() is also
 // included so that if the other end uses RecvFile, the file will have the same
 // name information.
-func SendFile(socket *os.File, file *os.File) error {
+func SendFile(socket, file *os.File) error {
 	name := file.Name()
 	if len(name) >= MaxNameLen {
 		return fmt.Errorf("sendfd: filename too long: %s", name)

--- a/notify_socket.go
+++ b/notify_socket.go
@@ -25,7 +25,7 @@ type notifySocket struct {
 	socketPath string
 }
 
-func newNotifySocket(context *cli.Context, notifySocketHost string, id string) *notifySocket {
+func newNotifySocket(context *cli.Context, notifySocketHost, id string) *notifySocket {
 	if notifySocketHost == "" {
 		return nil
 	}


### PR DESCRIPTION
Commit b2f8a74d "clothed" the naked return as inflicted by gofumpt v0.9.0. Since gofumpt v0.9.2 this rule was moved to "extra" category, not enabled by default. The only other "extra" rule is to group adjacent parameters with the same type, which also makes sense.

Enable gofumpt "extra" rules, and reformat the code accordingly.