### PR TITLE
Write provisional state.json with PID -1 before cgroup Apply

### DIFF
--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -46,7 +46,8 @@ type BaseState struct {
 	ID string `json:"id"`
 
 	// InitProcessPid is the init process id in the parent namespace.
-	InitProcessPid int `json:"init_process_pid"`
+	// Omitted when the init process PID is unknown.
+	InitProcessPid int `json:"init_process_pid,omitempty"`
 
 	// InitProcessStartTime is the init process start time in clock cycles since boot time.
 	InitProcessStartTime uint64 `json:"init_process_start"`

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -938,7 +938,7 @@ func (c *Container) currentState() *State {
 	var (
 		startTime           uint64
 		externalDescriptors []string
-		pid                 = -1
+		pid                 int
 	)
 	if c.initProcess != nil {
 		pid = c.initProcess.pid()

--- a/libcontainer/container_linux_test.go
+++ b/libcontainer/container_linux_test.go
@@ -1,8 +1,10 @@
 package libcontainer
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/opencontainers/cgroups"
@@ -288,5 +290,37 @@ func TestGetContainerStateAfterUpdate(t *testing.T) {
 	}
 	if state.Config.Cgroups.Resources.Memory != 2048 {
 		t.Fatalf("expected Memory to be 2048 but received %q", state.Config.Cgroups.Memory)
+	}
+}
+
+func TestSaveStateOmitsInitProcessPidWithoutInit(t *testing.T) {
+	container := &Container{
+		stateDir: t.TempDir(),
+		id:       "myid",
+		config: &configs.Config{
+			Cgroups: &cgroups.Cgroup{
+				Resources: &cgroups.Resources{},
+			},
+		},
+		cgroupManager: &mockCgroupManager{},
+	}
+	container.state = &stoppedState{c: container}
+
+	if err := container.saveState(container.currentState()); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(container.stateDir, stateFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := state["init_process_pid"]; ok {
+		t.Fatalf("did not expect init_process_pid in persisted state: %s", data)
 	}
 }

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -819,6 +819,24 @@ func (p *initProcess) start() (retErr error) {
 		}
 	}()
 
+	// Write a provisional state.json before cgroup Apply. This ensures that
+	// if the runc-create process is killed (e.g., SIGKILL from a higher-level
+	// runtime due to timeout), runc-delete can still find and clean up the
+	// container's cgroup and state directory.
+	//
+	// We temporarily nil out c.initProcess so that the saved state uses
+	// PID -1 (the default when initProcess is nil). This prevents external
+	// tools from seeing the container as "created" before the init process
+	// is fully set up, avoiding a race where "runc start" could be called
+	// with a stale STAGE_PARENT PID that will be reaped during creation.
+	savedInit := p.container.initProcess
+	p.container.initProcess = nil
+	_, uerr := p.container.updateState(nil)
+	p.container.initProcess = savedInit
+	if uerr != nil {
+		return fmt.Errorf("unable to store init state: %w", uerr)
+	}
+
 	// Do this before syncing with child so that no children can escape the
 	// cgroup. We don't need to worry about not doing this and not being root
 	// because we'd be using the rootless cgroup manager in that case.

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -824,8 +824,8 @@ func (p *initProcess) start() (retErr error) {
 	// runtime due to timeout), runc-delete can still find and clean up the
 	// container's cgroup and state directory.
 	//
-	// We temporarily nil out c.initProcess so that the saved state uses
-	// PID -1 (the default when initProcess is nil). This prevents external
+	// We temporarily nil out c.initProcess so that init_process_pid is omitted
+	// from the saved state (the default when initProcess is nil). This prevents external
 	// tools from seeing the container as "created" before the init process
 	// is fully set up, avoiding a race where "runc start" could be called
 	// with a stale STAGE_PARENT PID that will be reaped during creation.


### PR DESCRIPTION
Write a provisional `state.json` with PID -1 (sentinel) before cgroup Apply in `initProcess.start()`, and set `initProcess` to nil to achieve this.

If we **do not** set `initProcess` to nil, `state.json` will contain the real PID of the STAGE_PARENT process. This PID belongs to the first-stage `runc init` process, which will be reaped (killed) in `waitForChildExit()` and replaced by the final STAGE_INIT PID.

**The problem is:** if an external tool (such as conmon) invokes `runc state` within this time window, it will:

- Read the STAGE_PARENT PID from `state.json`
- Check whether this PID is alive (yes, it is temporarily still alive)
- Check whether the `exec.fifo` exists (yes, it is created at the beginning of `start()`)
- Conclude that the container status is `"created"`

The external tool then calls `runc start`, and `runc start` begins monitoring the health status of this STAGE_PARENT PID. However, almost simultaneously, `waitForChildExit()` inside `runc create` will reap this PID, causing `runc start` to detect that the "process is dead" and report an error.

**By setting `initProcess` to nil**, the PID written to `state.json` is -1 (a nonexistent process). When an external tool calls `runc state`, it will:

- Read PID -1
- Check `/proc/-1/stat` → does not exist
- `hasInit()` returns false → the container state is determined to be `"stopped"`
- The external tool sees `"stopped"` and continues waiting (it will not call `runc start`)

This continues until `runc create` reaches the `procReady` stage, at which point the actual STAGE_INIT PID has stabilized, and `updateState(p)` overwrites `state.json` with the correct PID, formally transitioning the container to `"created"`.