### PR TITLE
ci: make scheduled branch matrix dynamic

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,24 +22,68 @@ permissions:
   contents: read
 
 jobs:
+  # Figure out which branches to run CI on. This is the main branch, plus the
+  # three most recent release-X.Y branches (as per the support policy in
+  # RELEASES.md, we maintain latest, latest-1, and latest-2).
+  #
+  # Note this is based on branch existence rather than released versions, so
+  # from the moment a new release branch is created (at rc1, i.e. about two
+  # months before the .0 release) until that release is out, the oldest
+  # supported branch (latest-2) is not covered here. This is deliberate:
+  # testing the upcoming release is more valuable, and the branch in question
+  # is still tested on every PR and via workflow_dispatch.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.branches.outputs.result }}
+    steps:
+      - name: Find branches to test
+        id: branches
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          result-encoding: string
+          script: |
+            const re = /^release-(\d+)\.(\d+)$/;
+            const all = await github.paginate(github.rest.repos.listBranches, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const rel = all
+              .map((b) => b.name.match(re))
+              .filter((m) => m !== null)
+              .sort((a, b) => b[1] - a[1] || b[2] - a[2])
+              .slice(0, 3)
+              .map((m) => m[0]);
+            if (rel.length === 0) {
+              core.setFailed('No release-X.Y branches found.');
+            }
+            const branches = ['main', ...rel];
+            core.info(`Branches to test: ${branches.join(' ')}`);
+            return JSON.stringify(branches);
+
   trigger-workflow:
+    needs: prepare
     permissions:
       contents: read
       actions: write # Needed to trigger other workflows.
     strategy:
       matrix:
-        branch: ["main", "release-1.5", "release-1.4", "release-1.3"]
+        branch: ${{ fromJSON(needs.prepare.outputs.branches) }}
         wf_id: ["validate.yml", "test.yml"]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger ${{ matrix.wf_id }} workflow on ${{ matrix.branch}} branch
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          WF_ID: ${{ matrix.wf_id }}
+          BRANCH: ${{ matrix.branch }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: '${{ matrix.wf_id }}',
-              ref: '${{ matrix.branch }}'
+              workflow_id: process.env.WF_ID,
+              ref: process.env.BRANCH
             });


### PR DESCRIPTION
Follow-up to #5393 ([review comment](https://github.com/opencontainers/runc/pull/5393#discussion_r3771981868)).

The list of branches to run periodical CI on was hardcoded, meaning it had to be manually updated on every minor release (add the new release branch, drop the one that falls out of support per RELEASES.md), and would silently keep testing unsupported branches if we forgot.

Instead, a `prepare` job lists the repo branches via the API and picks the three most recent `release-X.Y` ones (`latest`, `latest-1`, `latest-2`), plus `main`, feeding them into the matrix via `fromJSON`.

Running the same selection logic against the current branch list of this repo yields `["main", "release-1.5", "release-1.4", "release-1.3"]`, i.e. exactly the list that was hardcoded before, so there is no behavior change today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)