### PR TITLE
[1.4] ci: add govulncheck job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,6 +71,11 @@ jobs:
           go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./...
           git diff --exit-code
 
+  govulncheck:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: golang/govulncheck-action@v1
+
   compile-buildtags:
     runs-on: ubuntu-24.04
     env:
@@ -317,6 +322,7 @@ jobs:
       - conmon
       - deps
       - get-images
+      - govulncheck
       - keyring
       - lint
       - modernize


### PR DESCRIPTION
A backport of #5383 to release-1.4.

This is to ensure our minimal dependencies do not have known vulnerabilities.

NOTES:
 - govulncheck is not and will not be included into golangci-lint, thus a separate job.
 - we do not specify Go version to be used here to avoid reporting vulnerabilities in stdlib which we're not interested in here;
 - this makes more sense for release-* branches (in which we don't routinely bump go deps) than for main.