### PR TITLE
libct/specconv: fix panic in initSystemdProps

### DIFF
--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -758,7 +758,7 @@ func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
 			return nil, fmt.Errorf("annotation %s=%s value parse error: %w", k, v, err)
 		}
 		// Check for Sec suffix.
-		if trimName := strings.TrimSuffix(name, "Sec"); len(trimName) < len(name) {
+		if trimName, ok := strings.CutSuffix(name, "Sec"); ok && len(trimName) > 0 {
 			// Check for a lowercase ascii a-z just before Sec.
 			if ch := trimName[len(trimName)-1]; ch >= 'a' && ch <= 'z' {
 				// Convert from Sec to USec.

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -751,6 +751,11 @@ func TestInitSystemdProps(t *testing.T) {
 			exp:  expT{false, "FOOSec", 123},
 		},
 		{
+			desc: "convert USec to Sec (short name)",
+			in:   inT{"org.systemd.property.Sec", "123"},
+			exp:  expT{false, "Sec", 123},
+		},
+		{
 			desc: "CollectMode",
 			in:   inT{"org.systemd.property.CollectMode", "'inactive-or-failed'"},
 			exp:  expT{false, "CollectMode", "inactive-or-failed"},


### PR DESCRIPTION
There is a chance of panic here -- eliminate it.
    
Add a test case (which panics before the fix).

Reported-by: @lukefr09 (see https://github.com/opencontainers/runc/pull/5130)
