### PR TITLE
Fix mount data null-byte validation and harden maskPaths tmpfs

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1348,7 +1348,7 @@ func maskPaths(paths []string, mountLabel string) error {
 		if st.IsDir() {
 			// Destination is a directory: bind mount a ro tmpfs over it.
 			dstType = "dir"
-			err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("", mountLabel))
+			err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY|unix.MS_NOSUID|unix.MS_NODEV|unix.MS_NOEXEC, label.FormatMountLabel("", mountLabel))
 		} else {
 			// Destination is a file: mount it to /dev/null.
 			dstType = "path"

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -676,7 +676,8 @@ func createLibcontainerMount(cwd string, m specs.Mount) (*configs.Mount, error) 
 	// to block this as early as possible.
 	if strings.IndexByte(mnt.Source, 0) >= 0 ||
 		strings.IndexByte(mnt.Destination, 0) >= 0 ||
-		strings.IndexByte(mnt.Device, 0) >= 0 {
+		strings.IndexByte(mnt.Device, 0) >= 0 ||
+		strings.IndexByte(mnt.Data, 0) >= 0 {
 		return nil, errors.New("mount field contains null byte")
 	}
 


### PR DESCRIPTION
## Summary

Fix two issues found during code review:

1. **Missing null-byte check for mount Data field**: The null-byte validation checks Source, Destination, and Device but omits the Data (mount options) field. Since these are serialized as netlink messages which don't handle null bytes specially, a null byte in Data could cause truncation of mount options.

2. **maskPaths tmpfs missing restrictive flags**: The tmpfs mount used by `maskPaths` to cover directories only sets `MS_RDONLY`. Add `MS_NOSUID|MS_NODEV|MS_NOEXEC` for defense in depth, consistent with the purpose of masking sensitive paths.

Signed-off-by: Luke Hinds <luke@stacklok.com>