### PR TITLE
readonlyPath: use statfsToMountFlags and preserve atime flags

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1263,7 +1263,7 @@ func readonlyPath(path string) error {
 	if err := unix.Statfs(path, &s); err != nil {
 		return &os.PathError{Op: "statfs", Path: path, Err: err}
 	}
-	flags := uintptr(s.Flags) & (unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
+	flags := uintptr(statfsToMountFlags(s)) & (unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC | mntAtimeFlags)
 
 	if err := mount(path, path, "", flags|unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
 		return err


### PR DESCRIPTION
## Summary

- `readonlyPath` masks only `MS_NOSUID|MS_NODEV|MS_NOEXEC` from the raw statfs `Flags` field, discarding atime flags. It also uses `s.Flags` (`ST_*` constants) directly in a bitmask against `MS_*` constants — this happens to work for those three flags because their `ST_*` and `MS_*` values coincide, but is not correct in general.
- Use `statfsToMountFlags()` to properly translate `ST_*` to `MS_*` values, and include `mntAtimeFlags` in the preserved mask, matching the approach used in the bind-mount remount path and `setReadonly()`.
- Without this fix, the remount can silently change atime behavior on readonlyPath mounts (e.g. dropping `MS_RELATIME`), and can fail with `EPERM` in user namespaces where the kernel locks atime flags.

Found during code review.

Signed-off-by: Luke Hinds <luke@stacklok.com>