### PR TITLE
tests/int: introduce the concept of unsafe tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,8 @@ task:
     BATS_VERSION: "v1.12.0"
     LIBPATHRS_VERSION: "0.2.4"
     RPMS: gcc git-core iptables jq glibc-static libseccomp-devel make criu fuse-sshfs container-selinux policycoreutils cargo lld wget
+    # Allow potentially unsafe tests.
+    RUNC_ALLOW_UNSAFE_TESTS: yes
     # yamllint disable rule:key-duplicates
     matrix:
       - DISTRO: almalinux-8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ env:
   LIBPATHRS_VERSION: "0.2.4"
   # Don't ignore C warnings. Note that the output of "go env CGO_CFLAGS" by default is "-g -O2", so we keep them.
   CGO_CFLAGS: -g -O2 -Werror
+  # Allow potentially unsafe tests.
+  RUNC_ALLOW_UNSAFE_TESTS: yes
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ RUN git config --global --add safe.directory /go/src/github.com/opencontainers/r
 
 WORKDIR /go/src/github.com/opencontainers/runc
 
+# Allow "unsafe" integration tests in a container.
+ENV RUNC_ALLOW_UNSAFE_TESTS=yes
+
 # Fixup for cgroup v2.
 COPY script/prepare-cgroup-v2.sh /
 ENTRYPOINT [ "/prepare-cgroup-v2.sh" ]

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -397,6 +397,8 @@ function simple_cr_with_netdevice() {
 }
 
 @test "checkpoint and restore with container specific CRIU config" {
+	requires unsafe # Modifies /etc/criu/default.conf.
+
 	tmp=$(mktemp /tmp/runc-criu-XXXXXX.conf)
 	# This is the file we write to /etc/criu/default.conf
 	tmplog1=$(mktemp /tmp/runc-criu-log-XXXXXX.log)

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -674,6 +674,12 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		unsafe)
+			# Skip the test unless a specific variable is set.
+			if [ ! -v RUNC_ALLOW_UNSAFE_TESTS ]; then
+				skip_me=1
+			fi
+			;;
 		*)
 			fail "BUG: Invalid requires $var."
 			;;


### PR DESCRIPTION
Some of runc integration tests may do something that I would not like when running those on my development laptop. Examples include

 - changing the root mount propagation (see https://github.com/opencontainers/runc/pull/5200);
 - replacing /root/runc (see https://github.com/opencontainers/runc/pull/5207);
 - changing the file in /etc (see checkpoint.bats).

Yet it is totally fine to do all that in a throwaway CI environment, or inside a Docker container.

Introduce a mechanism to skip specific "unsafe" tests unless an environment variable, RUNC_ALLOW_UNSAFE_TESTS, is set. Use it from a specific checkpoint/restore test which modifies /etc/criu/default.conf.