### PR TITLE
refactor: ignore other return values when an error occurs

### DIFF
--- a/libcontainer/seccomp/patchbpf/enosys_linux.go
+++ b/libcontainer/seccomp/patchbpf/enosys_linux.go
@@ -673,8 +673,10 @@ func filterFlags(config *configs.Seccomp, filter *libseccomp.ScmpFilter) (flags 
 		}
 	}
 	if apiLevel >= 7 {
-		if waitKill, err := filter.GetWaitKill(); err != nil && !errors.Is(err, unix.EINVAL) {
-			return 0, false, fmt.Errorf("unable to fetch SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV bit: %w", err)
+		if waitKill, err := filter.GetWaitKill(); err != nil {
+			if !errors.Is(err, unix.EINVAL) {
+				return 0, false, fmt.Errorf("unable to fetch SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV bit: %w", err)
+			}
 		} else if waitKill {
 			flags |= uint(C.C_FILTER_FLAG_WAIT_KILLABLE_RECV)
 		}


### PR DESCRIPTION
we shouldn't trust `waitKill` when we got the error `EINVAL`.

Ref:
https://github.com/opencontainers/runc/pull/5367#issuecomment-4935853198
https://github.com/opencontainers/runc/pull/5367#issuecomment-4935868647