### PR TITLE
Move poststart hook from runc create to runc start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EXTRA_BUILDTAGS` make variable is deprecated in favor of `RUNC_BUILDTAGS`
   and will be removed in runc 1.6. (#5171)
 
+### Fixed ###
+- The poststart hooks are now executed after starting the user-specified
+  process, fixing a runtime-spec conformance issue. (#4347, #5186)
+
 ## [1.5.0-rc.1] - 2026-03-12
 
 > 憎しみを束ねてもそれは脆い！

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -232,7 +232,11 @@ func (c *Container) Exec() error {
 
 func (c *Container) exec() error {
 	path := filepath.Join(c.stateDir, execFifoFilename)
-	return handleFifo(path, c.initProcess.pid())
+	if err := handleFifo(path, c.initProcess.pid()); err != nil {
+		return err
+	}
+
+	return c.postStart()
 }
 
 func handleFifo(path string, pid int) error {
@@ -254,6 +258,29 @@ func handleFifo(path string, pid int) error {
 			}
 		}
 	}
+}
+
+func (c *Container) postStart() (retErr error) {
+	if !c.config.HasHook(configs.Poststart) {
+		return nil
+	}
+
+	defer func() {
+		if retErr != nil {
+			// A poststart hook failed; kill the container.
+			if err := c.signal(unix.SIGKILL); err != nil && !errors.Is(err, ErrNotRunning) {
+				logrus.WithError(err).Warn("kill after failed poststart")
+			}
+			// We're still init's parent so wait is required.
+			_, _ = c.initProcess.wait()
+		}
+	}()
+
+	s, err := c.currentOCIState()
+	if err != nil {
+		return err
+	}
+	return c.config.Hooks.Run(configs.Poststart, s)
 }
 
 func readFromExecFifo(execFifo io.Reader) error {
@@ -374,19 +401,6 @@ func (c *Container) start(process *Process) (retErr error) {
 
 	if process.Init {
 		c.fifo.Close()
-		if c.config.HasHook(configs.Poststart) {
-			s, err := c.currentOCIState()
-			if err != nil {
-				return err
-			}
-
-			if err := c.config.Hooks.Run(configs.Poststart, s); err != nil {
-				if err := ignoreTerminateErrors(parent.terminate()); err != nil {
-					logrus.Warn(fmt.Errorf("error running poststart hook: %w", err))
-				}
-				return err
-			}
-		}
 	}
 	return nil
 }

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -35,7 +35,11 @@ function teardown() {
 		echo "testing hook $hook"
 		update_config '.hooks |= {"'$hook'": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
 		runc run "test_hook-$hook"
-		[[ "$output" != "Hello World" ]]
+		# Failed poststart hooks results in container being killed,
+		# but only after it has started, so output may or may not appear.
+		if [ "$hook" != "poststart" ]; then
+			[[ "$output" != "Hello World" ]]
+		fi
 		[ "$status" -ne 0 ]
 		[[ "$output" == *"error running $hook hook #1:"* ]]
 	done


### PR DESCRIPTION
The runtime-spec [1] currently says:

> 6. Runtime's start command is invoked with the unique identifier of
>    the container.
> 7. The startContainer hooks MUST be invoked by the runtime. If any
>    startContainer hook fails, the runtime MUST generate an error, stop
>    the container, and continue the lifecycle at step 12.
> 8. The runtime MUST run the user-specified program, as specified by
>    process.
> 9. The poststart hooks MUST be invoked by the runtime. If any
>    poststart hook fails, the runtime MUST generate an error, stop the
>    container, and continue the lifecycle at step 12.
> ...
> 11. Runtime's delete command is invoked with the unique identifier of
>     the container.
> 12. The container MUST be destroyed by undoing the steps performed
>     during create phase (step 2).
> 13. The poststop hooks MUST be invoked by the runtime. If any poststop
>     hook fails, the runtime MUST log a warning, but the remaining hooks
>     and lifecycle continue as if the hook had succeeded.

Currently, we do 9 before 8 (heck, even before 6), which is clearly
against the spec and results in issues like the one described in [2].

Let's move running poststart hook to after the user-specified process
has started.

NOTE this patch only fixes the order and does not implement removing
the container when the poststart hook failed (as this part of the spec
is controversial -- destroy et al and should probably be, and currently
are, part of "runc delete").

[1]: https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#lifecycle
[2]: https://github.com/opencontainers/runc/issues/5182

Fixes: #5182
Fixes: #4347
Closes: #4348