### PR TITLE
[1.3] libct: reuse tmpfs for directory masks

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -400,7 +400,7 @@ func mountCgroupV2(m mountEntry, c *mountConfig) error {
 		// Mask `/sys/fs/cgroup` to ensure it is read-only, even when `/sys` is mounted
 		// with `rbind,ro` (`runc spec --rootless` produces `rbind,ro` for `/sys`).
 		err = utils.WithProcfdFile(m.dstFile, func(procfd string) error {
-			return maskPaths(c.root, []string{procfd}, c.label)
+			return maskDir(procfd, c.label)
 		})
 	}
 	return err
@@ -1335,6 +1335,11 @@ func verifyDevNull(f *os.File) error {
 	})
 }
 
+// maskDir mounts a read-only tmpfs on top of the specified path.
+func maskDir(path, mountLabel string) error {
+	return mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
+}
+
 // maskPaths masks the top of the specified paths inside a container to avoid
 // security issues from processes reading information from non-namespace aware
 // mounts ( proc/kcore ).
@@ -1392,7 +1397,7 @@ func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 				}
 			}
 			if bindFailed || sharedMaskSrc == nil {
-				err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
+				err = maskDir(path, mountLabel)
 				if err == nil && !bindFailed && sharedMaskSrc == nil {
 					// Establish this mount as the reusable shared source. reopenAfterMount
 					// resolves the underlying inode via procfs and re-opens it through

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1345,7 +1345,10 @@ func maskDir(path, mountLabel string) error {
 // mounts ( proc/kcore ).
 // For files, maskPath bind mounts /dev/null over the top of the specified path.
 // For directories, maskPath mounts read-only tmpfs over the top of the specified path.
-func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
+func maskPaths(rootFs string, paths []string, mountLabel string) error {
+	if len(paths) == 0 {
+		return nil
+	}
 	devNull, err := os.OpenFile("/dev/null", unix.O_PATH, 0)
 	if err != nil {
 		return fmt.Errorf("can't mask paths: %w", err)
@@ -1403,7 +1406,7 @@ func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 					// resolves the underlying inode via procfs and re-opens it through
 					// rootFd, so the resulting fd is anchored to the real path inside the
 					// container rootfs even if path was a /proc/self/fd/N alias.
-					reopened, err := reopenAfterMount(rootFd, dstFh, unix.O_PATH|unix.O_CLOEXEC)
+					reopened, err := reopenAfterMount(rootFs, dstFh, unix.O_PATH|unix.O_CLOEXEC)
 					if err != nil {
 						return fmt.Errorf("can't reopen shared directory mask: %w", err)
 					}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -400,7 +400,7 @@ func mountCgroupV2(m mountEntry, c *mountConfig) error {
 		// Mask `/sys/fs/cgroup` to ensure it is read-only, even when `/sys` is mounted
 		// with `rbind,ro` (`runc spec --rootless` produces `rbind,ro` for `/sys`).
 		err = utils.WithProcfdFile(m.dstFile, func(procfd string) error {
-			return maskPaths([]string{procfd}, c.label)
+			return maskPaths(c.root, []string{procfd}, c.label)
 		})
 	}
 	return err
@@ -1340,7 +1340,7 @@ func verifyDevNull(f *os.File) error {
 // mounts ( proc/kcore ).
 // For files, maskPath bind mounts /dev/null over the top of the specified path.
 // For directories, maskPath mounts read-only tmpfs over the top of the specified path.
-func maskPaths(paths []string, mountLabel string) error {
+func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 	devNull, err := os.OpenFile("/dev/null", unix.O_PATH, 0)
 	if err != nil {
 		return fmt.Errorf("can't mask paths: %w", err)
@@ -1353,6 +1353,16 @@ func maskPaths(paths []string, mountLabel string) error {
 	procSelfFd, closer := utils.ProcThreadSelf("fd/")
 	defer closer()
 
+	var (
+		sharedMaskFile *os.File
+		sharedMaskSrc  *mountSource
+		bindFailed     bool
+	)
+	defer func() {
+		if sharedMaskFile != nil {
+			_ = sharedMaskFile.Close()
+		}
+	}()
 	for _, path := range paths {
 		// Open the target path; skip if it doesn't exist.
 		dstFh, err := os.OpenFile(path, unix.O_PATH|unix.O_CLOEXEC, 0)
@@ -1371,7 +1381,31 @@ func maskPaths(paths []string, mountLabel string) error {
 		if st.IsDir() {
 			// Destination is a directory: bind mount a ro tmpfs over it.
 			dstType = "dir"
-			err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
+			if !bindFailed && sharedMaskSrc != nil {
+				dstFd := filepath.Join(procSelfFd, strconv.Itoa(int(dstFh.Fd())))
+				err = mountViaFds("", sharedMaskSrc, path, dstFd, "", unix.MS_BIND, "")
+				if err != nil {
+					// A bind-mount inherits MNT_READONLY from the source vfsmount,
+					// but if it fails fall back to individual tmpfs mounts.
+					bindFailed = true
+					logrus.WithError(err).Warn("maskPaths: shared tmpfs bind-mount failed, falling back to per-directory tmpfs")
+				}
+			}
+			if bindFailed || sharedMaskSrc == nil {
+				err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
+				if err == nil && !bindFailed && sharedMaskSrc == nil {
+					// Establish this mount as the reusable shared source. reopenAfterMount
+					// resolves the underlying inode via procfs and re-opens it through
+					// rootFd, so the resulting fd is anchored to the real path inside the
+					// container rootfs even if path was a /proc/self/fd/N alias.
+					reopened, err := reopenAfterMount(rootFd, dstFh, unix.O_PATH|unix.O_CLOEXEC)
+					if err != nil {
+						return fmt.Errorf("can't reopen shared directory mask: %w", err)
+					}
+					sharedMaskFile = reopened
+					sharedMaskSrc = &mountSource{Type: mountSourcePlain, file: sharedMaskFile}
+				}
+			}
 		} else {
 			// Destination is a file: mount it to /dev/null.
 			dstType = "path"

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1371,7 +1371,7 @@ func maskPaths(paths []string, mountLabel string) error {
 		if st.IsDir() {
 			// Destination is a directory: bind mount a ro tmpfs over it.
 			dstType = "dir"
-			err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("", mountLabel))
+			err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
 		} else {
 			// Destination is a file: mount it to /dev/null.
 			dstType = "path"

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -141,17 +141,10 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 
-	if len(l.config.Config.MaskPaths) > 0 {
-		rootFd, err := os.OpenFile("/", unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_PATH, 0)
-		if err != nil {
-			return fmt.Errorf("open rootfs handle for masked paths: %w", err)
-		}
-		err = maskPaths(rootFd, l.config.Config.MaskPaths, l.config.Config.MountLabel)
-		rootFd.Close()
-		if err != nil {
-			return err
-		}
+	if err := maskPaths("/", l.config.Config.MaskPaths, l.config.Config.MountLabel); err != nil {
+		return err
 	}
+
 	pdeath, err := system.GetParentDeathSignal()
 	if err != nil {
 		return fmt.Errorf("can't get pdeath signal: %w", err)

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -141,8 +141,16 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 
-	if err := maskPaths(l.config.Config.MaskPaths, l.config.Config.MountLabel); err != nil {
-		return err
+	if len(l.config.Config.MaskPaths) > 0 {
+		rootFd, err := os.OpenFile("/", unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_PATH, 0)
+		if err != nil {
+			return fmt.Errorf("open rootfs handle for masked paths: %w", err)
+		}
+		err = maskPaths(rootFd, l.config.Config.MaskPaths, l.config.Config.MountLabel)
+		rootFd.Close()
+		if err != nil {
+			return err
+		}
 	}
 	pdeath, err := system.GetParentDeathSignal()
 	if err != nil {

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -6,7 +6,7 @@ function setup() {
 	setup_busybox
 
 	# Create fake rootfs.
-	mkdir rootfs/testdir
+	mkdir rootfs/testdir rootfs/testdir2 rootfs/testdir3
 	echo "Forbidden information!" >rootfs/testfile
 
 	# add extra masked paths
@@ -74,4 +74,34 @@ function teardown() {
 	# On cgroup v1, this may fail before checking if /sys is a symlink,
 	# so we merely check that it fails, and do not check the exact error
 	# message like for /proc above.
+}
+
+@test "mask paths [directories share tmpfs]" {
+	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir2", "/testdir3"]'
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	# shellcheck disable=SC2016
+	runc exec test_busybox sh -euc '
+		set -- $(stat -c %d /testdir /testdir2 /testdir3)
+		[ "$1" = "$2" ]
+		[ "$2" = "$3" ]
+	'
+	[ "$status" -eq 0 ]
+
+	runc exec test_busybox touch /testdir2/foo
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"Read-only file system"* ]]
+}
+
+@test "mask paths [directory with read-only rootfs]" {
+	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir2", "/testdir3"]'
+	update_config '.root.readonly = true'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	runc exec test_busybox ls /testdir
+	[ "$status" -eq 0 ]
+	[ -z "$output" ]
 }


### PR DESCRIPTION
Backport #5275 and #5285
This is not a clean backport: the first commit from #5275 has been omitted, and the final commit from #5285 has been modified in this PR.
----
This PR carries forward #5262.
----
Wondering if a problem that showed up recently in k8s when we added more masked paths can be handled better in `runc` itself? please see details below:

Kubernetes may add one sysfs thermal_throttle entry per CPU to maskedPaths. On large Intel systems this can produce many directory masks for a single container. runc currently handles each directory mask with a separate read-only tmpfs mount, and therefore a separate tmpfs superblock.

On Linux 4.18/RHEL 8 kernels, creating and tearing down many tmpfs superblocks can contend on the global shrinker_rwsem when containers start or stop concurrently.

Use one read-only tmpfs for directory masks and bind-mount it over the remaining directory targets. The first non-procfs-fd directory mount is reopened through the container root fd before it is reused. File masks still bind /dev/null, and procfs fd targets keep the existing one-tmpfs-per-target behavior because they are fd aliases rather than stable rootfs paths.

The bind mounts do not create additional tmpfs superblocks. They also retain the read-only mount flag inherited from the source vfsmount, so the masking semantics remain unchanged.

xref: https://github.com/kubernetes/kubernetes/issues/138512
xref: https://github.com/kubernetes/kubernetes/issues/138388
xref: https://github.com/kubernetes/kubernetes/pull/131018

(With some assistance from claude/codex)
----
This PR is a follow-up to #5275.

In that change, we started reusing a single tmpfs mount to mask multiple directories. While this optimization works well when masking more than one path, it introduces unnecessary overhead when only a single directory needs to be masked.

This change restores the original behavior for single-path masking while preserving the shared tmpfs logic for multiple paths.