### PR TITLE
ci: don't fail CI if criu-dev test fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,9 +131,11 @@ jobs:
         sudo chmod a+X $HOME # for Ubuntu 22.04 and later
 
     - name: integration test (fs driver)
+      continue-on-error: ${{ matrix.criu != '' }} # Don't let criu-dev errors fail CI.
       run: sudo -E PATH="$PATH" script -e -c 'make local${{ matrix.rootless }}integration'
 
     - name: integration test (systemd driver)
+      continue-on-error: ${{ matrix.criu != '' }} # Don't let criu-dev errors fail CI.
       run: |
         # Delegate all cgroup v2 controllers to rootless user via --systemd-cgroup.
         # The default (since systemd v252) is "pids memory cpu".


### PR DESCRIPTION
In view of recent criu-dev failure (see https://github.com/checkpoint-restore/criu/issues/2781, https://github.com/checkpoint-restore/criu/pull/2819), let's not fail the required "all-done" job when criu-dev tests fail.