### PR TITLE
libct: remove relabeling dead code, deprecate Mount.Relabel

### DIFF
--- a/libcontainer/configs/mount_linux.go
+++ b/libcontainer/configs/mount_linux.go
@@ -43,8 +43,10 @@ type Mount struct {
 	// Mount data applied to the mount.
 	Data string `json:"data,omitempty"`
 
-	// Relabel source if set, "z" indicates shared, "Z" indicates unshared.
-	Relabel string `json:"relabel,omitempty"`
+	// Relabel field is ignored.
+	//
+	// Deprecated: do not use. This field will be removed in runc 1.7.
+	Relabel string
 
 	// RecAttr represents mount properties to be applied recursively (AT_RECURSIVE), see mount_setattr(2).
 	RecAttr *unix.MountAttr `json:"rec_attr,omitempty"`

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -747,16 +747,6 @@ func mountToRootfs(c *mountConfig, m mountEntry) error {
 				return fmt.Errorf("failed to set user-requested vfs flags on bind-mount: %w", err)
 			}
 		}
-
-		if m.Relabel != "" {
-			if err := label.Validate(m.Relabel); err != nil {
-				return err
-			}
-			shared := label.IsShared(m.Relabel)
-			if err := label.Relabel(m.Source, mountLabel, shared); err != nil {
-				return err
-			}
-		}
 		return setRecAttr(m)
 	case "cgroup":
 		if cgroups.IsCgroup2UnifiedMode() {


### PR DESCRIPTION
There is no way to set `Mount.Relabel` field via OCI spec (config.json), and so the relabeling code is never used.

My guess it's a leftover from times when runc used to be part of Docker.

Remove it, and mark `Relabel` field as deprecated and for future removal.