### PR TITLE
criu: validate non-regular descriptor files

### DIFF
--- a/libcontainer/criu_linux.go
+++ b/libcontainer/criu_linux.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -108,6 +109,53 @@ func (c *Container) checkCriuVersion(minVersion int) error {
 }
 
 const descriptorsFilename = "descriptors.json"
+
+// maxRegularFileSize bounds reads of checkpoint metadata files, which are
+// expected to be small, so a maliciously large file can not cause unbounded
+// allocations.
+const maxRegularFileSize = 1 << 20 // 1 MiB
+
+// readRegularFileAt opens and reads name (relative to dir), ensuring it is a
+// regular file. Symlinks are rejected rather than followed, and special files
+// such as FIFOs are rejected without blocking (the initial open uses O_PATH,
+// which never blocks, and the fd is reopened only after the file type check,
+// so the checked inode is the one that is read). Reads are limited to
+// maxRegularFileSize.
+func readRegularFileAt(dir *os.File, name string) ([]byte, error) {
+	handle, err := utils.Openat(dir, name, unix.O_PATH|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer handle.Close()
+	path := handle.Name()
+
+	info, err := handle.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	if info.Size() > maxRegularFileSize {
+		return nil, fmt.Errorf("%s exceeds the %d-byte limit", path, maxRegularFileSize)
+	}
+
+	f, err := pathrs.Reopen(handle, unix.O_RDONLY)
+	if err != nil {
+		return nil, fmt.Errorf("reopen %s: %w", path, err)
+	}
+	defer f.Close()
+
+	// Limit the read as well in case the file grew after the stat above.
+	data, err := io.ReadAll(io.LimitReader(f, maxRegularFileSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxRegularFileSize {
+		return nil, fmt.Errorf("%s exceeds the %d-byte limit", path, maxRegularFileSize)
+	}
+	return data, nil
+}
 
 func (c *Container) addCriuDumpMount(req *criurpc.CriuReq, m *configs.Mount) {
 	mountDest := strings.TrimPrefix(m.Destination, c.config.Rootfs)
@@ -785,7 +833,7 @@ func (c *Container) Restore(process *Process, criuOpts *CriuOpts) error {
 		fds    []string
 		fdJSON []byte
 	)
-	if fdJSON, err = os.ReadFile(filepath.Join(criuOpts.ImagesDirectory, descriptorsFilename)); err != nil {
+	if fdJSON, err = readRegularFileAt(imageDir, descriptorsFilename); err != nil {
 		return err
 	}
 

--- a/libcontainer/criu_linux_test.go
+++ b/libcontainer/criu_linux_test.go
@@ -1,0 +1,100 @@
+//go:build !runc_nocriu
+
+package libcontainer
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReadRegularFileAt(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir, err := os.Open(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dir.Close()
+
+	regularName := "regular.json"
+	regularContent := []byte("{}")
+	if err := os.WriteFile(filepath.Join(tmpDir, regularName), regularContent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fifoName := "fifo.json"
+	fifoPath := filepath.Join(tmpDir, fifoName)
+	if err := unix.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkName := "symlink.json"
+	if err := os.Symlink(regularName, filepath.Join(tmpDir, symlinkName)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Mkdir(filepath.Join(tmpDir, "directory.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	oversizedName := "oversized.json"
+	oversized, err := os.Create(filepath.Join(tmpDir, oversizedName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := oversized.Truncate(maxRegularFileSize + 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := oversized.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		file    string
+		want    []byte
+		wantErr bool
+	}{
+		{name: "regular file", file: regularName, want: regularContent},
+		{name: "FIFO", file: fifoName, wantErr: true},
+		{name: "symbolic link", file: symlinkName, wantErr: true},
+		{name: "directory", file: "directory.json", wantErr: true},
+		{name: "oversized file", file: oversizedName, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			type result struct {
+				data []byte
+				err  error
+			}
+			resultCh := make(chan result, 1)
+			go func() {
+				data, err := readRegularFileAt(dir, test.file)
+				resultCh <- result{data: data, err: err}
+			}()
+
+			select {
+			case result := <-resultCh:
+				if test.wantErr {
+					if result.err == nil {
+						t.Fatal("expected an error, got nil")
+					}
+					return
+				}
+				if result.err != nil {
+					t.Fatal(result.err)
+				}
+				if !bytes.Equal(result.data, test.want) {
+					t.Fatalf("expected %q, got %q", test.want, result.data)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("readRegularFileAt blocked")
+			}
+		})
+	}
+}


### PR DESCRIPTION
When restore opens `descriptors.json` from the checkpoint image, a FIFO at this path may block the read indefinitely, so repeated restore attempts can exhaust caller threads in container runtimes. To fix this, we should open this file through the pre-opened image directory with `O_PATH`, verify the inode is a regular file, and reopen that handle for reading. This patch also rejects symlinks and other special files, and limits the read to 1 MiB to prevent unbounded allocations.