### PR TITLE
libct: include MaxCPU in CPU reset mask

### DIFF
--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -202,7 +202,7 @@ func tryResetCPUAffinity(pid int) {
 	// /sys/devices/system/cpu/possible and kernel_max.
 	// Instead, we use a huge buffer similarly to go 1.25 runtime in
 	// getCPUCount().
-	buf := unix.NewCPUSet(configs.MaxCPU)
+	buf := unix.NewCPUSet(configs.MaxCPU + 1)
 	buf.Fill()
 	if err := linux.SchedSetaffinity(pid, buf); err != nil {
 		logrus.WithError(err).Warnf("resetting the CPU affinity of pid %d failed -- the container process may inherit runc's CPU affinity", pid)

--- a/libcontainer/process_linux_test.go
+++ b/libcontainer/process_linux_test.go
@@ -1,0 +1,22 @@
+package libcontainer
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
+)
+
+func TestResetCPUAffinityMaskIncludesMaxCPU(t *testing.T) {
+	mask := unix.NewCPUSet(configs.MaxCPU + 1)
+	mask.Fill()
+
+	for _, cpu := range []int{0, configs.MaxCPU - 1, configs.MaxCPU} {
+		if !mask.IsSet(cpu) {
+			t.Errorf("reset mask does not include accepted CPU ID %d", cpu)
+		}
+	}
+	if mask.IsSet(configs.MaxCPU + 1) {
+		t.Errorf("reset mask unexpectedly includes CPU ID %d above the accepted maximum", configs.MaxCPU+1)
+	}
+}


### PR DESCRIPTION
Fixes an off-by-one in the CPU reset-mask allocation.

`configs.MaxCPU` is an inclusive CPU ID limit, while `unix.NewCPUSet` takes an exclusive upper bound. Using `NewCPUSet(configs.MaxCPU)` therefore omits the highest CPU ID runc accepts.

Allocates `configs.MaxCPU + 1` instead and adds a regression test covering the boundary.

Fixes #5388
