### PR TITLE
libcontainer: reuse tmpfs for directory masks

### DIFF
--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -139,7 +139,7 @@ func (e *mountError) Unwrap() error {
 
 // mount is a simple unix.Mount wrapper, returning an error with more context
 // in case it failed.
-func mount(source, target, fstype string, flags uintptr, data string) error {
+func mount(source, target, fstype string, flags uintptr, data string) error { //nolint:unparam // mount(2) wrapper
 	return mountViaFds(source, nil, target, "", fstype, flags, data)
 }
 

--- a/libcontainer/mount_linux.go
+++ b/libcontainer/mount_linux.go
@@ -139,7 +139,7 @@ func (e *mountError) Unwrap() error {
 
 // mount is a simple unix.Mount wrapper, returning an error with more context
 // in case it failed.
-func mount(source, target, fstype string, flags uintptr, data string) error { //nolint:unparam // mount(2) wrapper
+func mount(source, target, fstype string, flags uintptr, data string) error {
 	return mountViaFds(source, nil, target, "", fstype, flags, data)
 }
 

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -419,7 +419,7 @@ func mountCgroupV2(m mountEntry, c *mountConfig) error {
 		// Mask `/sys/fs/cgroup` to ensure it is read-only, even when `/sys` is mounted
 		// with `rbind,ro` (`runc spec --rootless` produces `rbind,ro` for `/sys`).
 		err = utils.WithProcfdFile(m.dstFile, func(procfd string) error {
-			return maskPaths([]string{procfd}, c.label)
+			return maskPaths(c.root, []string{procfd}, c.label)
 		})
 	}
 	return err
@@ -1328,12 +1328,53 @@ func verifyDevNull(f *os.File) error {
 	})
 }
 
+// mountFunc matches mountViaFds.
+type mountFunc func(source string, srcFile *mountSource, target, dstFd, fstype string, flags uintptr, data string) error
+
+// mountFn is the package-level mount implementation; tests override it.
+var mountFn mountFunc = mountViaFds
+
+// isProcFdPath reports whether path is one of the procfs fd aliases runc uses
+// for mount targets. These aliases should not be kept as reusable sources.
+//
+// The accepted forms are (where <pid> and <tid> are decimal integers):
+//
+//	/proc/thread-self/fd/...
+//	/proc/self/fd/...
+//	/proc/<pid>/fd/...
+//	/proc/self/task/<tid>/fd/...
+//	/proc/<pid>/task/<tid>/fd/...
+func isProcFdPath(path string) bool {
+	parts := strings.Split(strings.Trim(pathrs.LexicallyCleanPath(path), "/"), "/")
+	if len(parts) < 3 || parts[0] != "proc" {
+		return false
+	}
+	if parts[1] == "thread-self" {
+		return parts[2] == "fd"
+	}
+	if parts[2] == "fd" && (parts[1] == "self" || isProcID(parts[1])) {
+		return true
+	}
+	if len(parts) < 5 || parts[2] != "task" || parts[4] != "fd" {
+		return false
+	}
+	return isProcID(parts[3]) && (parts[1] == "self" || isProcID(parts[1]))
+}
+
+func isProcID(value string) bool {
+	_, err := strconv.ParseUint(value, 10, 64)
+	return err == nil
+}
+
 // maskPaths masks the top of the specified paths inside a container to avoid
 // security issues from processes reading information from non-namespace aware
 // mounts ( proc/kcore ).
 // For files, maskPath bind mounts /dev/null over the top of the specified path.
-// For directories, maskPath mounts read-only tmpfs over the top of the specified path.
-func maskPaths(paths []string, mountLabel string) error {
+// For directories, maskPath uses a shared read-only tmpfs: the first directory
+// gets a tmpfs mount, and later directories bind-mount the same tmpfs.
+// If the bind-mount of the shared source fails (e.g. due to kernel restrictions),
+// a fresh tmpfs is used for all remaining directories.
+func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 	devNull, err := os.OpenFile("/dev/null", unix.O_PATH, 0)
 	if err != nil {
 		return fmt.Errorf("can't mask paths: %w", err)
@@ -1345,6 +1386,49 @@ func maskPaths(paths []string, mountLabel string) error {
 	devNullSrc := &mountSource{Type: mountSourcePlain, file: devNull}
 	procSelfFd, closer := utils.ProcThreadSelf("fd/")
 	defer closer()
+
+	var (
+		sharedMaskFile *os.File
+		sharedMaskSrc  *mountSource
+		bindFailed     bool
+	)
+	defer func() {
+		if sharedMaskFile != nil {
+			_ = sharedMaskFile.Close()
+		}
+	}()
+	maskedDirs := make(map[string]struct{})
+
+	// maskDir mounts a read-only tmpfs over a directory target, reusing a
+	// shared source via bind-mount where possible.
+	maskDir := func(path, dstFd string, dstFh *os.File) error {
+		if !bindFailed && sharedMaskSrc != nil {
+			err := mountFn("", sharedMaskSrc, path, dstFd, "", unix.MS_BIND, "")
+			if err == nil {
+				return nil
+			}
+			// A bind-mount inherits MNT_READONLY from the source vfsmount,
+			// but if it fails fall back to individual tmpfs mounts.
+			bindFailed = true
+			logrus.WithError(err).Warn("maskPaths: shared tmpfs bind-mount failed, falling back to per-directory tmpfs")
+		}
+		// Fresh tmpfs (first dir, procfd path, or post-bind-failure fallback).
+		if err := mountFn("tmpfs", nil, path, dstFd, "tmpfs", unix.MS_RDONLY,
+			label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel)); err != nil {
+			return err
+		}
+		// Establish this mount as the reusable shared source, but skip
+		// procfs fd aliases because they are not stable rootfs paths.
+		if !bindFailed && sharedMaskSrc == nil && !isProcFdPath(path) {
+			reopened, err := reopenAfterMount(rootFd, dstFh, unix.O_PATH|unix.O_CLOEXEC)
+			if err != nil {
+				return fmt.Errorf("can't reopen shared directory mask: %w", err)
+			}
+			sharedMaskFile = reopened
+			sharedMaskSrc = &mountSource{Type: mountSourcePlain, file: sharedMaskFile}
+		}
+		return nil
+	}
 
 	for _, path := range paths {
 		// Open the target path; skip if it doesn't exist.
@@ -1362,14 +1446,20 @@ func maskPaths(paths []string, mountLabel string) error {
 		}
 		var dstType string
 		if st.IsDir() {
-			// Destination is a directory: bind mount a ro tmpfs over it.
 			dstType = "dir"
-			err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("", mountLabel))
+			cleanPath := pathrs.LexicallyCleanPath(path)
+			if _, ok := maskedDirs[cleanPath]; ok {
+				dstFh.Close()
+				continue
+			}
+			maskedDirs[cleanPath] = struct{}{}
+			dstFd := filepath.Join(procSelfFd, strconv.Itoa(int(dstFh.Fd())))
+			err = maskDir(path, dstFd, dstFh)
 		} else {
 			// Destination is a file: mount it to /dev/null.
 			dstType = "path"
 			dstFd := filepath.Join(procSelfFd, strconv.Itoa(int(dstFh.Fd())))
-			err = mountViaFds("", devNullSrc, path, dstFd, "", unix.MS_BIND, "")
+			err = mountFn("", devNullSrc, path, dstFd, "", unix.MS_BIND, "")
 		}
 		dstFh.Close()
 		if err != nil {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1334,38 +1334,6 @@ type mountFunc func(source string, srcFile *mountSource, target, dstFd, fstype s
 // mountFn is the package-level mount implementation; tests override it.
 var mountFn mountFunc = mountViaFds
 
-// isProcFdPath reports whether path is one of the procfs fd aliases runc uses
-// for mount targets. These aliases should not be kept as reusable sources.
-//
-// The accepted forms are (where <pid> and <tid> are decimal integers):
-//
-//	/proc/thread-self/fd/...
-//	/proc/self/fd/...
-//	/proc/<pid>/fd/...
-//	/proc/self/task/<tid>/fd/...
-//	/proc/<pid>/task/<tid>/fd/...
-func isProcFdPath(path string) bool {
-	parts := strings.Split(strings.Trim(pathrs.LexicallyCleanPath(path), "/"), "/")
-	if len(parts) < 3 || parts[0] != "proc" {
-		return false
-	}
-	if parts[1] == "thread-self" {
-		return parts[2] == "fd"
-	}
-	if parts[2] == "fd" && (parts[1] == "self" || isProcID(parts[1])) {
-		return true
-	}
-	if len(parts) < 5 || parts[2] != "task" || parts[4] != "fd" {
-		return false
-	}
-	return isProcID(parts[3]) && (parts[1] == "self" || isProcID(parts[1]))
-}
-
-func isProcID(value string) bool {
-	_, err := strconv.ParseUint(value, 10, 64)
-	return err == nil
-}
-
 // maskPaths masks the top of the specified paths inside a container to avoid
 // security issues from processes reading information from non-namespace aware
 // mounts ( proc/kcore ).
@@ -1417,9 +1385,11 @@ func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 			label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel)); err != nil {
 			return err
 		}
-		// Establish this mount as the reusable shared source, but skip
-		// procfs fd aliases because they are not stable rootfs paths.
-		if !bindFailed && sharedMaskSrc == nil && !isProcFdPath(path) {
+		// Establish this mount as the reusable shared source. reopenAfterMount
+		// resolves the underlying inode via procfs and re-opens it through
+		// rootFd, so the resulting fd is anchored to the real path inside the
+		// container rootfs even if path was a /proc/self/fd/N alias.
+		if !bindFailed && sharedMaskSrc == nil {
 			reopened, err := reopenAfterMount(rootFd, dstFh, unix.O_PATH|unix.O_CLOEXEC)
 			if err != nil {
 				return fmt.Errorf("can't reopen shared directory mask: %w", err)

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -1,9 +1,13 @@
 package libcontainer
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/utils"
 
 	"golang.org/x/sys/unix"
 )
@@ -206,5 +210,217 @@ func TestNeedsSetupDevStrangeSourceDest(t *testing.T) {
 	}
 	if !needsSetupDev(config) {
 		t.Fatal("expected needsSetupDev to be true, got false")
+	}
+}
+
+type recordedMount struct {
+	source      string
+	srcFileName string
+	srcFileType mountSourceType
+	target      string
+	dstFd       string
+	fstype      string
+	flags       uintptr
+	data        string
+}
+
+func recordMounts(calls *[]recordedMount) mountFunc {
+	return func(source string, srcFile *mountSource, target, dstFd, fstype string, flags uintptr, data string) error {
+		call := recordedMount{
+			source: source,
+			target: target,
+			dstFd:  dstFd,
+			fstype: fstype,
+			flags:  flags,
+			data:   data,
+		}
+		if srcFile != nil {
+			call.srcFileName = srcFile.file.Name()
+			call.srcFileType = srcFile.Type
+		}
+		*calls = append(*calls, call)
+		return nil
+	}
+}
+
+func TestMaskPathsWithSharedDirMask(t *testing.T) {
+	root := t.TempDir()
+	dir1 := filepath.Join(root, "dir1")
+	dir2 := filepath.Join(root, "dir2")
+	file := filepath.Join(root, "file")
+	missing := filepath.Join(root, "missing")
+	rootFd, err := os.OpenFile(root, unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_PATH, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rootFd.Close()
+	for _, dir := range []string{dir1, dir2} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(file, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := mountFn
+	t.Cleanup(func() { mountFn = old })
+	var calls []recordedMount
+	mountLabel := "system_u:object_r:container_file_t:s0"
+	mountFn = recordMounts(&calls)
+	if err := maskPaths(rootFd, []string{
+		missing,
+		dir1,
+		dir2,
+		filepath.Join(dir1, "."),
+		file,
+	}, mountLabel); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 mount calls, got %d: %#v", len(calls), calls)
+	}
+
+	if call := calls[0]; call.source != "tmpfs" || call.fstype != "tmpfs" || call.flags != unix.MS_RDONLY ||
+		call.target != dir1 || call.dstFd == "" || call.data != `nr_blocks=1,nr_inodes=1,context="system_u:object_r:container_file_t:s0"` {
+		t.Fatalf("unexpected shared tmpfs mount call: %#v", call)
+	}
+	if call := calls[1]; call.srcFileType != mountSourcePlain ||
+		call.target != dir2 || call.dstFd == "" || call.fstype != "" || call.flags != unix.MS_BIND || call.data != "" {
+		t.Fatalf("unexpected shared tmpfs bind mount call: %#v", call)
+	}
+	if call := calls[2]; call.srcFileName != "/dev/null" || call.srcFileType != mountSourcePlain ||
+		call.target != file || call.dstFd == "" || call.fstype != "" || call.flags != unix.MS_BIND || call.data != "" {
+		t.Fatalf("unexpected file mask mount call: %#v", call)
+	}
+}
+
+func TestIsProcFdPath(t *testing.T) {
+	for _, path := range []string{
+		"/proc/thread-self/fd/7",
+		"/proc/self/fd/7",
+		"/proc/self/task/123/fd/7",
+		"/proc/self/task/123/fd/../fd/7",
+		"/proc/123/fd/7",
+		"/proc/123/task/456/fd/7",
+	} {
+		if !isProcFdPath(path) {
+			t.Errorf("expected %q to be a procfd path", path)
+		}
+	}
+	for _, path := range []string{
+		"/proc/acpi",
+		"/proc/self/fdinfo/7",
+		"/proc/self/task/123/fdinfo/7",
+		"/proc/self/task/foo/fd/7",
+		"/proc/foo/fd/7",
+		"/proc/123/task/foo/fd/7",
+		"/sys/devices/system/cpu/cpu0/thermal_throttle",
+	} {
+		if isProcFdPath(path) {
+			t.Errorf("expected %q not to be a procfd path", path)
+		}
+	}
+}
+
+func TestMaskPathsDoesNotReuseProcFdMaskAsSharedSource(t *testing.T) {
+	root := t.TempDir()
+	dir1 := filepath.Join(root, "dir1")
+	dir2 := filepath.Join(root, "dir2")
+	dir3 := filepath.Join(root, "dir3")
+	rootFd, err := os.OpenFile(root, unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_PATH, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rootFd.Close()
+	for _, dir := range []string{dir1, dir2, dir3} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir1File, err := os.OpenFile(dir1, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dir1File.Close()
+	procFd, closer := utils.ProcThreadSelfFd(dir1File.Fd())
+	defer closer()
+
+	old := mountFn
+	t.Cleanup(func() { mountFn = old })
+	var calls []recordedMount
+	mountFn = recordMounts(&calls)
+	if err := maskPaths(rootFd, []string{procFd, dir2, dir3}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 mount calls, got %d: %#v", len(calls), calls)
+	}
+	for _, call := range calls[:2] {
+		if call.fstype != "tmpfs" || call.flags != unix.MS_RDONLY {
+			t.Fatalf("expected procfd source to force separate tmpfs mounts, got %#v", calls)
+		}
+	}
+	if call := calls[2]; call.srcFileType != mountSourcePlain ||
+		call.target != dir3 || call.fstype != "" || call.flags != unix.MS_BIND {
+		t.Fatalf("expected third directory to bind mount from second directory, got %#v", call)
+	}
+}
+
+func TestMaskPathsDirBindFallback(t *testing.T) {
+	root := t.TempDir()
+	dir1 := filepath.Join(root, "dir1")
+	dir2 := filepath.Join(root, "dir2")
+	dir3 := filepath.Join(root, "dir3")
+	rootFd, err := os.OpenFile(root, unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_PATH, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rootFd.Close()
+	for _, dir := range []string{dir1, dir2, dir3} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := mountFn
+	t.Cleanup(func() { mountFn = old })
+	var calls []recordedMount
+	base := recordMounts(&calls)
+	mountFn = func(source string, srcFile *mountSource, target, dstFd, fstype string, flags uintptr, data string) error {
+		if err := base(source, srcFile, target, dstFd, fstype, flags, data); err != nil {
+			return err
+		}
+		// Fail bind-mounts of the shared dir source to trigger fallback.
+		if flags&unix.MS_BIND != 0 && srcFile != nil {
+			return errors.New("bind mount not supported")
+		}
+		return nil
+	}
+
+	if err := maskPaths(rootFd, []string{dir1, dir2, dir3}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expected sequence:
+	//   call[0]: tmpfs on dir1 (establishes shared source)
+	//   call[1]: bind on dir2 -> FAILS (triggers bindFailed=true)
+	//   call[2]: tmpfs on dir2 (fallback)
+	//   call[3]: tmpfs on dir3 (bindFailed=true, no bind attempt)
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 mount calls, got %d: %#v", len(calls), calls)
+	}
+	if call := calls[0]; call.fstype != "tmpfs" || call.flags != unix.MS_RDONLY || call.target != dir1 {
+		t.Errorf("call[0]: expected tmpfs on dir1, got %#v", call)
+	}
+	if call := calls[1]; call.flags != unix.MS_BIND || call.srcFileType != mountSourcePlain || call.target != dir2 {
+		t.Errorf("call[1]: expected failed bind attempt on dir2, got %#v", call)
+	}
+	if call := calls[2]; call.fstype != "tmpfs" || call.flags != unix.MS_RDONLY || call.target != dir2 {
+		t.Errorf("call[2]: expected tmpfs fallback on dir2, got %#v", call)
+	}
+	if call := calls[3]; call.fstype != "tmpfs" || call.flags != unix.MS_RDONLY || call.target != dir3 {
+		t.Errorf("call[3]: expected tmpfs on dir3, got %#v", call)
 	}
 }

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/utils"
 
 	"golang.org/x/sys/unix"
 )
@@ -293,78 +292,6 @@ func TestMaskPathsWithSharedDirMask(t *testing.T) {
 	if call := calls[2]; call.srcFileName != "/dev/null" || call.srcFileType != mountSourcePlain ||
 		call.target != file || call.dstFd == "" || call.fstype != "" || call.flags != unix.MS_BIND || call.data != "" {
 		t.Fatalf("unexpected file mask mount call: %#v", call)
-	}
-}
-
-func TestIsProcFdPath(t *testing.T) {
-	for _, path := range []string{
-		"/proc/thread-self/fd/7",
-		"/proc/self/fd/7",
-		"/proc/self/task/123/fd/7",
-		"/proc/self/task/123/fd/../fd/7",
-		"/proc/123/fd/7",
-		"/proc/123/task/456/fd/7",
-	} {
-		if !isProcFdPath(path) {
-			t.Errorf("expected %q to be a procfd path", path)
-		}
-	}
-	for _, path := range []string{
-		"/proc/acpi",
-		"/proc/self/fdinfo/7",
-		"/proc/self/task/123/fdinfo/7",
-		"/proc/self/task/foo/fd/7",
-		"/proc/foo/fd/7",
-		"/proc/123/task/foo/fd/7",
-		"/sys/devices/system/cpu/cpu0/thermal_throttle",
-	} {
-		if isProcFdPath(path) {
-			t.Errorf("expected %q not to be a procfd path", path)
-		}
-	}
-}
-
-func TestMaskPathsDoesNotReuseProcFdMaskAsSharedSource(t *testing.T) {
-	root := t.TempDir()
-	dir1 := filepath.Join(root, "dir1")
-	dir2 := filepath.Join(root, "dir2")
-	dir3 := filepath.Join(root, "dir3")
-	rootFd, err := os.OpenFile(root, unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_PATH, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer rootFd.Close()
-	for _, dir := range []string{dir1, dir2, dir3} {
-		if err := os.Mkdir(dir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	dir1File, err := os.OpenFile(dir1, unix.O_PATH|unix.O_CLOEXEC, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer dir1File.Close()
-	procFd, closer := utils.ProcThreadSelfFd(dir1File.Fd())
-	defer closer()
-
-	old := mountFn
-	t.Cleanup(func() { mountFn = old })
-	var calls []recordedMount
-	mountFn = recordMounts(&calls)
-	if err := maskPaths(rootFd, []string{procFd, dir2, dir3}, ""); err != nil {
-		t.Fatal(err)
-	}
-	if len(calls) != 3 {
-		t.Fatalf("expected 3 mount calls, got %d: %#v", len(calls), calls)
-	}
-	for _, call := range calls[:2] {
-		if call.fstype != "tmpfs" || call.flags != unix.MS_RDONLY {
-			t.Fatalf("expected procfd source to force separate tmpfs mounts, got %#v", calls)
-		}
-	}
-	if call := calls[2]; call.srcFileType != mountSourcePlain ||
-		call.target != dir3 || call.fstype != "" || call.flags != unix.MS_BIND {
-		t.Fatalf("expected third directory to bind mount from second directory, got %#v", call)
 	}
 }
 

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -142,8 +142,16 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 
-	if err := maskPaths(l.config.Config.MaskPaths, l.config.Config.MountLabel); err != nil {
-		return err
+	if len(l.config.Config.MaskPaths) > 0 {
+		rootFd, err := os.OpenFile("/", unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_PATH, 0)
+		if err != nil {
+			return fmt.Errorf("open rootfs handle for masked paths: %w", err)
+		}
+		err = maskPaths(rootFd, l.config.Config.MaskPaths, l.config.Config.MountLabel)
+		rootFd.Close()
+		if err != nil {
+			return err
+		}
 	}
 	pdeath, err := system.GetParentDeathSignal()
 	if err != nil {

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -6,11 +6,11 @@ function setup() {
 	setup_busybox
 
 	# Create fake rootfs.
-	mkdir rootfs/testdir
+	mkdir rootfs/testdir rootfs/testdir2 rootfs/testdir3
 	echo "Forbidden information!" >rootfs/testfile
 
 	# add extra masked paths
-	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir", "/testfile"]'
+	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir", "/testdir2", "/testdir3", "/testfile"]'
 }
 
 function teardown() {
@@ -53,6 +53,34 @@ function teardown() {
 	runc exec test_busybox umount /testdir
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"Operation not permitted"* ]]
+}
+
+@test "mask paths [directories share tmpfs]" {
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	# shellcheck disable=SC2016
+	runc exec test_busybox sh -euc '
+		set -- $(stat -c %d /testdir /testdir2 /testdir3)
+		[ "$1" = "$2" ]
+		[ "$2" = "$3" ]
+	'
+	[ "$status" -eq 0 ]
+
+	runc exec test_busybox touch /testdir2/foo
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"Read-only file system"* ]]
+}
+
+@test "mask paths [directory with read-only rootfs]" {
+	update_config '.root.readonly = true'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	runc exec test_busybox ls /testdir
+	[ "$status" -eq 0 ]
+	[ -z "$output" ]
 }
 
 @test "mask paths [prohibit symlink /proc]" {


### PR DESCRIPTION
Wondering if a problem that showed up recently in k8s when we added more masked paths can be handled better in `runc` itself? please see details below:

Kubernetes may add one sysfs thermal_throttle entry per CPU to maskedPaths. On large Intel systems this can produce many directory masks for a single container. runc currently handles each directory mask with a separate read-only tmpfs mount, and therefore a separate tmpfs superblock.

On Linux 4.18/RHEL 8 kernels, creating and tearing down many tmpfs superblocks can contend on the global shrinker_rwsem when containers start or stop concurrently.

Use one read-only tmpfs for directory masks and bind-mount it over the remaining directory targets. The first non-procfs-fd directory mount is reopened through the container root fd before it is reused. File masks still bind /dev/null, and procfs fd targets keep the existing one-tmpfs-per-target behavior because they are fd aliases rather than stable rootfs paths.

The bind mounts do not create additional tmpfs superblocks. They also retain the read-only mount flag inherited from the source vfsmount, so the masking semantics remain unchanged.

xref: https://github.com/kubernetes/kubernetes/issues/138512
xref: https://github.com/kubernetes/kubernetes/issues/138388
xref: https://github.com/kubernetes/kubernetes/pull/131018

(With some assistance from claude/codex)