### PR TITLE
libct: intelrdt: improve directory cleanup logic

### DIFF
--- a/libcontainer/intelrdt/intelrdt.go
+++ b/libcontainer/intelrdt/intelrdt.go
@@ -151,7 +151,7 @@ type Manager struct {
 	config           *configs.Config
 	id               string
 	path             string
-	directoryCreated bool
+	shouldCleanupDir bool
 }
 
 // NewManager returns a new instance of Manager, or nil if the Intel RDT
@@ -187,10 +187,9 @@ func NewManager(config *configs.Config, id, path string) *Manager {
 // is actually available. Used by unit tests that mock intelrdt paths.
 func newManager(config *configs.Config, id, path string) *Manager {
 	return &Manager{
-		config:           config,
-		id:               id,
-		path:             path,
-		directoryCreated: false,
+		config: config,
+		id:     id,
+		path:   path,
 	}
 }
 
@@ -462,15 +461,10 @@ func (m *Manager) Apply(pid int) (err error) {
 		}
 	}
 
-	// If the directory doesn't exist we need to create it -> it means we also need
-	// to clean it up afterwards. Make a note to the manager.
-	if _, err := os.Stat(path); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			m.directoryCreated = true
-		}
-	}
-
-	if err := os.Mkdir(path, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+	if err := os.Mkdir(path, 0o755); err == nil || errors.Is(err, os.ErrExist) {
+		// Only clean up the directory if we actually created it.
+		m.shouldCleanupDir = err == nil
+	} else {
 		return newLastCmdError(err)
 	}
 
@@ -501,7 +495,7 @@ func (m *Manager) Destroy() error {
 	// group is likely externally managed, i.e. by some other entity than us.
 	// There are probably other containers/tasks sharing the same group. Also
 	// only remove the directory if it was created by us.
-	if m.config.IntelRdt.ClosID == "" && m.directoryCreated {
+	if m.config.IntelRdt.ClosID == "" && m.shouldCleanupDir {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		if err := os.Remove(m.GetPath()); err != nil && !errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
Follow-up to #3832.

It makes more sense to save whether we should cleanup the directory
after it gets created (to avoid error cases deleting a different
directory) as well as tying this check to the existing os.ErrExist
check rather than doing an extra stat(2).

Fixes: e2baa3a ("Intel RDT: update according to spec changes.")
Suggested-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>