### PR TITLE
RELEASES: finalise policy

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -61,13 +61,6 @@ Here is a hypothetical release timeline to see how this works in practice:
 
 ### Support Policy ###
 
-> **NOTE**: The following policy provides much longer support guarantees than
-> we have historically provided for older runc releases. In order to avoid
-> adding new support guarantees for old runc versions we have long-since
-> stopped supporting, the following support policy only applies for runc
-> releases from `1.2.0` onwards. In other words, runc `1.1.0` and `1.0.0` are
-> not guaranteed support by this policy.
-
 In order to ease the transition between minor runc releases, previous minor
 release branches of runc will be maintained for some time after the newest
 minor release is published. In the following text, `latest` refers to the


### PR DESCRIPTION
We have used this release policy for a year and it seems to work well
for everyone and we haven't received much feedback, so it seems
reasonable to say that we are committed to this policy now.

Also, now that runc 1.4.0 has been released, there is no need to single
out 1.1.x and earlier as no longer being supported, as latest-2 is now
1.2.x and thus 1.1.x would no longer be supported even with the new
support model.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>