### PR TITLE
[1.4] disable golangci-lint cache

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           sudo apt -q update
           sudo apt -qy install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.6
           skip-cache: true


### PR DESCRIPTION
This is a backport of #4970 and #4992 to release-1.4 branch.

----

This will result in slower runs but we are having issues with
golangci-lint (false positives) that are most probably related
to caching.

While at it, bump golangci-lint to latest version.

Related to golangci/golangci-lint#5979