### PR TITLE
tests/rootless.sh: use command -v instead of which

### DIFF
--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -215,7 +215,7 @@ for ROOTLESS_FEATURES in $features_powerset; do
 			rootless@localhost -- "${ssh_env[@]}" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	else
 		export "${ENV_LIST[@]}"
-		sudo -HE -u rootless PATH="$PATH" "$(which bats)" -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
+		sudo -HE -u rootless PATH="$PATH" "$(command -v bats)" -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	fi
 	cleanup
 done


### PR DESCRIPTION
Apparently, lima's experimental/fedora-rawhide image does not include which rpm, and we don't really want to bother installing it.

Replace "which" with "command -v". Looks like this was the only place; we already use "command -v" everywhere else.

This should fix lima (experimental/fedora-rawhide) CI.

This is an alternative to #5277 