### PR TITLE
libct: fix restored container status on init exit

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -1174,9 +1174,12 @@ func (c *Container) criuNotifications(resp *criurpc.CriuResp, process *Process, 
 			c.config.Namespaces = append(c.config.Namespaces,
 				configs.Namespace{Type: configs.NEWTIME})
 		}
-		if _, err := c.updateState(r); err != nil {
+		state, err := c.updateState(r)
+		if err != nil {
 			return err
 		}
+		// Mirror create: hasInit() needs initProcessStartTime for Status() after restore.
+		c.initProcessStartTime = state.InitProcessStartTime
 		if err := os.Remove(filepath.Join(c.stateDir, "checkpoint")); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				logrus.Error(err)

--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -207,6 +207,8 @@ func (r *restoredState) status() Status {
 func (r *restoredState) transition(s containerState) error {
 	switch s.(type) {
 	case *stoppedState, *runningState:
+		// Update c.state so refreshState can leave restoredState after exit.
+		r.c.state = s
 		return nil
 	}
 	return newStateTransitionError(r, s)

--- a/libcontainer/state_linux_test.go
+++ b/libcontainer/state_linux_test.go
@@ -85,6 +85,34 @@ func TestRestoredStateTransition(t *testing.T) {
 	)
 }
 
+// TestRestoredStateExitedReportsStopped covers the #5370 regression where
+// restoredState.transition accepted stopped/running without updating c.state,
+// so a restored container whose process later exited kept reporting Running.
+func TestRestoredStateExitedReportsStopped(t *testing.T) {
+	c := &Container{}
+	c.state = &restoredState{c: c}
+
+	// refreshState() path when the init process is gone: transition to stopped.
+	if err := c.state.transition(&stoppedState{c: c}); err != nil {
+		t.Fatalf("transition returned error: %v", err)
+	}
+	if got := c.state.status(); got != Stopped {
+		t.Fatalf("restored+exited reports %v, want Stopped", got)
+	}
+}
+
+func TestRunningStateExitedReportsStopped(t *testing.T) {
+	c := &Container{}
+	c.state = &runningState{c: c}
+
+	if err := c.state.transition(&stoppedState{c: c}); err != nil {
+		t.Fatalf("transition returned error: %v", err)
+	}
+	if got := c.state.status(); got != Stopped {
+		t.Fatalf("running+exited reports %v, want Stopped", got)
+	}
+}
+
 func TestRunningStateTransition(t *testing.T) {
 	testTransitions(
 		t,


### PR DESCRIPTION
Fixes #5370.

`restoredState.transition` accepted `stopped`/`running` without assigning `c.state`, so `refreshState` left a restored container stuck reporting `Running` after its init process exited.

With `transition` now updating `c.state`, `Status()`/`refreshState` correctly leave `restoredState` when init is gone. Restore must then also assign `initProcessStartTime` after `updateState`, matching create; otherwise `hasInit()` is false for a live restored process and checkpoint tests see `stopped` immediately.

Adds unit tests covering the transition state assignment for restored and running containers.
