### PR TITLE
ci: add scheduled runs for release branches

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,7 +18,7 @@ jobs:
   trigger-workflow:
     strategy:
       matrix:
-        branch: ["main", "release-1.3"]
+        branch: ["main", "release-1.5", "release-1.4", "release-1.3"]
         wf_id: ["validate.yml", "test.yml"]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Somehow we missed adding release-1.4 and release-1.5 branches to scheduled CI runs (added in commit 995a39a4c).

AFAIR this does not need to be backported (scheduled jobs are only run on main branch).