### PR TITLE
release: use runc-$version.tar.xz as archive name

### DIFF
--- a/script/release_sign.sh
+++ b/script/release_sign.sh
@@ -135,7 +135,7 @@ read -r
 [ -w "$releasedir" ] || sudo chown -R "$(id -u):$(id -g)" "$releasedir"
 
 # Sign everything.
-for bin in "$releasedir/$project".*; do
+for bin in "$releasedir/$project"*; do
 	[[ "$(basename "$bin")" == "$project.$hashcmd" ]] && continue # skip hash
 	gpg "${gpgflags[@]}" --detach-sign --armor "$bin"
 done


### PR DESCRIPTION
Because we add the runc-$version/ prefix to the archive we generate,
including the version in the name makes it easier for some tools to
operate on as it matches most other projects (for openSUSE we rename the
archive file to this format in order for the automated RPM scripts to
work properly).

Also, when doing several releases at the same time, being able to
double-check that the correct artefact versions were uploaded for each
release can be quite handy.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>