### PR TITLE
[1.4] ci: fix conmon job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -318,8 +318,12 @@ jobs:
       run: cd conmon && make
 
     - name: run conmon tests
+      # --strict turns a skipped test into a failure. We do not want any of
+      # these tests to be silently skipped here (that is how the breakage
+      # fixed by #5401 went unnoticed for a while), and none of them are
+      # expected to skip in this environment.
       run: |
-        RUNTIME_BINARY=$(pwd)/runc ./conmon/test/run-tests.sh -j $(nproc)
+        RUNTIME_BINARY=$(pwd)/runc ./conmon/test/run-tests.sh --strict -j $(nproc)
 
   all-done:
     needs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -308,7 +308,11 @@ jobs:
       with:
         repository: containers/conmon
         path: conmon
-        ref: v2.2.1
+        # XXX: this is conmon main with https://github.com/containers/conmon/pull/668,
+        # which makes the tests fail, rather than silently skip, and fixes a
+        # few other things. Switch to a released version once one is out
+        # (> v2.2.1).
+        ref: 9a6672b20dd63d2907732b380628b675c1008795
 
     - name: build conmon
       run: cd conmon && make

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -308,11 +308,11 @@ jobs:
       with:
         repository: containers/conmon
         path: conmon
-        # XXX: this is conmon main with https://github.com/containers/conmon/pull/668,
-        # which makes the tests fail, rather than silently skip, and fixes a
-        # few other things. Switch to a released version once one is out
-        # (> v2.2.1).
-        ref: 9a6672b20dd63d2907732b380628b675c1008795
+        # XXX: this is conmon main, which has a lot of test fixes (including
+        # making the tests fail, rather than silently skip, when the test
+        # image can not be pulled) that are not in any release yet. Switch to
+        # a released version once one is out (> v2.2.1).
+        ref: f4cefcd7a33932131ab1a0130ae0b0175368025a
 
     - name: build conmon
       run: cd conmon && make

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -289,6 +289,11 @@ jobs:
     - name: build runc
       run: make
 
+    - name: Allow userns for runc
+      # https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15
+      run: |
+        sed "s;^profile runc /usr/sbin/;profile runc-test $PWD/;" < /etc/apparmor.d/runc | sudo apparmor_parser
+
     - name: setup bats
       uses: bats-core/bats-action@4.0.0
       with:


### PR DESCRIPTION
Backport of #5401 and #5427 to release-1.4. Original descriptions follow.

----

## #5401

Fixes #5399.

The validate / conmon job was mostly passing only because it failed
to pull an image (due to running a big number of parallel pulls I guess)
and skipped the test. This is being fixed in
https://github.com/containers/conmon/pull/668).

Recently the pull started to succeed sometimes, which resulted in
test being actually run, and fail due to nested userns restriction
in Ubuntu, and the missing fixup for that.

This PR adds the fixup, and uses a fixed conmon tests from
https://github.com/containers/conmon/pull/668. 


----

## #5427

A follow-up to #5401.

**1. Bump conmon to f4cefcd.** The conmon job is still flaky with the conmon commit pinned by #5401 (9a6672b), see e.g.

```
not ok 43 ctr logs: journald with --log-tag
not ok 51 runtime: container execution with multiple log drivers
not ok 106 ctrl: resize the terminal
```
(https://github.com/opencontainers/runc/actions/runs/32771143543/job/97571539739)

```
not ok 45 ctr logs: k8s partial message
```
(https://github.com/opencontainers/runc/actions/runs/32768252319/job/97562527003)

Quite a few conmon test fixes have landed since 9a6672b, so bump the pin to the current conmon main (f4cefcd).

**2. Run the conmon tests in strict mode**, i.e. treat a skipped test as a failure. This is what #5401 was about in the first place: the job was green only because the tests were silently skipping. The current run has 119 tests and zero skips, so this only guards against a future regression.
