### PR TITLE
libct: refactor mac labels and sysctl setup

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -24,6 +25,7 @@ import (
 	"github.com/opencontainers/runc/internal/cmsg"
 	"github.com/opencontainers/runc/internal/linux"
 	"github.com/opencontainers/runc/internal/pathrs"
+	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/capabilities"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"
@@ -734,4 +736,26 @@ func setupPidfd(socket *os.File, initType string) error {
 		return fmt.Errorf("failed to send pidfd on socket: %w", err)
 	}
 	return unix.Close(pidFd)
+}
+
+// applyMACLabels configures the SELinux exec label and AppArmor profile to be
+// applied on the next execve.
+func applyMACLabels(config *initConfig) (closer func(), err error) {
+	// initialises the labeling system
+	selinux.GetEnabled()
+
+	if config.ProcessLabel != "" {
+		if err := selinux.SetExecLabel(config.ProcessLabel); err != nil {
+			return nil, fmt.Errorf("can't set process label: %w", err)
+		}
+		closer = func() {
+			selinux.SetExecLabel("") //nolint: errcheck
+		}
+	}
+
+	if err := apparmor.ApplyProfile(config.AppArmorProfile); err != nil {
+		return closer, fmt.Errorf("unable to apply apparmor profile: %w", err)
+	}
+
+	return closer, nil
 }

--- a/libcontainer/setns_init_linux.go
+++ b/libcontainer/setns_init_linux.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/runc/internal/linux"
-	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/keys"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runc/libcontainer/system"
@@ -49,6 +48,14 @@ func (l *linuxSetnsInit) Init() error {
 				return fmt.Errorf("unable to join session keyring: %w", err)
 			}
 		}
+	}
+
+	closer, err := applyMACLabels(l.config)
+	if closer != nil {
+		defer closer()
+	}
+	if err != nil {
+		return err
 	}
 
 	if l.config.CreateConsole {
@@ -98,12 +105,7 @@ func (l *linuxSetnsInit) Init() error {
 	if err := syncParentReady(l.pipe); err != nil {
 		return fmt.Errorf("sync ready: %w", err)
 	}
-	if l.config.ProcessLabel != "" {
-		if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
-			return err
-		}
-		defer selinux.SetExecLabel("") //nolint: errcheck
-	}
+
 	// Without NoNewPrivileges seccomp is a privileged operation, so we need to
 	// do this before dropping capabilities; otherwise do it as late as possible
 	// just before execve so as few syscalls take place after it as possible.
@@ -119,9 +121,7 @@ func (l *linuxSetnsInit) Init() error {
 	if err := finalizeNamespace(l.config); err != nil {
 		return err
 	}
-	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
-		return err
-	}
+
 	// Check for the arg early to make sure it exists.
 	name, err := exec.LookPath(l.config.Args[0])
 	if err != nil {

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -14,7 +14,6 @@ import (
 	"github.com/opencontainers/runc/internal/linux"
 	"github.com/opencontainers/runc/internal/pathrs"
 	"github.com/opencontainers/runc/internal/sys"
-	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/keys"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
@@ -79,6 +78,14 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 
+	closer, err := applyMACLabels(l.config)
+	if closer != nil {
+		defer closer()
+	}
+	if err != nil {
+		return err
+	}
+
 	if err := setupNetwork(l.config); err != nil {
 		return err
 	}
@@ -86,10 +93,7 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
-	// initialises the labeling system
-	selinux.GetEnabled()
-
-	err := prepareRootfs(l.pipe, l.config)
+	err = prepareRootfs(l.pipe, l.config)
 	if err != nil {
 		return err
 	}
@@ -128,9 +132,6 @@ func (l *linuxStandardInit) Init() error {
 		if err := unix.Setdomainname([]byte(domainname)); err != nil {
 			return &os.SyscallError{Syscall: "setdomainname", Err: err}
 		}
-	}
-	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
-		return fmt.Errorf("unable to apply apparmor profile: %w", err)
 	}
 
 	if err := sys.WriteSysctls(l.config.Config.Sysctl); err != nil {
@@ -180,12 +181,6 @@ func (l *linuxStandardInit) Init() error {
 	// write to a socket.
 	if err := syncParentReady(l.pipe); err != nil {
 		return fmt.Errorf("sync ready: %w", err)
-	}
-	if l.config.ProcessLabel != "" {
-		if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
-			return fmt.Errorf("can't set process label: %w", err)
-		}
-		defer selinux.SetExecLabel("") //nolint: errcheck
 	}
 	// Without NoNewPrivileges seccomp is a privileged operation, so we need to
 	// do this before dropping capabilities; otherwise do it as late as possible

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -93,6 +93,10 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 
+	if err := sys.WriteSysctls(l.config.Config.Sysctl); err != nil {
+		return err
+	}
+
 	err = prepareRootfs(l.pipe, l.config)
 	if err != nil {
 		return err
@@ -134,9 +138,6 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 
-	if err := sys.WriteSysctls(l.config.Config.Sysctl); err != nil {
-		return err
-	}
 	for _, path := range l.config.Config.ReadonlyPaths {
 		if err := readonlyPath(path); err != nil {
 			return fmt.Errorf("can't make %q read-only: %w", path, err)


### PR DESCRIPTION
This PR do some refactors:
1. libct: move Selinux/Apparmor setup earlier

    Move SELinux process label and AppArmor profile application into a new
    helper, applyMACLabels, in init_linux.go. This removes duplicated logic
    from standard_init_linux.go and setns_init_linux.go.
    
    The labels are applied earlier in the container init flow, but only
    take effect for the current process after execve, so this has no impact
    on the init process itself.    

2. libct: move sysctl setup earlier
    
    Settings under /proc/sys are mostly tied to namespaces rather than the
    rootfs path, so there is no need to wait until after rootfs setup to
    apply them. Move the sysctl writes to before prepareRootfs so they are
    configured earlier in the init process.