### PR TITLE
libct/exeseal: drop own F_SEAL_EXEC

### DIFF
--- a/libcontainer/exeseal/cloned_binary_linux.go
+++ b/libcontainer/exeseal/cloned_binary_linux.go
@@ -54,8 +54,7 @@ func sealMemfd(f **os.File) error {
 	// 05d351102dbe and <https://github.com/opencontainers/runc/pull/4640>).
 
 	// F_SEAL_EXEC -- Linux 6.3
-	const F_SEAL_EXEC = 0x20 //nolint:revive // this matches the unix.* name
-	_, _ = unix.FcntlInt(fd, unix.F_ADD_SEALS, F_SEAL_EXEC)
+	_, _ = unix.FcntlInt(fd, unix.F_ADD_SEALS, unix.F_SEAL_EXEC)
 
 	// Apply all original memfd seals.
 	_, err := unix.FcntlInt(fd, unix.F_ADD_SEALS, baseMemfdSeals)


### PR DESCRIPTION
Since golang.org/x/sys@v0.22 it is available from unix.