### PR TITLE
ci: switch build scripts from wget to curl

### DIFF
--- a/script/build-libpathrs.sh
+++ b/script/build-libpathrs.sh
@@ -75,7 +75,7 @@ function build_libpathrs() {
 	local tar="libpathrs-${ver}.tar.xz"
 
 	# Download, check, and extract.
-	wget "https://github.com/cyphar/libpathrs/releases/download/v${ver}/${tar}"{,.asc}
+	curl -fsSL --remote-name-all "https://github.com/cyphar/libpathrs/releases/download/v${ver}/${tar}"{,.asc}
 	sha256sum --strict --check - <<<"${LIBPATHRS_SHA256[${ver}]} *${tar}"
 
 	local srcdir

--- a/script/build-seccomp.sh
+++ b/script/build-seccomp.sh
@@ -27,7 +27,7 @@ function build_libseccomp() {
 	local tar="libseccomp-${ver}.tar.gz"
 
 	# Download, check, and extract.
-	wget "https://github.com/seccomp/libseccomp/releases/download/v${ver}/${tar}"{,.asc}
+	curl -fsSL --remote-name-all "https://github.com/seccomp/libseccomp/releases/download/v${ver}/${tar}"{,.asc}
 	sha256sum --strict --check - <<<"${SECCOMP_SHA256[${ver}]} *${tar}"
 
 	local srcdir

--- a/script/setup_host.sh
+++ b/script/setup_host.sh
@@ -34,7 +34,7 @@ platform:el9 | platform:el10)
 esac
 
 # Install common packages
-RPMS=(cargo container-selinux fuse-sshfs git-core glibc-static golang iptables jq libseccomp-devel lld make policycoreutils wget)
+RPMS=(cargo container-selinux curl fuse-sshfs git-core glibc-static golang iptables jq libseccomp-devel lld make policycoreutils)
 # Work around dnf mirror failures by retrying a few times.
 for i in $(seq 0 2); do
 	sleep "$i"


### PR DESCRIPTION
## Description

runc's build scripts and Dockerfile use a mix of `wget` (4 sites) and `curl` (8 sites) for HTTPS fetches. Per #5240, standardise on `curl` — it's already used in the majority of sites and is available on both Debian and Fedora base images runc builds against.

## Changes

- **`Dockerfile`** — replace the `wget -nv $CRIU_REPO/Release.key` step with `curl -fsSL`. The `golang:<version>-trixie` base image doesn't ship curl (per @eschmechel's caveat on the issue), so install it and `ca-certificates` via a small dedicated `apt-get install` step before the key fetch. Dropped the now-redundant standalone `curl` from the subsequent package list.
- **`script/build-libpathrs.sh`** and **`script/build-seccomp.sh`** — replace `wget "<url>"{,.asc}` with `curl -fsSLO "<url>"{,.asc}`. Bash brace expansion still yields two separate downloads (of the tarball and its `.asc` signature).
- **`script/setup_host.sh`** — replace `wget` with `curl` in the RPM install list so Fedora hosts get curl installed instead.

After this PR, `grep -r wget script Dockerfile` is empty.

## Testing

- Verified no other `wget` references remain under `script/`, Dockerfiles, or `.github/workflows`.
- `bash -n` parses all three modified shell scripts cleanly.
- Did not run the full CI locally (requires the base image); relying on the workflow to exercise the changed paths.

Closes #5240