### PR TITLE
seccomp: ignore unsupported wait-kill flag probe

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -673,7 +673,7 @@ func filterFlags(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (flags 
 		}
 	}
 	if apiLevel >= 7 {
-		if waitKill, err := filter.GetWaitKill(); err != nil {
+		if waitKill, err := filter.GetWaitKill(); err != nil && !errors.Is(err, unix.EINVAL) {
 			return 0, false, fmt.Errorf("unable to fetch SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV bit: %w", err)
 		} else if waitKill {
 			flags |= uint(C.C_FILTER_FLAG_WAIT_KILLABLE_RECV)


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/140039.

The logic here was added in https://github.com/opencontainers/runc/pull/5172/.