### PR TITLE
[1.5] runc list: fix error reporting for non-existent root

### DIFF
--- a/list.go
+++ b/list.go
@@ -114,7 +114,7 @@ func getContainers(context *cli.Context) ([]containerState, error) {
 	root := context.GlobalString("root")
 	list, err := os.ReadDir(root)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) && context.IsSet("root") {
+		if errors.Is(err, os.ErrNotExist) && !context.GlobalIsSet("root") {
 			// Ignore non-existing default root directory
 			// (no containers created yet).
 			return nil, nil

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -51,3 +51,15 @@ function teardown() {
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
 }
+
+@test "list with non-existent root fails" {
+	ROOT=/non-existent-dir runc list
+	[ "$status" -ne 0 ]
+}
+
+@test "list with default non-existent root succeeds" {
+	requires root # rootless auto-creates a directory under $XDG_RUNTIME_DIR.
+	test -d /root/runc && skip "requires missing /root/runc"
+	ROOT='' runc list
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Backport of #5297 to release-1.5 branch.

----

The idea of commit d1fca8e was right (report errors for non-existent root, unless using the default root dir) but the logic was inverted.

Fix the logic.

Test case for default root requires non-existent /root/runc, which is not always possible.

[v1.5 backport: use GlobalIsSet]

