### PR TITLE
libct: add a defer fd close in createDeviceNode

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -995,6 +995,8 @@ func createDeviceNode(rootfs string, node *devices.Device, bind bool) error {
 	if err != nil {
 		return fmt.Errorf("mkdir parent of device inode %q: %w", node.Path, err)
 	}
+	defer destDir.Close()
+
 	if bind {
 		return bindMountDeviceNode(destDir, destName, node)
 	}


### PR DESCRIPTION
Fix: #5021 

Without deferring the closure of this file descriptor, starting a container with a very large number of devices can hit the RLIMIT_NOFILE limit.
