### PR TITLE
specconv: fix systemd property handling bugs

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -722,19 +722,35 @@ func convertSecToUSec(value dbus.Variant) (dbus.Variant, error) {
 	case "y":
 		sec = uint64(vi.(byte)) * M
 	case "n":
-		sec = uint64(vi.(int16)) * M
+		v := vi.(int16)
+		if v < 0 {
+			return value, errors.New("negative value")
+		}
+		sec = uint64(v) * M
 	case "q":
 		sec = uint64(vi.(uint16)) * M
 	case "i":
-		sec = uint64(vi.(int32)) * M
+		v := vi.(int32)
+		if v < 0 {
+			return value, errors.New("negative value")
+		}
+		sec = uint64(v) * M
 	case "u":
 		sec = uint64(vi.(uint32)) * M
 	case "x":
-		sec = uint64(vi.(int64)) * M
+		v := vi.(int64)
+		if v < 0 {
+			return value, errors.New("negative value")
+		}
+		sec = uint64(v) * M
 	case "t":
 		sec = vi.(uint64) * M
 	case "d":
-		sec = uint64(vi.(float64) * M)
+		v := vi.(float64)
+		if v < 0 {
+			return value, errors.New("negative value")
+		}
+		sec = uint64(v * M)
 	default:
 		return value, errors.New("not a number")
 	}
@@ -758,7 +774,7 @@ func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
 			return nil, fmt.Errorf("annotation %s=%s value parse error: %w", k, v, err)
 		}
 		// Check for Sec suffix.
-		if trimName := strings.TrimSuffix(name, "Sec"); len(trimName) < len(name) {
+		if trimName := strings.TrimSuffix(name, "Sec"); len(trimName) > 0 && len(trimName) < len(name) {
 			// Check for a lowercase ascii a-z just before Sec.
 			if ch := trimName[len(trimName)-1]; ch >= 'a' && ch <= 'z' {
 				// Convert from Sec to USec.


### PR DESCRIPTION
## Summary

Fix two bugs in systemd property annotation handling:

1. **Panic on property name "Sec"**: `initSystemdProps` panics when a systemd property annotation has the name exactly "Sec" (after prefix stripping). `TrimSuffix("Sec", "Sec")` returns an empty string, and `trimName[len(trimName)-1]` causes an index-out-of-bounds panic. Add a `len(trimName) > 0` guard.

2. **Negative value wrapping in `convertSecToUSec`**: Negative signed integer values (int16, int32, int64) are silently converted to huge uint64 values via unsigned wrapping. For example, `int16(-1)` becomes `uint64(18446744073709551615) * 1000000`. Add negative value checks for the signed types and float64.

Found during code review.

Signed-off-by: Luke Hinds <luke@stacklok.com>