### PR TITLE
[1.5] libct: move cmsg helpers to new internal/cmsg package

### DIFF
--- a/internal/cmsg/cmsg.go
+++ b/internal/cmsg/cmsg.go
@@ -1,4 +1,6 @@
-package utils
+// Package cmsg provides helpers for sending and receiving SCM_RIGHTS messages
+// via sockets.
+package cmsg
 
 /*
  * Copyright 2016, 2017 SUSE LLC
@@ -21,8 +23,9 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/opencontainers/runc/internal/linux"
 	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/runc/internal/linux"
 )
 
 // MaxNameLen is the maximum length of the name of a file descriptor being sent

--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/runc/internal/cmsg"
 	"github.com/opencontainers/runc/internal/pathrs"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/utils"
@@ -1193,7 +1194,7 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 		defer master.Close()
 
 		// While we can access console.master, using the API is a good idea.
-		if err := utils.SendFile(process.ConsoleSocket, master); err != nil {
+		if err := cmsg.SendFile(process.ConsoleSocket, master); err != nil {
 			return err
 		}
 	case "status-ready":

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/runc/internal/cmsg"
 	"github.com/opencontainers/runc/internal/linux"
 	"github.com/opencontainers/runc/internal/pathrs"
 	"github.com/opencontainers/runc/libcontainer/capabilities"
@@ -406,7 +407,7 @@ func setupConsole(socket *os.File, config *initConfig, mount bool) error {
 		}
 	}
 	// While we can access console.master, using the API is a good idea.
-	if err := utils.SendRawFd(socket, pty.Name(), pty.Fd()); err != nil {
+	if err := cmsg.SendRawFd(socket, pty.Name(), pty.Fd()); err != nil {
 		return err
 	}
 	runtime.KeepAlive(pty)
@@ -728,7 +729,7 @@ func setupPidfd(socket *os.File, initType string) error {
 		return fmt.Errorf("failed to pidfd_open: %w", err)
 	}
 
-	if err := utils.SendRawFd(socket, initType, uintptr(pidFd)); err != nil {
+	if err := cmsg.SendRawFd(socket, initType, uintptr(pidFd)); err != nil {
 		unix.Close(pidFd)
 		return fmt.Errorf("failed to send pidfd on socket: %w", err)
 	}

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/console"
+	"github.com/opencontainers/runc/internal/cmsg"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/utils"
-
-	"golang.org/x/sys/unix"
 )
 
 func TestExecIn(t *testing.T) {
@@ -272,7 +273,7 @@ func TestExecInTTY(t *testing.T) {
 
 		done := make(chan (error))
 		go func() {
-			f, err := utils.RecvFile(parent)
+			f, err := cmsg.RecvFile(parent)
 			if err != nil {
 				done <- fmt.Errorf("RecvFile: %w", err)
 				return

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/fs2"
+	"github.com/opencontainers/runc/internal/cmsg"
 	"github.com/opencontainers/runc/internal/linux"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
@@ -1132,7 +1133,7 @@ func sendContainerProcessState(listenerPath string, state *specs.ContainerProces
 		return fmt.Errorf("cannot marshall seccomp state: %w", err)
 	}
 
-	if err := utils.SendRawFd(socket, string(b), file.Fd()); err != nil {
+	if err := cmsg.SendRawFd(socket, string(b), file.Fd()); err != nil {
 		return fmt.Errorf("cannot send seccomp fd to %s: %w", listenerPath, err)
 	}
 	runtime.KeepAlive(file)

--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/opencontainers/runc/libcontainer/utils"
-
 	"github.com/sirupsen/logrus"
+
+	"github.com/opencontainers/runc/internal/cmsg"
 )
 
 type syncType string
@@ -102,7 +102,7 @@ func doWriteSync(pipe *syncSocket, sync syncT) error {
 	}
 	if sync.Flags&syncFlagHasFd != 0 {
 		logrus.Debugf("writing sync file %s", sync)
-		if err := utils.SendFile(pipe.File(), sync.File); err != nil {
+		if err := cmsg.SendFile(pipe.File(), sync.File); err != nil {
 			return fmt.Errorf("sending file after sync %q: %w", sync.Type, err)
 		}
 	}
@@ -149,7 +149,7 @@ func doReadSync(pipe *syncSocket) (syncT, error) {
 	}
 	if sync.Flags&syncFlagHasFd != 0 {
 		logrus.Debugf("reading sync file %s", sync)
-		file, err := utils.RecvFile(pipe.File())
+		file, err := cmsg.RecvFile(pipe.File())
 		if err != nil {
 			return sync, fmt.Errorf("receiving fd from sync %v failed: %w", sync.Type, err)
 		}

--- a/libcontainer/utils/cmsg_deprecated.go
+++ b/libcontainer/utils/cmsg_deprecated.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/opencontainers/runc/internal/cmsg"
+)
+
+// RecvFile waits for a file descriptor to be sent over the given AF_UNIX
+// socket. The file name of the remote file descriptor will be recreated
+// locally (it is sent as non-auxiliary data in the same payload).
+//
+// Deprecated: This method is deprecated and has been moved to an internal
+// package (see [cmsg.RecvFile]). It will be removed in runc 1.6.
+func RecvFile(socket *os.File) (*os.File, error) {
+	return cmsg.RecvFile(socket)
+}
+
+// SendFile sends a file over the given AF_UNIX socket. file.Name() is also
+// included so that if the other end uses RecvFile, the file will have the same
+// name information.
+//
+// Deprecated: This method is deprecated and has been moved to an internal
+// package (see [cmsg.SendFile]). It will be removed in runc 1.6.
+func SendFile(socket, file *os.File) error {
+	return cmsg.SendFile(socket, file)
+}
+
+// SendRawFd sends a specific file descriptor over the given AF_UNIX socket.
+//
+// Deprecated: This method is deprecated and has been moved to an internal
+// package (see [cmsg.SendRawFd]). It will be removed in runc 1.6.
+func SendRawFd(socket *os.File, msg string, fd uintptr) error {
+	return cmsg.SendRawFd(socket, msg, fd)
+}

--- a/tests/cmd/pidfd-kill/pidfd-kill.go
+++ b/tests/cmd/pidfd-kill/pidfd-kill.go
@@ -14,7 +14,7 @@ import (
 	"github.com/urfave/cli"
 	"golang.org/x/sys/unix"
 
-	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runc/internal/cmsg"
 )
 
 const (
@@ -109,5 +109,5 @@ func recvPidfd(socketFile string) (*os.File, error) {
 	}
 	defer socket.Close()
 
-	return utils.RecvFile(socket)
+	return cmsg.RecvFile(socket)
 }

--- a/tests/cmd/recvtty/recvtty.go
+++ b/tests/cmd/recvtty/recvtty.go
@@ -34,8 +34,9 @@ import (
 	"sync"
 
 	"github.com/containerd/console"
-	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/urfave/cli"
+
+	"github.com/opencontainers/runc/internal/cmsg"
 )
 
 // version will be populated by the Makefile, read from
@@ -100,7 +101,7 @@ func handleSingle(path string, noStdin bool) error {
 	defer socket.Close()
 
 	// Get the master file descriptor from runC.
-	master, err := utils.RecvFile(socket)
+	master, err := cmsg.RecvFile(socket)
 	if err != nil {
 		return err
 	}
@@ -163,7 +164,7 @@ func handleNull(path string) error {
 			defer socket.Close()
 
 			// Get the master file descriptor from runC.
-			master, err := utils.RecvFile(socket)
+			master, err := cmsg.RecvFile(socket)
 			if err != nil {
 				return
 			}

--- a/tty.go
+++ b/tty.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 
 	"github.com/containerd/console"
+	"github.com/opencontainers/runc/internal/cmsg"
 	"github.com/opencontainers/runc/libcontainer"
-	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 type tty struct {
@@ -100,7 +100,7 @@ func (t *tty) initHostConsole() error {
 }
 
 func (t *tty) recvtty(socket *os.File) (Err error) {
-	f, err := utils.RecvFile(socket)
+	f, err := cmsg.RecvFile(socket)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport of #5227 to release-1.5.

----

These helpers all make more sense as a self-contained package and moving
them has the added benefit of removing an unneeded libpathrs dependency
(from libcontainer/utils's import of pathrs-lite) from several test
binaries.

Fixes #5221 
Signed-off-by: Aleksa Sarai <aleksa@amutable.com>

(cherry picked from commit ca509e76ffd170ede66bfa07d2a95096f38ae5c0)