### PR TITLE
docs: fix typo in CRIU --tcp-established option link text

### DIFF
--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -26,7 +26,7 @@ image files directory.
 
 **--tcp-established**
 : Allow checkpoint/restore of established TCP connections. See
-[criu --tcp-establised option](https://criu.org/CLI/opt/--tcp-established).
+[criu --tcp-established option](https://criu.org/CLI/opt/--tcp-established).
 
 **--tcp-skip-in-flight**
 : Skip in-flight TCP connections. See

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -24,7 +24,7 @@ image files directory.
 
 **--tcp-established**
 : Allow checkpoint/restore of established TCP connections. See
-[criu --tcp-establised option](https://criu.org/CLI/opt/--tcp-established).
+[criu --tcp-established option](https://criu.org/CLI/opt/--tcp-established).
 
 **--ext-unix-sk**
 : Allow checkpoint/restore of external unix sockets. See


### PR DESCRIPTION

**Repo:** opencontainers/runc (⭐ 11000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes a typo in the man pages for `runc checkpoint` and `runc restore`. The link text referenced a non-existent CRIU option `--tcp-establised` (missing an "h"). The URL it pointed to was already correct (`--tcp-established`), so only the visible link text was wrong.

## Why
Consistency between the visible documentation text and the actual CRIU option name avoids confusion for users reading the man pages and trying to look up the corresponding CRIU flag. The runc flag itself is correctly spelled as `--tcp-established` immediately above the link.

## Testing
- `git diff --stat` confirms only the two doc files are modified (2 insertions / 2 deletions).
- `grep -rn "establised" --exclude-dir=vendor` returns no matches after the change.
- Markdown rendering is unaffected — only the link's visible label changed.

## Risk
Low — documentation-only typo fix, no functional changes, no code paths touched.
