### PR TITLE
libcontainer: run restore hooks at post-setup-namespaces

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opencontainers/runc/internal/pathrs"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var criuFeatures *criurpc.CriuFeatures
@@ -1128,14 +1129,26 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 		if err := lockNetwork(c.config); err != nil {
 			return err
 		}
-	case "setup-namespaces":
+	case "post-mount":
+		// Run prestart/createRuntime hooks here. Per the OCI runtime spec,
+		// these hooks fire after the runtime environment has been created
+		// but before pivot_root, with the container in "created" state and
+		// the hook executing in the runtime namespace. post-mount is a proposed new
+		// CRIU notification that exposes that exact lifecycle position
+		// We override the OCI status to "created" because
+		// c.currentOCIState() reads from c.state, which at this point
+		// still holds the pre-restore stoppedState (the transition to
+		// restoredState happens in the post-restore case below). The OCI
+		// lifecycle position when these hooks fire is "created" by
+		// definition, so we report it as such.
 		if c.config.HasHook(configs.Prestart, configs.CreateRuntime) {
+			pid := notify.GetPid()
 			s, err := c.currentOCIState()
 			if err != nil {
-				return nil
+				return err
 			}
-			s.Pid = int(notify.GetPid())
-
+			s.Pid = int(pid)
+			s.Status = specs.StateCreated
 			if err := c.config.Hooks.Run(configs.Prestart, s); err != nil {
 				return err
 			}
@@ -1143,6 +1156,7 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 				return err
 			}
 		}
+
 	case "post-restore":
 		pid := notify.GetPid()
 

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -184,6 +184,73 @@ function simple_cr() {
 	simple_cr
 }
 
+@test "checkpoint and restore [ensure OCI lifecycle contract satisfied for prestart/createruntime hooks]" {
+	# Regression test for https://github.com/opencontainers/runc/issues/5296.
+	#
+	# Per the OCI runtime spec, prestart/createRuntime hooks fire when:
+	#   1. The container's runtime environment has been created (mount
+	#      tree assembled at declared destinations).
+	#   2. pivot_root has NOT yet been executed.
+	#   3. The container is in "created" state (user process not running).
+	#   4. The hook process is in the runtime namespace, not the container's.
+	#   5. The state JSON's bundle path is absolute.
+
+	touch source-marker
+	update_config '.mounts += [{"destination": "/RUNC_5296_BIND_MARKER", "type": "bind", "source": "'"$PWD"'/source-marker", "options": ["bind"]}]'
+
+	cat >"marker-check.sh" <<-'EOF'
+		#!/bin/sh
+		set -e
+		state=$(cat)
+		pid=$(echo "$state" | jq -r .pid)
+		status=$(echo "$state" | jq -r .status)
+		bundle=$(echo "$state" | jq -r .bundle)
+
+		# Contract: 3.container is in "created" state
+		[ "$status" = "created" ] || {
+			echo "expected status=created, got status=$status" >&2
+			exit 1
+		}
+
+		# Contract: 5.bundle path MUST be absolute.
+		case "$bundle" in
+			/*) ;;
+			*) echo "bundle path not absolute: $bundle" >&2; exit 1 ;;
+		esac
+
+		# Contract: 4.hook MUST execute in the runtime namespace
+		for ns in mnt pid net uts ipc cgroup; do
+			h=$(readlink /proc/self/ns/$ns 2>/dev/null || true)
+			c=$(readlink /proc/$pid/ns/$ns 2>/dev/null || true)
+			if [ -n "$h" ] && [ -n "$c" ] && [ "$h" = "$c" ]; then
+				echo "hook running in container's $ns namespace, expected runtime" >&2
+				exit 1
+			fi
+		done
+
+		# Contract: 1.runtime environment is created — mount tree assembled.
+		grep -qE ' /RUNC_5296_BIND_MARKER ' /proc/$pid/mountinfo || {
+			echo "bind mount not found at declared destination in mountinfo" >&2
+			exit 1
+		}
+
+		# Contract: 2.pivot_root has NOT yet been executed.
+		host_root=$(stat -c '%d:%i' /)
+		ctr_root=$(stat -c '%d:%i' /proc/$pid/root/)
+		[ "$host_root" = "$ctr_root" ] || {
+			echo "pivot_root already executed (host=$host_root ctr=$ctr_root)" >&2
+			exit 1
+		}
+	EOF
+	chmod +x marker-check.sh
+
+	for hook in prestart createRuntime; do
+		update_config '.hooks |= {"'$hook'": [{"path": "'"$PWD/marker-check.sh"'"}]}'
+		simple_cr
+		__runc delete -f test_busybox
+	done
+}
+
 @test "checkpoint and restore (bind mount, destination is symlink)" {
 	mkdir -p rootfs/real/conf
 	ln -s /real/conf rootfs/conf


### PR DESCRIPTION
prestart/createRuntime hooks were firing from CRIU's setup-namespaces
notification, before mount tree was restored. Hooks that required mount
tree to be setup (e.g. nvidia-container-runtime-hook) failed.

Move the hook firing to post-restore, so hooks see the fully-restored
mount tree. See commit message for the full technical rationale, in
particular why this fix targets `post-restore` rather than
`post-setup-namespaces`.

## Testing

Added `checkpoint and restore [hooks see restored mount tree]` to
`tests/integration/checkpoint.bats`.

- **Unpatched** (`libcontainer/criu_linux.go` reverted to main): restore
  fails — `error running prestart hook #0: exit status 1`, hook fires at
  setup-namespaces with no mount tree visible.
- **Patched**: 14/14 tests in `checkpoint.bats` pass, including the new one.

Fixes #5296