### PR TITLE
libct/seccomp: use errors.AsType

### DIFF
--- a/libcontainer/seccomp/seccomp_linux.go
+++ b/libcontainer/seccomp/seccomp_linux.go
@@ -180,15 +180,13 @@ func FlagSupported(flag specs.LinuxSeccompFlag) error {
 	err := setFlag(filter, flag)
 
 	// For flags we don't know, setFlag returns unknownFlagError.
-	var uf *unknownFlagError
-	if errors.As(err, &uf) {
+	if _, ok := errors.AsType[*unknownFlagError](err); ok {
 		return err
 	}
 	// For flags that are known to runc and libseccomp-golang but can not
 	// be applied because either libseccomp or the kernel is too old,
 	// seccomp.VersionError is returned.
-	var verErr *libseccomp.VersionError
-	if errors.As(err, &verErr) {
+	if _, ok := errors.AsType[*libseccomp.VersionError](err); ok {
 		// Not supported by libseccomp or the kernel.
 		return err
 	}


### PR DESCRIPTION
Follow up to PR #5413.

Commit 70e2e30a1 somehow missed this one place in `libcontainer/seccomp`; convert the remaining `errors.As` calls to `errors.AsType`.