### PR TITLE
libct: fix two CPU mask nits from #5343

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -307,9 +307,10 @@ type CPUAffinity struct {
 	Initial, Final unix.CPUSetDynamic
 }
 
-// MaxCPU is the highest CPU/NUMA node ID that [ToCPUSet] accepts.
-// It is an arbitrary sanity limit, used to avoid allocating
-// an unreasonably large mask for a bogus input.
+// MaxCPU is one past the highest CPU/NUMA node ID that [ToCPUSet] accepts,
+// i.e. the number of CPUs/nodes a mask can represent. It is an arbitrary
+// sanity limit, used to avoid allocating an unreasonably large mask for a
+// bogus input. It is exclusive, to match [unix.NewCPUSet].
 const MaxCPU = 64 * 1024
 
 // ToCPUSet parses a string in list format (e.g. "0-3,5,7-9")
@@ -349,8 +350,8 @@ func cpuStrToRanges(str string) (maxID int, ranges []cpuRange, _ error) {
 		if err != nil {
 			return 0, err
 		}
-		if ret > MaxCPU {
-			return 0, fmt.Errorf("values larger than %d are not supported", MaxCPU)
+		if ret >= MaxCPU {
+			return 0, fmt.Errorf("values larger than %d are not supported", MaxCPU-1)
 		}
 		return int(ret), nil
 	}

--- a/libcontainer/configs/tocpuset_test.go
+++ b/libcontainer/configs/tocpuset_test.go
@@ -59,9 +59,10 @@ func TestToCPUSet(t *testing.T) {
 		{in: "1024", out: set(1024)},
 		{in: "8191", out: set(8191)},
 		{in: "4096-4098", out: set(4096, 4097, 4098)},
-		{in: "0,65536", out: set(0, 65536)},
+		{in: "0,65534", out: set(0, 65534)},
 		// Maximum allowed value.
-		{in: "65536", out: set(65536)},
+		{in: "65535", out: set(65535)},
+		{in: "65532-65535", out: set(65532, 65533, 65534, 65535)},
 
 		// Error cases.
 		{in: "-", isErr: true},
@@ -74,8 +75,8 @@ func TestToCPUSet(t *testing.T) {
 		// Extra spaces inside a range is not OK.
 		{in: "1 - 2", isErr: true},
 		// Larger than the maximum supported value.
-		{in: "65537", isErr: true},
-		{in: "0-65537", isErr: true},
+		{in: "65536", isErr: true},
+		{in: "0-65536", isErr: true},
 	}
 
 	for _, tc := range testCases {

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -491,12 +491,12 @@ func memoryPolicy(config *configs.Config) error {
 	}
 	switch mpol.Mode {
 	case unix.MPOL_DEFAULT, unix.MPOL_LOCAL:
-		if mpol.Nodes != nil && mpol.Nodes.Count() != 0 {
+		if mpol.Nodes.Count() != 0 {
 			return fmt.Errorf("memory policy mode requires 0 nodes but got %d", mpol.Nodes.Count())
 		}
 	case unix.MPOL_BIND, unix.MPOL_INTERLEAVE,
 		unix.MPOL_PREFERRED_MANY, unix.MPOL_WEIGHTED_INTERLEAVE:
-		if mpol.Nodes == nil || mpol.Nodes.Count() == 0 {
+		if mpol.Nodes.Count() == 0 {
 			return fmt.Errorf("memory policy mode requires at least one node but got 0")
 		}
 	case unix.MPOL_PREFERRED:

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -213,7 +213,7 @@ func tryResetCPUAffinity(pid int) {
 // Starts setns process with specified initial CPU affinity.
 func (p *setnsProcess) startWithCPUAffinity() error {
 	aff := p.config.CPUAffinity
-	if aff == nil || aff.Initial == nil {
+	if aff == nil || len(aff.Initial) == 0 {
 		return p.cmd.Start()
 	}
 	errCh := make(chan error)
@@ -242,11 +242,11 @@ func (p *setnsProcess) setFinalCPUAffinity() error {
 	aff := p.config.CPUAffinity
 	// If there was no affinity configured at all, we want to reset
 	// the affinity to make sure we don't inherit an unexpected one.
-	if aff == nil || aff.Final == nil && aff.Initial == nil {
+	if aff == nil || len(aff.Final) == 0 && len(aff.Initial) == 0 {
 		tryResetCPUAffinity(p.pid())
 		return nil
 	}
-	if aff.Final == nil {
+	if len(aff.Final) == 0 {
 		return nil
 	}
 	if err := linux.SchedSetaffinity(p.pid(), aff.Final); err != nil {


### PR DESCRIPTION
Two follow-up fixes to #5343, found while re-reading the CPU mask changes.

## libct: use len() to check for empty CPU masks

When `CPUAffinity.Initial`/`Final` and `LinuxMemoryPolicy.Nodes` were `*unix.CPUSet`, a nil check was a complete "unset" test. As `unix.CPUSetDynamic` (a slice) it no longer is — a non-nil zero-length slice is now representable, and `{"Initial":[]}` in `state.json` unmarshals to exactly that.

Such a value passes the `!= nil` check and reaches `sched_setaffinity(2)` as a NULL pointer with a zero size, which the kernel reads as an empty mask and rejects with `EINVAL`, instead of resetting the affinity as intended.

Only reachable via a hand-edited `state.json` or a libcontainer user setting the field directly, but `len()` is the idiomatic slice check anyway and treats nil and empty alike. Also drops the now-redundant nil guards in the memory policy validator, since `Count()` on a nil slice is already 0.

`setupMemoryPolicy` is deliberately left as is: an empty `Nodes` is legitimate there, as `MPOL_DEFAULT`/`MPOL_LOCAL` want a NULL/zero-size nodemask, and the validator already rejects an empty `Nodes` for the modes that require one.

## libct: make MaxCPU exclusive

`MaxCPU` was documented and enforced as an inclusive bound (the highest ID `ToCPUSet` accepts), while `unix.NewCPUSet` takes an exclusive one. So `tryResetCPUAffinity`'s `NewCPUSet(MaxCPU)` mask was one ID short of what `ToCPUSet` can parse.

Harmless in practice — `sched_setaffinity(2)` truncates the mask to `cpumask_size()`, and no kernel is configured with anywhere near 64K CPUs — but one constant meaning two different things in two files is asking for a real off-by-one later.

Making `MaxCPU` exclusive means `NewCPUSet(MaxCPU)` is correct as written and `ToCPUSet`'s `NewCPUSet(maxID+1)` can never exceed it. This restores the `ret >= max` check and `max-1` wording that predated the constant, and shifts the test boundary cases down by one.

Fixes: #5388
Closes: #5389