### PR TITLE
[1.5] Fix netdev in CI

### DIFF
--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -24,12 +24,14 @@ function create_netns() {
 }
 
 function delete_netns() {
+	[ -v ns_name ] || return
+
 	# The interface shouldn't be on the host, but if we failed to move it to the container, it
 	# might. Let's delete it if we created one (i.e. if ns_name is defined).
-	[ -v ns_name ] && ip link del dev dummy0 2>/dev/null
+	ip link del dev dummy0 2>/dev/null
 
 	# Delete the namespace only if the ns_name variable is set.
-	[ -v ns_name ] && ip netns del "$ns_name"
+	ip netns del "$ns_name"
 
 	unset ns_name
 	unset ns_path

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -25,6 +25,7 @@ function setup() {
 
 	# Create a dummy interface to move to the container.
 	ip link add dummy0 type dummy
+	udevadm settle
 }
 
 function teardown() {

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -30,6 +30,9 @@ function delete_netns() {
 
 	# Delete the namespace only if the ns_name variable is set.
 	[ -v ns_name ] && ip netns del "$ns_name"
+
+	unset ns_name
+	unset ns_path
 }
 
 function setup() {

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -3,6 +3,17 @@
 load helpers
 
 function create_netns() {
+	mtu_value=1789
+	mac_address="00:11:22:33:44:55"
+	global_ip="169.254.169.77/32"
+
+	# Create a dummy interface to move to the container.
+	# Specify all link-level parameters at creation time, this way it is not created without
+	# those values unassigned and we might race with host's daemons to set them.
+	ip link add dummy0 address "$mac_address" mtu $mtu_value type dummy
+	udevadm settle
+	ip address add "$global_ip" dev dummy0
+
 	# Create a temporary name for the test network namespace.
 	tmp=$(mktemp -u)
 	ns_name=$(basename "$tmp")
@@ -13,6 +24,10 @@ function create_netns() {
 }
 
 function delete_netns() {
+	# The interface shouldn't be on the host, but if we failed to move it to the container, it
+	# might. Let's delete it if we created one (i.e. if ns_name is defined).
+	[ -v ns_name ] && ip link del dev dummy0 2>/dev/null
+
 	# Delete the namespace only if the ns_name variable is set.
 	[ -v ns_name ] && ip netns del "$ns_name"
 }
@@ -22,14 +37,9 @@ function setup() {
 	requires criu root
 
 	setup_busybox
-
-	# Create a dummy interface to move to the container.
-	ip link add dummy0 type dummy
-	udevadm settle
 }
 
 function teardown() {
-	ip link del dev dummy0
 	delete_netns
 	teardown_bundle
 }
@@ -140,15 +150,6 @@ function simple_cr() {
 }
 
 @test "checkpoint and restore with netdevice" {
-	# Set custom parameters to the netdevice to validate those are respected
-	mtu_value=1789
-	mac_address="00:11:22:33:44:55"
-	global_ip="169.254.169.77/32"
-
-	ip link set mtu "$mtu_value" dev dummy0
-	ip link set address "$mac_address" dev dummy0
-	ip address add "$global_ip" dev dummy0
-
 	# Tell runc which network namespace to use.
 	create_netns
 	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -35,7 +35,10 @@ function setup() {
 }
 
 function teardown() {
-	ip link del dev dummy0
+	# The interface might be on the host or not, depending the test. If it's on the host, let's
+	# delete it.
+	ip link del dev dummy0 2>/dev/null
+
 	delete_netns
 	teardown_bundle
 }

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -28,6 +28,7 @@ function setup() {
 
 	# Create a dummy interface to move to the container.
 	ip link add dummy0 type dummy
+	udevadm settle
 }
 
 function teardown() {

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -18,8 +18,10 @@ function setup_netns() {
 }
 
 function delete_netns() {
+	[ -v ns_name ] || return
+
 	# Delete the namespace only if the ns_name variable is set.
-	[ -v ns_name ] && ip netns del "$ns_name"
+	ip netns del "$ns_name"
 
 	unset ns_name
 	unset ns_path

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -20,6 +20,9 @@ function setup_netns() {
 function delete_netns() {
 	# Delete the namespace only if the ns_name variable is set.
 	[ -v ns_name ] && ip netns del "$ns_name"
+
+	unset ns_name
+	unset ns_path
 }
 
 function setup() {

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -252,6 +252,7 @@ function teardown() {
 
 	# Create a dummy interface to move to the container.
 	ip link add dummy0 type dummy
+	udevadm settle
 
 	update_config ' .linux.netDevices |= {"dummy0": {} }
 		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
@@ -269,6 +270,7 @@ function teardown() {
 
 	# Create a dummy interface to move to the container.
 	ip link add dummy0 type dummy
+	udevadm settle
 
 	update_config ' .linux.netDevices |= { "dummy0": { "name" : "ctr_dummy0" } }
 		| .process.args |= ["ip", "address", "show", "dev", "ctr_dummy0"]'


### PR DESCRIPTION
Backport of #5324 for 1.5. Not sure why it wasn't failing before, I_ think it was only rawhide and maybe now the patch landed in another fedora version (it seems 1.5 is using fedora 44 now)?

Anyways, here is the fix.