### PR TITLE
[1.3] libct/specconv: fix partial clear of atime mount flags

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -1112,11 +1112,11 @@ func parseMountOptions(options []string) *configs.Mount {
 			} else {
 				recAttrSet |= f.flag
 				recAttrClr &= ^f.flag
-				if f.flag&unix.MOUNT_ATTR__ATIME == f.flag {
-					// https://man7.org/linux/man-pages/man2/mount_setattr.2.html
-					// "cannot simply specify the access-time setting in attr_set, but must also include MOUNT_ATTR__ATIME in the attr_clr field."
-					recAttrClr |= unix.MOUNT_ATTR__ATIME
-				}
+			}
+			if f.flag&unix.MOUNT_ATTR__ATIME == f.flag {
+				// https://man7.org/linux/man-pages/man2/mount_setattr.2.html
+				// "cannot simply specify the access-time setting in attr_set, but must also include MOUNT_ATTR__ATIME in the attr_clr field."
+				recAttrClr |= unix.MOUNT_ATTR__ATIME
 			}
 		} else if f, exists := extensionFlags[o]; exists {
 			if f.clear {


### PR DESCRIPTION
Backport #5098 
----
When parsing mount options into recAttrSet and recAttrClr, the code sets attr_clr to individual atime flags (e.g. MOUNT_ATTR_NOATIME or MOUNT_ATTR_STRICTATIME) when clearing atime attributes. However, this violates the kernel's requirement documented in mount_setattr(2)[1]:

> Note that, since the access-time values are an enumeration
> rather than bit values, a caller wanting to transition to a
> different access-time setting cannot simply specify the
> access-time setting in attr_set, but must also include
> MOUNT_ATTR__ATIME in the attr_clr field.  The kernel will
> verify that MOUNT_ATTR__ATIME isn't partially set in
> attr_clr (i.e., either all bits in the MOUNT_ATTR__ATIME
> bit field are either set or clear), and that attr_set
> doesn't have any access-time bits set if MOUNT_ATTR__ATIME
> isn't set in attr_clr.

Passing only a single atime flag (e.g. MOUNT_ATTR_RELATIME) in attr_clr causes mount_setattr() to fail with EINVAL.

This change ensures that whenever an atime mode is updated, attr_clr includes MOUNT_ATTR__ATIME to properly reset the entire access-time attribute field before applying the new mode.

[1] https://man7.org/linux/man-pages/man2/mount_setattr.2.html


(cherry picked from commit 5560d55bfd84a49441c6812140412f1bcf863a1a)