### PR TITLE
integration: quote shell value to prevent word splitting

### DIFF
--- a/tests/integration/capabilities.bats
+++ b/tests/integration/capabilities.bats
@@ -31,7 +31,7 @@ function teardown() {
 }
 
 @test "runc run with new privileges" {
-	if [ $(awk '$1 == "NoNewPrivs:" { print $2; exit }' /proc/self/status) -ne 0 ]; then
+	if [ "$(awk '$1 == "NoNewPrivs:" { print $2; exit }' /proc/self/status)" -ne 0 ]; then
 		skip "requires unset NoNewPrivs"
 	fi
 	update_config '.process.noNewPrivileges = false'


### PR DESCRIPTION
Follow-up to #5079 