### PR TITLE
gha: install libpathrs for conmon test as well

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -281,6 +281,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt -y install libseccomp-dev libglib2.0-dev libsystemd-dev socat
+    - name: install libpathrs ${{ env.LIBPATHRS_VERSION }}
+      run: |
+        sudo -E PATH="$PATH" ./script/build-libpathrs.sh "$LIBPATHRS_VERSION" /usr
 
     - name: install Go
       uses: actions/setup-go@v6


### PR DESCRIPTION
Commit 192e3d416f13 ("ci: add conmon tests run") was merged without
rebasing on top of commit e2c989b ("build: enable libpathrs by
default"), causing build failures when it was merged.

The solution is to just use the same install script as the rest of CI
from commit 7322b05 ("ci: build and install libpathrs").

Fixes: 192e3d4 ("ci: add conmon tests run")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>