### PR TITLE
tests/fuzzing: remove user fuzzer package path

### DIFF
--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -8,5 +8,4 @@
 # OSS-fuzz environment.
 # More info about compile_go_fuzzer() can be found here:
 #     https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
-compile_go_fuzzer github.com/opencontainers/runc/libcontainer/user FuzzUser user_fuzzer
 compile_go_fuzzer github.com/opencontainers/runc/libcontainer/configs FuzzUnmarshalJSON configs_fuzzer


### PR DESCRIPTION
The `user` package was moved from
`github.com/opencontainers/runc/libcontainer/user` to the separate
`github.com/moby/sys/user` module.

The runc OSS-Fuzz build script still attempted to build a `FuzzUser` target
for the old package path. Since `github.com/moby/sys/user` is maintained as a
separate module, this fuzz target should not be built as part of runc.

This change removes the obsolete `FuzzUser` build target from
`tests/fuzzing/oss_fuzz_build.sh`.

The remaining runc fuzz targets are unchanged.