### PR TITLE
[release-1.4 backport] libct: retry with nr_inodes=2 to fix Focal mount errors

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1333,16 +1333,14 @@ func verifyDevNull(f *os.File) error {
 
 // maskDir mounts a read-only tmpfs on top of the specified path.
 func maskDir(path, mountLabel string) error {
-	// On most kernels `nr_inodes=1` works fine. However, Ubuntu 20.04 (Focal) with
-	// the official 5.4 kernel carries a private patch in mm/shmem.c that rejects
-	// "nr_inodes<2", so let's keep `nr_inodes=2` here!
-	// For reference, search for "case Opt_nr_inodes" in:
-	// https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/plain/mm/shmem.c?h=Ubuntu-5.4.0-216.236
-	err := mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=2", mountLabel))
-	// We don't know whether some kernels will fail with "nr_inodes=2",
-	// so let's fall back to mount a tmpfs without this option.
-	if errors.Is(err, unix.EINVAL) {
-		err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1", mountLabel))
+	err := mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=1", mountLabel))
+	if err != nil {
+		// On most kernels `nr_inodes=1` works fine. However, Ubuntu 20.04 (Focal) with
+		// the official 5.4 kernel carries a private patch in "mm/shmem.c" that rejects
+		// `nr_inodes<2`, so retry with `nr_inodes=2` here.
+		// For reference, search for "case Opt_nr_inodes" in:
+		// https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/plain/mm/shmem.c?h=Ubuntu-5.4.0-216.236
+		err = mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("nr_blocks=1,nr_inodes=2", mountLabel))
 	}
 	return err
 }


### PR DESCRIPTION
Backport of #5358 to release-1.4.

Cherry-picked from commit a5690a084d80b880ccb19592476eb355e1ed08a9.

----
Given that the majority of reviewers favor the 'nr_inodes=2' retry logic, we propose reverting #5353 and implementing the new approach:

On most kernels `nr_inodes=1` works fine. However, Ubuntu 20.04 (Focal) with
the official 5.4 kernel carries a private patch in "mm/shmem.c" that rejects
`nr_inodes<2`, so retry with `nr_inodes=2` here.
For reference, search for "case Opt_nr_inodes" in:
https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/plain/mm/shmem.c?h=Ubuntu-5.4.0-216.236

Fix: #5348 