### PR TITLE
script: add --retry 5 to curl

### DIFF
--- a/script/build-libpathrs.sh
+++ b/script/build-libpathrs.sh
@@ -75,7 +75,8 @@ function build_libpathrs() {
 	local tar="libpathrs-${ver}.tar.xz"
 
 	# Download, check, and extract.
-	curl -fsSL --remote-name-all "https://github.com/cyphar/libpathrs/releases/download/v${ver}/${tar}"{,.asc}
+	curl -fsSL --retry 5 --remote-name-all \
+		"https://github.com/cyphar/libpathrs/releases/download/v${ver}/${tar}"{,.asc}
 	sha256sum --strict --check - <<<"${LIBPATHRS_SHA256[${ver}]} *${tar}"
 
 	local srcdir

--- a/script/build-seccomp.sh
+++ b/script/build-seccomp.sh
@@ -28,7 +28,8 @@ function build_libseccomp() {
 	local tar="libseccomp-${ver}.tar.gz"
 
 	# Download, check, and extract.
-	curl -fsSL --remote-name-all "https://github.com/seccomp/libseccomp/releases/download/v${ver}/${tar}"{,.asc}
+	curl -fsSL --retry 5 --remote-name-all \
+		"https://github.com/seccomp/libseccomp/releases/download/v${ver}/${tar}"{,.asc}
 	sha256sum --strict --check - <<<"${SECCOMP_SHA256[${ver}]} *${tar}"
 
 	local srcdir


### PR DESCRIPTION
Sometimes github fails with 503 or other transient error code.

In other similar places (`.github/workflows/validate.yml`, `tests/integration/*.sh`)
we already use `curl --retry 5`, so let's add it here to avoid flakes.

Inspired by failures in https://github.com/opencontainers/runc/actions/runs/31610763532/job/94193379709?pr=5396