### PR TITLE
vendor: update moby/sys/userns to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/moby/sys/devices v0.1.0
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/moby/sys/user v0.4.1
-	github.com/moby/sys/userns v0.1.0
+	github.com/moby/sys/userns v0.2.0
 	github.com/mrunalp/fileutils v0.5.1
 	github.com/opencontainers/cgroups v0.0.8
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9Kou
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/user v0.4.1 h1:RgjRlaDKi/Xmyrz4t8lyzXT6v2ooFeO/7xtchmhVWE0=
 github.com/moby/sys/user v0.4.1/go.mod h1:E9QsW5WRe1kUAf7kW8hXKwu1uhsZEAdPLYHYSDudF4Y=
-github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
-github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
+github.com/moby/sys/userns v0.2.0 h1:nEtDtp7NCV/6dutSklNe8FrENPwFdc4mXnZqC/JWgXM=
+github.com/moby/sys/userns v0.2.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/mrunalp/fileutils v0.5.1 h1:F+S7ZlNKnrwHfSwdlgNSkKo67ReVf8o9fel6C3dkm/Q=
 github.com/mrunalp/fileutils v0.5.1/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/cgroups v0.0.8 h1:dQZyCsB73ggKJUzNl4FLbpvArrLv1tLOjMYPHswdUrI=

--- a/vendor/github.com/moby/sys/userns/userns_linux.go
+++ b/vendor/github.com/moby/sys/userns/userns_linux.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"syscall"
 )
+
+// See PROC_USER_INIT_INO in https://github.com/torvalds/linux/blob/v7.1/include/uapi/linux/nsfs.h#L50.
+const procUserInitIno = 0xEFFFFFFD
 
 var inUserNS = sync.OnceValue(runningInUserNS)
 
@@ -17,6 +21,20 @@ var inUserNS = sync.OnceValue(runningInUserNS)
 // [libcontainer/runc]: https://github.com/opencontainers/runc/blob/3778ae603c706494fd1e2c2faf83b406e38d687d/libcontainer/userns/userns_linux.go#L12-L49
 // [lcx/incus]: https://github.com/lxc/incus/blob/e45085dd42f826b3c8c3228e9733c0b6f998eafe/shared/util.go#L678-L700
 func runningInUserNS() bool {
+	var st syscall.Stat_t
+	if err := syscall.Stat("/proc/self/ns/user", &st); err == nil {
+		return st.Ino != procUserInitIno
+	} else if !os.IsNotExist(err) {
+		// As long as /proc/self/ns/user exists, we are on a modern kernel.
+		// Other errors indicate an unexpected procfs state, where assuming the
+		// init namespace would be unsafe.
+		return false
+	}
+
+	// Only fall back for older kernels that do not expose the user namespace
+	// through procfs at /proc/self/ns/user.
+	// TODO: Remove this fallback once Linux kernels older than 3.8 are no
+	// longer supported.
 	file, err := os.Open("/proc/self/uid_map")
 	if err != nil {
 		// This kernel-provided file only exists if user namespaces are supported.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -65,7 +65,7 @@ github.com/moby/sys/mountinfo
 # github.com/moby/sys/user v0.4.1
 ## explicit; go 1.18
 github.com/moby/sys/user
-# github.com/moby/sys/userns v0.1.0
+# github.com/moby/sys/userns v0.2.0
 ## explicit; go 1.21
 github.com/moby/sys/userns
 # github.com/mrunalp/fileutils v0.5.1


### PR DESCRIPTION
updating moby/sys/userns in runc so it can identiofy when its not on the root namespace (includes https://github.com/moby/sys/pull/240 )