### PR TITLE
runc list: fix error reporting for non-existent root

### DIFF
--- a/list.go
+++ b/list.go
@@ -119,7 +119,7 @@ func getContainers(cmd *cli.Command) ([]containerState, error) {
 	root := cmd.String("root")
 	list, err := os.ReadDir(root)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) && cmd.IsSet("root") {
+		if errors.Is(err, os.ErrNotExist) && !cmd.IsSet("root") {
 			// Ignore non-existing default root directory
 			// (no containers created yet).
 			return nil, nil

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -51,3 +51,15 @@ function teardown() {
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
 }
+
+@test "list with non-existent root fails" {
+	ROOT=/non-existent-dir runc list
+	[ "$status" -ne 0 ]
+}
+
+@test "list with default non-existent root succeeds" {
+	requires root # rootless auto-creates a directory under $XDG_RUNTIME_DIR.
+	test -d /root/runc && skip "requires missing /root/runc"
+	ROOT='' runc list
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
The idea of commit d1fca8e was right (report errors for non-existent root, unless using the default root dir) but the logic was inverted.

Fix the logic.

Fixes: #5203 