### PR TITLE
internal/sys: simplify WriteSysctls

### DIFF
--- a/internal/sys/sysctl_linux.go
+++ b/internal/sys/sysctl_linux.go
@@ -2,7 +2,6 @@ package sys
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -42,10 +41,7 @@ func WriteSysctls(sysctls map[string]string) error {
 		}
 		defer sysctlFile.Close()
 
-		n, err := io.WriteString(sysctlFile, value)
-		if n != len(value) && err == nil {
-			err = fmt.Errorf("short write to file (%d bytes != %d bytes)", n, len(value))
-		}
+		_, err = sysctlFile.WriteString(value)
 		if err != nil {
 			return fmt.Errorf("failed to write sysctl %s = %q: %w", key, value, err)
 		}


### PR DESCRIPTION
Apparently `Write` (and thus `WriteString`) must return an error (presumably `io.ErrShortWrite`) on short writes (see [1], [2]), so no explicit check for a short write is needed.

While at it, use `(*os.File).WriteString` directly rather than `io.WriteString`.

[1]: https://pkg.go.dev/os#File.Write
[2]: https://pkg.go.dev/io#Writer