### PR TITLE
[DNM] ci: add Go 1.27 rc to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.25.x, 1.26.x, 1.27.0-rc.2]
         libpathrs: ["libpathrs", ""]
         rootless: ["rootless", ""]
         race: ["-race", ""]
@@ -39,10 +39,14 @@ jobs:
           - criu: criu-dev
             go-version: 1.25.x
           - criu: criu-dev
+            go-version: 1.27.0-rc.2
+          - criu: criu-dev
             rootless: rootless
           # Do race detection only with latest stable Go version.
           - race: -race
             go-version: 1.25.x
+          - race: -race
+            go-version: 1.27.0-rc.2
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Add `1.27.0-rc.2` (the latest Go 1.27 release candidate) to the CI test matrix, so that any incompatibilities with the upcoming Go release are caught early.

As with earlier release candidates, the expensive `criu-dev` and `-race` jobs are not run with the rc -- those still only run with the latest stable Go.

Primarily meant as a test run to see whether runc is happy with Go 1.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)