### PR TITLE
[1.4] ci: update policycoreutils for CentOS 10

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
     CIRRUS_WORKING_DIR: /home/runc
     GO_VER_PREFIX: "1.25."
     BATS_VERSION: "v1.12.0"
-    RPMS: gcc git-core iptables jq glibc-static libseccomp-devel make criu fuse-sshfs container-selinux
+    RPMS: gcc git-core iptables jq glibc-static libseccomp-devel make criu fuse-sshfs container-selinux policycoreutils
     # yamllint disable rule:key-duplicates
     matrix:
       DISTRO: almalinux-8


### PR DESCRIPTION
Backport of #5123 to release-1.4 branch.

----

When container-selinux 4:2.246.0-1.el10 is installed, it produces the following %post script warnings:

> ...
>   Running scriptlet: container-selinux-4:2.246.0-1.el10.noarch            26/37
>   Installing       : container-selinux-4:2.246.0-1.el10.noarch            26/37
>   Running scriptlet: container-selinux-4:2.246.0-1.el10.noarch            26/37
> libsemanage.semanage_pipe_data: Child process /usr/libexec/selinux/hll/pp failed with code: 255. (No data available).
> libsemanage.semanage_compile_module: container: libsepol.policydb_read: policydb module version 24 does not match my version range 4-23.
> libsemanage.semanage_compile_module: container: libsepol.sepol_module_package_read: invalid module in module package (at section 0).
> libsemanage.semanage_compile_module: container: libsepol.sepol_ppfile_to_module_package: Failed to read policy package.
> libsemanage.semanage_direct_commit: Failed to compile hll files into cil files. (No data available).
> semodule:  Failed!
> ...

For some reason, dnf install still succeeds, but when the selinux tests fail with:

> chcon: failed to change context of '/tmp/bats-run-3MMyYP/runc.szTqBc/bundle/runc' to ‘system_u:object_r:container_runtime_exec_t:s0’: Invalid argument

All this is fixed once policycoreutils is added to the list of RPMS so it is updated (from 3.9-3.el10 to 3.10-1.el10) during the same transaction.


(cherry picked from commit 3235c5a90a6c865564130d11a8696c0188947df1)