### PR TITLE
ci: switch to ubuntu 24.04 for cross-i386 job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
 


### PR DESCRIPTION
Commit 67f6c37b ("ci/gha: switch to ubuntu 24.04") switched most GHA CI to Ubuntu 24.04 except for one job. It says:

> Leave ubuntu-22.04 for ci/cross-i386 (issue with systemctl restart hang
> after apt install). This can be addressed separately later.

Assuming the issue it already fixed (updated systemd or something), let's finalize the 24.04 switch.