### PR TITLE
[1.4] Deprecate cgroup v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ WantedBy=multi-user.target
 * [systemd cgroup driver](./docs/systemd.md)
 * [Terminals and standard IO](./docs/terminals.md)
 * [Experimental features](./docs/experimental.md)
+* [Deprecated features](./docs/deprecated.md)
 
 ## License
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,0 +1,11 @@
+# Deprecated features
+
+The following features are deprecated:
+
+Feature                                  | Deprecation  release | Removal release
+---------------------------------------- | -------------------- | ------------------
+cgroup v1                                | v1.4.0               | (May 2029)
+
+<!-- TBD: features that were already deprecated and removed -->
+
+- The latest release in May 2029 may not necessarily support cgroup v1, but there will be at least one maintained branch with the support for cgroup v1.


### PR DESCRIPTION
Backport of #4956.

- #4955