### PR TITLE
[1.4] tests/int/checkpoint: drop unneeded tests

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -126,18 +126,14 @@ function simple_cr() {
 	testcontainer test_busybox running
 
 	for _ in $(seq 2); do
-		# checkpoint the running container
 		runc "$@" checkpoint --work-path ./work-dir test_busybox
 		[ "$status" -eq 0 ]
 
-		# after checkpoint busybox is no longer running
 		testcontainer test_busybox checkpointed
 
-		# restore from checkpoint
 		runc "$@" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
 		[ "$status" -eq 0 ]
 
-		# busybox should be back up and running
 		testcontainer test_busybox running
 	done
 }
@@ -167,18 +163,14 @@ function simple_cr_with_netdevice() {
 	[[ "$output" == *"mtu $mtu_value "* ]]
 
 	for _ in $(seq 2); do
-		# checkpoint the running container
 		runc "$@" checkpoint --work-path ./work-dir test_busybox_netdevice
 		[ "$status" -eq 0 ]
 
-		# after checkpoint busybox is no longer running
 		testcontainer test_busybox_netdevice checkpointed
 
-		# restore from checkpoint
 		runc "$@" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox_netdevice
 		[ "$status" -eq 0 ]
 
-		# busybox should be back up and running
 		testcontainer test_busybox_netdevice running
 		run runc exec test_busybox_netdevice ip address show dev dummy0
 		[ "$status" -eq 0 ]
@@ -271,15 +263,12 @@ function simple_cr_with_netdevice() {
 	setup_pipes
 	runc_run_with_pipes test_busybox
 
-	#test checkpoint pre-dump
 	mkdir parent-dir
 	runc checkpoint --pre-dump --image-path ./parent-dir test_busybox
 	[ "$status" -eq 0 ]
 
-	# busybox should still be running
 	testcontainer test_busybox running
 
-	# checkpoint the running container
 	mkdir image-dir
 	mkdir work-dir
 	runc checkpoint --parent-path ../parent-dir --work-path ./work-dir --image-path ./image-dir test_busybox
@@ -288,7 +277,6 @@ function simple_cr_with_netdevice() {
 	# check parent path is valid
 	[ -e ./image-dir/parent ]
 
-	# after checkpoint busybox is no longer running
 	testcontainer test_busybox checkpointed
 
 	runc_restore_with_pipes ./work-dir test_busybox
@@ -302,7 +290,6 @@ function simple_cr_with_netdevice() {
 	setup_pipes
 	runc_run_with_pipes test_busybox
 
-	# checkpoint the running container
 	mkdir image-dir
 	mkdir work-dir
 
@@ -391,14 +378,12 @@ function simple_cr_with_netdevice() {
 		runc checkpoint --work-path ./work-dir test_busybox
 		[ "$status" -eq 0 ]
 
-		# after checkpoint busybox is no longer running
 		testcontainer test_busybox checkpointed
 
 		# restore from checkpoint; this should restore the container into the existing network namespace
 		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
 		[ "$status" -eq 0 ]
 
-		# busybox should be back up and running
 		testcontainer test_busybox running
 
 		# container should be running in same network namespace as before
@@ -436,23 +421,20 @@ function simple_cr_with_netdevice() {
 
 	testcontainer test_busybox running
 
-	# checkpoint the running container
 	runc checkpoint --work-path ./work-dir test_busybox
 	[ "$status" -eq 0 ]
 	run ! test -f ./work-dir/"$tmplog1"
 	test -f ./work-dir/"$tmplog2"
 
-	# after checkpoint busybox is no longer running
 	testcontainer test_busybox checkpointed
 
 	test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
-	# restore from checkpoint
+
 	runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 	run ! test -f ./work-dir/"$tmplog1"
 	test -f ./work-dir/"$tmplog2"
 
-	# busybox should be back up and running
 	testcontainer test_busybox running
 	unlink "$tmp"
 	test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
@@ -479,22 +461,18 @@ function simple_cr_with_netdevice() {
 
 	testcontainer test_busybox running
 
-	# checkpoint the running container
 	runc checkpoint --work-path ./work-dir test_busybox
 	[ "$status" -eq 0 ]
 
-	# after checkpoint busybox is no longer running
 	testcontainer test_busybox checkpointed
 
 	# cleanup mountpoints created by runc during creation
 	# the mountpoints should be recreated during restore - that is the actual thing tested here
 	rm -rf "${bind1:?}"/*
 
-	# restore from checkpoint
 	runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# busybox should be back up and running
 	testcontainer test_busybox running
 }
 
@@ -545,18 +523,14 @@ function simple_cr_with_netdevice() {
 
 	local execed_pid=""
 	for _ in $(seq 2); do
-		# checkpoint the running container
 		runc checkpoint --work-path ./work-dir test_busybox
 		[ "$status" -eq 0 ]
 
-		# after checkpoint busybox is no longer running
 		testcontainer test_busybox checkpointed
 
-		# restore from checkpoint
 		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
 		[ "$status" -eq 0 ]
 
-		# busybox should be back up and running
 		testcontainer test_busybox running
 
 		# verify that previously exec'd process is restored.

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -156,7 +156,7 @@ function simple_cr_with_netdevice() {
 	[ "$status" -eq 0 ]
 
 	testcontainer test_busybox_netdevice running
-	run runc exec test_busybox_netdevice ip address show dev dummy0
+	runc exec test_busybox_netdevice ip address show dev dummy0
 	[ "$status" -eq 0 ]
 	[[ "$output" == *" $global_ip "* ]]
 	[[ "$output" == *"ether $mac_address "* ]]
@@ -172,7 +172,7 @@ function simple_cr_with_netdevice() {
 		[ "$status" -eq 0 ]
 
 		testcontainer test_busybox_netdevice running
-		run runc exec test_busybox_netdevice ip address show dev dummy0
+		runc exec test_busybox_netdevice ip address show dev dummy0
 		[ "$status" -eq 0 ]
 		[[ "$output" == *" $global_ip "* ]]
 		[[ "$output" == *"ether $mac_address "* ]]

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -138,7 +138,7 @@ function simple_cr() {
 	done
 }
 
-function simple_cr_with_netdevice() {
+@test "checkpoint and restore with netdevice" {
 	# Set custom parameters to the netdevice to validate those are respected
 	mtu_value=1789
 	mac_address="00:11:22:33:44:55"
@@ -163,12 +163,12 @@ function simple_cr_with_netdevice() {
 	[[ "$output" == *"mtu $mtu_value "* ]]
 
 	for _ in $(seq 2); do
-		runc "$@" checkpoint --work-path ./work-dir test_busybox_netdevice
+		runc checkpoint --work-path ./work-dir test_busybox_netdevice
 		[ "$status" -eq 0 ]
 
 		testcontainer test_busybox_netdevice checkpointed
 
-		runc "$@" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox_netdevice
+		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox_netdevice
 		[ "$status" -eq 0 ]
 
 		testcontainer test_busybox_netdevice running
@@ -207,35 +207,6 @@ function simple_cr_with_netdevice() {
 	update_config '.linux.namespaces += [{"type": "cgroup"}]'
 
 	simple_cr
-}
-
-@test "checkpoint and restore with netdevice" {
-	simple_cr_with_netdevice
-}
-
-@test "checkpoint and restore with netdevice (bind mount, destination is symlink)" {
-	mkdir -p rootfs/real/conf
-	ln -s /real/conf rootfs/conf
-	update_config '	  .mounts += [{
-					source: ".",
-					destination: "/conf",
-					options: ["bind"]
-				}]'
-	simple_cr_with_netdevice
-}
-
-@test "checkpoint and restore with netdevice (with --debug)" {
-	simple_cr_with_netdevice --debug
-}
-
-@test "checkpoint and restore with netdevice (cgroupns)" {
-	# cgroupv2 already enables cgroupns so this case was tested above already
-	requires cgroups_v1 cgroupns
-
-	# enable CGROUPNS
-	update_config '.linux.namespaces += [{"type": "cgroup"}]'
-
-	simple_cr_with_netdevice
 }
 
 @test "checkpoint --pre-dump (bad --parent-path)" {

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -80,7 +80,6 @@ is_allowed_fdtarget() {
 
 	testcontainer test_busybox created
 
-	# start the command
 	runc start test_busybox
 	[ "$status" -eq 0 ]
 
@@ -98,7 +97,6 @@ is_allowed_fdtarget() {
 
 	testcontainer test_busybox created
 
-	# start the command
 	runc start test_busybox
 	[ "$status" -eq 0 ]
 
@@ -111,12 +109,9 @@ is_allowed_fdtarget() {
 
 	testcontainer test_busybox created
 
-	# check pid.txt was generated
 	[ -e pid.txt ]
-
 	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
 
-	# start the command
 	runc start test_busybox
 	[ "$status" -eq 0 ]
 
@@ -125,7 +120,6 @@ is_allowed_fdtarget() {
 
 @test "runc create --pid-file with new CWD" {
 	bundle="$(pwd)"
-	# create pid_file directory as the CWD
 	mkdir pid_file
 	cd pid_file
 
@@ -134,12 +128,9 @@ is_allowed_fdtarget() {
 
 	testcontainer test_busybox created
 
-	# check pid.txt was generated
 	[ -e pid.txt ]
-
 	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
 
-	# start the command
 	runc start test_busybox
 	[ "$status" -eq 0 ]
 

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -18,7 +18,6 @@ function check_debug() {
 }
 
 @test "global --debug" {
-	# run hello-world
 	runc --debug run test_hello
 	[ "$status" -eq 0 ]
 
@@ -28,7 +27,6 @@ function check_debug() {
 }
 
 @test "global --debug to --log" {
-	# run hello-world
 	runc --log log.out --debug run test_hello
 	[ "$status" -eq 0 ]
 
@@ -43,7 +41,6 @@ function check_debug() {
 }
 
 @test "global --debug to --log --log-format 'text'" {
-	# run hello-world
 	runc --log log.out --log-format "text" --debug run test_hello
 	[ "$status" -eq 0 ]
 
@@ -58,7 +55,6 @@ function check_debug() {
 }
 
 @test "global --debug to --log --log-format 'json'" {
-	# run hello-world
 	runc --log log.out --log-format "json" --debug run test_hello
 	[ "$status" -eq 0 ]
 

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -115,14 +115,11 @@ function test_runc_delete_host_pidns() {
 }
 
 @test "runc delete --force" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 
-	# force delete test_busybox
 	runc delete --force test_busybox
 
 	runc state test_busybox
@@ -209,11 +206,9 @@ EOF
 	set_cgroups_path
 	set_cgroup_mount_writable
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 
 	# create a sub process

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -47,7 +47,6 @@ function test_events() {
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	init_cgroup_paths
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -107,7 +106,6 @@ function test_events() {
 	# we need the container to hit OOM, so disable swap
 	update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}'
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -11,7 +11,6 @@ function teardown() {
 }
 
 @test "runc exec" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -42,7 +41,6 @@ function teardown() {
 }
 
 @test "runc exec --pid-file" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -51,9 +49,7 @@ function teardown() {
 	echo text echoed = "'""${output}""'"
 	[[ "${output}" == *"Hello from exec"* ]]
 
-	# check pid.txt was generated
 	[ -e pid.txt ]
-
 	output=$(cat pid.txt)
 	[[ "$output" =~ [0-9]+ ]]
 	[[ "$output" != $(__runc state test_busybox | jq '.pid') ]]
@@ -61,11 +57,9 @@ function teardown() {
 
 @test "runc exec --pid-file with new CWD" {
 	bundle="$(pwd)"
-	# create pid_file directory as the CWD
 	mkdir pid_file
 	cd pid_file
 
-	# run busybox detached
 	runc run -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -74,16 +68,13 @@ function teardown() {
 	echo text echoed = "'""${output}""'"
 	[[ "${output}" == *"Hello from exec"* ]]
 
-	# check pid.txt was generated
 	[ -e pid.txt ]
-
 	output=$(cat pid.txt)
 	[[ "$output" =~ [0-9]+ ]]
 	[[ "$output" != $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec ls -la" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -95,7 +86,6 @@ function teardown() {
 }
 
 @test "runc exec ls -la with --cwd" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -105,7 +95,6 @@ function teardown() {
 }
 
 @test "runc exec --env" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -119,7 +108,6 @@ function teardown() {
 	# --user can't work in rootless containers that don't have idmap.
 	[ $EUID -ne 0 ] && requires rootless_idmap
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -159,7 +147,6 @@ function teardown() {
 @test "runc exec --additional-gids" {
 	requires root
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -171,7 +158,6 @@ function teardown() {
 }
 
 @test "runc exec --preserve-fds" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -76,11 +76,9 @@ test_host_pidns_kill() {
 }
 
 @test "kill detached busybox" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 
 	runc kill test_busybox KILL

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -16,7 +16,6 @@ function teardown() {
 
 @test "list" {
 	bundle=$(pwd)
-	# run a few busyboxes detached
 	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
 	[ "$status" -eq 0 ]
 

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -18,7 +18,6 @@ function teardown() {
 }
 
 @test "mask paths [file]" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
@@ -36,7 +35,6 @@ function teardown() {
 }
 
 @test "mask paths [directory]" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -17,24 +17,19 @@ function teardown() {
 		set_cgroups_path
 	fi
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	testcontainer test_busybox running
 
-	# pause busybox
 	runc pause test_busybox
 	[ "$status" -eq 0 ]
 
-	# test state of busybox is paused
 	testcontainer test_busybox paused
 
-	# resume busybox
 	runc resume test_busybox
 	[ "$status" -eq 0 ]
 
-	# test state of busybox is back to running
 	testcontainer test_busybox running
 }
 
@@ -45,31 +40,25 @@ function teardown() {
 		set_cgroups_path
 	fi
 
-	# run test_busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
 	testcontainer test_busybox running
 
-	# pause test_busybox and nonexistent container
 	runc pause test_busybox
 	[ "$status" -eq 0 ]
 	runc pause nonexistent
 	[ "$status" -ne 0 ]
 
-	# test state of test_busybox is paused
 	testcontainer test_busybox paused
 
-	# resume test_busybox and nonexistent container
 	runc resume test_busybox
 	[ "$status" -eq 0 ]
 	runc resume nonexistent
 	[ "$status" -ne 0 ]
 
-	# test state of test_busybox is back to running
 	testcontainer test_busybox running
 
-	# delete test_busybox
 	runc delete --force test_busybox
 
 	runc state test_busybox

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -16,13 +16,11 @@ function teardown() {
 
 	testcontainer test_busybox created
 
-	# start container test_busybox
 	runc start test_busybox
 	[ "$status" -eq 0 ]
 
 	testcontainer test_busybox running
 
-	# delete test_busybox
 	runc delete --force test_busybox
 
 	runc state test_busybox

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -11,11 +11,8 @@ function teardown() {
 }
 
 @test "runc run detached" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
-
-	# check state
 	testcontainer test_busybox running
 }
 
@@ -28,43 +25,32 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 }
 
 @test "runc run detached --pid-file" {
-	# run busybox detached
 	runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 
-	# check pid.txt was generated
 	[ -e pid.txt ]
-
 	[[ "$(cat pid.txt)" == $(__runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc run detached --pid-file with new CWD" {
 	bundle="$(pwd)"
-	# create pid_file directory as the CWD
 	mkdir pid_file
 	cd pid_file
 
-	# run busybox detached
 	runc run --pid-file pid.txt -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 
-	# check pid.txt was generated
 	[ -e pid.txt ]
-
 	[[ "$(cat pid.txt)" == $(__runc state test_busybox | jq '.pid') ]]
 }

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -12,11 +12,8 @@ function teardown() {
 }
 
 @test "runc run" {
-	# run hello-world
 	runc run test_hello
 	[ "$status" -eq 0 ]
-
-	# check expected output
 	[[ "${output}" == *"Hello"* ]]
 }
 
@@ -29,11 +26,8 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-	# run hello-world
 	runc run test_hello
 	[ "$status" -eq 0 ]
-
-	# check expected output
 	[[ "${output}" == *"Hello"* ]]
 }
 
@@ -72,21 +66,17 @@ function teardown() {
 	cd rootfs
 	update_config '(.. | select(. == "rootfs")) |= "."'
 
-	# run hello-world
 	runc run test_hello
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Hello"* ]]
 }
 
 @test "runc run --pid-file" {
-	# run hello-world
 	runc run --pid-file pid.txt test_hello
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Hello"* ]]
 
-	# check pid.txt was generated
 	[ -e pid.txt ]
-
 	[[ "$(cat pid.txt)" =~ [0-9]+ ]]
 }
 

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -14,18 +14,15 @@ function teardown() {
 	runc state test_busybox
 	[ "$status" -ne 0 ]
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
 	wait_for_container 10 1 test_busybox stopped
 
-	# delete test_busybox
 	runc delete test_busybox
 	[ "$status" -eq 0 ]
 
@@ -40,24 +37,18 @@ function teardown() {
 	runc state test_busybox
 	[ "$status" -ne 0 ]
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# check state
 	testcontainer test_busybox running
 
-	# pause busybox
 	runc pause test_busybox
 	[ "$status" -eq 0 ]
 
-	# test state of busybox is paused
 	testcontainer test_busybox paused
 
-	# resume busybox
 	runc resume test_busybox
 	[ "$status" -eq 0 ]
 
-	# test state of busybox is back to running
 	testcontainer test_busybox running
 }

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -23,7 +23,6 @@ function teardown() {
 	# shellcheck disable=SC2016
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "for file in /proc/self/fd/[012]; do readlink $file; done"]'
 
-	# run busybox
 	runc run test_busybox
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ /dev/pts/+ ]]
@@ -40,7 +39,6 @@ function teardown() {
 	# shellcheck disable=SC2016
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
-	# run busybox
 	runc run test_busybox
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ 0 ]]
@@ -60,7 +58,6 @@ function teardown() {
 			| (.. | select(.gid? == 0)) .gid |= 100
 			| (.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
-	# run busybox
 	runc run test_busybox
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ 1000 ]]
@@ -72,7 +69,6 @@ function teardown() {
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# make sure we're running
 	testcontainer test_busybox running
 
 	# note that stdout/stderr are already redirected by bats' run
@@ -81,14 +77,11 @@ function teardown() {
 }
 
 @test "runc exec [tty ptsname]" {
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# make sure we're running
 	testcontainer test_busybox running
 
-	# run the exec
 	# shellcheck disable=SC2016
 	runc exec -t test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
 	[ "$status" -eq 0 ]
@@ -102,14 +95,11 @@ function teardown() {
 	# TODO: this can be made as a change to the gid test.
 	[ $EUID -ne 0 ] && requires rootless_idmap
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# make sure we're running
 	testcontainer test_busybox running
 
-	# run the exec
 	# shellcheck disable=SC2016
 	runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[ "$status" -eq 0 ]
@@ -126,14 +116,11 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 			| (.. | select(.gid? == 0)) .gid |= 100'
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# make sure we're running
 	testcontainer test_busybox running
 
-	# run the exec
 	# shellcheck disable=SC2016
 	runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[ "$status" -eq 0 ]
@@ -145,11 +132,9 @@ function teardown() {
 	# allow writing to filesystem
 	update_config '(.. | select(.readonly? != null)) .readonly |= false'
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 
-	# make sure we're running
 	testcontainer test_busybox running
 
 	tty_info_with_consize_size='
@@ -184,7 +169,6 @@ function teardown() {
     "cwd": "/"
 }'
 
-	# run the exec
 	runc exec -t -p <(echo "$tty_info") test_busybox
 	[ "$status" -eq 0 ]
 
@@ -202,13 +186,11 @@ function teardown() {
 	# Make sure that the handling of detached IO is done properly. See #1354.
 	__runc create test_busybox
 
-	# Start the command.
 	runc start test_busybox
 	[ "$status" -eq 0 ]
 
 	testcontainer test_busybox running
 
-	# Kill the container.
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
 }
@@ -216,7 +198,6 @@ function teardown() {
 @test "runc run [terminal=false]" {
 	# Disable terminal creation.
 	# Replace sh script with sleep.
-
 	update_config ' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["sleep", "1000s"]
 			| del(.. | select(.? == "sh"))'
@@ -229,7 +210,6 @@ function teardown() {
 	wait_for_container 15 1 test_busybox running
 	testcontainer test_busybox running
 
-	# Kill the container.
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
 }
@@ -246,7 +226,6 @@ function teardown() {
 
 	testcontainer test_busybox running
 
-	# Kill the container.
 	runc kill test_busybox KILL
 	[ "$status" -eq 0 ]
 }

--- a/tests/integration/umask.bats
+++ b/tests/integration/umask.bats
@@ -13,7 +13,6 @@ function teardown() {
 @test "umask" {
 	update_config '.process.user += {"umask":63}'
 
-	# run busybox detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[ "$status" -eq 0 ]
 

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -25,7 +25,6 @@ function setup() {
 	requires cgroups_memory cgroups_pids cgroups_cpuset
 	init_cgroup_paths
 
-	# run a few busyboxes detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
 
@@ -259,7 +258,6 @@ EOF
 @test "update cgroup cpu limits" {
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 
-	# run a few busyboxes detached
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	[ "$status" -eq 0 ]
 
@@ -763,7 +761,6 @@ EOF
 		echo "$root_runtime" >"$target_runtime"
 	done
 
-	# run a detached busybox
 	runc run -d --console-socket "$CONSOLE_SOCKET" test_update_rt
 	[ "$status" -eq 0 ]
 


### PR DESCRIPTION
Backport of #5222 (and a few pieces of #4945 for a clean backport).

----

Those tests were added by commit 8d180e96 ("Add support for Linux Network Devices"), apparently by copy-pasting the test cases which call simple_cr (all four of them).

While different simple_cr tests make sense as they cover different code paths in runc and/or check for various regression, the same variations with netdevice do not make sense, as having a net device is orthogonal to e.g. bind mount, --debug, or cgroupns.

Remove those.

(cherry picked from commit 2cd4782b704c06b2277fd081f16c5fe4883ae215)