### PR TITLE
list: fix IsSet check for global root flag

### DIFF
--- a/list.go
+++ b/list.go
@@ -114,7 +114,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 	root := context.GlobalString("root")
 	list, err := os.ReadDir(root)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) && context.IsSet("root") {
+		if errors.Is(err, os.ErrNotExist) && !context.GlobalIsSet("root") {
 			// Ignore non-existing default root directory
 			// (no containers created yet).
 			return nil, nil

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -2,6 +2,9 @@
 
 load helpers
 
+# Default root directory for runc (as defined in main.go).
+RUNC_DEFAULT_ROOT="/run/runc"
+
 function setup() {
 	setup_busybox
 	ALT_ROOT="$ROOT/alt"
@@ -9,6 +12,12 @@ function setup() {
 }
 
 function teardown() {
+	# Restore default root if it was backed up by the
+	# "non-existent default root" test.
+	if [ -d "${RUNC_DEFAULT_ROOT}.bak" ]; then
+		rm -rf "$RUNC_DEFAULT_ROOT"
+		mv "${RUNC_DEFAULT_ROOT}.bak" "$RUNC_DEFAULT_ROOT"
+	fi
 	ROOT="$ALT_ROOT" teardown_bundle
 	unset ALT_ROOT
 	teardown_bundle
@@ -50,4 +59,49 @@ function teardown() {
 	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
+}
+
+@test "list with non-existent default root succeeds" {
+	# The default root /run/runc is only used when running as real
+	# root; rootless uses $XDG_RUNTIME_DIR/runc instead.
+	requires root unsafe # Modifies /run/runc.
+
+	# Back up and remove the default root to guarantee it
+	# doesn't exist. Restored in teardown.
+	[ -d "$RUNC_DEFAULT_ROOT" ] && mv "$RUNC_DEFAULT_ROOT" "${RUNC_DEFAULT_ROOT}.bak"
+
+	# Use ROOT="" so the runc wrapper doesn't pass --root,
+	# letting runc use its default root.
+	ROOT="" runc list
+	[ "$status" -eq 0 ]
+
+	ROOT="" runc list --format json
+	[ "$status" -eq 0 ]
+	[ "$output" = "null" ]
+
+	ROOT="" runc list -q
+	[ "$status" -eq 0 ]
+	[ "$output" = "" ]
+}
+
+@test "list with empty default root succeeds" {
+	# The default root /run/runc is only used when running as real
+	# root; rootless uses $XDG_RUNTIME_DIR/runc instead.
+	requires root unsafe # Modifies /run/runc.
+
+	# Ensure the default root exists but is empty.
+	mkdir -p "$RUNC_DEFAULT_ROOT"
+
+	# Use ROOT="" so the runc wrapper doesn't pass --root,
+	# letting runc use its default root.
+	ROOT="" runc list
+	[ "$status" -eq 0 ]
+
+	ROOT="" runc list --format json
+	[ "$status" -eq 0 ]
+	[ "$output" = "null" ]
+
+	ROOT="" runc list -q
+	[ "$status" -eq 0 ]
+	[ "$output" = "" ]
 }


### PR DESCRIPTION
## Summary

Fix `runc list` erroring with `open /run/runc: no such file or directory` when the default root directory doesn't exist (i.e., no containers have been created yet).

Two bugs in `list.go` `getContainers()`:
- **Wrong method**: `context.IsSet("root")` always returns `false` in subcommand context because `root` is a global flag. Use `context.GlobalIsSet("root")` instead.
- **Inverted logic**: The condition should be `!context.GlobalIsSet("root")` — ignore a non-existing *default* root directory, but report error for an explicitly set non-existent `--root`.

Fixes #5203

## Test plan

Added two integration tests in `tests/integration/list.bats`:
- `list with non-existent default root succeeds` — backs up and removes `/run/runc`, then runs `ROOT="" runc list` (which goes through the standard wrapper without `--root`) to verify the fix returns an empty result instead of erroring.
- `list with empty default root succeeds` — ensures `runc list` works correctly when the default root exists but contains no containers.

Both tests skip for rootless (the default root `/run/runc` is only used as real root; rootless uses `$XDG_RUNTIME_DIR/runc` instead, which is auto-created by `app.Before`).

Verified locally:
- All three tests pass with the fix
- `list with non-existent default root succeeds` fails without the fix

Signed-off-by: RedMakeUp <girafeeblue@gmail.com>