### PR TITLE
build: use POSIX regex in libpathrs build

### DIFF
--- a/script/build-libpathrs.sh
+++ b/script/build-libpathrs.sh
@@ -99,7 +99,7 @@ function build_libpathrs() {
 	# /proc/self/maps and parse out the parent directory of the libc.so being
 	# used.
 	local native_libdir libdir=
-	native_libdir="$(awk '$NF ~ /\/libc\>.*\.so/ { print $NF; }' /proc/self/maps |
+	native_libdir="$(awk '$NF ~ /\/libc([.-].*)?\.so/ { print $NF }' /proc/self/maps |
 		sort -u | head -n1 | xargs dirname)"
 	if [[ "$native_libdir" == "$dest/"* ]]; then
 		libdir="$native_libdir"


### PR DESCRIPTION
word boundary anchor `\>` is present only in GNU awk implementation. This will not work if we are building libpathrs inside a container like debian/ubuntu which uses mawk. Therefore switch to a POSIX compatible regex that can be used with all implementations of awk to find the system libc path