### PR TITLE
Revert "Preventing containers from being unable to be deleted"

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -784,20 +784,6 @@ func (p *initProcess) start() (retErr error) {
 		return fmt.Errorf("unable to start init: %w", err)
 	}
 
-	// If the runc-create process is terminated due to receiving SIGKILL signal,
-	// it may lead to the runc-init process leaking due
-	// to issues like cgroup freezing,
-	// and it cannot be cleaned up by runc delete/stop
-	// because the container lacks a state.json file.
-	// This typically occurs when higher-level
-	// container runtimes terminate the runc create process due to context cancellation or timeout.
-	// If the runc-create process terminates due to SIGKILL before
-	// reaching this line of code, we won't encounter the cgroup freezing issue.
-	_, err = p.container.updateState(nil)
-	if err != nil {
-		return fmt.Errorf("unable to store init state before creating cgroup: %w", err)
-	}
-
 	defer func() {
 		if retErr != nil {
 			// Find out if init is killed by the kernel's OOM killer.


### PR DESCRIPTION
This fixes random failures to start a container in conmon integration tests (see #5151).

Fixes: #5151.

I guess we need to find another way to fix #4645.

This reverts commit 1b39997e73a14f1d8a39efbbf2ec44b89ef6cab3 / PR #4757.