### PR TITLE
CI: lima: add template name to cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,7 +226,7 @@ jobs:
     - uses: actions/cache@v5
       with:
         path: ~/.cache/lima
-        key: lima-${{ steps.lima-actions-setup.outputs.version }}
+        key: lima-${{ steps.lima-actions-setup.outputs.version }}-${{ matrix.template }}
 
     - name: "Start VM"
       # --plain is set to disable file sharing, port forwarding, built-in containerd, etc. for faster start up


### PR DESCRIPTION
The cache created for almalinux-8 could be overwritten for almalinux-9

Follow-up to
- #5239