### PR TITLE
integration: add userns and checkpoint integration test

### DIFF
--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -491,6 +491,19 @@ function have_criu() {
 	run ! grep -q '^criu-3\.17-[123]\.el9' <<<"$ver"
 }
 
+function have_criu_version() {
+	local major_required minor_required
+	major_required=$(echo "$1" | cut -d. -f1)
+	minor_required=$(echo "$1" | cut -d. -f2)
+
+	local current_ver major_current minor_current
+	current_ver=$(criu --version | grep Version | awk '{print $2}')
+	major_current=$(echo "$current_ver" | cut -d. -f1)
+	minor_current=$(echo "$current_ver" | cut -d. -f2)
+
+	[[ $major_current -gt $major_required || ($major_current -eq $major_required && $minor_current -ge $minor_required) ]]
+}
+
 # Allows a test to specify what things it requires. If the environment can't
 # support it, the test is skipped with a message.
 function requires() {
@@ -506,6 +519,12 @@ function requires() {
 			var=${var#criu_feature_}
 			if ! criu check --feature "$var"; then
 				skip "requires CRIU feature ${var}"
+			fi
+			;;
+		criu_version_*)
+			var=${var#criu_version_}
+			if ! have_criu_version "$var"; then
+				skip "requires CRIU version ${var}"
 			fi
 			;;
 		root)

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -280,3 +280,27 @@ function teardown() {
 	# is deleted during the namespace cleanup.
 	run ! ip link del dummy0
 }
+
+@test "checkpoint userns container" {
+	requires criu root criu_version_4.3
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	testcontainer test_busybox running
+
+	for _ in $(seq 2); do
+		runc checkpoint --work-path ./work-dir test_busybox
+		[ "$status" -eq 0 ]
+
+		testcontainer test_busybox checkpointed
+
+		# we need to chown images because child process can try to read them.
+		chown -R 100000:200000 ./checkpoint
+
+		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
+		[ "$status" -eq 0 ]
+
+		testcontainer test_busybox running
+	done
+}


### PR DESCRIPTION
This PR adds the integration test to checkpoint/restore container with user namespace (host id is not default).
Now it fails because in [prepare_cgns](https://github.com/checkpoint-restore/criu/blob/v4.2/criu/cgroup.c#L1195) function criu sends the wrong uid.

Fixes #5121