### PR TITLE
ci: switch some jobs to ubuntu-slim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,6 +282,6 @@ jobs:
     - test
     - cross-i386
     - fedora
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - run: echo "All jobs completed"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       pull-requests: read
       checks: write # to allow the action to annotate code in the PR.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:
@@ -53,7 +53,7 @@ jobs:
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
   modernize:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:
@@ -98,7 +98,7 @@ jobs:
         run: make EXTRA_BUILDTAGS="runc_nocriu"
 
   codespell:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - name: install deps
@@ -139,14 +139,14 @@ jobs:
         run : ./script/check-config.sh
 
   space-at-eol:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - run: rm -fr vendor
       - run: if git -P grep -I -n '\s$'; then echo "^^^ extra whitespace at EOL, please fix"; exit 1; fi
 
   deps:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - name: install go
@@ -168,7 +168,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - name: get pr commits
         if: github.event_name == 'pull_request' # Only check commits on pull requests.
@@ -190,7 +190,7 @@ jobs:
         run: echo "Nothing to check here."
 
   cfmt:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - name: checkout
       uses: actions/checkout@v6
@@ -204,7 +204,7 @@ jobs:
         git diff --exit-code
 
   check-go:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - name: check Go version
@@ -247,7 +247,7 @@ jobs:
 
 
   get-images:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - name: install bashbrew
@@ -333,6 +333,6 @@ jobs:
       - shellcheck
       - shfmt
       - space-at-eol
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - run: echo "All jobs completed"


### PR DESCRIPTION
Currently ubuntu-slim [1] is in preview, and it makes sense to try to switch some simpler jobs to it.

[1]: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners