### PR TITLE
gha: enforce CHANGELOG.md entries for PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -183,6 +183,34 @@ jobs:
         if: github.event_name != 'pull_request'
         run: echo "Nothing to check here."
 
+  changelog:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+      if: github.event_name == 'pull_request'
+      with:
+        fetch-depth: 0
+    - name: git fetch ${{ github.ref }}
+      if: github.event_name == 'pull_request'
+      run: |-
+        git fetch origin ${{ github.ref }}
+        git tag GITHUB_REF FETCH_HEAD
+    - name: git fetch ${{ github.base_ref }}
+      if: github.event_name == 'pull_request'
+      run: |-
+        git fetch origin ${{ github.base_ref }}
+        git tag GITHUB_BASE_REF FETCH_HEAD
+    - name: check that CHANGELOG.md has an entry
+      if: github.event_name == 'pull_request'
+      run: >-
+        git diff --name-only GITHUB_BASE_REF...GITHUB_REF         \
+          | grep CHANGELOG.md                                     \
+          || { echo "Every PR must have a CHANGELOG.md change."; exit 1; }
+
+    - name: succeed (not a PR) # Allow all-done to succeed for non-PRs.
+      if: github.event_name != 'pull_request'
+      run: echo "Nothing to check here."
+
   cfmt:
     runs-on: ubuntu-24.04
     steps:
@@ -267,6 +295,7 @@ jobs:
     needs:
       - check-go
       - cfmt
+      - changelog
       - codespell
       - commit
       - compile-buildtags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   patched kernels (such as the Tencent kernels). (opencontainers/cgroups#46,
   opencontainers/cgroups#50)
 
+### Changed ###
+- CI: All PRs now require a corresponding `CHANGELOG.md` change be included,
+  which should increase the quality and accuracy of our changelogs going
+  forward. (#5047)
+
 ## [1.4.0-rc.1] - 2025-09-05
 
 > おめェもボスになったんだろぉ？


### PR DESCRIPTION
Each release requires going through the list of PRs and trying to parse
out what a reasonable changelog entry is (possibly ~6 months after the
patch was last discussed and merged), which makes preparing release
notes quite time-consuming.

Given that the moment when the patch is merged is when the information
about the imapct of a patch is most apparent to the author and
reviewers, it seems prudent to require that every PR have a CHANGELOG.md
change. Trivial patches can just add a dummy entry in the changelog (in
future, we can expand this script to skip over commits that have some
special tag to avoid the need for dummy entries).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>