### PR TITLE
[DO NOT MERGE] vendor: bump opencontainers/cgroups to v0.0.9

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -276,6 +276,11 @@ jobs:
     - name: build runc
       run: make
 
+    - name: Allow userns for runc
+      # https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15
+      run: |
+        sed "s;^profile runc /usr/sbin/;profile runc-test $PWD/;" < /etc/apparmor.d/runc | sudo apparmor_parser
+
     - name: setup bats
       uses: bats-core/bats-action@4.0.0
       with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -295,7 +295,11 @@ jobs:
       with:
         repository: containers/conmon
         path: conmon
-        ref: v2.2.1
+        # XXX: this is conmon main with https://github.com/containers/conmon/pull/668,
+        # which makes the tests fail, rather than silently skip, and fixes a
+        # few other things. Switch to a released version once one is out
+        # (> v2.2.1).
+        ref: 9a6672b20dd63d2907732b380628b675c1008795
 
     - name: build conmon
       run: cd conmon && make

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/moby/sys/user v0.4.1
 	github.com/moby/sys/userns v0.2.0
 	github.com/mrunalp/fileutils v0.5.1
-	github.com/opencontainers/cgroups v0.0.8
+	github.com/opencontainers/cgroups v0.0.9
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/opencontainers/selinux v1.15.1
 	github.com/seccomp/libseccomp-golang v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/moby/sys/userns v0.2.0 h1:nEtDtp7NCV/6dutSklNe8FrENPwFdc4mXnZqC/JWgXM
 github.com/moby/sys/userns v0.2.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/mrunalp/fileutils v0.5.1 h1:F+S7ZlNKnrwHfSwdlgNSkKo67ReVf8o9fel6C3dkm/Q=
 github.com/mrunalp/fileutils v0.5.1/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
-github.com/opencontainers/cgroups v0.0.8 h1:dQZyCsB73ggKJUzNl4FLbpvArrLv1tLOjMYPHswdUrI=
-github.com/opencontainers/cgroups v0.0.8/go.mod h1:hPBRvnBhLZueEN0eJyozMeM3HeFGYlZW9KnO//px6G4=
+github.com/opencontainers/cgroups v0.0.9 h1:zHNGu6y7rGnbm8vqK92ZgOYNARcZ7XvnBobA5BOUkzE=
+github.com/opencontainers/cgroups v0.0.9/go.mod h1:hPBRvnBhLZueEN0eJyozMeM3HeFGYlZW9KnO//px6G4=
 github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5diQ8ibYCRkxg=
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.15.1 h1:ERxeh5caJvCzNAKdI8WQbJmB1LDTn4BuaAg8wihLBpA=

--- a/vendor/github.com/opencontainers/cgroups/.golangci.yml
+++ b/vendor/github.com/opencontainers/cgroups/.golangci.yml
@@ -10,6 +10,8 @@ formatters:
 linters:
   enable:
     - errorlint
+    - govet
+    - modernize
     - nolintlint
     - unconvert
     - unparam

--- a/vendor/github.com/opencontainers/cgroups/devices/ebpf_linux.go
+++ b/vendor/github.com/opencontainers/cgroups/devices/ebpf_linux.go
@@ -23,6 +23,15 @@ func findAttachedCgroupDeviceFilters(dirFd int) (_ []*ebpf.Program, retErr error
 		AttachFlags uint32
 		ProgIds     uint64 // __aligned_u64
 		ProgCnt     uint32
+		// Kernels v6.17+ have a bug: they write the Revision field no matter
+		// what size is provided to bpf(2). This was fixed in kernel v7.2
+		// (commit 21c4b99b27f3). None of the fields below are used here,
+		// but they must be declared to work around the kernel bug.
+		_               uint32 // padding
+		ProgAttachFlags uint64 // __aligned_u64
+		LinkIDs         uint64 // __aligned_u64
+		LinkAttachFlags uint64 // __aligned_u64
+		Revision        uint64
 	}
 
 	// Currently you can only have 64 eBPF programs attached to a cgroup.

--- a/vendor/github.com/opencontainers/cgroups/devices/v2.go
+++ b/vendor/github.com/opencontainers/cgroups/devices/v2.go
@@ -59,7 +59,7 @@ func setV2(dirPath string, r *cgroups.Resources) error {
 	if err != nil {
 		return err
 	}
-	dirFD, err := unix.Open(dirPath, unix.O_DIRECTORY|unix.O_RDONLY, 0o600)
+	dirFD, err := unix.Open(dirPath, unix.O_DIRECTORY|unix.O_RDONLY|unix.O_CLOEXEC, 0o600)
 	if err != nil {
 		return fmt.Errorf("cannot get dir FD for %s", dirPath)
 	}

--- a/vendor/github.com/opencontainers/cgroups/fs/fs.go
+++ b/vendor/github.com/opencontainers/cgroups/fs/fs.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -153,8 +153,9 @@ func (m *Manager) AddPid(subcgroup string, pid int) (retErr error) {
 	c := m.cgroups
 
 	for _, dir := range m.paths {
-		path := path.Join(dir, subcgroup)
-		if !strings.HasPrefix(path, dir) {
+		path := filepath.Join(dir, subcgroup)
+		// Make sure path is either dir itself or below it.
+		if path != dir && !strings.HasPrefix(path, dir+"/") {
 			return fmt.Errorf("bad sub cgroup path: %s", subcgroup)
 		}
 

--- a/vendor/github.com/opencontainers/cgroups/fs2/fs2.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/fs2.go
@@ -89,7 +89,8 @@ func (m *Manager) Apply(pid int) error {
 // a cgroup under under the manager's cgroup.
 func (m *Manager) AddPid(subcgroup string, pid int) error {
 	path := filepath.Join(m.dirPath, subcgroup)
-	if !strings.HasPrefix(path, m.dirPath) {
+	// Make sure path is either m.dirPath itself or below it.
+	if path != m.dirPath && !strings.HasPrefix(path, m.dirPath+"/") {
 		return fmt.Errorf("bad sub cgroup path: %s", subcgroup)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -71,7 +71,7 @@ github.com/moby/sys/userns
 # github.com/mrunalp/fileutils v0.5.1
 ## explicit; go 1.13
 github.com/mrunalp/fileutils
-# github.com/opencontainers/cgroups v0.0.8
+# github.com/opencontainers/cgroups v0.0.9
 ## explicit; go 1.24.0
 github.com/opencontainers/cgroups
 github.com/opencontainers/cgroups/devices


### PR DESCRIPTION
Bump github.com/opencontainers/cgroups to HEAD (`v0.0.9-0.20260813001401-974f3a5079fe`) to test the upcoming v0.0.9 release against runc CI.

Once cgroups v0.0.9 is tagged, this will be redone with the release tag.