### PR TITLE
chore: fix some typos in comments

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -109,7 +109,7 @@ type Config struct {
 	Umask *uint32 `json:"umask,omitempty"`
 
 	// Readonlyfs will remount the container's rootfs as readonly where only externally mounted
-	// bind mounts are writtable.
+	// bind mounts are writable.
 	Readonlyfs bool `json:"readonlyfs,omitempty"`
 
 	// Specifies the mount propagation flags to be applied to /.

--- a/libcontainer/internal/userns/userns_maps_linux.c
+++ b/libcontainer/internal/userns/userns_maps_linux.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 /*
- * All of the code here is run inside an aync-signal-safe context, so we need
+ * All of the code here is run inside an async-signal-safe context, so we need
  * to be careful to not call any functions that could cause issues. In theory,
  * since we are a Go program, there are fewer restrictions in practice, it's
  * better to be safe than sorry.

--- a/man/runc-checkpoint.8.md
+++ b/man/runc-checkpoint.8.md
@@ -26,7 +26,7 @@ image files directory.
 
 **--tcp-established**
 : Allow checkpoint/restore of established TCP connections. See
-[criu --tcp-establised option](https://criu.org/CLI/opt/--tcp-established).
+[criu --tcp-established option](https://criu.org/CLI/opt/--tcp-established).
 
 **--tcp-skip-in-flight**
 : Skip in-flight TCP connections. See

--- a/man/runc-ps.8.md
+++ b/man/runc-ps.8.md
@@ -19,7 +19,7 @@ column, the result is undefined.
 # OPTIONS
 **--format**|**-f** **table**|**json**
 : Output format. Default is **table**. The **json** format shows a mere array
-of PIDs belonging to a container; if used, all **ps** options are gnored.
+of PIDs belonging to a container; if used, all **ps** options are ignored.
 
 # SEE ALSO
 **runc-list**(8),

--- a/man/runc-restore.8.md
+++ b/man/runc-restore.8.md
@@ -24,7 +24,7 @@ image files directory.
 
 **--tcp-established**
 : Allow checkpoint/restore of established TCP connections. See
-[criu --tcp-establised option](https://criu.org/CLI/opt/--tcp-established).
+[criu --tcp-established option](https://criu.org/CLI/opt/--tcp-established).
 
 **--ext-unix-sk**
 : Allow checkpoint/restore of external unix sockets. See


### PR DESCRIPTION
Just some typos found by https://github.com/crate-ci/typos