### PR TITLE
integration: Skip test for new privileges if NoNewPrivs is set

### DIFF
--- a/tests/integration/capabilities.bats
+++ b/tests/integration/capabilities.bats
@@ -31,6 +31,9 @@ function teardown() {
 }
 
 @test "runc run with new privileges" {
+	if [ $(awk '$1 == "NoNewPrivs:" { print $2; exit }' /proc/self/status) -ne 0 ]; then
+		skip "requires unset NoNewPrivs"
+	fi
 	update_config '.process.noNewPrivileges = false'
 	runc run test_new_privileges
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Skip test for new privileges if NoNewPrivs is set.

Otherwise the test for https://www.thkukuk.de/blog/no_new_privs/ will fail:
https://openqa.opensuse.org/tests/5575299

Verification run: https://openqa.opensuse.org/tests/5575346
