### PR TITLE
ci: bump Go 1.26rc2 -> 1.26.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
-        go-version: [1.24.x, 1.25.x, 1.26.0-rc.2]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         rootless: ["rootless", ""]
         race: ["-race", ""]
         criu: ["", "criu-dev"]
@@ -35,14 +35,14 @@ jobs:
           - criu: criu-dev
             go-version: 1.24.x
           - criu: criu-dev
-            go-version: 1.26.0-rc.2
+            go-version: 1.25.x
           - criu: criu-dev
             rootless: rootless
           # Do race detection only with latest stable Go version.
           - race: -race
             go-version: 1.24.x
           - race: -race
-            go-version: 1.26.0-rc.2
+            go-version: 1.25.x
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Since Go 1.26.0 is released today.

~~Note: it is probably still not available from GHA actions/setup-go so CI failure is expected. Still have to to wait for green CI to merge this.~~