### PR TITLE
libcontainer: assert ST_RDONLY after maskedPaths bind mount (defence-in-depth)

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1379,7 +1379,10 @@ func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 		}
 		maskedPaths[cleanPath] = struct{}{}
 
-		var dstType string
+		var (
+			dstType   string
+			assertRO  bool // verify ST_RDONLY after this mask succeeds
+		)
 		if st.IsDir() {
 			// Destination is a directory: bind mount a ro tmpfs over it.
 			dstType = "dir"
@@ -1391,21 +1394,31 @@ func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 					// but if it fails fall back to individual tmpfs mounts.
 					bindFailed = true
 					logrus.WithError(err).Warn("maskPaths: shared tmpfs bind-mount failed, falling back to per-directory tmpfs")
+				} else {
+					// We rely on MNT_READONLY being inherited from the
+					// MS_RDONLY tmpfs source vfsmount; assert it post-bind
+					// as defence-in-depth in case the kernel ever stops
+					// propagating that flag.
+					assertRO = true
 				}
 			}
 			if bindFailed || sharedMaskSrc == nil {
 				err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
-				if err == nil && !bindFailed && sharedMaskSrc == nil {
-					// Establish this mount as the reusable shared source. reopenAfterMount
-					// resolves the underlying inode via procfs and re-opens it through
-					// rootFd, so the resulting fd is anchored to the real path inside the
-					// container rootfs even if path was a /proc/self/fd/N alias.
-					reopened, err := reopenAfterMount(rootFd, dstFh, unix.O_PATH|unix.O_CLOEXEC)
-					if err != nil {
-						return fmt.Errorf("can't reopen shared directory mask: %w", err)
+				if err == nil {
+					// Per-path tmpfs mount: same belt-and-suspenders check.
+					assertRO = true
+					if !bindFailed && sharedMaskSrc == nil {
+						// Establish this mount as the reusable shared source. reopenAfterMount
+						// resolves the underlying inode via procfs and re-opens it through
+						// rootFd, so the resulting fd is anchored to the real path inside the
+						// container rootfs even if path was a /proc/self/fd/N alias.
+						reopened, err := reopenAfterMount(rootFd, dstFh, unix.O_PATH|unix.O_CLOEXEC)
+						if err != nil {
+							return fmt.Errorf("can't reopen shared directory mask: %w", err)
+						}
+						sharedMaskFile = reopened
+						sharedMaskSrc = &mountSource{Type: mountSourcePlain, file: sharedMaskFile}
 					}
-					sharedMaskFile = reopened
-					sharedMaskSrc = &mountSource{Type: mountSourcePlain, file: sharedMaskFile}
 				}
 			}
 		} else {
@@ -1417,6 +1430,22 @@ func maskPaths(rootFd *os.File, paths []string, mountLabel string) error {
 		dstFh.Close()
 		if err != nil {
 			return fmt.Errorf("can't mask %s %q: %w", dstType, path, err)
+		}
+		if assertRO {
+			// Confirm the freshly-installed directory mask is read-only.
+			// Both the shared-bind and per-path tmpfs paths above derive
+			// their read-only-ness from an MS_RDONLY source, but a future
+			// kernel regression or unexpected mount-propagation interaction
+			// could leave the destination writable, which would silently
+			// undermine the maskedPaths guarantee. Statfs the destination
+			// and refuse to continue if ST_RDONLY is not set.
+			var rost unix.Statfs_t
+			if err := unix.Statfs(path, &rost); err != nil {
+				return fmt.Errorf("can't verify mask read-only state for %q: %w", path, err)
+			}
+			if rost.Flags&unix.ST_RDONLY == 0 {
+				return fmt.Errorf("masked path %q is not read-only after mount (ST_RDONLY not set)", path)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Add a post-bind `ST_RDONLY` assertion on the directory-mask code paths in `maskPaths()` as defence-in-depth.

Today, `maskPaths()` creates a single read-only tmpfs (`unix.MS_RDONLY`) and then reuses it as the bind source for every subsequent directory mask. The destination mounts are read-only purely because the kernel propagates `MNT_READONLY` from the source vfsmount onto each bind-mount. That propagation is an intentional kernel invariant and works today, but it is also the *only* mechanism keeping shared-source masked directories read-only: if it ever regressed, or if a specific destination's mount-propagation interaction silently cleared `MS_RDONLY`, masking would still appear to succeed while leaving the masked tree writable.

This change adds a belt-and-suspenders check: after a successful directory mask (both the shared-bind path and the per-path tmpfs fallback), `statfs` the destination and refuse to continue if `ST_RDONLY` is not set on the resulting mount. The error message names the offending path so any future regression is immediately debuggable.

The file-mask path (`/dev/null` over a regular file) is unaffected — that case doesn't rely on `MS_RDONLY`.

## Why

Consistency with existing patterns in the same file:

- `readonlyPath()` already `statfs`'s after the initial bind and uses the result to drive the remount step.
- `mountEntry.srcStatfs()` exists specifically to cross-check the source's flags.

So we already trust `statfs` as a verification primitive elsewhere. Extending the pattern to `maskPaths()` closes a small but real gap where the read-only guarantee on shared masked directories has no post-condition check.

## Behaviour

- No behaviour change on any currently-supported kernel where bind-mount `MNT_READONLY` inheritance works as documented.
- If the assertion ever fires, the container fails to start with a clear error (`masked path %q is not read-only after mount (ST_RDONLY not set)`) rather than coming up with a writable mask.
- The check is scoped to the directory-mask paths where `MS_RDONLY` is actually expected.

## Test plan

- `go build ./libcontainer/...` — clean.
- `go vet ./libcontainer/...` — clean.
- `go test -short ./libcontainer/` — passes.
- `maskPaths()` requires a real container rootfs / privileged mount namespace and has no existing unit-test scaffolding in `libcontainer/*_test.go`, so this change is exercised end-to-end via the integration suite (`tests/integration`) rather than a new unit test. Happy to add one if maintainers want a specific fixture.

## Risk

Minimal — the assertion only runs on the success path of a directory mask, performs a single `statfs(2)`, and either no-ops (today) or surfaces a previously-silent invariant violation.

Signed-off-by present on the commit (DCO).
