### PR TITLE
Makefile: add RUNC_BUILDTAGS, deprecate EXTRA_BUILDTAGS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,12 +84,10 @@ jobs:
       run: |
         sudo -E PATH="$PATH" ./script/build-libpathrs.sh "$LIBPATHRS_VERSION" /usr
 
-    - name: configure custom BUILDTAGS
+    - name: remove libpathrs build tag
       if: ${{ matrix.libpathrs == '' }}
-      run: |-
-        # Strip out libpathrs from the default buildtags.
-        CUSTOM_BUILDTAGS="$(make -pn | sed -En '/^BUILDTAGS :?=/ { s/.*=// ; s/\blibpathrs\b//p }')"
-        echo "CUSTOM_BUILDTAGS=$CUSTOM_BUILDTAGS" >>"$GITHUB_ENV"
+      run: |
+        echo RUNC_BUILDTAGS=-libpathrs >>"$GITHUB_ENV"
 
     - name: install CRIU
       if: ${{ matrix.criu == '' }}
@@ -121,11 +119,7 @@ jobs:
         check-latest: true
 
     - name: build
-      run: |
-        sudo -E PATH="$PATH" make \
-            ${CUSTOM_BUILDTAGS:+BUILDTAGS="$CUSTOM_BUILDTAGS"} \
-            EXTRA_FLAGS="${{ matrix.race }}" \
-            all
+      run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
 
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@4.0.0
@@ -144,7 +138,7 @@ jobs:
 
     - name: unit test
       if: matrix.rootless != 'rootless'
-      run: sudo -E PATH="$PATH" -- make ${CUSTOM_BUILDTAGS:+BUILDTAGS="$CUSTOM_BUILDTAGS"} TESTFLAGS="${{ matrix.race }}" localunittest
+      run: sudo -E PATH="$PATH" -- make TESTFLAGS="${{ matrix.race }}" localunittest
 
     - name: add rootless user
       if: matrix.rootless == 'rootless'
@@ -154,7 +148,7 @@ jobs:
 
     - name: integration test (fs driver)
       continue-on-error: ${{ matrix.criu != '' }} # Don't let criu-dev errors fail CI.
-      run: sudo -E PATH="$PATH" script -e -c 'make ${CUSTOM_BUILDTAGS:+BUILDTAGS="$CUSTOM_BUILDTAGS"} local${{ matrix.rootless }}integration'
+      run: sudo -E PATH="$PATH" script -e -c 'make local${{ matrix.rootless }}integration'
 
     - name: integration test (systemd driver)
       continue-on-error: ${{ matrix.criu != '' }} # Don't let criu-dev errors fail CI.
@@ -165,7 +159,7 @@ jobs:
         printf "[Service]\nDelegate=yes\n" | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
         sudo systemctl daemon-reload
         # Run the tests.
-        sudo -E PATH="$PATH" script -e -c 'make RUNC_USE_SYSTEMD=yes ${CUSTOM_BUILDTAGS:+BUILDTAGS="$CUSTOM_BUILDTAGS"} local${{ matrix.rootless }}integration'
+        sudo -E PATH="$PATH" script -e -c 'make RUNC_USE_SYSTEMD=yes local${{ matrix.rootless }}integration'
 
   # We need to continue support for 32-bit ARM.
   # However, we do not have 32-bit ARM CI, so we use i386 for testing 32bit stuff.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -95,7 +95,7 @@ jobs:
       - name: compile with no build tags
         run: make BUILDTAGS=""
       - name: compile with runc_nocriu build tag
-        run: make EXTRA_BUILDTAGS="runc_nocriu"
+        run: make RUNC_BUILDTAGS="runc_nocriu"
 
   codespell:
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added ###
+
+- When building runc, `RUNC_BUILDTAGS` make or shell environment variable can
+  be used to add build tags and/or remove existing build tags (when a tag is
+  prefixed with `-`). (#5171)
+
+### Deprecated ###
+- `EXTRA_BUILDTAGS` make variable is deprecated in favor of `RUNC_BUILDTAGS`
+  and will be removed in runc 1.6. (#5171)
+
 ## [1.5.0-rc.1] - 2026-03-12
 
 > 憎しみを束ねてもそれは脆い！

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,17 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
-EXTRA_BUILDTAGS :=
 BUILDTAGS := seccomp urfave_cli_no_docs libpathrs
-BUILDTAGS += $(EXTRA_BUILDTAGS)
+# Tags prefixed with - in RUNC_BUILDTAGS are removed from BUILDTAGS; others are added.
+RUNC_BUILDTAGS ?=
+BUILDTAGS_REMOVE := $(patsubst -%,%,$(filter -%,$(RUNC_BUILDTAGS)))
+BUILDTAGS_ADD    := $(filter-out -%,$(RUNC_BUILDTAGS))
+BUILDTAGS := $(filter-out $(BUILDTAGS_REMOVE),$(BUILDTAGS)) $(BUILDTAGS_ADD)
+# TODO: remove EXTRA_BUILDTAGS for runc 1.6.
+ifdef EXTRA_BUILDTAGS
+  $(warning EXTRA_BUILDTAGS is deprecated; use RUNC_BUILDTAGS instead)
+  BUILDTAGS += $(EXTRA_BUILDTAGS)
+endif
 
 COMMIT := $(shell git describe --dirty --long --always)
 EXTRA_VERSION :=

--- a/README.md
+++ b/README.md
@@ -93,35 +93,32 @@ Bear in mind to include some separator for readability.
 #### Build Tags
 
 `runc` supports optional build tags for compiling support of various features,
-with some of them enabled by default (see `BUILDTAGS` in top-level `Makefile`).
+with some of them enabled by default in the top-level Makefile.
 
-To change build tags from the default, set the `BUILDTAGS` variable for make,
-e.g. to disable seccomp:
+The following build tags are currently recognized:
+
+| Build Tag     | Feature                               | Set by Default | Dependencies        |
+|---------------|---------------------------------------|----------------|---------------------|
+| `seccomp`     | Syscall filtering using `libseccomp`. | yes            | `libseccomp`        |
+| `libpathrs`   | Use [`libpathrs`][] for path safety.  | yes            | [`libpathrs`][]     |
+| `runc_nocriu` | **Disables** runc checkpoint/restore. | no             | `criu`              |
+
+[`libpathrs`]: https://github.com/cyphar/libpathrs
+
+To add or remove build tags from the default set, use the `RUNC_BUILDTAGS`
+make or shell variable. Tags prefixed with `-` are removed from the default set;
+others are added. For example:
 
 ```bash
-make BUILDTAGS=""
+# Add runc_nocriu and remove seccomp tag.
+make RUNC_BUILDTAGS="runc_nocriu -seccomp"
 ```
-
-To add some more build tags to the default set, use the `EXTRA_BUILDTAGS`
-make variable, e.g. to disable checkpoint/restore:
-
-```bash
-make EXTRA_BUILDTAGS="runc_nocriu"
-```
-
-| Build Tag     | Feature                               | Enabled by Default | Dependencies        |
-|---------------|---------------------------------------|--------------------|---------------------|
-| `seccomp`     | Syscall filtering using `libseccomp`. | yes                | `libseccomp`        |
-| `libpathrs`   | Use [`libpathrs`][] for path safety.  | yes                | [`libpathrs`][]     |
-| `runc_nocriu` | **Disables** runc checkpoint/restore. | no                 | `criu`              |
 
 The following build tags were used earlier, but are now obsoleted:
  - **runc_nodmz** (since runc v1.2.1 runc dmz binary is dropped)
  - **nokmem** (since runc v1.0.0-rc94 kernel memory settings are ignored)
  - **apparmor** (since runc v1.0.0-rc93 the feature is always enabled)
  - **selinux**  (since runc v1.0.0-rc93 the feature is always enabled)
-
-[`libpathrs`]: https://github.com/cyphar/libpathrs
 
 ### Running the test suite
 


### PR DESCRIPTION
A bit of history. EXTRA_BUILDTAGS was introduced in commit dac417174, as a quick way to add some extra Go build tags to the runc build.

Later, commit 767bc008 changed Makefile to not get EXTRA_TAGS from the shell environment, as the name is quite generic and some unrelated environment variable with that name can affect runc build. While such change does make sense, it makes it more complicated to pass build tags in CI and otherwise (see e.g. commit 0e1fe368a).

Moreover, runc build uses some Go build tags by default (via Makefile), and while it is easy to add more build tags (via EXTRA_BUILDTAGS), in order to remove some existing tags one has to redefine BUILDTAGS from scratch, which is not very convenient (again, see commit 0e1fe368a which gets the value of BUILDTAGS from the Makefile in order to remove a single tag).

To handle all of the above, let's do this:
 - implement RUNC_BUILDTAGS, fixing the issue of not-so-unique name;
 - allow to get RUNC_BUILDTAGS from shell environment;
 - implement a feature to remove a build tag from default set by prefixing it with "-" (as in RUNC_BUILDTAGS="-seccomp");
 - document all this in README;
 - make CI use the new feature;
 - keep EXTRA_BUILDTAGS for backward compatibility, add a make warning
   and a TODO to remove it for runc 1.6.
 
 Fixes: #5165.