### PR TITLE
Fix `runc exec -p` with absent process.env not setting HOME

### DIFF
--- a/libcontainer/env.go
+++ b/libcontainer/env.go
@@ -22,10 +22,7 @@ import (
 //
 // Returns the prepared environment.
 func prepareEnv(env []string, uid int) ([]string, error) {
-	if env == nil {
-		return nil, nil
-	}
-	var homeIsSet bool
+	homeIsSet := false
 
 	// Deduplication code based on dedupEnv from Go 1.22 os/exec.
 

--- a/libcontainer/env_test.go
+++ b/libcontainer/env_test.go
@@ -22,6 +22,10 @@ func TestPrepareEnv(t *testing.T) {
 		env, wantEnv []string
 	}{
 		{
+			env:     nil,
+			wantEnv: []string{home},
+		},
+		{
 			env:     []string{},
 			wantEnv: []string{home},
 		},

--- a/tests/integration/env.bats
+++ b/tests/integration/env.bats
@@ -95,3 +95,34 @@ function teardown() {
 	#
 	[ "$(wc -l <<<"$output")" -eq 4 ]
 }
+
+# Check that runc exec -p process.json takes env from
+# process.json only, not from config.json, and that HOME
+# is always set.
+@test "env [runc exec -p]" {
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	cat <<_EOF_ >process.json
+{
+    "terminal": false,
+    "args": [
+        "/bin/env"
+    ],
+    "cwd": "/",
+    "env": [
+        "FOO=bar"
+    ]
+}
+_EOF_
+
+	runc exec -p process.json test_busybox
+	[ "$status" -eq 0 ]
+	# Env should have entries from process.json.
+	[[ "$output" == *'FOO=bar'* ]]
+	# ...and HOME set from container's /etc/passwd.
+	[[ "$output" == *'HOME=/root'* ]]
+	# Env should NOT contain entries from config.json.
+	[[ "$output" != *'TERM='* ]]
+	[[ "$output" != *'PATH='* ]]
+}

--- a/tests/integration/env.bats
+++ b/tests/integration/env.bats
@@ -126,3 +126,20 @@ _EOF_
 	[[ "$output" != *'TERM='* ]]
 	[[ "$output" != *'PATH='* ]]
 }
+
+@test "env HOME is set for runc exec -p with no process.env" {
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	# "env" is not set.
+	cat <<_EOF_ >process.json
+{
+    "args": ["/bin/env"],
+    "cwd": "/"
+}
+_EOF_
+	runc exec -p process.json test_busybox
+	[ "$status" -eq 0 ]
+	# Env should have HOME set from container's /etc/passwd.
+	[[ "$output" == *'HOME=/root'* ]]
+}

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -100,8 +100,12 @@ function teardown() {
 
 	runc exec --env RUNC_EXEC_TEST=true test_busybox env
 	[ "$status" -eq 0 ]
-
-	[[ ${output} == *"RUNC_EXEC_TEST=true"* ]]
+	[[ "$output" == *"RUNC_EXEC_TEST=true"* ]]
+	# Env should inherit what's in config.json.
+	[[ "$output" == *'PATH='* ]]
+	[[ "$output" == *'TERM='* ]]
+	# Env should have HOME set from container's /etc/passwd.
+	[[ "$output" == *'HOME='* ]]
 }
 
 @test "runc exec --user" {


### PR DESCRIPTION
1. runc exec -p: fix adding HOME to nil env
    
    Before commit 7dc24868, when process.env was nil, prepareEnv
    returned a flag telling HOME is not set, and it was added.
    
    Commit 7dc24868 moved the functionality of adding HOME into
    prepareEnv but did not properly handle nil case. As a result,
    runc exec -p with process.json having no env set resulted in
    an exec with no HOME set.
    
    Fix this, and add unit and integration tests.
    
    Fixes: 7dc24868 ("libct: switch to numeric UID/GID/groups")
    
    Fixes: #5265. 

2. Misc related tests additions (no new issues found).