### PR TITLE
ci: add govulncheck job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,11 @@ jobs:
         run: |
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
+  govulncheck:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: golang/govulncheck-action@v1
+
   compile-buildtags:
     runs-on: ubuntu-24.04
     env:
@@ -304,6 +309,7 @@ jobs:
       - conmon
       - deps
       - get-images
+      - govulncheck
       - keyring
       - lint
       - release


### PR DESCRIPTION
This is to ensure our minimal dependencies do not have known vulnerabilities.

NOTES:
 - govulncheck is not and will not be included into golangci-lint, thus a separate job.
 - we do not specify Go version to be used here to avoid reporting vulnerabilities in stdlib which we're not interested in here;
 - this is semi-useless for main branch as our dependencies are kept updated by dependabot. This makes more sense for release-* branches in which we don't routinely bump go deps.