### PR TITLE
integration: handle silent MAC address assignment failures on Fedora

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -28,7 +28,7 @@ function setup() {
 }
 
 function teardown() {
-	ip link del dev dummy0
+	ip link del dev dummy0 &>/dev/null
 	delete_netns
 	teardown_bundle
 }

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -147,6 +147,7 @@ function simple_cr() {
 	ip link set mtu "$mtu_value" dev dummy0
 	ip link set address "$mac_address" dev dummy0
 	ip address add "$global_ip" dev dummy0
+	ip link set dev dummy0 up
 	# Even when a specific MAC address is explicitly set, Fedora may still randomize it.
 	# Read back the actual address to confirm.
 	mac_address=$(ip link show dummy0 | awk '$1=="link/ether"{print $2}')

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -147,6 +147,9 @@ function simple_cr() {
 	ip link set mtu "$mtu_value" dev dummy0
 	ip link set address "$mac_address" dev dummy0
 	ip address add "$global_ip" dev dummy0
+	# Even when a specific MAC address is explicitly set, Fedora may still randomize it.
+	# Read back the actual address to confirm.
+	mac_address=$(ip link show dummy0 | awk '$1=="link/ether"{print $2}')
 
 	# Tell runc which network namespace to use.
 	create_netns

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -31,7 +31,7 @@ function setup() {
 }
 
 function teardown() {
-	ip link del dev dummy0
+	ip link del dev dummy0 &>/dev/null
 	delete_netns
 	teardown_bundle
 }

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -141,6 +141,9 @@ function teardown() {
 	mac_address="00:11:22:33:44:55"
 	# set a custom mac address to the interface
 	ip link set address "$mac_address" dev dummy0
+	# Even when a specific MAC address is explicitly set, Fedora may still randomize it.
+	# Read back the actual address to confirm.
+	mac_address=$(ip link show dummy0 | awk '$1=="link/ether"{print $2}')
 
 	runc run test_busybox
 	[ "$status" -eq 0 ]
@@ -178,6 +181,9 @@ function teardown() {
 	ip link set address "$mac_address" dev dummy0
 	# Set a custom ip address to the interface.
 	ip address add "$global_ip" dev dummy0
+	# Even when a specific MAC address is explicitly set, Fedora may still randomize it.
+	# Read back the actual address to confirm.
+	mac_address=$(ip link show dummy0 | awk '$1=="link/ether"{print $2}')
 
 	runc run test_busybox
 	[ "$status" -eq 0 ]

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -141,6 +141,7 @@ function teardown() {
 	mac_address="00:11:22:33:44:55"
 	# set a custom mac address to the interface
 	ip link set address "$mac_address" dev dummy0
+	ip link set dev dummy0 up
 	# Even when a specific MAC address is explicitly set, Fedora may still randomize it.
 	# Read back the actual address to confirm.
 	mac_address=$(ip link show dummy0 | awk '$1=="link/ether"{print $2}')
@@ -181,6 +182,7 @@ function teardown() {
 	ip link set address "$mac_address" dev dummy0
 	# Set a custom ip address to the interface.
 	ip address add "$global_ip" dev dummy0
+	ip link set dev dummy0 up
 	# Even when a specific MAC address is explicitly set, Fedora may still randomize it.
 	# Read back the actual address to confirm.
 	mac_address=$(ip link show dummy0 | awk '$1=="link/ether"{print $2}')


### PR DESCRIPTION
Fix #5013 
On Fedora, certain conditions can cause MAC address assignment to fail
without clear indication. To ensure reliability across distributions,
the code now explicitly reads back the MAC address after attempting to
set it and verifies the result.

This PR also refactor the tear down script to reduce unnecessary log when testing net dev:
`Cannot find device "dummy0"`.