### PR TITLE
Fix CRIU-related bugs in error handling and fd checks

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -435,8 +435,8 @@ func (c *Container) Checkpoint(criuOpts *CriuOpts) error {
 			if err != nil {
 				return fmt.Errorf("invalid --status-fd argument %d: %w", fd, err)
 			}
-			// and writable
-			if flags&unix.O_WRONLY == 0 {
+			// and writable (O_WRONLY or O_RDWR, but not O_RDONLY)
+			if flags&unix.O_ACCMODE == unix.O_RDONLY {
 				return fmt.Errorf("invalid --status-fd argument %d: not writable", fd)
 			}
 
@@ -1125,7 +1125,7 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 		if c.config.HasHook(configs.Prestart, configs.CreateRuntime) {
 			s, err := c.currentOCIState()
 			if err != nil {
-				return nil
+				return err
 			}
 			s.Pid = int(notify.GetPid())
 

--- a/libcontainer/notify_v2_linux.go
+++ b/libcontainer/notify_v2_linux.go
@@ -12,7 +12,7 @@ import (
 )
 
 func registerMemoryEventV2(cgDir, evName, cgEvName string) (<-chan struct{}, error) {
-	fd, err := unix.InotifyInit()
+	fd, err := unix.InotifyInit1(unix.IN_CLOEXEC)
 	if err != nil {
 		return nil, fmt.Errorf("unable to init inotify: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fix three bugs found during code review:

1. **Swallowed error in criuNotifications**: The "setup-namespaces" case returns `nil` instead of `err` when `currentOCIState()` fails, silently skipping Prestart/CreateRuntime hooks during CRIU restore. This could leave the container in an inconsistent state.

2. **Status-fd writability check rejects O_RDWR**: The check `flags&O_WRONLY == 0` is false for `O_RDWR` (value 2) since `O_WRONLY` is 1. Use `O_ACCMODE` to properly extract the access mode and compare against `O_RDONLY`.

3. **Missing IN_CLOEXEC on InotifyInit**: `registerMemoryEventV2` uses `InotifyInit()` which does not set close-on-exec, potentially leaking the inotify fd to child processes. Use `InotifyInit1(IN_CLOEXEC)` instead.

Signed-off-by: Luke Hinds <luke@stacklok.com>