### PR TITLE
libct/configs: exclude Relabel from json [un]marshaling

### DIFF
--- a/libcontainer/configs/mount_linux.go
+++ b/libcontainer/configs/mount_linux.go
@@ -46,7 +46,7 @@ type Mount struct {
 	// Relabel field is ignored.
 	//
 	// Deprecated: do not use. This field will be removed in runc 1.7.
-	Relabel string
+	Relabel string `json:"-"`
 
 	// RecAttr represents mount properties to be applied recursively (AT_RECURSIVE), see mount_setattr(2).
 	RecAttr *unix.MountAttr `json:"rec_attr,omitempty"`


### PR DESCRIPTION
When deprecating Relabel field, its json attributes were mistakenly removed, so now it is:
 - saved to JSON under "Relabel" (rather than "relabel");
 - won't be ignored if empty.

Let's fix it before it's too late.

Fixes: 8b2b5e94 ("libct: remove relabeling dead code") / PR #5152