### PR TITLE
[release-1.4 backport] libct: Enforce nr_inodes=2 to fix Focal mount errors

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1338,7 +1338,13 @@ func maskDir(path, mountLabel string) error {
 	// "nr_inodes<2", so let's keep `nr_inodes=2` here!
 	// For reference, search for "case Opt_nr_inodes" in:
 	// https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/plain/mm/shmem.c?h=Ubuntu-5.4.0-216.236
-	return mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=2", mountLabel))
+	err := mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=2", mountLabel))
+	// We don't know whether some kernels will fail with "nr_inodes=2",
+	// so let's fall back to mount a tmpfs without this option.
+	if errors.Is(err, unix.EINVAL) {
+		err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1", mountLabel))
+	}
+	return err
 }
 
 // maskPaths masks the top of the specified paths inside a container to avoid

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1333,7 +1333,12 @@ func verifyDevNull(f *os.File) error {
 
 // maskDir mounts a read-only tmpfs on top of the specified path.
 func maskDir(path, mountLabel string) error {
-	return mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
+	// On most kernels `nr_inodes=1` works fine. However, Ubuntu 20.04 (Focal) with
+	// the official 5.4 kernel carries a private patch in mm/shmem.c that rejects
+	// "nr_inodes<2", so let's keep `nr_inodes=2` here!
+	// For reference, search for "case Opt_nr_inodes" in:
+	// https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/plain/mm/shmem.c?h=Ubuntu-5.4.0-216.236
+	return mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=2", mountLabel))
 }
 
 // maskPaths masks the top of the specified paths inside a container to avoid


### PR DESCRIPTION
Backport of #5353 to release-1.4.

Cherry-picked from commits:
- feea25820e019d2073b370f629e15cc9bf8ae281 (libct: Enforce nr_inodes=2 to fix Focal mount errors)
- 79ac57770f9f156d6851fa7f27857cde591d23b4 (libct: add a fallback for nr_inodes=2)