### PR TITLE
[1.5] CHANGELOG: move "better errors from runc init" to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,9 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `runc exec` will now request systemd to move the `exec` process into the
   container cgroup, making the procedure more rootless-friendly. (#4822)
 - seccomp: minor documentation updates. (#4902)
-- Errors from `runc init` have historically been quite painful to understand
-  and debug, we have made several improvements to make them more comprehensive
-  and thus useful when debugging issues. (#4951, #4928)
 - Update spec conformance documentation for OCI runtime-spec v1.3.0. (#4948,
   #5150)
 - Our release archives now have the name `runc-$version.tar.xz` to make distro
@@ -178,6 +175,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - libct: switch to `(*CPUSet).Fill`. (#4927)
 - docs/spec-conformance.md: update for spec v1.3.0. (#4948)
+- Errors from `runc init` have historically been quite painful to understand
+  and debug, we have made several improvements to make them more comprehensive
+  and thus useful when debugging issues. (#5040, #4951, #4928)
 
 [CVE-2025-52881]: https://github.com/opencontainers/runc/security/advisories/GHSA-cgrx-mc8f-2prm
 


### PR DESCRIPTION
Backport of #5175 to release-1.5.

----

Found out that these changes were backported to release-1.4 (PR 5040) and made its way into runc v1.4.0, but were missing from its CHANGELOG.

Move the item to v1.4.0 changelog, and add a backport PR reference.

(cherry picked from commit e232a541bd5eee2a9405397ae2d82b6bc2c50772)