### PR TITLE
Fix flakiness in TestHook

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -784,6 +784,7 @@ func TestPassExtraFiles(t *testing.T) {
 		ExtraFiles: []*os.File{pipein1, pipein2},
 		Stdin:      nil,
 		Stdout:     &stdout,
+		Stderr:     new(strings.Builder),
 		Init:       true,
 	}
 	err = container.Run(&process)

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -1075,11 +1075,14 @@ func TestHook(t *testing.T) {
 	container, err := newContainer(t, config)
 	ok(t, err)
 
-	// e.g: 'ls /prestart ...'
 	var cmd strings.Builder
 	cmd.WriteString("ls ")
 	for _, hook := range hookFiles {
-		cmd.WriteString("/" + hook + " ")
+		// The poststart hook is racing with this ls command (run as the
+		// container init), so we don't check that hook worked here yet.
+		if hook != "poststart" {
+			cmd.WriteString("/" + hook + " ")
+		}
 	}
 
 	var stdout strings.Builder
@@ -1097,6 +1100,13 @@ func TestHook(t *testing.T) {
 
 	// Wait for process
 	waitProcess(&pconfig, t)
+
+	// Check that poststart hook worked.
+	f, err = os.Open(config.Rootfs + "/poststart")
+	if err != nil {
+		t.Fatalf("poststart hook failed: %s", err)
+	}
+	f.Close()
 
 	if err := container.Destroy(); err != nil {
 		t.Fatalf("container destroy %s", err)

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -421,6 +421,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		ExtraFiles: []*os.File{pipein1, pipein2},
 		Stdin:      nil,
 		Stdout:     &stdout,
+		Stderr:     new(strings.Builder),
 	}
 	err = container.Run(inprocess)
 	ok(t, err)


### PR DESCRIPTION
Since commit 3cdda46 (PR #5186) the poststart hooks runs after the container
process start, and so they race.

Add a sleep to container command line to allow the poststart hook to win.

Fixes: #5245 
