### PR TITLE
libct/int: TestFdLeaks: deflake

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1694,7 +1695,11 @@ func fdList(t *testing.T) []string {
 	fds, err := fdDir.Readdirnames(-1)
 	ok(t, err)
 
-	return fds
+	// Remove the fdDir fd.
+	extraFd := strconv.Itoa(int(fdDir.Fd()))
+	return slices.DeleteFunc(fds, func(fd string) bool {
+		return fd == extraFd
+	})
 }
 
 func testFdLeaks(t *testing.T, systemd bool) {
@@ -1716,7 +1721,7 @@ func testFdLeaks(t *testing.T, systemd bool) {
 	runContainerOk(t, config, "true")
 	fds1 := fdList(t)
 
-	if reflect.DeepEqual(fds0, fds1) {
+	if slices.Equal(fds0, fds1) {
 		return
 	}
 	// Show the extra opened files.


### PR DESCRIPTION
Since the recent CVE fixes, TestFdLeaksSystemd sometimes fails:

	=== RUN   TestFdLeaksSystemd
	    exec_test.go:1750: extra fd 9 -> /12224/task/13831/fd
	    exec_test.go:1753: found 1 extra fds after container.Run
	--- FAIL: TestFdLeaksSystemd (0.10s)

It might have been caused by the change to the test code in commit ff6fe13 ("utils: use safe procfs for /proc/self/fd loop code") -- we are now opening a file descriptor during the logic to get a list of file descriptors. If the file descriptor happens to be allocated to a different number, you'll get an error.

Let's try to filter out the fd used to read a directory.

May fix #5010 