### PR TITLE
libct/configs: mark MPOL_* constants as deprecated

### DIFF
--- a/libcontainer/configs/memorypolicy.go
+++ b/libcontainer/configs/memorypolicy.go
@@ -3,20 +3,22 @@ package configs
 import "golang.org/x/sys/unix"
 
 // Memory policy modes and flags as defined in /usr/include/linux/mempolicy.h
-
+//
+// Deprecated: use constants from [unix] instead.
+//
 //nolint:revive,staticcheck,nolintlint // ignore ALL_CAPS errors in consts from numaif.h, will match unix.* in the future
 const (
-	MPOL_DEFAULT             = 0
-	MPOL_PREFERRED           = 1
-	MPOL_BIND                = 2
-	MPOL_INTERLEAVE          = 3
-	MPOL_LOCAL               = 4
-	MPOL_PREFERRED_MANY      = 5
-	MPOL_WEIGHTED_INTERLEAVE = 6
+	MPOL_DEFAULT             = unix.MPOL_DEFAULT
+	MPOL_PREFERRED           = unix.MPOL_PREFERRED
+	MPOL_BIND                = unix.MPOL_BIND
+	MPOL_INTERLEAVE          = unix.MPOL_INTERLEAVE
+	MPOL_LOCAL               = unix.MPOL_LOCAL
+	MPOL_PREFERRED_MANY      = unix.MPOL_PREFERRED_MANY
+	MPOL_WEIGHTED_INTERLEAVE = unix.MPOL_WEIGHTED_INTERLEAVE
 
-	MPOL_F_STATIC_NODES   = 1 << 15
-	MPOL_F_RELATIVE_NODES = 1 << 14
-	MPOL_F_NUMA_BALANCING = 1 << 13
+	MPOL_F_STATIC_NODES   = unix.MPOL_F_STATIC_NODES
+	MPOL_F_RELATIVE_NODES = unix.MPOL_F_RELATIVE_NODES
+	MPOL_F_NUMA_BALANCING = unix.MPOL_F_NUMA_BALANCING
 )
 
 // LinuxMemoryPolicy contains memory policy configuration.

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -490,16 +490,16 @@ func memoryPolicy(config *configs.Config) error {
 		return nil
 	}
 	switch mpol.Mode {
-	case configs.MPOL_DEFAULT, configs.MPOL_LOCAL:
+	case unix.MPOL_DEFAULT, unix.MPOL_LOCAL:
 		if mpol.Nodes != nil && mpol.Nodes.Count() != 0 {
 			return fmt.Errorf("memory policy mode requires 0 nodes but got %d", mpol.Nodes.Count())
 		}
-	case configs.MPOL_BIND, configs.MPOL_INTERLEAVE,
-		configs.MPOL_PREFERRED_MANY, configs.MPOL_WEIGHTED_INTERLEAVE:
+	case unix.MPOL_BIND, unix.MPOL_INTERLEAVE,
+		unix.MPOL_PREFERRED_MANY, unix.MPOL_WEIGHTED_INTERLEAVE:
 		if mpol.Nodes == nil || mpol.Nodes.Count() == 0 {
 			return fmt.Errorf("memory policy mode requires at least one node but got 0")
 		}
-	case configs.MPOL_PREFERRED:
+	case unix.MPOL_PREFERRED:
 		// Zero or more nodes are allowed by the kernel.
 	default:
 		return fmt.Errorf("invalid memory policy mode: %d", mpol.Mode)


### PR DESCRIPTION
Alas, these new constants are already in v1.4.0 release so we can't remove those right away, but we can mark them as deprecated now and target removal for v1.5.0.

So,
 - mark them as deprecated;
 - redefine via unix.MPOL_* counterparts;
 - fix the validator code to use unix.MPOL_* directly.

This amends commit a0e809a8 (PR #4993).