### PR TITLE
ci: replace some third-party actions

### DIFF
--- a/.github/shellcheck-tty.json
+++ b/.github/shellcheck-tty.json
@@ -1,0 +1,24 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "shellcheck-tty",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^In\\s(.+)\\sline\\s(\\d+):$",
+          "file": 1,
+          "line": 2
+        },
+        {
+          "regexp": ".*"
+        },
+        {
+          "regexp": "(SC(\\d+)(\\s\\(\\w+\\))?:\\s.+)$",
+          "message": 1,
+          "code": 2,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -171,27 +171,42 @@ jobs:
   commit:
     permissions:
       contents: read
-      pull-requests: read # Needed by get-pr-commits to list the PR's commits.
+      pull-requests: read # Needed to list the PR's commits.
     runs-on: ubuntu-24.04
     steps:
-      - name: get pr commits
-        if: github.event_name == 'pull_request' # Only check commits on pull requests.
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # v1.3.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: check commit subject line length
+        # Only check commits on pull requests. For other events, the step is
+        # skipped and the job succeeds (so that all-done can succeed, too).
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Save to a file first, so that a gh failure fails the step (rather
+          # than being masked by jq succeeding on empty input).
+          gh api --paginate --slurp \
+            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" \
+            > "$RUNNER_TEMP/commits.json"
 
-      - name: check subject line length
-        if: github.event_name == 'pull_request' # Only check commits on pull requests.
-        uses: tim-actions/commit-message-checker-with-regex@094fc16ff83d04e2ec73edb5eaf6aa267db33791 # v0.3.2
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.{0,72}(\n.*)*$'
-          error: 'Subject too long (max 72)'
+          # A page is an array, and --slurp gives an array of pages, thus
+          # the double iteration. Merge commits are skipped.
+          long=$(jq -r '
+              .[][]
+              | select(.parents | length <= 1)
+              | (.commit.message | split("\n")[0]) as $subject
+              | select(($subject | length) > 72)
+              | "\(.sha[0:12]) \($subject)"
+            ' "$RUNNER_TEMP/commits.json")
 
-      - name: succeed (not a PR) # Allow all-done to succeed for non-PRs.
-        if: github.event_name != 'pull_request'
-        run: echo "Nothing to check here."
+          if [ -z "$long" ]; then
+            echo "All commit subject lines are 72 characters or less."
+            exit 0
+          fi
+
+          while read -r commit; do
+            echo "::error::subject line too long (max 72 characters): $commit"
+          done <<<"$long"
+          exit 1
 
   cfmt:
     runs-on: ubuntu-24.04

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -132,7 +132,9 @@ jobs:
           sudo rm -f /usr/bin/shellcheck
           # Add ~/bin to $PATH.
           echo ~/bin >> "$GITHUB_PATH"
-      - uses: lumaxis/shellcheck-problem-matchers@bf6e0860fd06e4910738c6160dcd2889146ce824 # v2.3.1
+      - name: add problem matcher
+        # Show shellcheck (tty format) findings as annotations.
+        run: echo "::add-matcher::.github/shellcheck-tty.json"
       - name: run
         run: make shellcheck
       - name: check-config.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,7 +110,9 @@ jobs:
           sudo rm -f /usr/bin/shellcheck
           # Add ~/bin to $PATH.
           echo ~/bin >> $GITHUB_PATH
-      - uses: lumaxis/shellcheck-problem-matchers@v2
+      - name: add problem matcher
+        # Show shellcheck (tty format) findings as annotations.
+        run: echo "::add-matcher::.github/shellcheck-tty.json"
       - name: run
         run: make shellcheck
       - name: check-config.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -143,29 +143,27 @@ jobs:
 
 
   commit:
-    permissions:
-      contents: read
-      pull-requests: read
+    # Only check commits on pull requests. For other events, all the steps are
+    # skipped and the job succeeds (so that all-done can succeed, too).
     runs-on: ubuntu-24.04
     steps:
-      - name: get pr commits
-        if: github.event_name == 'pull_request' # Only check commits on pull requests.
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.3.1
+      - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: check subject line length
-        if: github.event_name == 'pull_request' # Only check commits on pull requests.
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.2
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.{0,72}(\n.*)*$'
-          error: 'Subject too long (max 72)'
-
-      - name: succeed (not a PR) # Allow all-done to succeed for non-PRs.
-        if: github.event_name != 'pull_request'
-        run: echo "Nothing to check here."
+          # Only need the PR commits.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ github.event.pull_request.commits }}
+      - name: check commit subject line length
+        if: github.event_name == 'pull_request'
+        run: |
+          # Assign first, so that a git failure fails the step (rather than
+          # being masked by grep finding nothing).
+          subjects=$(git log --format='%s' -${{ github.event.pull_request.commits }})
+          echo "$subjects"
+          if grep -E '.{73,}' <<<"$subjects"; then
+            echo "^^^ subject line(s) too long (max 72 characters), please fix"
+            exit 1
+          fi
 
   cfmt:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Two independent cleanups in the `validate` workflow, each replacing a
third-party action with a few lines in-tree.

## 1. `commit` job: simplify the subject length check

Replace two third-party actions (`tim-actions/get-pr-commits` and
`tim-actions/commit-message-checker-with-regex`) with a few lines of shell
using the GitHub API (based off of https://github.com/moby/moby/pull/53327, thanks @thaJeztah!).
No checkout is needed at all, so no source reaches the runner.

Verified on this PR: the job concludes `success` in 3 steps and ~3s (down
from 5 steps and 4s with a shallow checkout), and a temporary commit with a
100-character subject was flagged (and only that one), exiting 1.

## 2. `shellcheck` job: drop `lumaxis/shellcheck-problem-matchers`

That action does nothing but ship a JSON file and echo an `::add-matcher::`
command, so we now do that ourselves, with the matcher in
`.github/shellcheck-tty.json`.

Its matcher was also only annotating `warning` and `error` findings, for two
reasons: its severity capture group lists `(note|warning|error)`, while
shellcheck severities are `error`, `warning`, `info` and `style`; and the
runner honors only `error`, `warning` and `notice`, silently skipping any
other match (`Runner.Worker/Handlers/OutputManager.cs`). As `info` and
`style` are the bulk of what shellcheck reports, most findings were never
annotated. Ours uses a fixed severity instead (any finding fails the job
anyway) and keeps the severity word in the message.

Verified on a fork PR, on a file with four shellcheck problems (one `info`,
one `style`, two `warning`):

* no matcher at all: no annotations, just the generic "Process completed with
  exit code 2";
* upstream matcher: 2 of 4 annotated;
* this one: all 4, at the right file and line.

Note that the usual gcc-format matchers have the same problem, as `shellcheck
-f gcc` reports both `info` and `style` as `note`, which is not `notice`.
