### PR TITLE
feature: PoC to mknod devices for user namespace containers

### DIFF
--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -8,9 +8,11 @@ import (
 	"strconv"
 	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
+	devices "github.com/opencontainers/cgroups/devices/config"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/internal/userns"
 	"github.com/opencontainers/runc/libcontainer/utils"
@@ -337,6 +339,32 @@ func mountFd(nsHandles *userns.Handles, m *configs.Mount) (_ *mountSource, retEr
 		}
 		sourceType = mountSourcePlain
 	}
+	return &mountSource{
+		Type: sourceType,
+		file: mountFile,
+	}, nil
+}
+
+// Use mknod to create devices in the initial user namespace to pass devices with 0660 permissions
+func usernsMknod(rootfs string, node *devices.Device) (*mountSource, error) {
+	var err error
+
+	destPath, err := securejoin.SecureJoin(rootfs, node.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = createDeviceNode(rootfs, node, false)
+	if err != nil {
+		return nil, err
+	}
+
+	mountFile, err := os.OpenFile(destPath, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceType := mountSourcePlain
 	return &mountSource{
 		Type: sourceType,
 		file: mountFile,

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
@@ -25,6 +26,7 @@ import (
 
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/fs2"
+	"github.com/opencontainers/runc/internal/sys"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	"github.com/opencontainers/runc/libcontainer/internal/userns"
@@ -729,7 +731,45 @@ func (p *initProcess) goCreateMountSources(ctx context.Context) (mountSourceRequ
 				if !ok {
 					break loop
 				}
-				src, err := mountFd(nsHandles, m)
+				var src *mountSource
+				var err error
+				if m.Device == "usernsMknod" {
+					// Create device in initial user ns
+					for _, device := range p.config.Config.Devices {
+						if device.Path == m.Source {
+							src, err = usernsMknod(p.config.Config.Rootfs, device)
+							break
+						}
+					}
+					if src == nil && err == nil {
+						err = fmt.Errorf("can not find device node")
+					}
+				} else if m.Device != "tmpfs" {
+					src, err = mountFd(nsHandles, m)
+				} else {
+					// Mount tmpfs in initial user ns and chown it
+					entry := mountEntry{Mount: m}
+					mountConfig := &mountConfig{
+						root:            p.config.Config.Rootfs,
+						label:           p.config.Config.MountLabel,
+						rootlessCgroups: p.config.Config.RootlessCgroups,
+						cgroupns:        p.config.Config.Namespaces.Contains(configs.NEWCGROUP),
+					}
+					err := mountToRootfs(mountConfig, entry)
+					if err == nil {
+						destPath, _ := securejoin.SecureJoin(mountConfig.root, m.Destination)
+						mountFile, err := os.OpenFile(destPath, unix.O_PATH|unix.O_CLOEXEC, 0)
+						uid, _ := p.config.Config.HostRootUID()
+						gid, _ := p.config.Config.HostRootGID()
+						err = sys.FchownFile(mountFile, uid, gid)
+						if err == nil {
+							src = &mountSource{
+								file: mountFile,
+								Type: mountSourcePlain,
+							}
+						}
+					}
+				}
 				logrus.Debugf("mount source thread: handling request for %q: %v %v", m.Source, src, err)
 				responseCh <- response{
 					src: src,

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -14,13 +14,13 @@ import (
 
 	"github.com/cyphar/filepath-securejoin/pathrs-lite/procfs"
 	"github.com/moby/sys/mountinfo"
-	"github.com/moby/sys/userns"
 	"github.com/mrunalp/fileutils"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
+	"github.com/moby/sys/userns"
 	"github.com/opencontainers/cgroups"
 	devices "github.com/opencontainers/cgroups/devices/config"
 	"github.com/opencontainers/cgroups/fs2"
@@ -113,6 +113,9 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 		rootlessCgroups: config.RootlessCgroups,
 		cgroupns:        config.Namespaces.Contains(configs.NEWCGROUP),
 	}
+
+	useMknodInInitialUserNS := (userns.RunningInUserNS() || config.Namespaces.Contains(configs.NEWUSER)) && !config.RootlessEUID
+
 	for _, m := range config.Mounts {
 		entry := mountEntry{Mount: m}
 		// Figure out whether we need to request runc to give us an
@@ -120,7 +123,7 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 		// necessary. For bind-mounts, this is only necessary if we cannot
 		// resolve the parent mount (this is only hit if you are running in a
 		// userns -- but for rootless the host-side thread can't help).
-		wantSourceFile := m.IsIDMapped()
+		wantSourceFile := m.IsIDMapped() || useMknodInInitialUserNS && pathrs.LexicallyCleanPath(m.Destination) == "/dev"
 		if m.IsBind() && !config.RootlessEUID {
 			if _, err := os.Stat(m.Source); err != nil {
 				wantSourceFile = true
@@ -143,7 +146,7 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 			// that while m.Source might contain symlinks, the (*os.File).Name
 			// is based on the path provided to os.OpenFile, not what it
 			// resolves to. So this should never happen.
-			if sync.File.Name() != m.Source {
+			if sync.File.Name() != m.Source && (!useMknodInInitialUserNS || m.Destination != "/dev") {
 				return fmt.Errorf("returned mountfd for %q doesn't match requested mount configuration: mountfd path is %q", m.Source, sync.File.Name())
 			}
 			// Unmarshal the procMountFd argument (the file is sync.File).
@@ -160,6 +163,9 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 			src.file = sync.File
 			entry.srcFile = src
 		}
+		if useMknodInInitialUserNS && pathrs.LexicallyCleanPath(m.Destination) == "/dev" {
+			continue
+		}
 		if err := mountToRootfs(mountConfig, entry); err != nil {
 			return fmt.Errorf("error mounting %q to rootfs at %q: %w", m.Source, m.Destination, err)
 		}
@@ -167,9 +173,46 @@ func prepareRootfs(pipe *syncSocket, iConfig *initConfig) (err error) {
 
 	setupDev := needsSetupDev(config)
 	if setupDev {
-		if err := createDevices(config); err != nil {
-			return fmt.Errorf("error creating device nodes: %w", err)
+		if !useMknodInInitialUserNS {
+			if err := createDevices(config, config.RootlessEUID); err != nil {
+				return fmt.Errorf("error creating device nodes: %w", err)
+			}
+		} else {
+			for _, node := range config.Devices {
+				if pathrs.LexicallyCleanPath(node.Path) == "/dev/ptmx" {
+					continue
+				}
+
+				// We need to bind /dev/null to restore masked pathes.
+				if pathrs.LexicallyCleanPath(node.Path) == "/dev/null" {
+					if err := createDeviceNode(config.Rootfs, node, true); err != nil {
+						return fmt.Errorf("error creating device nodes: %w", err)
+					}
+				}
+
+				m := &configs.Mount{
+					Source:      node.Path,
+					Destination: node.Path,
+					Device:      "usernsMknod",
+				}
+
+				// Request a source file from the host.
+				if err := writeSyncArg(pipe, procMountPlease, m); err != nil {
+					return fmt.Errorf("failed to request mountfd for %q: %w", m.Source, err)
+				}
+
+				sync, err := readSyncFull(pipe, procMountFd)
+				if err != nil {
+					return fmt.Errorf("mountfd request for %q failed: %w", m.Source, err)
+				}
+
+				if sync.File == nil {
+					return fmt.Errorf("mountfd request for %q: response missing attached fd", m.Source)
+				}
+				defer sync.File.Close()
+			}
 		}
+
 		if err := setupPtmx(config); err != nil {
 			return fmt.Errorf("error setting up ptmx: %w", err)
 		}
@@ -935,8 +978,7 @@ func reOpenDevNull() error {
 }
 
 // Create the device nodes in the container.
-func createDevices(config *configs.Config) error {
-	useBindMount := userns.RunningInUserNS() || config.Namespaces.Contains(configs.NEWUSER)
+func createDevices(config *configs.Config, useBindMount bool) error {
 	for _, node := range config.Devices {
 
 		// The /dev/ptmx device is setup by setupPtmx()

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -1116,17 +1116,15 @@ func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
 			"gid_map": gidMap,
 		}).Debugf("config uses path-based userns configuration -- current uid and gid mappings cached")
 	}
-	rootUID, err := config.HostRootUID()
-	if err != nil {
-		return err
-	}
-	rootGID, err := config.HostRootGID()
-	if err != nil {
-		return err
-	}
 	for _, node := range config.Devices {
-		node.Uid = uint32(rootUID)
-		node.Gid = uint32(rootGID)
+		hostUID, err := config.HostUID(int(node.Uid))
+		if err == nil {
+			node.Uid = uint32(hostUID)
+		}
+		hostGID, err := config.HostGID(int(node.Gid))
+		if err == nil {
+			node.Gid = uint32(hostGID)
+		}
 	}
 	return nil
 }

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -280,3 +280,69 @@ function teardown() {
 	# is deleted during the namespace cleanup.
 	run ! ip link del dummy0
 }
+
+@test "checkpoint userns with the new device" {
+	requires criu root
+
+	update_config ' .linux.devices += [{"path": "/dev/another", "type": "c", "major": 1, "minor": 9, "fileMode": 432}]'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	testcontainer test_busybox running
+
+	runc exec test_busybox head -n 1 /dev/another
+	[ "$status" -eq 0 ]
+
+	for _ in $(seq 2); do
+		runc checkpoint --work-path ./work-dir test_busybox
+		[ "$status" -eq 0 ]
+
+		testcontainer test_busybox checkpointed
+
+		# we need to chown images because child process can try to read them.
+		chown -R 100000:200000 ./checkpoint
+
+		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
+		[ "$status" -eq 0 ]
+
+		testcontainer test_busybox running
+
+		runc exec test_busybox head -n  1 /dev/another
+		[ "$status" -eq 0 ]
+	done
+}
+
+@test "checkpoint userns with the new device and non-root user" {
+	requires criu root
+
+	update_config ' .process.user.uid = 42
+		| .process.user.gid = 42
+		| .linux.devices += [{"path": "/dev/another", "type": "c", "major": 1, "minor": 9, "fileMode": 432, "uid": 42, "gid": 42}]'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	testcontainer test_busybox running
+
+	runc exec test_busybox head -n 1 /dev/another
+	[ "$status" -eq 0 ]
+
+	for _ in $(seq 2); do
+		runc checkpoint --work-path ./work-dir test_busybox
+		[ "$status" -eq 0 ]
+
+		testcontainer test_busybox checkpointed
+
+		# we need to chown images because child process can try to read them.
+		chown -R 100000:200000 ./checkpoint
+
+		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
+		[ "$status" -eq 0 ]
+
+		testcontainer test_busybox running
+
+		runc exec test_busybox head -n  1 /dev/another
+		[ "$status" -eq 0 ]
+	done
+}


### PR DESCRIPTION
The pull request is a PoC to call mknod to create devices for user namespace containers. This feature removes the limitation that the device should be created before container creation.
The main idea is to call mknod in the initial user namespace and container mount namespace. Also, runc should chown the created device to set the right uid/gid in the user namespace.

The main Kernel restrictions for this solution:
1) Mknod capability is checked only in the initial user namespace https://elixir.bootlin.com/linux/v6.17.9/source/fs/namei.c#L4228 .
2) /dev mount also should be created in the initial user namespace https://elixir.bootlin.com/linux/v6.17.9/source/fs/super.c#L358 . Otherwise, its super block will have SB_I_NODEV and you won't be able to open device https://elixir.bootlin.com/linux/v6.17.9/source/fs/namei.c#L3441 .

To solve these problems we can reuse the existing mechanism - goCreateMountSources function https://github.com/opencontainers/runc/blob/v1.4.0/libcontainer/process_linux.go#L604
We will call mknod and mount tmpfs in the initial user namespace and container mount namespace. Also, we will chown them for the right uid/gid. 

The main change for criu is that such devices won't be listed in the /proc/$pid/mountinfo (because we use mknod not bind).
Also, now i have some problems (Operation not permitted for remount) with restoring masked pathes (like /proc/kcore) that's why /dev/null is mount binded.

/dev before:
```bash
total 4
drwxr-xr-x    5 root     root           360 Mar  3 10:41 .
drwxr-xr-x   13 root     root          4096 Mar  3 10:41 ..
crw--w----    1 root     tty       136,   0 Mar  3 10:41 console
lrwxrwxrwx    1 root     root            11 Mar  3 10:41 core -> /proc/kcore
lrwxrwxrwx    1 root     root            13 Mar  3 10:41 fd -> /proc/self/fd
crw-rw-rw-    1 nobody   nobody      1,   7 Mar  3 09:51 full
drwxrwxrwt    2 root     nobody          40 Mar  3 10:41 mqueue
crw-rw-rw-    1 nobody   nobody      1,   3 Mar  3 09:51 null
lrwxrwxrwx    1 root     root             8 Mar  3 10:41 ptmx -> pts/ptmx
drwxr-xr-x    2 root     root             0 Mar  3 10:41 pts
crw-rw-rw-    1 nobody   nobody      1,   8 Mar  3 09:51 random
drwxrwxrwt    2 root     root            40 Mar  3 10:41 shm
lrwxrwxrwx    1 root     root            15 Mar  3 10:41 stderr -> /proc/self/fd/2
lrwxrwxrwx    1 root     root            15 Mar  3 10:41 stdin -> /proc/self/fd/0
lrwxrwxrwx    1 root     root            15 Mar  3 10:41 stdout -> /proc/self/fd/1
crw-rw-rw-    1 nobody   nobody      5,   0 Mar  3 10:41 tty
crw-rw-rw-    1 nobody   nobody      1,   9 Mar  3 09:51 urandom
crw-rw-rw-    1 nobody   nobody      1,   5 Mar  3 09:51 zero
```

/dev after:
```bash
total 4
drwxr-xr-x    5 root     root           380 Mar  3 10:31 .
drwxr-xr-x   13 root     root          4096 Mar  3 10:31 ..
crw-rw----    1 root     root        1,   9 Mar  3 10:31 another
crw--w----    1 root     tty       136,   0 Mar  3 10:31 console
lrwxrwxrwx    1 root     root            11 Mar  3 10:31 core -> /proc/kcore
lrwxrwxrwx    1 root     root            13 Mar  3 10:31 fd -> /proc/self/fd
crw-rw-rw-    1 root     root        1,   7 Mar  3 10:31 full
drwxrwxrwt    2 root     nobody          40 Mar  3 10:31 mqueue
crw-rw-rw-    1 nobody   nobody      1,   3 Mar  3 09:51 null
lrwxrwxrwx    1 root     root             8 Mar  3 10:31 ptmx -> pts/ptmx
drwxr-xr-x    2 root     root             0 Mar  3 10:31 pts
crw-rw-rw-    1 root     root        1,   8 Mar  3 10:31 random
drwxrwxrwt    2 root     root            40 Mar  3 10:31 shm
lrwxrwxrwx    1 root     root            15 Mar  3 10:31 stderr -> /proc/self/fd/2
lrwxrwxrwx    1 root     root            15 Mar  3 10:31 stdin -> /proc/self/fd/0
lrwxrwxrwx    1 root     root            15 Mar  3 10:31 stdout -> /proc/self/fd/1
crw-rw-rw-    1 root     root        5,   0 Mar  3 10:32 tty
crw-rw-rw-    1 root     root        1,   9 Mar  3 10:31 urandom
crw-rw-rw-    1 root     root        1,   5 Mar  3 10:31 zero
```

mountinfo before:
```bash
573 406 252:0 /tmp/bats-run-lRvmOr/runc.9GZDZi/bundle/rootfs / ro,relatime - ext4 /dev/mapper/ubuntu--vg-ubuntu--lv rw
575 573 0:61 / /proc rw,relatime - proc proc rw
576 573 0:62 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,uid=100000,gid=200000,inode64
577 576 0:63 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=200005,mode=620,ptmxmode=666
578 576 0:64 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k,uid=100000,gid=200000,inode64
579 576 0:59 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
580 573 0:65 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
581 580 0:29 /user.slice/user-1000.slice/target_userns /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw
582 576 0:5 /null /dev/null rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
583 576 0:5 /random /dev/random rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
584 576 0:5 /full /dev/full rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
585 576 0:5 /tty /dev/tty rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
586 576 0:5 /zero /dev/zero rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
587 576 0:5 /urandom /dev/urandom rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
407 576 0:63 /0 /dev/console rw,nosuid,noexec,relatime - devpts devpts rw,gid=200005,mode=620,ptmxmode=666
408 575 0:61 /bus /proc/bus ro,relatime - proc proc rw
409 575 0:61 /fs /proc/fs ro,relatime - proc proc rw
410 575 0:61 /irq /proc/irq ro,relatime - proc proc rw
411 575 0:61 /sys /proc/sys ro,relatime - proc proc rw
412 575 0:61 /sysrq-trigger /proc/sysrq-trigger ro,relatime - proc proc rw
526 575 0:66 / /proc/acpi ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
527 575 0:67 / /proc/asound ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
528 575 0:5 /null /proc/kcore rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
529 575 0:5 /null /proc/keys rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
530 575 0:5 /null /proc/latency_stats rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
531 575 0:5 /null /proc/timer_list rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
532 580 0:68 / /sys/firmware ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
533 575 0:69 / /proc/scsi ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
```

mountinfo after:
```bash
573 406 252:0 /tmp/bats-run-g9OAEQ/runc.jlHm5o/bundle/rootfs / ro,relatime - ext4 /dev/mapper/ubuntu--vg-ubuntu--lv rw
575 573 0:61 / /proc rw,relatime - proc proc rw
576 573 0:62 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64
577 576 0:63 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=200005,mode=620,ptmxmode=666
578 576 0:64 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k,uid=100000,gid=200000,inode64
579 576 0:59 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
580 573 0:65 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
581 580 0:29 /user.slice/user-1000.slice/test_busybox /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw
582 576 0:5 /null /dev/null rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
407 576 0:63 /0 /dev/console rw,nosuid,noexec,relatime - devpts devpts rw,gid=200005,mode=620,ptmxmode=666
408 575 0:61 /bus /proc/bus ro,relatime - proc proc rw
409 575 0:61 /fs /proc/fs ro,relatime - proc proc rw
410 575 0:61 /irq /proc/irq ro,relatime - proc proc rw
411 575 0:61 /sys /proc/sys ro,relatime - proc proc rw
412 575 0:61 /sysrq-trigger /proc/sysrq-trigger ro,relatime - proc proc rw
526 575 0:66 / /proc/acpi ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
527 575 0:67 / /proc/asound ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
528 575 0:5 /null /proc/kcore rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
529 575 0:5 /null /proc/keys rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
530 575 0:5 /null /proc/latency_stats rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
531 575 0:5 /null /proc/timer_list rw,nosuid,relatime master:2 - devtmpfs udev rw,size=4785984k,nr_inodes=1196496,mode=755,inode64
532 580 0:68 / /sys/firmware ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
533 575 0:69 / /proc/scsi ro,relatime - tmpfs tmpfs ro,uid=100000,gid=200000,inode64
```
Current PoC limitations are all about criu:
1) The devices major/minor should be the same for checkpoint/restore.
2) The user namespace info (host id, container id, length) should be the same for checkpoint/restore.
3) Only simple mount scenarios are checked (e.g. not checked if user will mount container dev to some path).

Ps: now in my env i have some problems that dump / restore phases can be stuck but from restore log it should be ok. Maybe this is a misconfiguration in my env :=(. 

CRIU changes: [link](https://github.com/checkpoint-restore/criu/pull/2923). 

Closes: https://github.com/opencontainers/runc/issues/5137
