### PR TITLE
[1.4] tests/int: Disable coredumps for SCMP_ACT_KILL tests

### DIFF
--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -155,6 +155,7 @@ function flags_value() {
 @test "runc run [seccomp] (SCMP_ACT_KILL)" {
 	update_config '  .process.args = ["/bin/sh", "-c", "mkdir /dev/shm/foo"]
 			| .process.noNewPrivileges = false
+			| .process.rlimits = [{"type": "RLIMIT_CORE", "soft": 0, "hard": 0}]
 			| .linux.seccomp = {
 				"defaultAction":"SCMP_ACT_ALLOW",
 				"architectures":["SCMP_ARCH_X86","SCMP_ARCH_X32","SCMP_ARCH_X86_64","SCMP_ARCH_AARCH64","SCMP_ARCH_ARM"],
@@ -173,6 +174,7 @@ function flags_value() {
 				"architectures":["SCMP_ARCH_X86","SCMP_ARCH_X32","SCMP_ARCH_X86_64","SCMP_ARCH_AARCH64","SCMP_ARCH_ARM"],
 				"syscalls":[{"names":["mkdir","mkdirat"], "action":"SCMP_ACT_KILL"}]
 			}
+			| .process.rlimits = [{"type": "RLIMIT_CORE", "soft": 0, "hard": 0}]
 			| .hooks = {
 				"startContainer": [ {
 						"path": "/bin/sh",


### PR DESCRIPTION
Backport of #5124 to release-1.4.

----

SCMP_ACT_KILL terminates the process with a fatal signal, which may produce a core dump depending on the host configuration.

While this is harmless on ephemeral CI instances, it can leave unwanted core files on developer or customer systems. It also interferes with test environments that detect unexpected core dumps.


(cherry picked from commit f18e97d312f31f109c5ef2485b62cad04e819529)