### PR TITLE
[1.3] *: fix codespell lint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This release includes a fix for the following low-severity security issue:
   #5253, #5269, #5288)
 
 ### Added ###
-- When masking directories with `maskPaths`, runc will now re-use a single
+- When masking directories with `maskPaths`, runc will now reuse a single
   `tmpfs` instance (which is not writeable) to reduce the number `tmpfs`
   superblocks that need to be reaped when containers die (in particular,
   Kubernetes applies masks to per-CPU sysfs directories which get expensive
@@ -172,7 +172,7 @@ This release includes fixes for the following high-severity security issues:
 > Mr. President, we must not allow a mine shaft gap!
 
 ### Fixed
- * Removed pre-emptive "full access to cgroups" warning when calling `runc
+ * Removed preemptive "full access to cgroups" warning when calling `runc
    pause` or `runc unpause` as an unprivileged user without
    `--systemd-cgroups`. Now the warning is only emitted if an actual permission
    error was encountered. (#4709)
@@ -588,7 +588,7 @@ This release includes fixes for the following high-severity security issues:
    `github.com/checkpoint-restore/go-criu`. (#3652)
  * Add `--pidfd-socket` to `runc run` and `runc exec` to allow for management
    processes to receive a pidfd for the new process, allowing them to avoid pid
-   re-use attacks. (#4045)
+   reuse attacks. (#4045)
 
 [mount_setattr.2]: https://man7.org/linux/man-pages/man2/mount_setattr.2.html
 [cve-2019-5736]: https://github.com/advisories/GHSA-gxmr-w5mj-v8hh

--- a/libcontainer/internal/userns/usernsfd_linux.go
+++ b/libcontainer/internal/userns/usernsfd_linux.go
@@ -61,7 +61,7 @@ type Handles struct {
 
 // Release all resources associated with this Handle. All existing files
 // returned from Get() will continue to work even after calling Release(). The
-// same Handles can be re-used after calling Release().
+// same Handles can be reused after calling Release().
 func (hs *Handles) Release() {
 	hs.m.Lock()
 	defer hs.m.Unlock()

--- a/libcontainer/utils/utils_unix.go
+++ b/libcontainer/utils/utils_unix.go
@@ -113,7 +113,7 @@ func runtime_IsPollDescriptor(fd uintptr) bool //nolint:revive
 //
 // NOTE: That this function is incredibly dangerous to use in most Go code, as
 // closing file descriptors from underneath *os.File handles can lead to very
-// bad behaviour (the closed file descriptor can be re-used and then any
+// bad behaviour (the closed file descriptor can be reused and then any
 // *os.File operations would apply to the wrong file). This function is only
 // intended to be called from the last stage of runc init.
 func UnsafeCloseFrom(minFd int) error {

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -217,7 +217,7 @@ function teardown() {
 	# Also create a network namespace that *is not owned* by the above userns.
 	# NOTE: Having no permissions in a namespaces makes it necessary to modify
 	# the config so that we don't get mount errors (for reference: no netns
-	# permissions == no sysfs mounts, no pidns permissoins == no procfs mounts,
+	# permissions == no sysfs mounts, no pidns permissions == no procfs mounts,
 	# no utsns permissions == no sethostname(2), no ipc permissions == no
 	# mqueue mounts, etc).
 	netns_path="$(mktemp "$BATS_RUN_TMPDIR/netns.XXXXXX")"


### PR DESCRIPTION
For some reason, codespell started flagging older spelling issues in CI
despite being locked to a particular version. In any case, this fixes
them (as well as ones picked up by codespell v2.4, just in case).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>