### PR TITLE
conformance: poststart hooks spec now matches runc

### DIFF
--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -8,7 +8,6 @@ The following features are not implemented yet:
 Spec version | Feature                                        | PR
 -------------|------------------------------------------------|----------------------------------------------------------
 v1.1.0       | `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV`       | [#3862](https://github.com/opencontainers/runc/pull/3862)
-v1.3.0       | Fail on a failure of a poststart hook.         | [#4348](https://github.com/opencontainers/runc/pull/4348)
 
 ## Architectures
 


### PR DESCRIPTION
This entry was added by commit 653161f ("docs/spec-conformance.md:
update for spec v1.3.0") but the spec was updated before the v1.3.0
release to remove this requirement for poststart hooks in order to match
runc's current behaviour.

Fixes: 653161f ("docs/spec-conformance.md: update for spec v1.3.0")
Ref: opencontainers/runtime-spec#1262
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>