### PR TITLE
[1.5] libct/test: Disable GC on test run to catch leaking fds

### DIFF
--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime/debug"
 	"slices"
 	"strconv"
 	"strings"
@@ -1711,8 +1712,13 @@ func testFdLeaks(t *testing.T, systemd bool) {
 	if testing.Short() {
 		return
 	}
-
 	config := newTemplateConfig(t, &tParam{systemd: systemd})
+
+	// Disable GC to prevent finalizers from closing leaked fds
+	// between fdList() and the readlink check below.
+	oldGC := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGC)
+
 	// Run a container once to exclude file descriptors that are only
 	// opened once during the process lifetime by the library and are
 	// never closed. Those are not considered leaks.

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -776,6 +776,7 @@ func TestPassExtraFiles(t *testing.T) {
 		ExtraFiles: []*os.File{pipein1, pipein2},
 		Stdin:      nil,
 		Stdout:     &stdout,
+		Stderr:     new(strings.Builder),
 		Init:       true,
 	}
 	err = container.Run(&process)

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -421,6 +421,7 @@ func TestExecinPassExtraFiles(t *testing.T) {
 		ExtraFiles: []*os.File{pipein1, pipein2},
 		Stdin:      nil,
 		Stdout:     &stdout,
+		Stderr:     new(strings.Builder),
 	}
 	err = container.Run(inprocess)
 	ok(t, err)


### PR DESCRIPTION
Backport of #5243 to release-1.5. Original description follows.

Also picks 905958ea (`tests/int: show stderr if command failed part II`)
from #5256, a follow-up to bf4fcc30 which is already in release-1.5.

----

libct/test: Disable GC on test run to catch leaking fds
    
This test is racy for a long time now. All the logs I could find in CI
seem to be dangling symlinks, like the test shows "23 -> ". This means
the fd was closed before we did the call to readlink().
    
Let's try to disable the GC. This should get rid of the "fds are getting
closed before we read them" part.

Updates: #4297
