### PR TITLE
tests/int: revamp (drop `runc()`, use `run -N`, add asserts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ integration: runcimage
 
 .PHONY: localintegration
 localintegration: runc test-binaries
-	bats -t tests/integration$(TESTPATH)
+	bats -t --print-output-on-failure tests/integration$(TESTPATH)
 
 .PHONY: rootlessintegration
 rootlessintegration: runcimage

--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,8 @@ cfmt:
 .PHONY: shellcheck
 shellcheck:
 	shellcheck tests/integration/*.bats tests/integration/*.sh \
-		tests/integration/*.bash tests/integration/bin/* tests/*.sh \
-		man/*.sh script/*
+		tests/integration/*.bash tests/integration/lib/*.bash \
+		tests/integration/bin/* tests/*.sh man/*.sh script/*
 	# TODO: add shellcheck for more sh files (contrib/completions/bash/runc).
 
 .PHONY: shfmt

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ cfmt:
 .PHONY: shellcheck
 shellcheck:
 	shellcheck tests/integration/*.bats tests/integration/*.sh \
-		tests/integration/*.bash tests/*.sh \
+		tests/integration/*.bash tests/integration/bin/* tests/*.sh \
 		man/*.sh script/*
 	# TODO: add shellcheck for more sh files (contrib/completions/bash/runc).
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -50,4 +50,35 @@ cd bats-core
 [Helper functions](https://github.com/opencontainers/runc/blob/master/tests/integration/helpers.bash)
 are provided in order to facilitate writing tests.
 
+Call runc (and any other command) via bats' `run` helper, giving the expected
+exit code, and check its output with the assertion helpers:
+
+```bash
+run -0 runc list -q
+assert_line --index 0 "test_box1"
+
+run ! runc state test_busybox
+assert_output --partial "does not exist"
+```
+
+The `-N` argument to `run` makes bats fail the test unless the command exits
+with code N, and `run !` unless it fails with any non-zero code. Use `run -0`
+for a command that has to succeed; a bare `run` accepts any exit code, so use
+it only where the exit code is genuinely irrelevant.
+
+The available assertions, a subset of the
+[bats-assert](https://github.com/bats-core/bats-assert) API implemented in
+[lib/assert.bash](https://github.com/opencontainers/runc/blob/master/tests/integration/lib/assert.bash),
+are:
+
+```bash
+assert_output [--partial | --regexp] EXPECTED
+refute_output [--partial | --regexp] UNEXPECTED
+assert_line --index IDX [--partial | --regexp] EXPECTED
+```
+
+Prefer these over `[ ... ]` or `[[ ... ]]` comparisons: when an assertion
+fails, the test log shows both the expected and the actual value, while a bare
+test expression only shows the expression itself.
+
 Please see existing tests for examples.

--- a/tests/integration/apparmor.bats
+++ b/tests/integration/apparmor.bats
@@ -14,5 +14,5 @@ function teardown() {
 @test "runc run [unloaded apparmor profile]" {
 	update_config '	  .process.apparmorProfile = "runc-test-definitely-not-loaded"'
 	run ! runc run test_apparmor
-	[[ "$output" == *"apparmor profile "*"runc-test-definitely-not-loaded"*"profile not loaded"* ]]
+	assert_output --regexp 'apparmor profile .*runc-test-definitely-not-loaded.*profile not loaded'
 }

--- a/tests/integration/apparmor.bats
+++ b/tests/integration/apparmor.bats
@@ -13,7 +13,6 @@ function teardown() {
 
 @test "runc run [unloaded apparmor profile]" {
 	update_config '	  .process.apparmorProfile = "runc-test-definitely-not-loaded"'
-	runc run test_apparmor
-	[ "$status" -ne 0 ]
+	run ! runc run test_apparmor
 	[[ "$output" == *"apparmor profile "*"runc-test-definitely-not-loaded"*"profile not loaded"* ]]
 }

--- a/tests/integration/bin/runc
+++ b/tests/integration/bin/runc
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Wrapper for the runc binary under test.
+#
+# It adds the flags every test invocation needs, and, unlike a shell function,
+# can be used from bats' run helper, as well as after commands that require a
+# real binary, such as taskset or timeout.
+#
+# The directory containing this script is prepended to PATH by helpers.bash,
+# which also exports the variables used below.
+
+set -u
+
+opts=()
+[ -v RUNC_USE_SYSTEMD ] && opts+=("--systemd-cgroup")
+[ -n "${ROOT:-}" ] && opts+=("--root" "$ROOT/state")
+
+exec "$RUNC" "${opts[@]}" "$@"

--- a/tests/integration/capabilities.bats
+++ b/tests/integration/capabilities.bats
@@ -14,18 +14,18 @@ function teardown() {
 @test "runc run no capability" {
 	run -0 runc run test_no_caps
 
-	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
-	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
-	[[ "${output}" == *"NoNewPrivs:	1"* ]]
+	assert_output --partial "CapInh:	0000000000000000"
+	assert_output --partial "CapAmb:	0000000000000000"
+	assert_output --partial "NoNewPrivs:	1"
 }
 
 @test "runc run with unknown capability" {
 	update_config '.process.capabilities.bounding = ["CAP_UNKNOWN", "UNKNOWN_CAP"]'
 	run -0 runc run test_unknown_caps
 
-	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
-	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
-	[[ "${output}" == *"NoNewPrivs:	1"* ]]
+	assert_output --partial "CapInh:	0000000000000000"
+	assert_output --partial "CapAmb:	0000000000000000"
+	assert_output --partial "NoNewPrivs:	1"
 }
 
 @test "runc run with new privileges" {
@@ -35,9 +35,9 @@ function teardown() {
 	update_config '.process.noNewPrivileges = false'
 	run -0 runc run test_new_privileges
 
-	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
-	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
-	[[ "${output}" == *"NoNewPrivs:	0"* ]]
+	assert_output --partial "CapInh:	0000000000000000"
+	assert_output --partial "CapAmb:	0000000000000000"
+	assert_output --partial "NoNewPrivs:	0"
 }
 
 @test "runc run with some capabilities" {
@@ -46,11 +46,11 @@ function teardown() {
 	update_config '.process.capabilities.permitted = ["CAP_SYS_ADMIN", "CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"]'
 	run -0 runc run test_some_caps
 
-	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
-	[[ "${output}" == *"CapBnd:	0000000000200000"* ]]
-	[[ "${output}" == *"CapEff:	0000000000200000"* ]]
-	[[ "${output}" == *"CapPrm:	0000000000200000"* ]]
-	[[ "${output}" == *"NoNewPrivs:	1"* ]]
+	assert_output --partial "CapInh:	0000000000000000"
+	assert_output --partial "CapBnd:	0000000000200000"
+	assert_output --partial "CapEff:	0000000000200000"
+	assert_output --partial "CapPrm:	0000000000200000"
+	assert_output --partial "NoNewPrivs:	1"
 }
 
 @test "runc exec --cap" {
@@ -60,11 +60,11 @@ function teardown() {
 
 	run -0 runc exec test_exec_cap cat /proc/self/status
 	# Check no capabilities are set.
-	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
-	[[ "${output}" == *"CapPrm:	0000000000000000"* ]]
-	[[ "${output}" == *"CapEff:	0000000000000000"* ]]
-	[[ "${output}" == *"CapBnd:	0000000000000000"* ]]
-	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
+	assert_output --partial "CapInh:	0000000000000000"
+	assert_output --partial "CapPrm:	0000000000000000"
+	assert_output --partial "CapEff:	0000000000000000"
+	assert_output --partial "CapBnd:	0000000000000000"
+	assert_output --partial "CapAmb:	0000000000000000"
 
 	run -0 runc exec --cap CAP_KILL --cap CAP_AUDIT_WRITE test_exec_cap cat /proc/self/status
 	# Check capabilities are added into bounding/effective/permitted only,
@@ -72,11 +72,11 @@ function teardown() {
 	#
 	# CAP_KILL is 5, the bit mask is 0x20 (1 << 5).
 	# CAP_AUDIT_WRITE is 26, the bit mask is 0x20000000 (1 << 26).
-	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
-	[[ "${output}" == *"CapPrm:	0000000020000020"* ]]
-	[[ "${output}" == *"CapEff:	0000000020000020"* ]]
-	[[ "${output}" == *"CapBnd:	0000000020000020"* ]]
-	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
+	assert_output --partial "CapInh:	0000000000000000"
+	assert_output --partial "CapPrm:	0000000020000020"
+	assert_output --partial "CapEff:	0000000020000020"
+	assert_output --partial "CapBnd:	0000000020000020"
+	assert_output --partial "CapAmb:	0000000000000000"
 }
 
 @test "runc exec --cap [ambient is set from spec]" {
@@ -94,20 +94,20 @@ function teardown() {
 	# CAP_CHOWN is 0, the bit mask is 0x1 (1 << 0)
 	# CAP_KILL is 5, the bit mask is 0x20 (1 << 5).
 	# CAP_SYSLOG is 34, the bit mask is 0x400000000 (1 << 34).
-	[[ "${output}" == *"CapInh:	0000000400000001"* ]]
-	[[ "${output}" == *"CapPrm:	0000000000000021"* ]]
-	[[ "${output}" == *"CapEff:	0000000000000021"* ]]
-	[[ "${output}" == *"CapBnd:	0000000400000021"* ]]
-	[[ "${output}" == *"CapAmb:	0000000000000001"* ]]
+	assert_output --partial "CapInh:	0000000400000001"
+	assert_output --partial "CapPrm:	0000000000000021"
+	assert_output --partial "CapEff:	0000000000000021"
+	assert_output --partial "CapBnd:	0000000400000021"
+	assert_output --partial "CapAmb:	0000000000000001"
 
 	# Check that if config.json has an inheritable capability set,
 	# runc exec --cap adds ambient capabilities.
 	run -0 runc exec --cap CAP_SYSLOG test_some_caps cat /proc/self/status
-	[[ "${output}" == *"CapInh:	0000000400000001"* ]]
-	[[ "${output}" == *"CapPrm:	0000000400000021"* ]]
-	[[ "${output}" == *"CapEff:	0000000400000021"* ]]
-	[[ "${output}" == *"CapBnd:	0000000400000021"* ]]
-	[[ "${output}" == *"CapAmb:	0000000400000001"* ]]
+	assert_output --partial "CapInh:	0000000400000001"
+	assert_output --partial "CapPrm:	0000000400000021"
+	assert_output --partial "CapEff:	0000000400000021"
+	assert_output --partial "CapBnd:	0000000400000021"
+	assert_output --partial "CapAmb:	0000000400000001"
 }
 
 @test "runc run [ambient caps not set in inheritable result in a warning]" {
@@ -119,6 +119,6 @@ function teardown() {
 	#
 	# CAP_CHOWN is 0, the bit mask is 0x1 (1 << 0)
 	# CAP_KILL is 5, the bit mask is 0x20 (1 << 5).
-	[[ "$output" == *"can't raise ambient capability CAP_CHOWN: "* ]]
-	[[ "${output}" == *"CapAmb:	0000000000000020"* ]]
+	assert_output --partial "can't raise ambient capability CAP_CHOWN: "
+	assert_output --partial "CapAmb:	0000000000000020"
 }

--- a/tests/integration/capabilities.bats
+++ b/tests/integration/capabilities.bats
@@ -12,8 +12,7 @@ function teardown() {
 }
 
 @test "runc run no capability" {
-	runc run test_no_caps
-	[ "$status" -eq 0 ]
+	run -0 runc run test_no_caps
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
@@ -22,8 +21,7 @@ function teardown() {
 
 @test "runc run with unknown capability" {
 	update_config '.process.capabilities.bounding = ["CAP_UNKNOWN", "UNKNOWN_CAP"]'
-	runc run test_unknown_caps
-	[ "$status" -eq 0 ]
+	run -0 runc run test_unknown_caps
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
@@ -35,8 +33,7 @@ function teardown() {
 		skip "requires unset NoNewPrivs"
 	fi
 	update_config '.process.noNewPrivileges = false'
-	runc run test_new_privileges
-	[ "$status" -eq 0 ]
+	run -0 runc run test_new_privileges
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
@@ -47,8 +44,7 @@ function teardown() {
 	update_config '.process.user = {"uid":0}'
 	update_config '.process.capabilities.bounding = ["CAP_SYS_ADMIN"]'
 	update_config '.process.capabilities.permitted = ["CAP_SYS_ADMIN", "CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"]'
-	runc run test_some_caps
-	[ "$status" -eq 0 ]
+	run -0 runc run test_some_caps
 
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapBnd:	0000000000200000"* ]]
@@ -60,11 +56,9 @@ function teardown() {
 @test "runc exec --cap" {
 	update_config '	  .process.args = ["/bin/sh"]
 			| .process.capabilities = {}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_exec_cap
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_exec_cap
 
-	runc exec test_exec_cap cat /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_exec_cap cat /proc/self/status
 	# Check no capabilities are set.
 	[[ "${output}" == *"CapInh:	0000000000000000"* ]]
 	[[ "${output}" == *"CapPrm:	0000000000000000"* ]]
@@ -72,8 +66,7 @@ function teardown() {
 	[[ "${output}" == *"CapBnd:	0000000000000000"* ]]
 	[[ "${output}" == *"CapAmb:	0000000000000000"* ]]
 
-	runc exec --cap CAP_KILL --cap CAP_AUDIT_WRITE test_exec_cap cat /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cap CAP_KILL --cap CAP_AUDIT_WRITE test_exec_cap cat /proc/self/status
 	# Check capabilities are added into bounding/effective/permitted only,
 	# but not to inheritable or ambient.
 	#
@@ -93,11 +86,9 @@ function teardown() {
 			| .process.capabilities.effective = ["CAP_KILL"]
 			| .process.capabilities.bounding = ["CAP_KILL", "CAP_CHOWN", "CAP_SYSLOG"]
 			| .process.capabilities.ambient = ["CAP_CHOWN"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_some_caps
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_some_caps
 
-	runc exec test_some_caps cat /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_some_caps cat /proc/self/status
 	# Check that capabilities are as set in spec.
 	#
 	# CAP_CHOWN is 0, the bit mask is 0x1 (1 << 0)
@@ -111,8 +102,7 @@ function teardown() {
 
 	# Check that if config.json has an inheritable capability set,
 	# runc exec --cap adds ambient capabilities.
-	runc exec --cap CAP_SYSLOG test_some_caps cat /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cap CAP_SYSLOG test_some_caps cat /proc/self/status
 	[[ "${output}" == *"CapInh:	0000000400000001"* ]]
 	[[ "${output}" == *"CapPrm:	0000000400000021"* ]]
 	[[ "${output}" == *"CapEff:	0000000400000021"* ]]
@@ -123,8 +113,7 @@ function teardown() {
 @test "runc run [ambient caps not set in inheritable result in a warning]" {
 	update_config '   .process.capabilities.inheritable = ["CAP_KILL"]
                        | .process.capabilities.ambient = ["CAP_KILL", "CAP_CHOWN"]'
-	runc run test_amb
-	[ "$status" -eq 0 ]
+	run -0 runc run test_amb
 	# This should result in CAP_KILL set in ambient,
 	# and a warning about inability to set CAP_CHOWN.
 	#

--- a/tests/integration/cgroup_delegation.bats
+++ b/tests/integration/cgroup_delegation.bats
@@ -27,11 +27,9 @@ function setup() {
 }
 
 @test "runc exec (cgroup v2, ro cgroupfs, new cgroupns) does not chown cgroup" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
-	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
 	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
 }
 
@@ -41,21 +39,17 @@ function setup() {
 	# inherit cgroup namespace (remove cgroup from namespaces list)
 	update_config '.linux.namespaces |= map(select(.type != "cgroup"))'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
-	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
 	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
 }
 
 @test "runc exec (cgroup v2, rw cgroupfs, new cgroupns) does chown cgroup" {
 	set_cgroup_mount_writable
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
-	runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
 	[ "$output" = "root" ] # /sys/fs/cgroup owned by root (of user namespace)
 }

--- a/tests/integration/cgroup_delegation.bats
+++ b/tests/integration/cgroup_delegation.bats
@@ -30,7 +30,7 @@ function setup() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
 	run -0 runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
+	assert_output "nobody" # /sys/fs/cgroup owned by unmapped user
 }
 
 @test "runc exec (cgroup v2, rw cgroupfs, inherit cgroupns) does not chown cgroup" {
@@ -42,7 +42,7 @@ function setup() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
 	run -0 runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$output" = "nobody" ] # /sys/fs/cgroup owned by unmapped user
+	assert_output "nobody" # /sys/fs/cgroup owned by unmapped user
 }
 
 @test "runc exec (cgroup v2, rw cgroupfs, new cgroupns) does chown cgroup" {
@@ -51,5 +51,5 @@ function setup() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroup_chown
 
 	run -0 runc exec test_cgroup_chown sh -c "stat -c %U /sys/fs/cgroup"
-	[ "$output" = "root" ] # /sys/fs/cgroup owned by root (of user namespace)
+	assert_output "root" # /sys/fs/cgroup owned by root (of user namespace)
 }

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -21,7 +21,7 @@ function setup() {
 	set_cgroups_path
 
 	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[[ "$output" == *"unable to apply cgroup configuration"*"permission denied"* ]]
+	assert_output --regexp 'unable to apply cgroup configuration.*permission denied'
 }
 
 @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error" {
@@ -31,7 +31,7 @@ function setup() {
 
 	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[[ "$output" == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] ||
-		[[ "$output" == *"cannot set pids limit: container could not join or create cgroup"* ]]
+		assert_output --partial "cannot set pids limit: container could not join or create cgroup"
 }
 
 @test "runc create (limits + cgrouppath + permission on the cgroup dir) succeeds" {
@@ -64,7 +64,7 @@ function setup() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 
 	run -0 runc exec test_cgroups_permissions echo "cgroups_exec"
-	[[ ${lines[0]} == *"cgroups_exec"* ]]
+	assert_line --index 0 --partial "cgroups_exec"
 }
 
 @test "runc exec (cgroup v2 + init process in non-root cgroup) succeeds" {
@@ -76,7 +76,7 @@ function setup() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
 
 	run -0 runc exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers
-	[[ ${lines[0]} == *"memory"* ]]
+	assert_line --index 0 --partial "memory"
 
 	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
 	assert_line --index 0 "0::/"
@@ -117,7 +117,7 @@ EOF
 	update_config '.linux.resources.unified |= {"memory.min": "131072"}'
 
 	run ! runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[[ "$output" == *'invalid configuration'* ]]
+	assert_output --partial 'invalid configuration'
 }
 
 @test "runc run (blkio weight)" {
@@ -467,7 +467,7 @@ convert_hugetlb_size() {
 
 	# Exec should not timeout or succeed.
 	run -255 runc exec ct1 echo ok
-	[[ "$output" == *"cannot exec in a paused container"* ]]
+	assert_output --partial "cannot exec in a paused container"
 }
 
 @test "runc exec --ignore-paused" {
@@ -499,11 +499,11 @@ convert_hugetlb_size() {
 
 	# Run a second container sharing the cgroup with the first one.
 	run ! runc --debug run -d --console-socket "$CONSOLE_SOCKET" ct2
-	[[ "$output" == *"container's cgroup is not empty"* ]]
+	assert_output --partial "container's cgroup is not empty"
 
 	# Same but using runc create.
 	run ! runc create --console-socket "$CONSOLE_SOCKET" ct3
-	[[ "$output" == *"container's cgroup is not empty"* ]]
+	assert_output --partial "container's cgroup is not empty"
 }
 
 @test "runc run/create should refuse pre-existing frozen cgroup" {
@@ -529,12 +529,12 @@ convert_hugetlb_size() {
 	# Start a container.
 	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 	# A warning should be printed.
-	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
+	assert_output --partial "container's cgroup unexpectedly frozen"
 
 	# Same check for runc create.
 	run -1 runc create --console-socket "$CONSOLE_SOCKET" ct2
 	# A warning should be printed.
-	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
+	assert_output --partial "container's cgroup unexpectedly frozen"
 
 	# Cleanup.
 	rmdir "$FREEZER_DIR"

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -12,8 +12,7 @@ function setup() {
 }
 
 @test "runc create (no limits + no cgrouppath + no permission) succeeds" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 }
 
 @test "runc create (rootless + no limits + cgrouppath + no permission) fails with permission error" {
@@ -21,8 +20,7 @@ function setup() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 1 ]
+	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[[ "$output" == *"unable to apply cgroup configuration"*"permission denied"* ]]
 }
 
@@ -31,8 +29,7 @@ function setup() {
 
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 1 ]
+	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	[[ "$output" == *"rootless needs no limits + no cgrouppath when no permission is granted for cgroups"* ]] ||
 		[[ "$output" == *"cannot set pids limit: container could not join or create cgroup"* ]]
 }
@@ -43,8 +40,7 @@ function setup() {
 	set_cgroups_path
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 	if [ -v CGROUP_V2 ]; then
 		if [ -v RUNC_USE_SYSTEMD ]; then
 			if [ $EUID -eq 0 ]; then
@@ -65,11 +61,9 @@ function setup() {
 	set_cgroups_path
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_permissions
 
-	runc exec test_cgroups_permissions echo "cgroups_exec"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_permissions echo "cgroups_exec"
 	[[ ${lines[0]} == *"cgroups_exec"* ]]
 }
 
@@ -79,49 +73,40 @@ function setup() {
 	set_cgroups_path
 	set_cgroup_mount_writable
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
 
-	runc exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group cat /sys/fs/cgroup/cgroup.controllers
 	[[ ${lines[0]} == *"memory"* ]]
 
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
 	[[ ${lines[0]} = "0::/" ]]
 
-	runc exec test_cgroups_group mkdir /sys/fs/cgroup/foo
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group mkdir /sys/fs/cgroup/foo
 
-	runc exec test_cgroups_group sh -c "echo 1 > /sys/fs/cgroup/foo/cgroup.procs"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group sh -c "echo 1 > /sys/fs/cgroup/foo/cgroup.procs"
 
 	# the init process is now in "/foo", but an exec process can still join "/"
 	# because we haven't enabled any domain controller.
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
 	[[ ${lines[0]} = "0::/" ]]
 
 	# turn on a domain controller (memory)
-	runc exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
 
 	# an exec process can no longer join "/" after turning on a domain controller.
 	# falls back to "/foo".
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
 	[[ ${lines[0]} = "0::/foo" ]]
 
 	# teardown: remove "/foo"
-	runc exec test_cgroups_group sh -eux <<'EOF'
+	run runc exec test_cgroups_group sh -eux <<'EOF'
 echo -memory > /sys/fs/cgroup/cgroup.subtree_control
 for pid in $(cat /sys/fs/cgroup/foo/cgroup.procs); do
 	echo $pid > /sys/fs/cgroup/cgroup.procs || true
 done
 rmdir /sys/fs/cgroup/foo
 EOF
-	runc exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group test ! -d /sys/fs/cgroup/foo
 }
 
 @test "runc run (cgroup v1 + unified resources should fail)" {
@@ -131,8 +116,7 @@ EOF
 	set_resources_limit
 	update_config '.linux.resources.unified |= {"memory.min": "131072"}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -ne 0 ]
+	run ! runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	[[ "$output" == *'invalid configuration'* ]]
 }
 
@@ -143,14 +127,13 @@ EOF
 	set_cgroups_path
 	update_config '.linux.resources.blockIO |= {"weight": 750}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
-	runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.bfq.weight'
+	run runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.bfq.weight'
 	if [[ "$status" -eq 0 ]]; then
 		[ "$output" = 'default 750' ]
 	else
-		runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
+		run runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
 		[ "$output" = 'default 7475' ]
 	fi
 }
@@ -188,8 +171,7 @@ EOF
 			| .linux.resources.blockIO.weightDevice |= [
 				{ major: '"$major"', minor: '"$minor"', weight: 444 }
 			]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
 
 	if [ -v CGROUP_V2 ]; then
 		file="io.bfq.weight"
@@ -199,7 +181,7 @@ EOF
 	weights1=$(get_cgroup_value $file)
 
 	# Check that runc update works.
-	runc update -r - test_dev_weight <<EOF
+	run runc update -r - test_dev_weight <<EOF
 {
   "blockIO": {
     "weight": 111,
@@ -240,8 +222,7 @@ EOF
 			   ]
 			| .linux.resources.unified |=
 				{"io.max": "'"$major1"':'"$minor1"' riops=333 wiops=444\n'"$major2"':'"$minor2"' riops=555 wiops=666\n"}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_dev_weight
 
 	weights=$(get_cgroup_value "io.max")
 	grep "^$major1:$minor1 .* riops=333 wiops=444$" <<<"$weights"
@@ -255,8 +236,7 @@ EOF
 	set_cgroups_path
 	update_config '.linux.resources.cpu.idle = 1'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 	check_cgroup_value "cpu.idle" "1"
 }
 
@@ -300,8 +280,7 @@ convert_hugetlb_size() {
 	done
 
 	set_cgroups_path
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_hugetlb
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_hugetlb
 
 	lim="max"
 	[ -v CGROUP_V1 ] && lim="limit_in_bytes"
@@ -332,8 +311,7 @@ convert_hugetlb_size() {
 	set_cgroups_path
 	update_config '.linux.resources.pids.limit = 0'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_pids
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_pids
 	# systemd doesn't support TasksMax=0 so runc will silently remap it to 1
 	# (for consistency, we do this for systemd *and* cgroupfs).
 	check_cgroup_value "pids.max" "1"
@@ -348,8 +326,7 @@ convert_hugetlb_size() {
 	set_cgroups_path
 	update_config '.linux.resources.pids.limit = -1'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_pids
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_pids
 	check_cgroup_value "pids.max" "max"
 	# systemd < v227 shows UINT64_MAX instead of "infinity".
 	check_systemd_value "TasksMax" "infinity" "18446744073709551615"
@@ -369,11 +346,9 @@ convert_hugetlb_size() {
 				"cpu.weight": "42"
 			}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
-	runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.min *.max *.low *.high'
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.min *.max *.low *.high'
 	echo "$output"
 
 	echo "$output" | grep -q '^memory.min:131072$'
@@ -401,11 +376,9 @@ convert_hugetlb_size() {
 				"memory.swap.max": "20971520"
 			}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
-	runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.max'
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_unified sh -c 'cd /sys/fs/cgroup && grep . *.max'
 	echo "$output"
 
 	echo "$output" | grep -q '^memory.max:20512768$'
@@ -434,19 +407,15 @@ convert_hugetlb_size() {
 				"cpu.weight": "42"
 			}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
-	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
 	[ "$output" = '131072' ]
 
-	runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
 	[ "$output" = '41943040' ]
 
-	runc exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
 	[ "$output" = '42' ]
 	check_systemd_value "TasksMax" 42
 
@@ -461,12 +430,10 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
 	# Make sure we don't have any extra cgroups inside
-	runc exec test_cgroups_unified find /sys/fs/cgroup/ -type d
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_unified find /sys/fs/cgroup/ -type d
 	[ "$(wc -l <<<"$output")" -eq 1 ]
 }
 
@@ -475,15 +442,13 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
-	[ "$status" -eq 0 ]
+	run -0 runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_cgroups_group
 
 	pid=$(cat pid.txt)
 	run_cgroup=$(tail -1 </proc/"$pid"/cgroup)
 	[[ "$run_cgroup" == *"runc-cgroups-integration-test"* ]]
 
-	runc exec test_cgroups_group cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
 	exec_cgroup=${lines[-1]}
 	[[ $exec_cgroup == *"runc-cgroups-integration-test"* ]]
 
@@ -497,14 +462,11 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
-	runc pause ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
+	run -0 runc pause ct1
 
 	# Exec should not timeout or succeed.
-	runc exec ct1 echo ok
-	[ "$status" -eq 255 ]
+	run -255 runc exec ct1 echo ok
 	[[ "$output" == *"cannot exec in a paused container"* ]]
 }
 
@@ -514,20 +476,17 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
-	runc pause ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
+	run -0 runc pause ct1
 
 	# Resume the container a bit later.
 	(
 		sleep 2
-		runc resume ct1
+		run runc resume ct1
 	) &
 
 	# Exec should succeed (once the container is resumed).
-	runc exec --ignore-paused ct1 echo ok
-	[ "$status" -eq 0 ]
+	run -0 runc exec --ignore-paused ct1 echo ok
 	[ "$output" = "ok" ]
 }
 
@@ -536,17 +495,14 @@ convert_hugetlb_size() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 
 	# Run a second container sharing the cgroup with the first one.
-	runc --debug run -d --console-socket "$CONSOLE_SOCKET" ct2
-	[ "$status" -ne 0 ]
+	run ! runc --debug run -d --console-socket "$CONSOLE_SOCKET" ct2
 	[[ "$output" == *"container's cgroup is not empty"* ]]
 
 	# Same but using runc create.
-	runc create --console-socket "$CONSOLE_SOCKET" ct3
-	[ "$status" -ne 0 ]
+	run ! runc create --console-socket "$CONSOLE_SOCKET" ct3
 	[[ "$output" == *"container's cgroup is not empty"* ]]
 }
 
@@ -571,14 +527,12 @@ convert_hugetlb_size() {
 	echo "$STATE" >"$FREEZER"
 
 	# Start a container.
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 1 ]
+	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 	# A warning should be printed.
 	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
 
 	# Same check for runc create.
-	runc create --console-socket "$CONSOLE_SOCKET" ct2
-	[ "$status" -eq 1 ]
+	run -1 runc create --console-socket "$CONSOLE_SOCKET" ct2
 	# A warning should be printed.
 	[[ "$output" == *"container's cgroup unexpectedly frozen"* ]]
 

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -113,7 +113,7 @@ function setup() {
 	[[ ${lines[0]} = "0::/foo" ]]
 
 	# teardown: remove "/foo"
-	cat <<'EOF' | runc exec test_cgroups_group sh -eux
+	runc exec test_cgroups_group sh -eux <<'EOF'
 echo -memory > /sys/fs/cgroup/cgroup.subtree_control
 for pid in $(cat /sys/fs/cgroup/foo/cgroup.procs); do
 	echo $pid > /sys/fs/cgroup/cgroup.procs || true

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -99,7 +99,7 @@ function setup() {
 	[[ ${lines[0]} = "0::/foo" ]]
 
 	# teardown: remove "/foo"
-	run runc exec test_cgroups_group sh -eux <<'EOF'
+	run -0 runc exec test_cgroups_group sh -eux <<'EOF'
 echo -memory > /sys/fs/cgroup/cgroup.subtree_control
 for pid in $(cat /sys/fs/cgroup/foo/cgroup.procs); do
 	echo $pid > /sys/fs/cgroup/cgroup.procs || true
@@ -133,7 +133,7 @@ EOF
 	if [[ "$status" -eq 0 ]]; then
 		[ "$output" = 'default 750' ]
 	else
-		run runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
+		run -0 runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
 		[ "$output" = 'default 7475' ]
 	fi
 }
@@ -181,7 +181,7 @@ EOF
 	weights1=$(get_cgroup_value $file)
 
 	# Check that runc update works.
-	run runc update -r - test_dev_weight <<EOF
+	run -0 runc update -r - test_dev_weight <<EOF
 {
   "blockIO": {
     "weight": 111,

--- a/tests/integration/cgroups.bats
+++ b/tests/integration/cgroups.bats
@@ -79,7 +79,7 @@ function setup() {
 	[[ ${lines[0]} == *"memory"* ]]
 
 	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
-	[[ ${lines[0]} = "0::/" ]]
+	assert_line --index 0 "0::/"
 
 	run -0 runc exec test_cgroups_group mkdir /sys/fs/cgroup/foo
 
@@ -88,7 +88,7 @@ function setup() {
 	# the init process is now in "/foo", but an exec process can still join "/"
 	# because we haven't enabled any domain controller.
 	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
-	[[ ${lines[0]} = "0::/" ]]
+	assert_line --index 0 "0::/"
 
 	# turn on a domain controller (memory)
 	run -0 runc exec test_cgroups_group sh -euxc 'echo $$ > /sys/fs/cgroup/foo/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
@@ -96,7 +96,7 @@ function setup() {
 	# an exec process can no longer join "/" after turning on a domain controller.
 	# falls back to "/foo".
 	run -0 runc exec test_cgroups_group cat /proc/self/cgroup
-	[[ ${lines[0]} = "0::/foo" ]]
+	assert_line --index 0 "0::/foo"
 
 	# teardown: remove "/foo"
 	run -0 runc exec test_cgroups_group sh -eux <<'EOF'
@@ -131,10 +131,10 @@ EOF
 
 	run runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.bfq.weight'
 	if [[ "$status" -eq 0 ]]; then
-		[ "$output" = 'default 750' ]
+		assert_output 'default 750'
 	else
 		run -0 runc exec test_cgroups_unified sh -c 'cat /sys/fs/cgroup/io.weight'
-		[ "$output" = 'default 7475' ]
+		assert_output 'default 7475'
 	fi
 }
 
@@ -410,13 +410,13 @@ convert_hugetlb_size() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_cgroups_unified
 
 	run -0 runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.min
-	[ "$output" = '131072' ]
+	assert_output '131072'
 
 	run -0 runc exec test_cgroups_unified cat /sys/fs/cgroup/memory.max
-	[ "$output" = '41943040' ]
+	assert_output '41943040'
 
 	run -0 runc exec test_cgroups_unified cat /sys/fs/cgroup/pids.max
-	[ "$output" = '42' ]
+	assert_output '42'
 	check_systemd_value "TasksMax" 42
 
 	check_cpu_quota 5000 50000
@@ -487,7 +487,7 @@ convert_hugetlb_size() {
 
 	# Exec should succeed (once the container is resumed).
 	run -0 runc exec --ignore-paused ct1 echo ok
-	[ "$output" = "ok" ]
+	assert_output "ok"
 }
 
 @test "runc run/create should error for a non-empty cgroup" {

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -55,7 +55,7 @@ function setup_pipes() {
 	update_config ' (.. | select(.terminal? != null)) .terminal |= false
 			| (.. | select(.[]? == "sh")) += ["-c", "for i in `seq 10`; do read xxx || continue; echo ponG $xxx; done"]'
 
-	# Create three sets of pipes for __runc run.
+	# Create three sets of pipes for runc run.
 	# for stderr
 	exec {pipe}<> <(:)
 	exec {err_r}</proc/self/fd/$pipe
@@ -101,7 +101,7 @@ function runc_run_with_pipes() {
 	# redirected to a bats log file, which is not accessible to CRIU
 	# (i.e. outside of container) so checkpointing will fail.
 	ret=0
-	__runc run -d "$1" <&${in_r} >&${out_w} 2>&${err_w} || ret=$?
+	runc run -d "$1" <&${in_r} >&${out_w} 2>&${err_w} || ret=$?
 	if [ "$ret" -ne 0 ]; then
 		echo "runc run -d $1 (status: $ret):"
 		exec {err_w}>&-
@@ -120,9 +120,9 @@ function runc_restore_with_pipes() {
 	shift
 
 	ret=0
-	__runc restore -d --work-path "$workdir" --image-path ./image-dir "$@" "$name" <&${in_r} >&${out_w} 2>&${err_w} || ret=$?
+	runc restore -d --work-path "$workdir" --image-path ./image-dir "$@" "$name" <&${in_r} >&${out_w} 2>&${err_w} || ret=$?
 	if [ "$ret" -ne 0 ]; then
-		echo "__runc restore $name failed (status: $ret)"
+		echo "runc restore $name failed (status: $ret)"
 		exec {err_w}>&-
 		cat <&${err_r}
 		fail "runc restore failed"
@@ -130,27 +130,23 @@ function runc_restore_with_pipes() {
 
 	testcontainer "$name" running
 
-	runc exec --cwd /bin "$name" echo ok
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cwd /bin "$name" echo ok
 	[ "$output" = "ok" ]
 }
 
 function simple_cr() {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	for _ in $(seq 2); do
 		# Use --manage-cgroups-mode=ignore as a workaround to prevent CRIU from mutating cgroup v2 superblock options.
 		# See: https://github.com/checkpoint-restore/criu/issues/3029
-		runc "$@" checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
-		[ "$status" -eq 0 ]
+		run -0 runc "$@" checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
 
 		testcontainer test_busybox checkpointed
 
-		runc "$@" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
-		[ "$status" -eq 0 ]
+		run -0 runc "$@" restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
 
 		testcontainer test_busybox running
 	done
@@ -161,28 +157,23 @@ function simple_cr() {
 	create_netns
 	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
 	update_config ' .linux.netDevices |= {"dummy0": {} }'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox_netdevice
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox_netdevice
 
 	testcontainer test_busybox_netdevice running
-	runc exec test_busybox_netdevice ip address show dev dummy0
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox_netdevice ip address show dev dummy0
 	[[ "$output" == *" $global_ip "* ]]
 	[[ "$output" == *"ether $mac_address "* ]]
 	[[ "$output" == *"mtu $mtu_value "* ]]
 
 	for _ in $(seq 2); do
-		runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox_netdevice
-		[ "$status" -eq 0 ]
+		run -0 runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox_netdevice
 
 		testcontainer test_busybox_netdevice checkpointed
 
-		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox_netdevice
-		[ "$status" -eq 0 ]
+		run -0 runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox_netdevice
 
 		testcontainer test_busybox_netdevice running
-		runc exec test_busybox_netdevice ip address show dev dummy0
-		[ "$status" -eq 0 ]
+		run -0 runc exec test_busybox_netdevice ip address show dev dummy0
 		[[ "$output" == *" $global_ip "* ]]
 		[[ "$output" == *"ether $mac_address "* ]]
 		[[ "$output" == *"mtu $mtu_value "* ]]
@@ -219,20 +210,17 @@ function simple_cr() {
 }
 
 @test "checkpoint --pre-dump (bad --parent-path)" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	# runc should fail with absolute parent image path.
-	runc checkpoint --parent-path "$(pwd)"/parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
+	run ! runc checkpoint --parent-path "$(pwd)"/parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
 	[[ "${output}" == *"--parent-path"* ]]
-	[ "$status" -ne 0 ]
 
 	# runc should fail with invalid parent image path.
-	runc checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
+	run ! runc checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
 	[[ "${output}" == *"--parent-path"* ]]
-	[ "$status" -ne 0 ]
 }
 
 @test "checkpoint --pre-dump and restore" {
@@ -244,15 +232,13 @@ function simple_cr() {
 	runc_run_with_pipes test_busybox
 
 	mkdir parent-dir
-	runc checkpoint --pre-dump --image-path ./parent-dir --manage-cgroups-mode ignore test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc checkpoint --pre-dump --image-path ./parent-dir --manage-cgroups-mode ignore test_busybox
 
 	testcontainer test_busybox running
 
 	mkdir image-dir
 	mkdir work-dir
-	runc checkpoint --parent-path ../parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc checkpoint --parent-path ../parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
 
 	# check parent path is valid
 	[ -e ./image-dir/parent ]
@@ -283,7 +269,7 @@ function simple_cr() {
 	# TCP port for lazy migration
 	port=27277
 
-	__runc checkpoint \
+	runc checkpoint \
 		--lazy-pages \
 		--page-server 0.0.0.0:${port} \
 		--status-fd ${lazy_w} \
@@ -347,27 +333,24 @@ function simple_cr() {
 	# tell runc which network namespace to use
 	update_config '(.. | select(.type? == "network")) .path |= "'"$ns_path"'"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	for _ in $(seq 2); do
 		# checkpoint the running container; this automatically tells CRIU to
 		# handle the network namespace defined in config.json as an external
-		runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
-		[ "$status" -eq 0 ]
+		run -0 runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
 
 		testcontainer test_busybox checkpointed
 
 		# restore from checkpoint; this should restore the container into the existing network namespace
-		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
-		[ "$status" -eq 0 ]
+		run -0 runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
 
 		testcontainer test_busybox running
 
 		# container should be running in same network namespace as before
-		pid=$(__runc state test_busybox | jq '.pid')
+		pid=$(runc state test_busybox | jq '.pid')
 		ns_inode_new=$(readlink /proc/"$pid"/ns/net | sed -e 's/.*\[\(.*\)\]/\1/')
 		echo "old network namespace inode $ns_inode"
 		echo "new network namespace inode $ns_inode_new"
@@ -398,13 +381,11 @@ function simple_cr() {
 	# Make sure the RPC defined configuration file overwrites the previous
 	echo "log-file=$tmplog2" >"$tmp"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
 	run ! test -f ./work-dir/"$tmplog1"
 	test -f ./work-dir/"$tmplog2"
 
@@ -412,8 +393,7 @@ function simple_cr() {
 
 	test -f ./work-dir/"$tmplog2" && unlink ./work-dir/"$tmplog2"
 
-	runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
 	run ! test -f ./work-dir/"$tmplog1"
 	test -f ./work-dir/"$tmplog2"
 
@@ -438,13 +418,11 @@ function simple_cr() {
 					options: ["rw", "bind"]
 				}]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
 
 	testcontainer test_busybox checkpointed
 
@@ -452,8 +430,7 @@ function simple_cr() {
 	# the mountpoints should be recreated during restore - that is the actual thing tested here
 	rm -rf "${bind1:?}"/*
 
-	runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
 
 	testcontainer test_busybox running
 }
@@ -461,8 +438,7 @@ function simple_cr() {
 @test "checkpoint then restore into a different cgroup (via --manage-cgroups-mode ignore)" {
 	set_resources_limit
 	set_cgroups_path
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 
 	local orig_path
@@ -470,17 +446,15 @@ function simple_cr() {
 	# Check that the cgroup exists.
 	test -d "$orig_path"
 
-	runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
 	testcontainer test_busybox checkpointed
 	# Check that the cgroup is gone.
 	run ! test -d "$orig_path"
 
 	# Restore into a different cgroup.
 	set_cgroups_path # Changes the path.
-	runc restore -d --manage-cgroups-mode ignore --pid-file pid \
+	run -0 runc restore -d --manage-cgroups-mode ignore --pid-file pid \
 		--work-path ./work-dir --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
 	testcontainer test_busybox running
 
 	# Check that the old cgroup path doesn't exist.
@@ -498,32 +472,27 @@ function simple_cr() {
 }
 
 @test "checkpoint/restore and exec" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	local execed_pid=""
 	for _ in $(seq 2); do
-		runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
-		[ "$status" -eq 0 ]
+		run -0 runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox
 
 		testcontainer test_busybox checkpointed
 
-		runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
-		[ "$status" -eq 0 ]
+		run -0 runc restore -d --work-path ./work-dir --console-socket "$CONSOLE_SOCKET" --manage-cgroups-mode ignore test_busybox
 
 		testcontainer test_busybox running
 
 		# verify that previously exec'd process is restored.
 		if [ -n "$execed_pid" ]; then
-			runc exec test_busybox ls -ld "/proc/$execed_pid"
-			[ "$status" -eq 0 ]
+			run -0 runc exec test_busybox ls -ld "/proc/$execed_pid"
 		fi
 
 		# exec a new background process.
-		runc exec test_busybox sh -c 'sleep 1000 < /dev/null &> /dev/null & echo $!'
-		[ "$status" -eq 0 ]
+		run -0 runc exec test_busybox sh -c 'sleep 1000 < /dev/null &> /dev/null & echo $!'
 		execed_pid=$output
 	done
 }

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -87,7 +87,7 @@ function check_pipes() {
 	stderr=$(cat <&${err_r})
 	exec {err_r}>&-
 
-	[[ "${output}" == *"ponG Ping"* ]]
+	assert_output --partial "ponG Ping"
 	if [ -n "$stderr" ]; then
 		fail "runc stderr: $stderr"
 	fi
@@ -161,9 +161,9 @@ function simple_cr() {
 
 	testcontainer test_busybox_netdevice running
 	run -0 runc exec test_busybox_netdevice ip address show dev dummy0
-	[[ "$output" == *" $global_ip "* ]]
-	[[ "$output" == *"ether $mac_address "* ]]
-	[[ "$output" == *"mtu $mtu_value "* ]]
+	assert_output --partial " $global_ip "
+	assert_output --partial "ether $mac_address "
+	assert_output --partial "mtu $mtu_value "
 
 	for _ in $(seq 2); do
 		run -0 runc checkpoint --work-path ./work-dir --manage-cgroups-mode ignore test_busybox_netdevice
@@ -174,9 +174,9 @@ function simple_cr() {
 
 		testcontainer test_busybox_netdevice running
 		run -0 runc exec test_busybox_netdevice ip address show dev dummy0
-		[[ "$output" == *" $global_ip "* ]]
-		[[ "$output" == *"ether $mac_address "* ]]
-		[[ "$output" == *"mtu $mtu_value "* ]]
+		assert_output --partial " $global_ip "
+		assert_output --partial "ether $mac_address "
+		assert_output --partial "mtu $mtu_value "
 	done
 }
 
@@ -216,11 +216,11 @@ function simple_cr() {
 
 	# runc should fail with absolute parent image path.
 	run ! runc checkpoint --parent-path "$(pwd)"/parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
-	[[ "${output}" == *"--parent-path"* ]]
+	assert_output --partial "--parent-path"
 
 	# runc should fail with invalid parent image path.
 	run ! runc checkpoint --parent-path ./parent-dir --work-path ./work-dir --image-path ./image-dir --manage-cgroups-mode ignore test_busybox
-	[[ "${output}" == *"--parent-path"* ]]
+	assert_output --partial "--parent-path"
 }
 
 @test "checkpoint --pre-dump and restore" {

--- a/tests/integration/checkpoint.bats
+++ b/tests/integration/checkpoint.bats
@@ -131,7 +131,7 @@ function runc_restore_with_pipes() {
 	testcontainer "$name" running
 
 	run -0 runc exec --cwd /bin "$name" echo ok
-	[ "$output" = "ok" ]
+	assert_output "ok"
 }
 
 function simple_cr() {

--- a/tests/integration/cpu_affinity.bats
+++ b/tests/integration/cpu_affinity.bats
@@ -106,16 +106,12 @@ function cpus_to_mask() {
 }
 
 @test "runc run [CPU affinity should reset]" {
-	# We need to use RUNC_CMDLINE since taskset requires a proper binary, not a
-	# bash function (which is what runc and __runc are).
-	setup_runc_cmdline
-
 	first="$(first_cpu)"
 
 	# Running without cpuset should result in an affinity for all CPUs.
 	update_config '.process.args = [ "/bin/grep", "-F", "Cpus_allowed_list:", "/proc/self/status" ]'
 	update_config 'del(.linux.resources.cpu)'
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" run ctr
+	sane_run taskset -c "$first" runc run ctr
 	[ "$status" -eq 0 ]
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	[[ "$output" == $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK" ]]
@@ -125,17 +121,13 @@ function cpus_to_mask() {
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	set_cgroups_path
 
-	# We need to use RUNC_CMDLINE since taskset requires a proper binary, not a
-	# bash function (which is what runc and __runc are).
-	setup_runc_cmdline
-
 	first="$(first_cpu)"
 	second="$((first + 1))" # Hacky; might not work in all environments.
 
 	# Running with a cpuset should result in an affinity that matches.
 	update_config '.process.args = [ "/bin/grep", "-F", "Cpus_allowed_list:", "/proc/self/status" ]'
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$first-$second"'"}'
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" run ctr
+	sane_run taskset -c "$first" runc run ctr
 	[ "$status" -eq 0 ]
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
@@ -144,7 +136,7 @@ function cpus_to_mask() {
 
 	# Ditto for a cpuset that has no overlap with the original cpumask.
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$second"'"}'
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" run ctr
+	sane_run taskset -c "$first" runc run ctr
 	[ "$status" -eq 0 ]
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
@@ -153,18 +145,14 @@ function cpus_to_mask() {
 }
 
 @test "runc exec [default CPU affinity should reset]" {
-	# We need to use RUNC_CMDLINE since taskset requires a proper binary, not a
-	# bash function (which is what runc and __runc are).
-	setup_runc_cmdline
-
 	first="$(first_cpu)"
 
 	# Running without cpuset should result in an affinity for all CPUs.
 	update_config '.process.args = [ "/bin/sleep", "infinity" ]'
 	update_config 'del(.linux.resources.cpu)'
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" run -d --console-socket "$CONSOLE_SOCKET" ctr3
+	sane_run taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr3
 	[ "$status" -eq 0 ]
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" exec ctr3 grep -F Cpus_allowed_list: /proc/self/status
+	sane_run taskset -c "$first" runc exec ctr3 grep -F Cpus_allowed_list: /proc/self/status
 	[ "$status" -eq 0 ]
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	[[ "$output" == $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK" ]]
@@ -174,19 +162,15 @@ function cpus_to_mask() {
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	set_cgroups_path
 
-	# We need to use RUNC_CMDLINE since taskset requires a proper binary, not a
-	# bash function (which is what runc and __runc are).
-	setup_runc_cmdline
-
 	first="$(first_cpu)"
 	second="$((first + 1))" # Hacky; might not work in all environments.
 
 	# Running with a cpuset should result in an affinity that matches.
 	update_config '.process.args = [ "/bin/sleep", "infinity" ]'
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$first-$second"'"}'
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" run -d --console-socket "$CONSOLE_SOCKET" ctr
+	sane_run taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
 	[ "$status" -eq 0 ]
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" exec ctr grep -F Cpus_allowed_list: /proc/self/status
+	sane_run taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
 	[ "$status" -eq 0 ]
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
@@ -199,9 +183,9 @@ function cpus_to_mask() {
 
 	# Ditto for a cpuset that has no overlap with the original cpumask.
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$second"'"}'
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" run -d --console-socket "$CONSOLE_SOCKET" ctr
+	sane_run taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
 	[ "$status" -eq 0 ]
-	sane_run taskset -c "$first" "${RUNC_CMDLINE[@]}" exec ctr grep -F Cpus_allowed_list: /proc/self/status
+	sane_run taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
 	[ "$status" -eq 0 ]
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set

--- a/tests/integration/cpu_affinity.bats
+++ b/tests/integration/cpu_affinity.bats
@@ -55,7 +55,7 @@ function cpus_to_mask() {
 }'
 		mask=$(cpus_to_mask "$cpus")
 		echo "CPUS: $cpus, mask: $mask"
-		run runc --debug exec --process <(echo "$proc") ct1
+		run -0 runc --debug exec --process <(echo "$proc") ct1
 		[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
 	done
 }
@@ -80,7 +80,7 @@ function cpus_to_mask() {
 		mask=$(cpus_to_mask "$cpus")
 		exp=${cpus//,/-} # "," --> "-".
 		echo "CPUS: $cpus, mask: $mask, final: $exp"
-		run runc --debug exec --process <(echo "$proc") ct1
+		run -0 runc --debug exec --process <(echo "$proc") ct1
 		[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
 		[[ "$output" == *"Cpus_allowed_list:	$exp"* ]] # Mind the literal tab.
 	done

--- a/tests/integration/cpu_affinity.bats
+++ b/tests/integration/cpu_affinity.bats
@@ -41,8 +41,7 @@ function cpus_to_mask() {
 	first="$(first_cpu)"
 	second=$((first + 1)) # Hacky; might not work in all environments.
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 
 	for cpus in "$second" "$first-$second" "$first,$second" "$first"; do
 		proc='
@@ -56,7 +55,7 @@ function cpus_to_mask() {
 }'
 		mask=$(cpus_to_mask "$cpus")
 		echo "CPUS: $cpus, mask: $mask"
-		runc --debug exec --process <(echo "$proc") ct1
+		run runc --debug exec --process <(echo "$proc") ct1
 		[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
 	done
 }
@@ -65,8 +64,7 @@ function cpus_to_mask() {
 	first="$(first_cpu)"
 	second=$((first + 1)) # Hacky; might not work in all environments.
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 
 	for cpus in "$second" "$first-$second" "$first,$second" "$first"; do
 		proc='
@@ -82,7 +80,7 @@ function cpus_to_mask() {
 		mask=$(cpus_to_mask "$cpus")
 		exp=${cpus//,/-} # "," --> "-".
 		echo "CPUS: $cpus, mask: $mask, final: $exp"
-		runc --debug exec --process <(echo "$proc") ct1
+		run runc --debug exec --process <(echo "$proc") ct1
 		[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
 		[[ "$output" == *"Cpus_allowed_list:	$exp"* ]] # Mind the literal tab.
 	done
@@ -95,11 +93,9 @@ function cpus_to_mask() {
 	update_config "	  .process.execCPUAffinity.initial = \"$initial\"
 			| .process.execCPUAffinity.final = \"$final\""
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 
-	runc --debug exec ct1 grep "Cpus_allowed_list:" /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 runc --debug exec ct1 grep "Cpus_allowed_list:" /proc/self/status
 	mask=$(cpus_to_mask "$initial")
 	[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
 	[[ "$output" == *"Cpus_allowed_list:	$final"* ]] # Mind the literal tab.
@@ -111,8 +107,7 @@ function cpus_to_mask() {
 	# Running without cpuset should result in an affinity for all CPUs.
 	update_config '.process.args = [ "/bin/grep", "-F", "Cpus_allowed_list:", "/proc/self/status" ]'
 	update_config 'del(.linux.resources.cpu)'
-	sane_run taskset -c "$first" runc run ctr
-	[ "$status" -eq 0 ]
+	run -0 taskset -c "$first" runc run ctr
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	[[ "$output" == $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK" ]]
 }
@@ -127,8 +122,7 @@ function cpus_to_mask() {
 	# Running with a cpuset should result in an affinity that matches.
 	update_config '.process.args = [ "/bin/grep", "-F", "Cpus_allowed_list:", "/proc/self/status" ]'
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$first-$second"'"}'
-	sane_run taskset -c "$first" runc run ctr
-	[ "$status" -eq 0 ]
+	run -0 taskset -c "$first" runc run ctr
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?
@@ -136,8 +130,7 @@ function cpus_to_mask() {
 
 	# Ditto for a cpuset that has no overlap with the original cpumask.
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$second"'"}'
-	sane_run taskset -c "$first" runc run ctr
-	[ "$status" -eq 0 ]
+	run -0 taskset -c "$first" runc run ctr
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?
@@ -150,10 +143,8 @@ function cpus_to_mask() {
 	# Running without cpuset should result in an affinity for all CPUs.
 	update_config '.process.args = [ "/bin/sleep", "infinity" ]'
 	update_config 'del(.linux.resources.cpu)'
-	sane_run taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr3
-	[ "$status" -eq 0 ]
-	sane_run taskset -c "$first" runc exec ctr3 grep -F Cpus_allowed_list: /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr3
+	run -0 taskset -c "$first" runc exec ctr3 grep -F Cpus_allowed_list: /proc/self/status
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	[[ "$output" == $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK" ]]
 }
@@ -168,25 +159,20 @@ function cpus_to_mask() {
 	# Running with a cpuset should result in an affinity that matches.
 	update_config '.process.args = [ "/bin/sleep", "infinity" ]'
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$first-$second"'"}'
-	sane_run taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
-	[ "$status" -eq 0 ]
-	sane_run taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
+	run -0 taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?
 	[ -v RUNC_USE_SYSTEMD ] || [[ "$output" == $'Cpus_allowed_list:\t'"$first-$second" ]]
 
 	# Stop the container so we can reconfigure it.
-	runc delete -f ctr
-	[ "$status" -eq 0 ]
+	run -0 runc delete -f ctr
 
 	# Ditto for a cpuset that has no overlap with the original cpumask.
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$second"'"}'
-	sane_run taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
-	[ "$status" -eq 0 ]
-	sane_run taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
-	[ "$status" -eq 0 ]
+	run -0 taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
+	run -0 taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
 	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?

--- a/tests/integration/cpu_affinity.bats
+++ b/tests/integration/cpu_affinity.bats
@@ -108,8 +108,8 @@ function cpus_to_mask() {
 	update_config '.process.args = [ "/bin/grep", "-F", "Cpus_allowed_list:", "/proc/self/status" ]'
 	update_config 'del(.linux.resources.cpu)'
 	run -0 taskset -c "$first" runc run ctr
-	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
-	[[ "$output" == $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK" ]]
+	refute_output $'Cpus_allowed_list:\t'"$first"
+	assert_output $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK"
 }
 
 @test "runc run [CPU affinity should reset to cgroup cpuset]" {
@@ -123,7 +123,7 @@ function cpus_to_mask() {
 	update_config '.process.args = [ "/bin/grep", "-F", "Cpus_allowed_list:", "/proc/self/status" ]'
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$first-$second"'"}'
 	run -0 taskset -c "$first" runc run ctr
-	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
+	refute_output $'Cpus_allowed_list:\t'"$first"
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?
 	[ -v RUNC_USE_SYSTEMD ] || [[ "$output" == $'Cpus_allowed_list:\t'"$first-$second" ]]
@@ -131,7 +131,7 @@ function cpus_to_mask() {
 	# Ditto for a cpuset that has no overlap with the original cpumask.
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$second"'"}'
 	run -0 taskset -c "$first" runc run ctr
-	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
+	refute_output $'Cpus_allowed_list:\t'"$first"
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?
 	[ -v RUNC_USE_SYSTEMD ] || [[ "$output" == $'Cpus_allowed_list:\t'"$second" ]]
@@ -145,8 +145,8 @@ function cpus_to_mask() {
 	update_config 'del(.linux.resources.cpu)'
 	run -0 taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr3
 	run -0 taskset -c "$first" runc exec ctr3 grep -F Cpus_allowed_list: /proc/self/status
-	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
-	[[ "$output" == $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK" ]]
+	refute_output $'Cpus_allowed_list:\t'"$first"
+	assert_output $'Cpus_allowed_list:\t'"$INITIAL_CPU_MASK"
 }
 
 @test "runc exec [default CPU affinity should reset to cgroup cpuset]" {
@@ -161,7 +161,7 @@ function cpus_to_mask() {
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$first-$second"'"}'
 	run -0 taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
 	run -0 taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
-	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
+	refute_output $'Cpus_allowed_list:\t'"$first"
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?
 	[ -v RUNC_USE_SYSTEMD ] || [[ "$output" == $'Cpus_allowed_list:\t'"$first-$second" ]]
@@ -173,7 +173,7 @@ function cpus_to_mask() {
 	update_config '.linux.resources.cpu = {"mems": "0", "cpus": "'"$second"'"}'
 	run -0 taskset -c "$first" runc run -d --console-socket "$CONSOLE_SOCKET" ctr
 	run -0 taskset -c "$first" runc exec ctr grep -F Cpus_allowed_list: /proc/self/status
-	[[ "$output" != $'Cpus_allowed_list:\t'"$first" ]]
+	refute_output $'Cpus_allowed_list:\t'"$first"
 	# XXX: For some reason, systemd-cgroup leads to us using the all-set
 	#      cpumask rather than the cpuset we configured?
 	[ -v RUNC_USE_SYSTEMD ] || [[ "$output" == $'Cpus_allowed_list:\t'"$second" ]]

--- a/tests/integration/cpu_affinity.bats
+++ b/tests/integration/cpu_affinity.bats
@@ -56,7 +56,7 @@ function cpus_to_mask() {
 		mask=$(cpus_to_mask "$cpus")
 		echo "CPUS: $cpus, mask: $mask"
 		run -0 runc --debug exec --process <(echo "$proc") ct1
-		[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
+		assert_output --regexp "nsexec.*: affinity: $mask"
 	done
 }
 
@@ -81,8 +81,8 @@ function cpus_to_mask() {
 		exp=${cpus//,/-} # "," --> "-".
 		echo "CPUS: $cpus, mask: $mask, final: $exp"
 		run -0 runc --debug exec --process <(echo "$proc") ct1
-		[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
-		[[ "$output" == *"Cpus_allowed_list:	$exp"* ]] # Mind the literal tab.
+		assert_output --regexp "nsexec.*: affinity: $mask"
+		assert_output --partial "Cpus_allowed_list:	$exp" # Mind the literal tab.
 	done
 }
 
@@ -97,8 +97,8 @@ function cpus_to_mask() {
 
 	run -0 runc --debug exec ct1 grep "Cpus_allowed_list:" /proc/self/status
 	mask=$(cpus_to_mask "$initial")
-	[[ "$output" == *"nsexec"*": affinity: $mask"* ]]
-	[[ "$output" == *"Cpus_allowed_list:	$final"* ]] # Mind the literal tab.
+	assert_output --regexp "nsexec.*: affinity: $mask"
+	assert_output --partial "Cpus_allowed_list:	$final" # Mind the literal tab.
 }
 
 @test "runc run [CPU affinity should reset]" {

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -152,8 +152,8 @@ is_allowed_fdtarget() {
 	exp="Such configuration is strongly discouraged"
 	run -0 runc create --console-socket "$CONSOLE_SOCKET" test
 	if [ $EUID -ne 0 ] && ! rootless_cgroup; then
-		[[ "$output" = *"$exp"* ]]
+		assert_output --partial "$exp"
 	else
-		[[ "$output" != *"$exp"* ]]
+		refute_output --partial "$exp"
 	fi
 }

--- a/tests/integration/create.bats
+++ b/tests/integration/create.bats
@@ -46,12 +46,11 @@ is_allowed_fdtarget() {
 }
 
 @test "runc create[detect fd leak as comprehensively as possible]" {
-	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc create --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
-	pid=$(__runc state test_busybox | jq '.pid')
+	pid=$(runc state test_busybox | jq '.pid')
 	violation_found=0
 
 	while IFS= read -rd '' link; do
@@ -79,45 +78,38 @@ is_allowed_fdtarget() {
 }
 
 @test "runc create" {
-	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc create --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc start test_busybox
 
 	testcontainer test_busybox running
 }
 
 @test "runc create exec" {
-	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc create --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
-	runc exec test_busybox true
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox true
 
 	testcontainer test_busybox created
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc start test_busybox
 
 	testcontainer test_busybox running
 }
 
 @test "runc create --pid-file" {
-	runc create --pid-file pid.txt --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc create --pid-file pid.txt --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
 	[ -e pid.txt ]
-	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
+	[[ $(cat pid.txt) = $(runc state test_busybox | jq '.pid') ]]
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc start test_busybox
 
 	testcontainer test_busybox running
 }
@@ -127,16 +119,14 @@ is_allowed_fdtarget() {
 	mkdir pid_file
 	cd pid_file
 
-	runc create --pid-file pid.txt -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc create --pid-file pid.txt -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
 	[ -e pid.txt ]
-	[[ $(cat pid.txt) = $(__runc state test_busybox | jq '.pid') ]]
+	[[ $(cat pid.txt) = $(runc state test_busybox | jq '.pid') ]]
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc start test_busybox
 
 	testcontainer test_busybox running
 }
@@ -160,8 +150,7 @@ is_allowed_fdtarget() {
 	fi
 
 	exp="Such configuration is strongly discouraged"
-	runc create --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	run -0 runc create --console-socket "$CONSOLE_SOCKET" test
 	if [ $EUID -ne 0 ] && ! rootless_cgroup; then
 		[[ "$output" = *"$exp"* ]]
 	else

--- a/tests/integration/cwd.bats
+++ b/tests/integration/cwd.bats
@@ -21,11 +21,9 @@ function teardown() {
 			| .process.user.uid = 42
 			| .process.args |= ["sleep", "1h"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --user 0 test_busybox true
-	[ "$status" -eq 0 ]
+	run -0 runc exec --user 0 test_busybox true
 }
 
 # Verify a cwd owned by the container user can be chdir'd to,
@@ -53,8 +51,7 @@ function teardown() {
 			| .process.cwd = "'"$ROOTLESS_AUX_DIR"'"
 			| .process.args |= ["ls", "'"$ROOTLESS_AUX_DIR"'"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # Verify a cwd not owned by the container user can be chdir'd to,
@@ -69,6 +66,5 @@ function teardown() {
 			| .process.user.uid = 42
 			| .process.args |= ["ls", "/tmp"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -18,8 +18,7 @@ function check_debug() {
 }
 
 @test "global --debug" {
-	runc --debug run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc --debug run test_hello
 
 	# check expected debug output was sent to stderr
 	[[ "${output}" == *"level=debug"* ]]
@@ -27,8 +26,7 @@ function check_debug() {
 }
 
 @test "global --debug to --log" {
-	runc --log log.out --debug run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc --log log.out --debug run test_hello
 
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]
@@ -41,8 +39,7 @@ function check_debug() {
 }
 
 @test "global --debug to --log --log-format 'text'" {
-	runc --log log.out --log-format "text" --debug run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc --log log.out --log-format "text" --debug run test_hello
 
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]
@@ -55,8 +52,7 @@ function check_debug() {
 }
 
 @test "global --debug to --log --log-format 'json'" {
-	runc --log log.out --log-format "json" --debug run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc --log log.out --log-format "json" --debug run test_hello
 
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -21,7 +21,7 @@ function check_debug() {
 	run -0 runc --debug run test_hello
 
 	# check expected debug output was sent to stderr
-	[[ "${output}" == *"level=debug"* ]]
+	assert_output --partial "level=debug"
 	check_debug "$output"
 }
 
@@ -29,12 +29,12 @@ function check_debug() {
 	run -0 runc --log log.out --debug run test_hello
 
 	# check output does not include debug info
-	[[ "${output}" != *"level=debug"* ]]
+	refute_output --partial "level=debug"
 
 	cat log.out >&2
 	# check expected debug output was sent to log.out
 	output=$(cat log.out)
-	[[ "${output}" == *"level=debug"* ]]
+	assert_output --partial "level=debug"
 	check_debug "$output"
 }
 
@@ -42,12 +42,12 @@ function check_debug() {
 	run -0 runc --log log.out --log-format "text" --debug run test_hello
 
 	# check output does not include debug info
-	[[ "${output}" != *"level=debug"* ]]
+	refute_output --partial "level=debug"
 
 	cat log.out >&2
 	# check expected debug output was sent to log.out
 	output=$(cat log.out)
-	[[ "${output}" == *"level=debug"* ]]
+	assert_output --partial "level=debug"
 	check_debug "$output"
 }
 
@@ -55,11 +55,11 @@ function check_debug() {
 	run -0 runc --log log.out --log-format "json" --debug run test_hello
 
 	# check output does not include debug info
-	[[ "${output}" != *"level=debug"* ]]
+	refute_output --partial "level=debug"
 
 	cat log.out >&2
 	# check expected debug output was sent to log.out
 	output=$(cat log.out)
-	[[ "${output}" == *'"level":"debug"'* ]]
+	assert_output --partial '"level":"debug"'
 	check_debug "$output"
 }

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -104,7 +104,7 @@ function test_runc_delete_host_pidns() {
 	run ! runc state testbusyboxdelete
 
 	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope 2>/dev/null || true)
-	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
+	assert_output ""
 }
 
 @test "runc delete --force" {
@@ -190,7 +190,7 @@ EOF
 	run ! runc state test_busybox
 
 	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d 2>/dev/null || true)
-	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
+	assert_output ""
 }
 
 @test "runc delete --force in cgroupv2 with subcgroups" {

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -40,14 +40,13 @@ function test_runc_delete_host_pidns() {
 				  ) // .)'
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	cgpath=$(get_cgroup_path "pids")
 	init_pid=$(cat "$cgpath"/cgroup.procs)
 
 	# Start a few more processes.
 	for _ in 1 2 3 4 5; do
-		__runc exec -d test_busybox sleep 1h
+		runc exec -d test_busybox sleep 1h
 	done
 
 	# Now kill the container's init process. Since the container do
@@ -65,11 +64,9 @@ function test_runc_delete_host_pidns() {
 	done
 
 	# Must kill those processes and remove container.
-	runc delete "$@" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc delete "$@" test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ] # "Container does not exist"
+	run ! runc state test_busybox # "Container does not exist"
 
 	# Wait and check that all the processes are gone.
 	wait_pids_gone 10 0.2 "${pids[@]}"
@@ -90,8 +87,7 @@ function test_runc_delete_host_pidns() {
 	[ $EUID -ne 0 ] && requires systemd
 	set_resources_limit
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" testbusyboxdelete
 
 	testcontainer testbusyboxdelete running
 	# Ensure the find statement used later is correct.
@@ -100,35 +96,29 @@ function test_runc_delete_host_pidns() {
 		fail "expected cgroup not found"
 	fi
 
-	runc kill testbusyboxdelete KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill testbusyboxdelete KILL
 	wait_for_container 10 1 testbusyboxdelete stopped
 
-	runc delete testbusyboxdelete
-	[ "$status" -eq 0 ]
+	run -0 runc delete testbusyboxdelete
 
-	runc state testbusyboxdelete
-	[ "$status" -ne 0 ]
+	run ! runc state testbusyboxdelete
 
 	output=$(find /sys/fs/cgroup -name testbusyboxdelete -o -name \*-testbusyboxdelete.scope 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
 }
 
 @test "runc delete --force" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc delete --force test_busybox
+	run runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 }
 
 @test "runc delete --force ignore not exist" {
-	runc delete --force notexists
-	[ "$status" -eq 0 ]
+	run -0 runc delete --force notexists
 }
 
 # Issue 4047, case "runc delete".
@@ -149,14 +139,11 @@ function test_runc_delete_host_pidns() {
 		set_cgroups_path
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" ct1
 	testcontainer ct1 running
 
-	runc pause ct1
-	[ "$status" -eq 0 ]
-	runc delete --force ct1
-	[ "$status" -eq 0 ]
+	run -0 runc pause ct1
+	run -0 runc delete --force ct1
 }
 
 @test "runc delete --force in cgroupv1 with subcgroups" {
@@ -168,19 +155,18 @@ function test_runc_delete_host_pidns() {
 
 	local subsystems="memory freezer"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	__runc exec -d test_busybox sleep 1d
+	runc exec -d test_busybox sleep 1d
 
 	# find the pid of sleep
-	pid=$(__runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
+	pid=$(runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
 	[[ ${pid} =~ [0-9]+ ]]
 
 	# create a sub-cgroup
-	runc exec test_busybox sh <<EOF
+	run -0 runc exec test_busybox sh <<EOF
 set -e -u -x
 for s in ${subsystems}; do
   cd /sys/fs/cgroup/\$s
@@ -190,7 +176,6 @@ for s in ${subsystems}; do
   cat tasks
 done
 EOF
-	[ "$status" -eq 0 ]
 	[[ "$output" =~ [0-9]+ ]]
 
 	for s in ${subsystems}; do
@@ -200,10 +185,9 @@ EOF
 		[ -d "${path}" ] || fail "test failed to create memory sub-cgroup ($path not found)"
 	done
 
-	runc delete --force test_busybox
+	run runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 
 	output=$(find /sys/fs/cgroup -wholename '*testbusyboxdelete*' -type d 2>/dev/null || true)
 	[ "$output" = "" ] || fail "cgroup not cleaned up correctly: $output"
@@ -214,16 +198,15 @@ EOF
 	set_cgroups_path
 	set_cgroup_mount_writable
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	# create a sub process
-	__runc exec -d test_busybox sleep 1d
+	runc exec -d test_busybox sleep 1d
 
 	# find the pid of sleep
-	pid=$(__runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
+	pid=$(runc exec test_busybox ps -a | grep 1d | awk '{print $1}')
 	[[ ${pid} =~ [0-9]+ ]]
 
 	# create subcgroups
@@ -237,18 +220,16 @@ EOF
   echo ${pid} > cgroup.threads
   cat cgroup.threads
 EOF
-	runc exec test_busybox sh <nest.sh
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox sh <nest.sh
 	[[ "$output" =~ [0-9]+ ]]
 
 	# check create subcgroups success
 	[ -d "$CGROUP_V2_PATH"/foo ]
 
 	# force delete test_busybox
-	runc delete --force test_busybox
+	run runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 
 	# check delete subcgroups success
 	[ ! -d "$CGROUP_V2_PATH"/foo ]
@@ -264,8 +245,7 @@ EOF
 			   }
 			| .process.args |= ["/bin/sleep", "10"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test-failed-unit
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test-failed-unit
 
 	wait_for_container 10 1 test-failed-unit stopped
 
@@ -275,7 +255,7 @@ EOF
 	# Expect "unit is not active" exit code.
 	run -3 systemctl status $user "$SD_UNIT_NAME"
 
-	runc delete test-failed-unit
+	run runc delete test-failed-unit
 	# Expect "no such unit" exit code.
 	run -4 systemctl status $user "$SD_UNIT_NAME"
 }

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -176,7 +176,7 @@ for s in ${subsystems}; do
   cat tasks
 done
 EOF
-	[[ "$output" =~ [0-9]+ ]]
+	assert_output --regexp '[0-9]+'
 
 	for s in ${subsystems}; do
 		name=CGROUP_${s^^}_BASE_PATH
@@ -221,7 +221,7 @@ EOF
   cat cgroup.threads
 EOF
 	run -0 runc exec test_busybox sh <nest.sh
-	[[ "$output" =~ [0-9]+ ]]
+	assert_output --regexp '[0-9]+'
 
 	# check create subcgroups success
 	[ -d "$CGROUP_V2_PATH"/foo ]

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -180,7 +180,7 @@ function test_runc_delete_host_pidns() {
 	[[ ${pid} =~ [0-9]+ ]]
 
 	# create a sub-cgroup
-	cat <<EOF | runc exec test_busybox sh
+	runc exec test_busybox sh <<EOF
 set -e -u -x
 for s in ${subsystems}; do
   cd /sys/fs/cgroup/\$s

--- a/tests/integration/delete.bats
+++ b/tests/integration/delete.bats
@@ -112,7 +112,7 @@ function test_runc_delete_host_pidns() {
 
 	testcontainer test_busybox running
 
-	run runc delete --force test_busybox
+	run -0 runc delete --force test_busybox
 
 	run ! runc state test_busybox
 }
@@ -185,7 +185,7 @@ EOF
 		[ -d "${path}" ] || fail "test failed to create memory sub-cgroup ($path not found)"
 	done
 
-	run runc delete --force test_busybox
+	run -0 runc delete --force test_busybox
 
 	run ! runc state test_busybox
 
@@ -227,7 +227,7 @@ EOF
 	[ -d "$CGROUP_V2_PATH"/foo ]
 
 	# force delete test_busybox
-	run runc delete --force test_busybox
+	run -0 runc delete --force test_busybox
 
 	run ! runc state test_busybox
 
@@ -255,7 +255,7 @@ EOF
 	# Expect "unit is not active" exit code.
 	run -3 systemctl status $user "$SD_UNIT_NAME"
 
-	run runc delete test-failed-unit
+	run -0 runc delete test-failed-unit
 	# Expect "no such unit" exit code.
 	run -4 systemctl status $user "$SD_UNIT_NAME"
 }

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -14,8 +14,7 @@ function teardown() {
 	update_config ' .linux.devices += [{"path": "/dev/tty", "type": "c", "major": 5, "minor": 0}]
 		      | .process.args |= ["ls", "-lLn", "/dev/tty"]'
 
-	runc run test_dev
-	[ "$status" -eq 0 ]
+	run -0 runc run test_dev
 
 	if [ $EUID -ne 0 ]; then
 		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"65534".+"65534".+"5,".+"0".+"/dev/tty" ]]
@@ -28,8 +27,7 @@ function teardown() {
 	update_config ' .linux.devices += [{"path": "/dev/ptmx", "type": "c", "major": 5, "minor": 2}]
 		      | .process.args |= ["ls", "-lLn", "/dev/ptmx"]'
 
-	runc run test_dev
-	[ "$status" -eq 0 ]
+	run -0 runc run test_dev
 	[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"0".+"0".+"5,".+"2".+"/dev/ptmx" ]]
 }
 
@@ -43,29 +41,24 @@ function teardown() {
 			| .process.capabilities.permitted += ["CAP_SYSLOG"]
 			| .process.args |= ["sh"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_deny
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_deny
 
 	# test write
-	runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
 	# test read
-	runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
-	runc update test_deny --pids-limit 42
+	run runc update test_deny --pids-limit 42
 
 	# test write
-	runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
 	# test read
-	runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 }
 
@@ -80,23 +73,19 @@ function teardown() {
 			| .process.capabilities.permitted += ["CAP_SYSLOG"]
 			| .hostname = "myhostname"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_allow_char
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_allow_char
 
 	# test write
-	runc exec test_allow_char sh -c 'hostname | tee /dev/kmsg'
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_allow_char sh -c 'hostname | tee /dev/kmsg'
 	[[ "${lines[0]}" == *'myhostname'* ]]
 
 	# test read
-	runc exec test_allow_char sh -c 'head -n 1 /dev/kmsg'
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_allow_char sh -c 'head -n 1 /dev/kmsg'
 
 	# test access
 	TEST_NAME="dev_access_test"
 	gcc -static -o "rootfs/bin/${TEST_NAME}" "${TESTDATA}/${TEST_NAME}.c"
-	runc exec test_allow_char sh -c "${TEST_NAME} /dev/kmsg"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_allow_char sh -c "${TEST_NAME} /dev/kmsg"
 }
 
 @test "runc run [device cgroup allow rm block device]" {
@@ -114,32 +103,26 @@ function teardown() {
 			| .process.capabilities.effective += ["CAP_MKNOD"]
 			| .process.capabilities.permitted += ["CAP_MKNOD"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_allow_block
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_allow_block
 
 	# test mknod
-	runc exec test_allow_block sh -c 'mknod /dev/fooblock b '"$major"' '"$minor"''
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_allow_block sh -c 'mknod /dev/fooblock b '"$major"' '"$minor"''
 
 	# test read
-	runc exec test_allow_block sh -c 'fdisk -l '"$device"''
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_allow_block sh -c 'fdisk -l '"$device"''
 }
 
 # https://github.com/opencontainers/runc/issues/3551
 @test "runc exec vs systemctl daemon-reload" {
 	requires systemd root
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_exec
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_exec
 
-	runc exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
 
 	systemctl daemon-reload
 
-	runc exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t test_exec sh -c "ls -l /proc/self/fd/0; echo 123"
 }
 
 # https://github.com/opencontainers/runc/issues/4568
@@ -150,6 +133,6 @@ function teardown() {
 	requires systemd_v230
 
 	set_cgroups_path
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_need_reload
+	run runc run -d --console-socket "$CONSOLE_SOCKET" test_need_reload
 	check_systemd_value "NeedDaemonReload" "no"
 }

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -51,7 +51,7 @@ function teardown() {
 	run -1 runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
 	[[ "${output}" == *'Operation not permitted'* ]]
 
-	run runc update test_deny --pids-limit 42
+	run -0 runc update test_deny --pids-limit 42
 
 	# test write
 	run -1 runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
@@ -133,6 +133,6 @@ function teardown() {
 	requires systemd_v230
 
 	set_cgroups_path
-	run runc run -d --console-socket "$CONSOLE_SOCKET" test_need_reload
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_need_reload
 	check_systemd_value "NeedDaemonReload" "no"
 }

--- a/tests/integration/dev.bats
+++ b/tests/integration/dev.bats
@@ -17,9 +17,9 @@ function teardown() {
 	run -0 runc run test_dev
 
 	if [ $EUID -ne 0 ]; then
-		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"65534".+"65534".+"5,".+"0".+"/dev/tty" ]]
+		assert_line --index 0 --regexp 'crw-rw-rw.+1.+65534.+65534.+5,.+0.+/dev/tty'
 	else
-		[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"0".+"0".+"5,".+"0".+"/dev/tty" ]]
+		assert_line --index 0 --regexp 'crw-rw-rw.+1.+0.+0.+5,.+0.+/dev/tty'
 	fi
 }
 
@@ -28,7 +28,7 @@ function teardown() {
 		      | .process.args |= ["ls", "-lLn", "/dev/ptmx"]'
 
 	run -0 runc run test_dev
-	[[ "${lines[0]}" =~ "crw-rw-rw".+"1".+"0".+"0".+"5,".+"2".+"/dev/ptmx" ]]
+	assert_line --index 0 --regexp 'crw-rw-rw.+1.+0.+0.+5,.+2.+/dev/ptmx'
 }
 
 @test "runc run/update [device cgroup deny]" {
@@ -45,21 +45,21 @@ function teardown() {
 
 	# test write
 	run -1 runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
-	[[ "${output}" == *'Operation not permitted'* ]]
+	assert_output --partial 'Operation not permitted'
 
 	# test read
 	run -1 runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
-	[[ "${output}" == *'Operation not permitted'* ]]
+	assert_output --partial 'Operation not permitted'
 
 	run -0 runc update test_deny --pids-limit 42
 
 	# test write
 	run -1 runc exec test_deny sh -c 'hostname | tee /dev/kmsg'
-	[[ "${output}" == *'Operation not permitted'* ]]
+	assert_output --partial 'Operation not permitted'
 
 	# test read
 	run -1 runc exec test_deny sh -c 'head -n 1 /dev/kmsg'
-	[[ "${output}" == *'Operation not permitted'* ]]
+	assert_output --partial 'Operation not permitted'
 }
 
 @test "runc run [device cgroup allow rw char device]" {
@@ -77,7 +77,7 @@ function teardown() {
 
 	# test write
 	run -0 runc exec test_allow_char sh -c 'hostname | tee /dev/kmsg'
-	[[ "${lines[0]}" == *'myhostname'* ]]
+	assert_line --index 0 --partial 'myhostname'
 
 	# test read
 	run -0 runc exec test_allow_char sh -c 'head -n 1 /dev/kmsg'

--- a/tests/integration/env.bats
+++ b/tests/integration/env.bats
@@ -110,12 +110,12 @@ _EOF_
 
 	run -0 runc exec -p process.json test_busybox
 	# Env should have entries from process.json.
-	[[ "$output" == *'FOO=bar'* ]]
+	assert_output --partial 'FOO=bar'
 	# ...and HOME set from container's /etc/passwd.
-	[[ "$output" == *'HOME=/root'* ]]
+	assert_output --partial 'HOME=/root'
 	# Env should NOT contain entries from config.json.
-	[[ "$output" != *'TERM='* ]]
-	[[ "$output" != *'PATH='* ]]
+	refute_output --partial 'TERM='
+	refute_output --partial 'PATH='
 }
 
 @test "env HOME is set for runc exec -p with no process.env" {
@@ -130,5 +130,5 @@ _EOF_
 _EOF_
 	run -0 runc exec -p process.json test_busybox
 	# Env should have HOME set from container's /etc/passwd.
-	[[ "$output" == *'HOME=/root'* ]]
+	assert_output --partial 'HOME=/root'
 }

--- a/tests/integration/env.bats
+++ b/tests/integration/env.bats
@@ -24,7 +24,7 @@ function teardown() {
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == '/override' ]]
+	assert_line --index 0 '/override'
 }
 
 @test "empty HOME env var is overridden" {
@@ -32,7 +32,7 @@ function teardown() {
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == '/root' ]]
+	assert_line --index 0 '/root'
 }
 
 @test "empty HOME env var is overridden with multiple overrides" {
@@ -40,7 +40,7 @@ function teardown() {
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == '/root' ]]
+	assert_line --index 0 '/root'
 }
 
 @test "env var HOME is set only once" {
@@ -70,7 +70,7 @@ function teardown() {
 	update_config ' .process.args += ["-c", "echo ONE=\"$ONE\""]'
 
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == "ONE=three" ]]
+	assert_line --index 0 "ONE=three"
 }
 
 @test "env var with new-line is honored" {

--- a/tests/integration/env.bats
+++ b/tests/integration/env.bats
@@ -23,8 +23,7 @@ function teardown() {
 	update_config ' .process.env += ["HOME=/override"]'
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == '/override' ]]
 }
 
@@ -32,8 +31,7 @@ function teardown() {
 	update_config ' .process.env += ["HOME="]'
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == '/root' ]]
 }
 
@@ -41,8 +39,7 @@ function teardown() {
 	update_config ' .process.env += ["HOME=/override", "HOME="]'
 	update_config ' .process.args += ["-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == '/root' ]]
 }
 
@@ -51,8 +48,7 @@ function teardown() {
 	update_config ' .process.args = ["env"]'
 	update_config ' .process.env = ["HOME=", "PATH=/usr/bin:/bin"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# There should be 2 words/env-vars: HOME and PATH.
 	[ "$(wc -w <<<"$output")" -eq 2 ]
@@ -63,8 +59,7 @@ function teardown() {
 	update_config ' .process.args = ["env"]'
 	update_config ' .process.env = ["ONE=two", "ONE=", "PATH=/usr/bin:/bin"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# There should be 3 words/env-vars: ONE, PATH and HOME.
 	[ "$(wc -w <<<"$output")" -eq 3 ]
@@ -74,8 +69,7 @@ function teardown() {
 	update_config ' .process.env += ["ONE=two", "ONE=three"]'
 	update_config ' .process.args += ["-c", "echo ONE=\"$ONE\""]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == "ONE=three" ]]
 }
 
@@ -83,8 +77,7 @@ function teardown() {
 	update_config ' .process.env = ["NEW_LINE_ENV=\n", "PATH=/usr/bin:/bin"]'
 	update_config ' .process.args = ["env"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# There should be 4 lines
 	# NEW_LINE is a \n and when printed, it takes another line:
@@ -100,8 +93,7 @@ function teardown() {
 # process.json only, not from config.json, and that HOME
 # is always set.
 @test "env [runc exec -p]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	cat <<_EOF_ >process.json
 {
@@ -116,8 +108,7 @@ function teardown() {
 }
 _EOF_
 
-	runc exec -p process.json test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc exec -p process.json test_busybox
 	# Env should have entries from process.json.
 	[[ "$output" == *'FOO=bar'* ]]
 	# ...and HOME set from container's /etc/passwd.
@@ -128,8 +119,7 @@ _EOF_
 }
 
 @test "env HOME is set for runc exec -p with no process.env" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# "env" is not set.
 	cat <<_EOF_ >process.json
@@ -138,8 +128,7 @@ _EOF_
     "cwd": "/"
 }
 _EOF_
-	runc exec -p process.json test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc exec -p process.json test_busybox
 	# Env should have HOME set from container's /etc/passwd.
 	[[ "$output" == *'HOME=/root'* ]]
 }

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -38,8 +38,8 @@ function test_events() {
 	[ -e events.log ]
 
 	output=$(head -1 events.log)
-	[[ "$output" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
-	[[ "$output" == *"data"* ]]
+	assert_output --regexp '^\{"type":"stats","id":"test_busybox",'
+	assert_output --partial "data"
 }
 
 @test "events --stats" {
@@ -50,8 +50,8 @@ function test_events() {
 
 	# generate stats
 	run -0 runc events --stats test_busybox
-	[[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
-	[[ "${lines[0]}" == *"data"* ]]
+	assert_line --index 0 --regexp '^\{"type":"stats","id":"test_busybox",'
+	assert_line --index 0 --partial "data"
 }
 
 @test "events --stats with psi data" {

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -22,17 +22,16 @@ function test_events() {
 		retry_every="$2"
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# Spawn two subshels:
 	# 1. Event logger that sends stats events to events.log.
-	(__runc events ${interval:+ --interval "$interval"} test_busybox >events.log) &
+	(runc events ${interval:+ --interval "$interval"} test_busybox >events.log) &
 	# 2. Waits for an event that includes test_busybox then kills the
 	#    test_busybox container which causes the event logger to exit.
 	(
 		retry 10 "$retry_every" grep -q test_busybox events.log
-		__runc delete -f test_busybox
+		runc delete -f test_busybox
 	) &
 	wait # for both subshells to finish
 
@@ -47,12 +46,10 @@ function test_events() {
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	init_cgroup_paths
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# generate stats
-	runc events --stats test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc events --stats test_busybox
 	[[ "${lines[0]}" == [\{]"\"type\""[:]"\"stats\""[,]"\"id\""[:]"\"test_busybox\""[,]* ]]
 	[[ "${lines[0]}" == *"data"* ]]
 }
@@ -64,17 +61,14 @@ function test_events() {
 
 	update_config '.linux.resources.cpu |= { "quota": 1000 }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# Stress the CPU a bit. Need something that runs for more than 10s.
-	runc exec test_busybox dd if=/dev/zero bs=1 count=128K of=/dev/null
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox dd if=/dev/zero bs=1 count=128K of=/dev/null
 
-	runc exec test_busybox sh -c 'tail /sys/fs/cgroup/*.pressure'
+	run runc exec test_busybox sh -c 'tail /sys/fs/cgroup/*.pressure'
 
-	runc events --stats test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc events --stats test_busybox
 
 	# Check PSI metrics.
 	jq '.data.cpu.psi' <<<"${lines[0]}"
@@ -91,11 +85,9 @@ function test_events() {
 	requires cgroups_v2 cgroups_hugetlb
 	init_cgroup_paths
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc events --stats test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc events --stats test_busybox
 	# Ensure hugetlb node is present.
 	jq -e '.data.hugetlb // empty' <<<"${lines[0]}"
 }
@@ -120,20 +112,19 @@ function test_events() {
 	# we need the container to hit OOM, so disable swap
 	update_config '(.. | select(.resources? != null)) .resources.memory |= {"limit": 33554432, "swap": 33554432}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# spawn two sub processes (shells)
 	# the first sub process is an event logger that sends stats events to events.log
 	# the second sub process exec a memory hog process to cause a oom condition
 	# and waits for an oom event
-	(__runc events test_busybox >events.log) &
+	(runc events test_busybox >events.log) &
 	(
 		retry 10 1 grep -q test_busybox events.log
 		# shellcheck disable=SC2016
-		__runc exec -d test_busybox sh -c 'test=$(dd if=/dev/urandom ibs=5120k)'
+		runc exec -d test_busybox sh -c 'test=$(dd if=/dev/urandom ibs=5120k)'
 		retry 30 1 grep -q oom events.log
-		__runc delete -f test_busybox
+		runc delete -f test_busybox
 	) &
 	wait # wait for the above sub shells to finish
 

--- a/tests/integration/events.bats
+++ b/tests/integration/events.bats
@@ -66,7 +66,7 @@ function test_events() {
 	# Stress the CPU a bit. Need something that runs for more than 10s.
 	run -0 runc exec test_busybox dd if=/dev/zero bs=1 count=128K of=/dev/null
 
-	run runc exec test_busybox sh -c 'tail /sys/fs/cgroup/*.pressure'
+	run -0 runc exec test_busybox sh -c 'tail /sys/fs/cgroup/*.pressure'
 
 	run -0 runc events --stats test_busybox
 

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -18,48 +18,38 @@ function teardown() {
 }
 
 @test "runc exec" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox echo Hello from exec
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox echo Hello from exec
 	echo text echoed = "'""${output}""'"
 	[[ "${output}" == *"Hello from exec"* ]]
 }
 
 @test "runc exec [exit codes]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox false
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_busybox false
 
-	runc exec test_busybox sh -c "exit 42"
-	[ "$status" -eq 42 ]
+	run -42 runc exec test_busybox sh -c "exit 42"
 
-	runc exec --pid-file /non-existent/directory test_busybox true
-	[ "$status" -eq 255 ]
+	run -255 runc exec --pid-file /non-existent/directory test_busybox true
 
-	runc exec test_busybox no-such-binary
-	[ "$status" -eq 255 ]
+	run -255 runc exec test_busybox no-such-binary
 
-	runc exec no_such_container true
-	[ "$status" -eq 255 ]
+	run -255 runc exec no_such_container true
 }
 
 @test "runc exec --pid-file" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --pid-file pid.txt test_busybox echo Hello from exec
-	[ "$status" -eq 0 ]
+	run -0 runc exec --pid-file pid.txt test_busybox echo Hello from exec
 	echo text echoed = "'""${output}""'"
 	[[ "${output}" == *"Hello from exec"* ]]
 
 	[ -e pid.txt ]
 	output=$(cat pid.txt)
 	[[ "$output" =~ [0-9]+ ]]
-	[[ "$output" != $(__runc state test_busybox | jq '.pid') ]]
+	[[ "$output" != $(runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec --pid-file with new CWD" {
@@ -67,46 +57,38 @@ function teardown() {
 	mkdir pid_file
 	cd pid_file
 
-	runc run -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --pid-file pid.txt test_busybox echo Hello from exec
-	[ "$status" -eq 0 ]
+	run -0 runc exec --pid-file pid.txt test_busybox echo Hello from exec
 	echo text echoed = "'""${output}""'"
 	[[ "${output}" == *"Hello from exec"* ]]
 
 	[ -e pid.txt ]
 	output=$(cat pid.txt)
 	[[ "$output" =~ [0-9]+ ]]
-	[[ "$output" != $(__runc state test_busybox | jq '.pid') ]]
+	[[ "$output" != $(runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc exec ls -la" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox ls -la
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox ls -la
 	[[ ${lines[0]} == *"total"* ]]
 	[[ ${lines[1]} == *"."* ]]
 	[[ ${lines[2]} == *".."* ]]
 }
 
 @test "runc exec ls -la with --cwd" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --cwd /bin test_busybox pwd
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cwd /bin test_busybox pwd
 	[[ ${output} == "/bin"* ]]
 }
 
 @test "runc exec --env" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --env RUNC_EXEC_TEST=true test_busybox env
-	[ "$status" -eq 0 ]
+	run -0 runc exec --env RUNC_EXEC_TEST=true test_busybox env
 	[[ "$output" == *"RUNC_EXEC_TEST=true"* ]]
 	# Env should inherit what's in config.json.
 	[[ "$output" == *'PATH='* ]]
@@ -119,11 +101,9 @@ function teardown() {
 	# --user can't work in rootless containers that don't have idmap.
 	[ $EUID -ne 0 ] && requires rootless_idmap
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec --user 1000:1000 test_busybox id
-	[ "$status" -eq 0 ]
+	run -0 runc exec --user 1000:1000 test_busybox id
 	[[ "${output}" == "uid=1000 gid=1000"* ]]
 
 	# Check the default value of HOME ("/") is set even in case when
@@ -134,8 +114,7 @@ function teardown() {
 	# a historical de facto behavior we're afraid to change.
 
 	# shellcheck disable=SC2016
-	runc exec --user 1000 test_busybox sh -u -c 'echo $HOME'
-	[ "$status" -eq 0 ]
+	run -0 runc exec --user 1000 test_busybox sh -u -c 'echo $HOME'
 	[[ "$output" = "/" ]]
 }
 
@@ -143,11 +122,10 @@ function teardown() {
 @test "runc exec --user vs /dev/null ownership" {
 	requires root
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	ls -l /dev/null
-	__runc exec -d --user 1000:1000 test_busybox id </dev/null
+	runc exec -d --user 1000:1000 test_busybox id </dev/null
 	ls -l /dev/null
 	UG=$(stat -c %u:%g /dev/null)
 
@@ -158,25 +136,21 @@ function teardown() {
 @test "runc exec --additional-gids" {
 	requires root
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	wait_for_container 15 1 test_busybox
 
-	runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
-	[ "$status" -eq 0 ]
+	run -0 runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
 	[ "$output" = "1000 100 65534" ]
 }
 
 @test "runc exec --preserve-fds" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	echo hello >preserve-fds.test
 	# fd 3 is used by bats, so we use 4
 	exec 4<preserve-fds.test
-	runc exec --preserve-fds=2 test_busybox cat /proc/self/fd/4
-	[ "$status" -eq 0 ]
+	run -0 runc exec --preserve-fds=2 test_busybox cat /proc/self/fd/4
 	[ "${output}" = "hello" ]
 }
 
@@ -187,20 +161,17 @@ function check_exec_debug() {
 }
 
 @test "runc --debug exec" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test
 
-	runc --debug exec test true
-	[ "$status" -eq 0 ]
+	run -0 runc --debug exec test true
 	[[ "${output}" == *"level=debug"* ]]
 	check_exec_debug "$output"
 }
 
 @test "runc --debug --log exec" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test
 
-	runc --debug --log log.out exec test true
+	run runc --debug --log log.out exec test true
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]
 
@@ -217,12 +188,11 @@ function check_exec_debug() {
 	set_cgroups_path
 	set_cgroup_mount_writable
 
-	__runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 
 	# Check we can't join parent cgroup.
-	runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
 	[[ "$output" == *"bad sub cgroup path"* ]]
 
 	# Check we can't join a sibling cgroup sharing our name prefix.
@@ -232,48 +202,39 @@ function check_exec_debug() {
 	# SIBLING_CGROUP is removed by teardown.
 	SIBLING_CGROUP="$(dirname "$cpu_path")/$sibling"
 	mkdir "$SIBLING_CGROUP"
-	runc exec --cgroup "../$sibling" test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup "../$sibling" test_busybox cat /proc/self/cgroup
 	[[ "$output" == *"bad sub cgroup path"* ]]
 
 	# Same as above, for a particular controller.
-	runc exec --cgroup "cpu:../$sibling" test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup "cpu:../$sibling" test_busybox cat /proc/self/cgroup
 	[[ "$output" == *"bad sub cgroup path"* ]]
 
 	# Check we can't join non-existing subcgroup.
-	runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
 	[[ "$output" == *" adding pid "*"o such file or directory"* ]]
 
 	# Check we can't join non-existing subcgroup (for a particular controller).
-	runc exec --cgroup cpu:nonexistent test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup cpu:nonexistent test_busybox cat /proc/self/cgroup
 	[[ "$output" == *" adding pid "*"o such file or directory"* ]]
 
 	# Check we can't specify non-existent controller.
-	runc exec --cgroup whaaat:/ test_busybox true
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup whaaat:/ test_busybox true
 	[[ "$output" == *"unknown controller "* ]]
 
 	# Check we can join top-level cgroup (implicit).
-	runc exec test_busybox cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox cat /proc/self/cgroup
 	run ! grep -v ":$REL_CGROUPS_PATH\$" <<<"$output"
 
 	# Check we can join top-level cgroup (explicit).
-	runc exec --cgroup / test_busybox cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cgroup / test_busybox cat /proc/self/cgroup
 	run ! grep -v ":$REL_CGROUPS_PATH\$" <<<"$output"
 
 	# Create a few subcgroups.
 	# Note that cpu,cpuacct may be mounted together or separate.
-	runc exec test_busybox sh -euc "mkdir -p /sys/fs/cgroup/memory/submem /sys/fs/cgroup/cpu/subcpu /sys/fs/cgroup/cpuacct/subcpu"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox sh -euc "mkdir -p /sys/fs/cgroup/memory/submem /sys/fs/cgroup/cpu/subcpu /sys/fs/cgroup/cpuacct/subcpu"
 
 	# Check that explicit --cgroup works.
-	runc exec --cgroup memory:submem --cgroup cpu,cpuacct:subcpu test_busybox cat /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cgroup memory:submem --cgroup cpu,cpuacct:subcpu test_busybox cat /proc/self/cgroup
 	[[ "$output" == *":memory:$REL_CGROUPS_PATH/submem"* ]]
 	[[ "$output" == *":cpu"*":$REL_CGROUPS_PATH/subcpu"* ]]
 }
@@ -284,12 +245,11 @@ function check_exec_debug() {
 	set_cgroups_path
 	set_cgroup_mount_writable
 
-	__runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 
 	# Check we can't join parent cgroup.
-	runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
 	[[ "$output" == *"bad sub cgroup path"* ]]
 
 	# Check we can't join a sibling cgroup sharing our name prefix.
@@ -298,64 +258,51 @@ function check_exec_debug() {
 	# SIBLING_CGROUP is removed by teardown.
 	SIBLING_CGROUP="$(dirname "$CGROUP_V2_PATH")/$sibling"
 	mkdir "$SIBLING_CGROUP"
-	runc exec --cgroup "../$sibling" test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup "../$sibling" test_busybox cat /proc/self/cgroup
 	[[ "$output" == *"bad sub cgroup path"* ]]
 
 	# Check we can't join non-existing subcgroup.
-	runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
 	[[ "$output" == *" cgroup"*"o such file or directory"* ]]
 
 	# Check we can join top-level cgroup (implicit).
-	runc exec test_busybox grep '^0::/$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox grep '^0::/$' /proc/self/cgroup
 
 	# Check we can join top-level cgroup (explicit).
-	runc exec --cgroup / test_busybox grep '^0::/$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cgroup / test_busybox grep '^0::/$' /proc/self/cgroup
 
 	# Now move "init" to a subcgroup, and check it was moved.
-	runc exec test_busybox sh -euc "mkdir /sys/fs/cgroup/foobar \
+	run -0 runc exec test_busybox sh -euc "mkdir /sys/fs/cgroup/foobar \
 		&& echo 1 > /sys/fs/cgroup/foobar/cgroup.procs \
 		&& grep -w foobar /proc/1/cgroup"
-	[ "$status" -eq 0 ]
 
 	# The following part is taken from
 	# @test "runc exec (cgroup v2 + init process in non-root cgroup) succeeds"
 
 	# The init process is now in "/foo", but an exec process can still
 	# join "/" because we haven't enabled any domain controller yet.
-	runc exec test_busybox grep '^0::/$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox grep '^0::/$' /proc/self/cgroup
 
 	# Turn on a domain controller (memory).
-	runc exec test_busybox sh -euc 'echo $$ > /sys/fs/cgroup/foobar/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox sh -euc 'echo $$ > /sys/fs/cgroup/foobar/cgroup.procs; echo +memory > /sys/fs/cgroup/cgroup.subtree_control'
 
 	# An exec process can no longer join "/" after turning on a domain
 	# controller.  Check that cgroup v2 fallback to init cgroup works.
-	runc exec test_busybox sh -euc "cat /proc/self/cgroup && grep '^0::/foobar$' /proc/self/cgroup"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox sh -euc "cat /proc/self/cgroup && grep '^0::/foobar$' /proc/self/cgroup"
 
 	# Check that --cgroup / disables the init cgroup fallback.
-	runc exec --cgroup / test_busybox true
-	[ "$status" -ne 0 ]
+	run ! runc exec --cgroup / test_busybox true
 	[[ "$output" == *" adding pid "*" to cgroups"*"evice or resource busy"* ]]
 
 	# Check that explicit --cgroup foobar works.
-	runc exec --cgroup foobar test_busybox grep '^0::/foobar$' /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cgroup foobar test_busybox grep '^0::/foobar$' /proc/self/cgroup
 
 	# Check all processes is in foobar (this check is redundant).
-	runc exec --cgroup foobar test_busybox sh -euc '! grep -vwH foobar /proc/*/cgroup'
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cgroup foobar test_busybox sh -euc '! grep -vwH foobar /proc/*/cgroup'
 
 	# Add a second subcgroup, check we're in it.
-	runc exec --cgroup foobar test_busybox mkdir /sys/fs/cgroup/second
-	[ "$status" -eq 0 ]
-	runc exec --cgroup second test_busybox grep -w second /proc/self/cgroup
-	[ "$status" -eq 0 ]
+	run -0 runc exec --cgroup foobar test_busybox mkdir /sys/fs/cgroup/second
+	run -0 runc exec --cgroup second test_busybox grep -w second /proc/self/cgroup
 }
 
 # https://github.com/opencontainers/runc/issues/5089
@@ -373,8 +320,7 @@ function check_exec_debug() {
 	update_config '	  .linux.namespaces -= [{"type": "cgroup"}]
 			| .process.args = ["sh", "-c", "echo 1 > '$NEW_CGROUP'/cgroup.procs && exec sleep 1h"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ $status -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 	sleep 1
 	# Remove the original container cgroup. If systemd cgroup manager is used by runc,
@@ -384,12 +330,11 @@ function check_exec_debug() {
 
 	# Test that runc exec is able to fallback to container's init cgroup
 	# even if the original cgroup is gone.
-	runc exec test_busybox cat /proc/self/cgroup
-	[ $status -eq 0 ]
+	run -0 runc exec test_busybox cat /proc/self/cgroup
 	[ "$output" = "0::$NEW_CGROUP_REL" ]
 
 	# Cleanup.
-	runc delete -f test_busybox
+	run runc delete -f test_busybox
 	rmdir "$NEW_CGROUP"
 }
 
@@ -399,9 +344,8 @@ function check_exec_debug() {
 sh
 EOF
 	chmod +x rootfs/run.sh
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	runc exec -t test_busybox /run.sh
-	[ "$status" -ne 0 ]
+	run runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	run ! runc exec -t test_busybox /run.sh
 
 	# After the sync socket closed, we should not send error to parent
 	# process, or else we will get a unnecessary error log(#4171).
@@ -417,10 +361,8 @@ EOF
 	[ $EUID -ne 0 ] && requires rootless_idmap
 	echo 'tempuser:x:2000:2000:tempuser:/home/tempuser:/bin/sh' >>rootfs/etc/passwd
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test
 
-	runc exec -u 2000 test sh -c "echo \$HOME"
-	[ "$status" -eq 0 ]
+	run -0 runc exec -u 2000 test sh -c "echo \$HOME"
 	[ "${lines[0]}" = "/home/tempuser" ]
 }

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -49,7 +49,7 @@ function teardown() {
 	[ -e pid.txt ]
 	output=$(cat pid.txt)
 	[[ "$output" =~ [0-9]+ ]]
-	[[ "$output" != $(runc state test_busybox | jq '.pid') ]]
+	refute_output "$(runc state test_busybox | jq '.pid')"
 }
 
 @test "runc exec --pid-file with new CWD" {
@@ -66,7 +66,7 @@ function teardown() {
 	[ -e pid.txt ]
 	output=$(cat pid.txt)
 	[[ "$output" =~ [0-9]+ ]]
-	[[ "$output" != $(runc state test_busybox | jq '.pid') ]]
+	refute_output "$(runc state test_busybox | jq '.pid')"
 }
 
 @test "runc exec ls -la" {
@@ -115,7 +115,7 @@ function teardown() {
 
 	# shellcheck disable=SC2016
 	run -0 runc exec --user 1000 test_busybox sh -u -c 'echo $HOME'
-	[[ "$output" = "/" ]]
+	assert_output "/"
 }
 
 # https://github.com/opencontainers/runc/issues/3674.
@@ -141,7 +141,7 @@ function teardown() {
 	wait_for_container 15 1 test_busybox
 
 	run -0 runc exec --user 1000:1000 --additional-gids 100 --additional-gids 65534 test_busybox id -G
-	[ "$output" = "1000 100 65534" ]
+	assert_output "1000 100 65534"
 }
 
 @test "runc exec --preserve-fds" {
@@ -151,7 +151,7 @@ function teardown() {
 	# fd 3 is used by bats, so we use 4
 	exec 4<preserve-fds.test
 	run -0 runc exec --preserve-fds=2 test_busybox cat /proc/self/fd/4
-	[ "${output}" = "hello" ]
+	assert_output "hello"
 }
 
 function check_exec_debug() {
@@ -331,7 +331,7 @@ function check_exec_debug() {
 	# Test that runc exec is able to fallback to container's init cgroup
 	# even if the original cgroup is gone.
 	run -0 runc exec test_busybox cat /proc/self/cgroup
-	[ "$output" = "0::$NEW_CGROUP_REL" ]
+	assert_output "0::$NEW_CGROUP_REL"
 
 	# Cleanup.
 	run -0 runc delete -f test_busybox
@@ -364,5 +364,5 @@ EOF
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test
 
 	run -0 runc exec -u 2000 test sh -c "echo \$HOME"
-	[ "${lines[0]}" = "/home/tempuser" ]
+	assert_line --index 0 "/home/tempuser"
 }

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -171,7 +171,7 @@ function check_exec_debug() {
 @test "runc --debug --log exec" {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test
 
-	run runc --debug --log log.out exec test true
+	run -0 runc --debug --log log.out exec test true
 	# check output does not include debug info
 	[[ "${output}" != *"level=debug"* ]]
 
@@ -334,7 +334,7 @@ function check_exec_debug() {
 	[ "$output" = "0::$NEW_CGROUP_REL" ]
 
 	# Cleanup.
-	run runc delete -f test_busybox
+	run -0 runc delete -f test_busybox
 	rmdir "$NEW_CGROUP"
 }
 
@@ -344,7 +344,7 @@ function check_exec_debug() {
 sh
 EOF
 	chmod +x rootfs/run.sh
-	run runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	run ! runc exec -t test_busybox /run.sh
 
 	# After the sync socket closed, we should not send error to parent

--- a/tests/integration/exec.bats
+++ b/tests/integration/exec.bats
@@ -22,7 +22,7 @@ function teardown() {
 
 	run -0 runc exec test_busybox echo Hello from exec
 	echo text echoed = "'""${output}""'"
-	[[ "${output}" == *"Hello from exec"* ]]
+	assert_output --partial "Hello from exec"
 }
 
 @test "runc exec [exit codes]" {
@@ -44,11 +44,11 @@ function teardown() {
 
 	run -0 runc exec --pid-file pid.txt test_busybox echo Hello from exec
 	echo text echoed = "'""${output}""'"
-	[[ "${output}" == *"Hello from exec"* ]]
+	assert_output --partial "Hello from exec"
 
 	[ -e pid.txt ]
 	output=$(cat pid.txt)
-	[[ "$output" =~ [0-9]+ ]]
+	assert_output --regexp '[0-9]+'
 	refute_output "$(runc state test_busybox | jq '.pid')"
 }
 
@@ -61,11 +61,11 @@ function teardown() {
 
 	run -0 runc exec --pid-file pid.txt test_busybox echo Hello from exec
 	echo text echoed = "'""${output}""'"
-	[[ "${output}" == *"Hello from exec"* ]]
+	assert_output --partial "Hello from exec"
 
 	[ -e pid.txt ]
 	output=$(cat pid.txt)
-	[[ "$output" =~ [0-9]+ ]]
+	assert_output --regexp '[0-9]+'
 	refute_output "$(runc state test_busybox | jq '.pid')"
 }
 
@@ -73,28 +73,28 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	run -0 runc exec test_busybox ls -la
-	[[ ${lines[0]} == *"total"* ]]
-	[[ ${lines[1]} == *"."* ]]
-	[[ ${lines[2]} == *".."* ]]
+	assert_line --index 0 --partial "total"
+	assert_line --index 1 --partial "."
+	assert_line --index 2 --partial ".."
 }
 
 @test "runc exec ls -la with --cwd" {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	run -0 runc exec --cwd /bin test_busybox pwd
-	[[ ${output} == "/bin"* ]]
+	assert_output --regexp '^/bin'
 }
 
 @test "runc exec --env" {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	run -0 runc exec --env RUNC_EXEC_TEST=true test_busybox env
-	[[ "$output" == *"RUNC_EXEC_TEST=true"* ]]
+	assert_output --partial "RUNC_EXEC_TEST=true"
 	# Env should inherit what's in config.json.
-	[[ "$output" == *'PATH='* ]]
-	[[ "$output" == *'TERM='* ]]
+	assert_output --partial 'PATH='
+	assert_output --partial 'TERM='
 	# Env should have HOME set from container's /etc/passwd.
-	[[ "$output" == *'HOME='* ]]
+	assert_output --partial 'HOME='
 }
 
 @test "runc exec --user" {
@@ -104,7 +104,7 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	run -0 runc exec --user 1000:1000 test_busybox id
-	[[ "${output}" == "uid=1000 gid=1000"* ]]
+	assert_output --regexp '^uid=1000 gid=1000'
 
 	# Check the default value of HOME ("/") is set even in case when
 	#  - HOME is not set in process.Env, and
@@ -164,7 +164,7 @@ function check_exec_debug() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test
 
 	run -0 runc --debug exec test true
-	[[ "${output}" == *"level=debug"* ]]
+	assert_output --partial "level=debug"
 	check_exec_debug "$output"
 }
 
@@ -173,12 +173,12 @@ function check_exec_debug() {
 
 	run -0 runc --debug --log log.out exec test true
 	# check output does not include debug info
-	[[ "${output}" != *"level=debug"* ]]
+	refute_output --partial "level=debug"
 
 	cat log.out >&2
 	# check expected debug output was sent to log.out
 	output=$(cat log.out)
-	[[ "${output}" == *"level=debug"* ]]
+	assert_output --partial "level=debug"
 	check_exec_debug "$output"
 }
 
@@ -193,7 +193,7 @@ function check_exec_debug() {
 
 	# Check we can't join parent cgroup.
 	run ! runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
-	[[ "$output" == *"bad sub cgroup path"* ]]
+	assert_output --partial "bad sub cgroup path"
 
 	# Check we can't join a sibling cgroup sharing our name prefix.
 	local cpu_path sibling
@@ -203,23 +203,23 @@ function check_exec_debug() {
 	SIBLING_CGROUP="$(dirname "$cpu_path")/$sibling"
 	mkdir "$SIBLING_CGROUP"
 	run ! runc exec --cgroup "../$sibling" test_busybox cat /proc/self/cgroup
-	[[ "$output" == *"bad sub cgroup path"* ]]
+	assert_output --partial "bad sub cgroup path"
 
 	# Same as above, for a particular controller.
 	run ! runc exec --cgroup "cpu:../$sibling" test_busybox cat /proc/self/cgroup
-	[[ "$output" == *"bad sub cgroup path"* ]]
+	assert_output --partial "bad sub cgroup path"
 
 	# Check we can't join non-existing subcgroup.
 	run ! runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
-	[[ "$output" == *" adding pid "*"o such file or directory"* ]]
+	assert_output --regexp ' adding pid .*o such file or directory'
 
 	# Check we can't join non-existing subcgroup (for a particular controller).
 	run ! runc exec --cgroup cpu:nonexistent test_busybox cat /proc/self/cgroup
-	[[ "$output" == *" adding pid "*"o such file or directory"* ]]
+	assert_output --regexp ' adding pid .*o such file or directory'
 
 	# Check we can't specify non-existent controller.
 	run ! runc exec --cgroup whaaat:/ test_busybox true
-	[[ "$output" == *"unknown controller "* ]]
+	assert_output --partial "unknown controller "
 
 	# Check we can join top-level cgroup (implicit).
 	run -0 runc exec test_busybox cat /proc/self/cgroup
@@ -235,8 +235,8 @@ function check_exec_debug() {
 
 	# Check that explicit --cgroup works.
 	run -0 runc exec --cgroup memory:submem --cgroup cpu,cpuacct:subcpu test_busybox cat /proc/self/cgroup
-	[[ "$output" == *":memory:$REL_CGROUPS_PATH/submem"* ]]
-	[[ "$output" == *":cpu"*":$REL_CGROUPS_PATH/subcpu"* ]]
+	assert_output --partial ":memory:$REL_CGROUPS_PATH/submem"
+	assert_output --regexp ":cpu.*:$REL_CGROUPS_PATH/subcpu"
 }
 
 @test "runc exec --cgroup subcgroup [v2]" {
@@ -250,7 +250,7 @@ function check_exec_debug() {
 
 	# Check we can't join parent cgroup.
 	run ! runc exec --cgroup ".." test_busybox cat /proc/self/cgroup
-	[[ "$output" == *"bad sub cgroup path"* ]]
+	assert_output --partial "bad sub cgroup path"
 
 	# Check we can't join a sibling cgroup sharing our name prefix.
 	local sibling
@@ -259,11 +259,11 @@ function check_exec_debug() {
 	SIBLING_CGROUP="$(dirname "$CGROUP_V2_PATH")/$sibling"
 	mkdir "$SIBLING_CGROUP"
 	run ! runc exec --cgroup "../$sibling" test_busybox cat /proc/self/cgroup
-	[[ "$output" == *"bad sub cgroup path"* ]]
+	assert_output --partial "bad sub cgroup path"
 
 	# Check we can't join non-existing subcgroup.
 	run ! runc exec --cgroup nonexistent test_busybox cat /proc/self/cgroup
-	[[ "$output" == *" cgroup"*"o such file or directory"* ]]
+	assert_output --regexp ' cgroup.*o such file or directory'
 
 	# Check we can join top-level cgroup (implicit).
 	run -0 runc exec test_busybox grep '^0::/$' /proc/self/cgroup
@@ -292,7 +292,7 @@ function check_exec_debug() {
 
 	# Check that --cgroup / disables the init cgroup fallback.
 	run ! runc exec --cgroup / test_busybox true
-	[[ "$output" == *" adding pid "*" to cgroups"*"evice or resource busy"* ]]
+	assert_output --regexp ' adding pid .* to cgroups.*evice or resource busy'
 
 	# Check that explicit --cgroup foobar works.
 	run -0 runc exec --cgroup foobar test_busybox grep '^0::/foobar$' /proc/self/cgroup
@@ -352,7 +352,7 @@ EOF
 	# Although we never close the sync socket when doing exec,
 	# but we need to keep this test to ensure this behavior is always right.
 	[ ${#lines[@]} -eq 1 ]
-	[[ ${lines[0]} = *"exec /run.sh: no such file or directory"* ]]
+	assert_line --index 0 --partial "exec /run.sh: no such file or directory"
 }
 
 # https://github.com/opencontainers/runc/issues/4688

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -10,13 +10,11 @@ function setup() {
 }
 
 @test "runc -h" {
-	runc -h
-	[ "$status" -eq 0 ]
+	run -0 runc -h
 	[[ ${lines[0]} =~ NAME:+ ]]
 	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 
-	runc --help
-	[ "$status" -eq 0 ]
+	run -0 runc --help
 	[[ ${lines[0]} =~ NAME:+ ]]
 	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
 }
@@ -46,8 +44,7 @@ function setup() {
 
 	for cmd in "${cmds[@]}"; do
 		for arg in "-h" "--help"; do
-			runc "$cmd" "$arg"
-			[ "$status" -eq 0 ]
+			run -0 runc "$cmd" "$arg"
 			[[ ${lines[0]} =~ NAME:+ ]]
 			[[ ${lines[1]} =~ $bin\ $cmd+ ]]
 		done
@@ -55,7 +52,6 @@ function setup() {
 }
 
 @test "runc foo -h" {
-	runc foo -h
-	[ "$status" -ne 0 ]
+	run ! runc foo -h
 	[[ "${output}" == *"No help topic for 'foo'"* ]]
 }

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -11,12 +11,12 @@ function setup() {
 
 @test "runc -h" {
 	run -0 runc -h
-	[[ ${lines[0]} =~ NAME:+ ]]
-	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
+	assert_line --index 0 --regexp 'NAME:+'
+	assert_line --index 1 --regexp 'runc - Open Container Initiative runtime+'
 
 	run -0 runc --help
-	[[ ${lines[0]} =~ NAME:+ ]]
-	[[ ${lines[1]} =~ runc\ '-'\ Open\ Container\ Initiative\ runtime+ ]]
+	assert_line --index 0 --regexp 'NAME:+'
+	assert_line --index 1 --regexp 'runc - Open Container Initiative runtime+'
 }
 
 @test "runc command -h" {
@@ -45,13 +45,13 @@ function setup() {
 	for cmd in "${cmds[@]}"; do
 		for arg in "-h" "--help"; do
 			run -0 runc "$cmd" "$arg"
-			[[ ${lines[0]} =~ NAME:+ ]]
-			[[ ${lines[1]} =~ $bin\ $cmd+ ]]
+			assert_line --index 0 --regexp 'NAME:+'
+			assert_line --index 1 --regexp "$bin $cmd+"
 		done
 	done
 }
 
 @test "runc foo -h" {
 	run ! runc foo -h
-	[[ "${output}" == *"No help topic for 'foo'"* ]]
+	assert_output --partial "No help topic for 'foo'"
 }

--- a/tests/integration/help.bats
+++ b/tests/integration/help.bats
@@ -22,9 +22,8 @@ function setup() {
 }
 
 @test "runc command -h" {
-	local runc
-	# shellcheck disable=SC2153
-	runc="$(basename "$RUNC")"
+	local bin
+	bin=$(basename "$RUNC")
 	local cmds=(
 		checkpoint
 		create
@@ -50,7 +49,7 @@ function setup() {
 			runc "$cmd" "$arg"
 			[ "$status" -eq 0 ]
 			[[ ${lines[0]} =~ NAME:+ ]]
-			[[ ${lines[1]} =~ $runc\ $cmd+ ]]
+			[[ ${lines[1]} =~ $bin\ $cmd+ ]]
 		done
 	done
 }

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -2,7 +2,7 @@
 
 set -u
 
-bats_require_minimum_version 1.5.0
+bats_require_minimum_version 1.7.0
 
 # Root directory of integration tests.
 INTEGRATION_ROOT=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -55,38 +55,12 @@ ARCH=$(uname -m)
 # Seccomp agent socket.
 SECCCOMP_AGENT_SOCKET="$BATS_TMPDIR/seccomp-agent.sock"
 
-# Wrapper around "run" that logs output to make tests easier to debug.
-function sane_run() {
-	local cmd="$1"
-	local cmdname="${CMDNAME:-$(basename "$cmd")}"
-	shift
-
-	run "$cmd" "$@"
-
-	# Some debug information to make life easier. bats will only print it if the
-	# test failed, in which case the output is useful.
-	# shellcheck disable=SC2154
-	echo "$cmdname $* (status=$status)" >&2
-	# shellcheck disable=SC2154
-	echo "$output" >&2
-}
-
-# Wrapper for runc.
-function runc() {
-	CMDNAME="$(basename "$RUNC")" sane_run __runc "$@"
-}
-
-# Raw wrapper for runc (i.e. one that does not use bats' run helper).
-function __runc() {
-	"${INTEGRATION_ROOT}/bin/runc" "$@"
-}
-
 # Wrapper for runc spec.
 function runc_spec() {
 	local rootless=""
 	[ $EUID -ne 0 ] && rootless="--rootless"
 
-	runc spec $rootless
+	run runc spec $rootless
 
 	# Always add additional mappings if we have idmaps.
 	if [[ $EUID -ne 0 && "$ROOTLESS_FEATURES" == *"idmap"* ]]; then
@@ -731,12 +705,14 @@ function retry() {
 
 	for ((i = 0; i < attempts; i++)); do
 		run "$@"
+		# shellcheck disable=SC2154 # set by run
 		if [[ "$status" -eq 0 ]]; then
 			return 0
 		fi
 		sleep "$delay"
 	done
 
+	# shellcheck disable=SC2154 # set by run
 	echo "Command \"$*\" failed $attempts times. Output: $output"
 	false
 }
@@ -744,9 +720,9 @@ function retry() {
 # retry until the given container has state
 function wait_for_container() {
 	if [ $# -eq 3 ]; then
-		retry "$1" "$2" __runc state "$3"
+		retry "$1" "$2" runc state "$3"
 	elif [ $# -eq 4 ]; then
-		retry "$1" "$2" eval "__runc state $3 | grep -qw $4"
+		retry "$1" "$2" eval "runc state $3 | grep -qw $4"
 	else
 		echo "Usage: wait_for_container ATTEMPTS DELAY ID [STATUS]" 1>&2
 		return 1
@@ -755,7 +731,7 @@ function wait_for_container() {
 
 function testcontainer() {
 	# test state of container
-	runc state "$1"
+	run runc state "$1"
 	if [ "$2" = "checkpointed" ]; then
 		[ "$status" -eq 1 ]
 		return
@@ -891,8 +867,8 @@ function teardown_bundle() {
 
 	teardown_recvtty
 	local ct
-	for ct in $(__runc list -q); do
-		__runc delete -f "$ct"
+	for ct in $(runc list -q); do
+		runc delete -f "$ct"
 	done
 	rm -rf "$ROOT"
 	remove_parent

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -13,6 +13,25 @@ eval "$IMAGES"
 unset IMAGES
 
 : "${RUNC:="${INTEGRATION_ROOT}/../../runc"}"
+export RUNC
+
+# Directory with the runc wrapper (see bin/runc). Must be in PATH so that runc
+# can be used from bats' run helper, and after commands like taskset. It must
+# also come first, so that no other runc binary is used instead.
+if [[ "$PATH" != "${INTEGRATION_ROOT}/bin:"* ]]; then
+	PATH="${INTEGRATION_ROOT}/bin:$PATH"
+	export PATH
+fi
+if [ "$(type -P runc)" != "${INTEGRATION_ROOT}/bin/runc" ]; then
+	echo "runc in PATH ($(type -P runc)) is not the test wrapper" >&2
+	exit 1
+fi
+
+# The runc wrapper is a separate process, so this has to be exported
+# (unlike with the shell function it replaced).
+if [ -v RUNC_USE_SYSTEMD ]; then
+	export RUNC_USE_SYSTEMD
+fi
 
 # Path to binaries compiled from packages in tests/cmd by "make test-binaries").
 TESTBINDIR=${INTEGRATION_ROOT}/../cmd/_bin
@@ -57,17 +76,9 @@ function runc() {
 	CMDNAME="$(basename "$RUNC")" sane_run __runc "$@"
 }
 
-function setup_runc_cmdline() {
-	RUNC_CMDLINE=("$RUNC")
-	[[ -v RUNC_USE_SYSTEMD ]] && RUNC_CMDLINE+=("--systemd-cgroup")
-	[[ -n "${ROOT:-}" ]] && RUNC_CMDLINE+=("--root" "$ROOT/state")
-	export RUNC_CMDLINE
-}
-
-# Raw wrapper for runc.
+# Raw wrapper for runc (i.e. one that does not use bats' run helper).
 function __runc() {
-	setup_runc_cmdline
-	"${RUNC_CMDLINE[@]}" "$@"
+	"${INTEGRATION_ROOT}/bin/runc" "$@"
 }
 
 # Wrapper for runc spec.
@@ -847,6 +858,7 @@ function setup_bundle() {
 
 	# Root for various container directories (state, tty, bundle).
 	ROOT=$(mktemp -d "$BATS_RUN_TMPDIR/runc.XXXXXX")
+	export ROOT
 	mkdir -p "$ROOT/state" "$ROOT/bundle/rootfs"
 
 	# Directories created by mktemp -d have 0700 permission bits. Tests

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -740,7 +740,7 @@ function testcontainer() {
 		return
 	fi
 	[ "$status" -eq 0 ]
-	[[ "${output}" == *"$2"* ]]
+	assert_output --partial "$2"
 }
 
 # Check that all the listed processes are gone. Use after kill/stop etc.

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -60,7 +60,7 @@ function runc_spec() {
 	local rootless=""
 	[ $EUID -ne 0 ] && rootless="--rootless"
 
-	run runc spec $rootless
+	run -0 runc spec $rootless
 
 	# Always add additional mappings if we have idmaps.
 	if [[ $EUID -ne 0 && "$ROOTLESS_FEATURES" == *"idmap"* ]]; then

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -55,6 +55,9 @@ ARCH=$(uname -m)
 # Seccomp agent socket.
 SECCCOMP_AGENT_SOCKET="$BATS_TMPDIR/seccomp-agent.sock"
 
+# Assertion helpers (assert_output, refute_output, assert_line).
+load lib/assert
+
 # Wrapper for runc spec.
 function runc_spec() {
 	local rootless=""

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -14,7 +14,7 @@ function teardown() {
 	update_config '.hooks |= {"createRuntime": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
 
 	run ! runc create --console-socket "$CONSOLE_SOCKET" test_hooks
-	[[ "$output" == *"error running createRuntime hook #1:"* ]]
+	assert_output --partial "error running createRuntime hook #1:"
 }
 
 @test "runc create [hook fails]" {
@@ -22,7 +22,7 @@ function teardown() {
 		echo "testing hook $hook"
 		update_config '.hooks |= {"'$hook'": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
 		run ! runc create --console-socket "$CONSOLE_SOCKET" test_hooks
-		[[ "$output" == *"error running $hook hook #1:"* ]]
+		assert_output --partial "error running $hook hook #1:"
 	done
 }
 
@@ -38,7 +38,7 @@ function teardown() {
 		if [ "$hook" != "poststart" ]; then
 			refute_output "Hello World"
 		fi
-		[[ "$output" == *"error running $hook hook #1:"* ]]
+		assert_output --partial "error running $hook hook #1:"
 	done
 }
 
@@ -68,11 +68,11 @@ function teardown() {
 	# exactly as set in config.json.
 	update_config '.hooks |= {"startContainer": [{"path": "/bin/busybox", "args": ["cat", "/nosuchfile"]}]}'
 	run ! runc run ct1
-	[[ "$output" == *"cat: can't open"*"/nosuchfile"* ]]
+	assert_output --regexp "cat: can't open.*/nosuchfile"
 
 	# Busybox also accepts commands where argv[0] is "busybox",
 	# and argv[1] is applet name. Test this as well.
 	update_config '.hooks |= {"startContainer": [{"path": "/bin/busybox", "args": ["busybox", "cat", "/nosuchfile"]}]}'
 	run ! runc run ct1
-	[[ "$output" == *"cat: can't open"*"/nosuchfile"* ]]
+	assert_output --regexp "cat: can't open.*/nosuchfile"
 }

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -36,7 +36,7 @@ function teardown() {
 		# Failed poststart hooks results in container being killed,
 		# but only after it has started, so output may or may not appear.
 		if [ "$hook" != "poststart" ]; then
-			[[ "$output" != "Hello World" ]]
+			refute_output "Hello World"
 		fi
 		[[ "$output" == *"error running $hook hook #1:"* ]]
 	done

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -13,8 +13,7 @@ function teardown() {
 @test "runc create [second createRuntime hook fails]" {
 	update_config '.hooks |= {"createRuntime": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
 
-	runc create --console-socket "$CONSOLE_SOCKET" test_hooks
-	[ "$status" -ne 0 ]
+	run ! runc create --console-socket "$CONSOLE_SOCKET" test_hooks
 	[[ "$output" == *"error running createRuntime hook #1:"* ]]
 }
 
@@ -22,8 +21,7 @@ function teardown() {
 	for hook in prestart createRuntime createContainer; do
 		echo "testing hook $hook"
 		update_config '.hooks |= {"'$hook'": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
-		runc create --console-socket "$CONSOLE_SOCKET" test_hooks
-		[ "$status" -ne 0 ]
+		run ! runc create --console-socket "$CONSOLE_SOCKET" test_hooks
 		[[ "$output" == *"error running $hook hook #1:"* ]]
 	done
 }
@@ -34,13 +32,12 @@ function teardown() {
 	for hook in prestart createRuntime createContainer startContainer poststart; do
 		echo "testing hook $hook"
 		update_config '.hooks |= {"'$hook'": [{"path": "/bin/true"}, {"path": "/bin/false"}]}'
-		runc run "test_hook-$hook"
+		run ! runc run "test_hook-$hook"
 		# Failed poststart hooks results in container being killed,
 		# but only after it has started, so output may or may not appear.
 		if [ "$hook" != "poststart" ]; then
 			[[ "$output" != "Hello World" ]]
 		fi
-		[ "$status" -ne 0 ]
 		[[ "$output" == *"error running $hook hook #1:"* ]]
 	done
 }
@@ -62,8 +59,7 @@ function teardown() {
 	update_config '	  .process.args = ["/bin/true"]
 			| .process.env = ["ONE=two", "FOO=bar"]
 			| .hooks |= {"startContainer": [{"path": "/check-env.sh"}]}'
-	runc run ct1
-	[ "$status" -eq 0 ]
+	run -0 runc run ct1
 }
 
 # https://github.com/opencontainers/runc/issues/1663
@@ -71,14 +67,12 @@ function teardown() {
 	# Check that argv[0] and argv[1] passed to the hook's binary
 	# exactly as set in config.json.
 	update_config '.hooks |= {"startContainer": [{"path": "/bin/busybox", "args": ["cat", "/nosuchfile"]}]}'
-	runc run ct1
-	[ "$status" -ne 0 ]
+	run ! runc run ct1
 	[[ "$output" == *"cat: can't open"*"/nosuchfile"* ]]
 
 	# Busybox also accepts commands where argv[0] is "busybox",
 	# and argv[1] is applet name. Test this as well.
 	update_config '.hooks |= {"startContainer": [{"path": "/bin/busybox", "args": ["busybox", "cat", "/nosuchfile"]}]}'
-	runc run ct1
-	[ "$status" -ne 0 ]
+	run ! runc run ct1
 	[[ "$output" == *"cat: can't open"*"/nosuchfile"* ]]
 }

--- a/tests/integration/hooks_so.bats
+++ b/tests/integration/hooks_so.bats
@@ -43,8 +43,7 @@ function teardown() {
 		.root.readonly |= false |
 		.process.args = ["/bin/sh", "-c", "ldconfig -p | grep librunc"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 
 	echo "Checking create-runtime library"
 	echo "$output" | grep "$HOOKLIBCR"

--- a/tests/integration/host-mntns.bats
+++ b/tests/integration/host-mntns.bats
@@ -23,9 +23,8 @@ function teardown() {
 			| .linux.namespaces -= [{"type": "mount"}]
 			| .linux.maskedPaths = []
 			| .linux.readonlyPaths = []'
-	runc run test_host_mntns
-	[ "$status" -eq 0 ]
-	runc delete -f test_host_mntns
+	run -0 runc run test_host_mntns
+	run runc delete -f test_host_mntns
 
 	# There should be one such file.
 	run -0 ls createRuntimeHook.*

--- a/tests/integration/host-mntns.bats
+++ b/tests/integration/host-mntns.bats
@@ -24,7 +24,7 @@ function teardown() {
 			| .linux.maskedPaths = []
 			| .linux.readonlyPaths = []'
 	run -0 runc run test_host_mntns
-	run runc delete -f test_host_mntns
+	run -0 runc delete -f test_host_mntns
 
 	# There should be one such file.
 	run -0 ls createRuntimeHook.*

--- a/tests/integration/idmap.bats
+++ b/tests/integration/idmap.bats
@@ -122,8 +122,7 @@ function setup_idmap_basic_mount() {
 		"hard": 20
 	}]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=0=0="* ]]
 }
 
@@ -133,8 +132,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=0=0="* ]]
 }
 
@@ -143,8 +141,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=100000=100000="* ]]
 }
 
@@ -154,8 +151,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "touch /tmp/mount-1/bar && stat -c =%u=%g= /tmp/mount-1/bar"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=0=0="* ]]
 }
 
@@ -164,9 +160,8 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["sh", "-c", "touch /tmp/mount-1/bar && stat -c =%u=%g= /tmp/mount-1/bar"]'
 
-	runc run test_debian
 	# The write must fail because the user is unmapped.
-	[ "$status" -ne 0 ]
+	run ! runc run test_debian
 	[[ "$output" == *"Value too large for defined data type"* ]] # ERANGE
 }
 
@@ -178,8 +173,7 @@ function setup_idmap_basic_mount() {
 	# Add the shared option to the idmap mount.
 	update_config '.mounts |= map((select(.source == "source-1/") | .options += ["shared"]) // .)'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"shared"* ]]
 }
 
@@ -191,8 +185,7 @@ function setup_idmap_basic_mount() {
 	# Switch the mount to have a relative mount destination.
 	update_config '.mounts |= map((select(.source == "source-1/") | .destination = "tmp/mount-1") // .)'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=0=0="* ]]
 }
 
@@ -203,8 +196,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/{,bind-}mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-1/foo.txt:0=0="* ]]
 	[[ "$output" == *"=/tmp/bind-mount-1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
 }
@@ -215,8 +207,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/{,bind-}mount-1/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-1/foo.txt:100000=100000="* ]]
 	[[ "$output" == *"=/tmp/bind-mount-1/foo.txt:0=0="* ]]
 }
@@ -231,8 +222,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-[12]/foo.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-1/foo.txt:0=0="* ]]
 	[[ "$output" == *"=/tmp/mount-2/foo.txt:1=1="* ]]
 }
@@ -248,8 +238,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1{,-alt{,-sym}}/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:0=11="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1=22="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:2=33="* ]]
@@ -270,8 +259,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1{,-alt{,-sym}}/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:100000=100011="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:100001=100022="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:100002=100033="* ]]
@@ -293,8 +281,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi[123]/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1100=1911="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1101=1922="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:1102=1933="* ]]
@@ -314,8 +301,7 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi[123]/{foo,bar,baz}.txt"]'
 
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1100=1911="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1101=1922="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:1102=1933="* ]]
@@ -349,8 +335,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:3000=3303="* ]]
@@ -376,8 +361,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:3000=3303="* ]]
@@ -408,8 +392,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
@@ -445,8 +428,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
@@ -484,8 +466,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
@@ -521,8 +502,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
@@ -560,8 +540,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
@@ -597,8 +576,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
@@ -626,8 +604,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]
@@ -655,8 +632,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]
@@ -677,11 +653,10 @@ function setup_idmap_basic_mount() {
 		| .linux.gidMappings += [{"containerID": 0, "hostID": 100000, "size": 65536}]'
 	update_config '.process.args = ["sleep", "infinity"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
 
 	# Configure our container to attach to the first container's userns.
-	target_pid="$(__runc state target_userns | jq .pid)"
+	target_pid="$(runc state target_userns | jq .pid)"
 	update_config '.linux.namespaces |= map(if .type == "user" then (.path = "/proc/'"$target_pid"'/ns/" + .type) else . end)'
 	update_config 'del(.linux.uidMappings) | del(.linux.gidMappings)'
 
@@ -697,8 +672,7 @@ function setup_idmap_basic_mount() {
 		]'
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
-	runc run test_debian
-	[ "$status" -eq 0 ]
+	run -0 runc run test_debian
 	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
 	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]

--- a/tests/integration/idmap.bats
+++ b/tests/integration/idmap.bats
@@ -123,7 +123,7 @@ function setup_idmap_basic_mount() {
 	}]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=0=0="* ]]
+	assert_output --partial "=0=0="
 }
 
 @test "simple idmap mount [userns]" {
@@ -133,7 +133,7 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=0=0="* ]]
+	assert_output --partial "=0=0="
 }
 
 @test "simple idmap mount [no userns]" {
@@ -142,7 +142,7 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["sh", "-c", "stat -c =%u=%g= /tmp/mount-1/foo.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=100000=100000="* ]]
+	assert_output --partial "=100000=100000="
 }
 
 @test "write to an idmap mount [userns]" {
@@ -152,7 +152,7 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["sh", "-c", "touch /tmp/mount-1/bar && stat -c =%u=%g= /tmp/mount-1/bar"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=0=0="* ]]
+	assert_output --partial "=0=0="
 }
 
 @test "write to an idmap mount [no userns]" {
@@ -162,7 +162,7 @@ function setup_idmap_basic_mount() {
 
 	# The write must fail because the user is unmapped.
 	run ! runc run test_debian
-	[[ "$output" == *"Value too large for defined data type"* ]] # ERANGE
+	assert_output --partial "Value too large for defined data type" # ERANGE
 }
 
 @test "idmap mount with propagation flag [userns]" {
@@ -174,7 +174,7 @@ function setup_idmap_basic_mount() {
 	update_config '.mounts |= map((select(.source == "source-1/") | .options += ["shared"]) // .)'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"shared"* ]]
+	assert_output --partial "shared"
 }
 
 @test "idmap mount with relative path [userns]" {
@@ -186,7 +186,7 @@ function setup_idmap_basic_mount() {
 	update_config '.mounts |= map((select(.source == "source-1/") | .destination = "tmp/mount-1") // .)'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=0=0="* ]]
+	assert_output --partial "=0=0="
 }
 
 @test "idmap mount with bind mount [userns]" {
@@ -197,8 +197,8 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/{,bind-}mount-1/foo.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-1/foo.txt:0=0="* ]]
-	[[ "$output" == *"=/tmp/bind-mount-1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
+	assert_output --partial "=/tmp/mount-1/foo.txt:0=0="
+	assert_output --partial "=/tmp/bind-mount-1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
 }
 
 @test "idmap mount with bind mount [no userns]" {
@@ -208,8 +208,8 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/{,bind-}mount-1/foo.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-1/foo.txt:100000=100000="* ]]
-	[[ "$output" == *"=/tmp/bind-mount-1/foo.txt:0=0="* ]]
+	assert_output --partial "=/tmp/mount-1/foo.txt:100000=100000="
+	assert_output --partial "=/tmp/bind-mount-1/foo.txt:0=0="
 }
 
 @test "two idmap mounts (same mapping) with two bind mounts [userns]" {
@@ -223,8 +223,8 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-[12]/foo.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-1/foo.txt:0=0="* ]]
-	[[ "$output" == *"=/tmp/mount-2/foo.txt:1=1="* ]]
+	assert_output --partial "=/tmp/mount-1/foo.txt:0=0="
+	assert_output --partial "=/tmp/mount-2/foo.txt:1=1="
 }
 
 @test "same idmap mount (different mappings) [userns]" {
@@ -239,15 +239,15 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1{,-alt{,-sym}}/{foo,bar,baz}.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:0=11="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1=22="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:2=33="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt/foo.txt:1000=2011="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt/bar.txt:1001=2022="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt/baz.txt:1002=2033="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt-sym/foo.txt:2000=3011="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt-sym/bar.txt:2001=3022="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt-sym/baz.txt:2002=3033="* ]]
+	assert_output --partial "=/tmp/mount-multi1/foo.txt:0=11="
+	assert_output --partial "=/tmp/mount-multi1/bar.txt:1=22="
+	assert_output --partial "=/tmp/mount-multi1/baz.txt:2=33="
+	assert_output --partial "=/tmp/mount-multi1-alt/foo.txt:1000=2011="
+	assert_output --partial "=/tmp/mount-multi1-alt/bar.txt:1001=2022="
+	assert_output --partial "=/tmp/mount-multi1-alt/baz.txt:1002=2033="
+	assert_output --partial "=/tmp/mount-multi1-alt-sym/foo.txt:2000=3011="
+	assert_output --partial "=/tmp/mount-multi1-alt-sym/bar.txt:2001=3022="
+	assert_output --partial "=/tmp/mount-multi1-alt-sym/baz.txt:2002=3033="
 }
 
 @test "same idmap mount (different mappings) [no userns]" {
@@ -260,15 +260,15 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1{,-alt{,-sym}}/{foo,bar,baz}.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:100000=100011="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:100001=100022="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:100002=100033="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt/foo.txt:101000=102011="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt/bar.txt:101001=102022="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt/baz.txt:101002=102033="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt-sym/foo.txt:102000=103011="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt-sym/bar.txt:102001=103022="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1-alt-sym/baz.txt:102002=103033="* ]]
+	assert_output --partial "=/tmp/mount-multi1/foo.txt:100000=100011="
+	assert_output --partial "=/tmp/mount-multi1/bar.txt:100001=100022="
+	assert_output --partial "=/tmp/mount-multi1/baz.txt:100002=100033="
+	assert_output --partial "=/tmp/mount-multi1-alt/foo.txt:101000=102011="
+	assert_output --partial "=/tmp/mount-multi1-alt/bar.txt:101001=102022="
+	assert_output --partial "=/tmp/mount-multi1-alt/baz.txt:101002=102033="
+	assert_output --partial "=/tmp/mount-multi1-alt-sym/foo.txt:102000=103011="
+	assert_output --partial "=/tmp/mount-multi1-alt-sym/bar.txt:102001=103022="
+	assert_output --partial "=/tmp/mount-multi1-alt-sym/baz.txt:102002=103033="
 }
 
 @test "multiple idmap mounts (different mappings) [userns]" {
@@ -282,15 +282,15 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi[123]/{foo,bar,baz}.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1100=1911="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1101=1922="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:1102=1933="* ]]
-	[[ "$output" == *"=/tmp/mount-multi2/foo.txt:2200=2911="* ]]
-	[[ "$output" == *"=/tmp/mount-multi2/bar.txt:2201=2922="* ]]
-	[[ "$output" == *"=/tmp/mount-multi2/baz.txt:2202=2933="* ]]
-	[[ "$output" == *"=/tmp/mount-multi3/foo.txt:3528=3491="* ]]
-	[[ "$output" == *"=/tmp/mount-multi3/bar.txt:3133=3337="* ]]
-	[[ "$output" == *"=/tmp/mount-multi3/baz.txt:3999=3444="* ]]
+	assert_output --partial "=/tmp/mount-multi1/foo.txt:1100=1911="
+	assert_output --partial "=/tmp/mount-multi1/bar.txt:1101=1922="
+	assert_output --partial "=/tmp/mount-multi1/baz.txt:1102=1933="
+	assert_output --partial "=/tmp/mount-multi2/foo.txt:2200=2911="
+	assert_output --partial "=/tmp/mount-multi2/bar.txt:2201=2922="
+	assert_output --partial "=/tmp/mount-multi2/baz.txt:2202=2933="
+	assert_output --partial "=/tmp/mount-multi3/foo.txt:3528=3491="
+	assert_output --partial "=/tmp/mount-multi3/bar.txt:3133=3337="
+	assert_output --partial "=/tmp/mount-multi3/baz.txt:3999=3444="
 }
 
 @test "multiple idmap mounts (different mappings) [no userns]" {
@@ -302,15 +302,15 @@ function setup_idmap_basic_mount() {
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi[123]/{foo,bar,baz}.txt"]'
 
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1100=1911="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:1101=1922="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:1102=1933="* ]]
-	[[ "$output" == *"=/tmp/mount-multi2/foo.txt:2200=2911="* ]]
-	[[ "$output" == *"=/tmp/mount-multi2/bar.txt:2201=2922="* ]]
-	[[ "$output" == *"=/tmp/mount-multi2/baz.txt:2202=2933="* ]]
-	[[ "$output" == *"=/tmp/mount-multi3/foo.txt:3528=3491="* ]]
-	[[ "$output" == *"=/tmp/mount-multi3/bar.txt:3133=3337="* ]]
-	[[ "$output" == *"=/tmp/mount-multi3/baz.txt:3999=3444="* ]]
+	assert_output --partial "=/tmp/mount-multi1/foo.txt:1100=1911="
+	assert_output --partial "=/tmp/mount-multi1/bar.txt:1101=1922="
+	assert_output --partial "=/tmp/mount-multi1/baz.txt:1102=1933="
+	assert_output --partial "=/tmp/mount-multi2/foo.txt:2200=2911="
+	assert_output --partial "=/tmp/mount-multi2/bar.txt:2201=2922="
+	assert_output --partial "=/tmp/mount-multi2/baz.txt:2202=2933="
+	assert_output --partial "=/tmp/mount-multi3/foo.txt:3528=3491="
+	assert_output --partial "=/tmp/mount-multi3/bar.txt:3133=3337="
+	assert_output --partial "=/tmp/mount-multi3/baz.txt:3999=3444="
 }
 
 @test "idmap mount (complicated mapping) [userns]" {
@@ -336,9 +336,9 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1000=1101="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:2000=2202="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:3000=3303="* ]]
+	assert_output --partial "=/tmp/mount-multi1/foo.txt:1000=1101="
+	assert_output --partial "=/tmp/mount-multi1/bar.txt:2000=2202="
+	assert_output --partial "=/tmp/mount-multi1/baz.txt:3000=3303="
 }
 
 @test "idmap mount (complicated mapping) [no userns]" {
@@ -362,9 +362,9 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-multi1/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-multi1/foo.txt:1000=1101="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/bar.txt:2000=2202="* ]]
-	[[ "$output" == *"=/tmp/mount-multi1/baz.txt:3000=3303="* ]]
+	assert_output --partial "=/tmp/mount-multi1/foo.txt:1000=1101="
+	assert_output --partial "=/tmp/mount-multi1/bar.txt:2000=2202="
+	assert_output --partial "=/tmp/mount-multi1/baz.txt:3000=3303="
 }
 
 @test "idmap mount (non-recursive idmap) [userns]" {
@@ -393,16 +393,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:1000=1101="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:2000=2202="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:3000=3303="
 	# Because we used "idmap", the child mounts were not remapped recursively.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
 }
 
 @test "idmap mount (non-recursive idmap) [no userns]" {
@@ -429,16 +429,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:101000=101101="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:102000=102202="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:103000=103303="
 	# Because we used "idmap", the child mounts were not remapped recursively.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:100=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:101=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:102=233="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:200=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:201=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:202=233="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:100=211="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:101=222="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:102=233="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:200=211="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:201=222="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:202=233="
 }
 
 @test "idmap mount (idmap flag) [userns]" {
@@ -467,16 +467,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:1000=1101="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:2000=2202="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:3000=3303="
 	# Because we used "idmap", the child mounts were not remapped recursively.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
 }
 
 @test "idmap mount (idmap flag) [no userns]" {
@@ -503,16 +503,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:101000=101101="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:102000=102202="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:103000=103303="
 	# Because we used "idmap", the child mounts were not remapped recursively.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:100=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:101=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:102=233="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:200=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:201=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:202=233="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:100=211="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:101=222="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:102=233="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:200=211="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:201=222="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:202=233="
 }
 
 @test "idmap mount (ridmap flag) [userns]" {
@@ -541,16 +541,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:1000=1101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:2000=2202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:3000=3303="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:1000=1101="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:2000=2202="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:3000=3303="
 	# The child mounts have the same mapping applied.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:1000=1101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:1001=2202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:1002=3303="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:2000=1101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:2001=2202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:2002=3303="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:1000=1101="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:1001=2202="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:1002=3303="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:2000=1101="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:2001=2202="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:2002=3303="
 }
 
 @test "idmap mount (ridmap flag) [no userns]" {
@@ -577,16 +577,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:101000=101101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:102000=102202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:103000=103303="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:101000=101101="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:102000=102202="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:103000=103303="
 	# The child mounts have the same mapping applied.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:101000=101101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:101001=102202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:101002=103303="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:102000=101101="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:102001=102202="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:102002=103303="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:101000=101101="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:101001=102202="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:101002=103303="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:102000=101101="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:102001=102202="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:102002=103303="
 }
 
 @test "idmap mount (idmap flag, implied mapping) [userns]" {
@@ -605,16 +605,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:100=211="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:200=222="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:300=233="
 	# Because we used "idmap", the child mounts were not remapped recursively.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
 }
 
 @test "idmap mount (ridmap flag, implied mapping) [userns]" {
@@ -633,16 +633,16 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:100=211="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:200=222="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:300=233="
 	# The child mounts have the same mapping applied.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:100=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:101=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:102=233="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:200=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:201=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:202=233="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:100=211="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:101=222="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:102=233="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:200=211="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:201=222="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:202=233="
 }
 
 @test "idmap mount (idmap flag, implied mapping, userns join) [userns]" {
@@ -673,14 +673,14 @@ function setup_idmap_basic_mount() {
 
 	update_config '.process.args = ["bash", "-c", "stat -c =%n:%u=%g= /tmp/mount-tree{,/multi1,/multi2}/{foo,bar,baz}.txt"]'
 	run -0 runc run test_debian
-	[[ "$output" == *"=/tmp/mount-tree/foo.txt:100=211="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/bar.txt:200=222="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/baz.txt:300=233="* ]]
+	assert_output --partial "=/tmp/mount-tree/foo.txt:100=211="
+	assert_output --partial "=/tmp/mount-tree/bar.txt:200=222="
+	assert_output --partial "=/tmp/mount-tree/baz.txt:300=233="
 	# Because we used "idmap", the child mounts were not remapped recursively.
-	[[ "$output" == *"=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
-	[[ "$output" == *"=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="* ]]
+	assert_output --partial "=/tmp/mount-tree/multi1/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi1/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/foo.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/bar.txt:$OVERFLOW_UID=$OVERFLOW_GID="
+	assert_output --partial "=/tmp/mount-tree/multi2/baz.txt:$OVERFLOW_UID=$OVERFLOW_GID="
 }

--- a/tests/integration/ioprio.bats
+++ b/tests/integration/ioprio.bats
@@ -14,17 +14,14 @@ function teardown() {
 	# Create a container with a specific I/O priority.
 	update_config '.process.ioPriority = {"class": "IOPRIO_CLASS_BE", "priority": 4}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_ioprio
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_ioprio
 
 	# Check the init process.
-	runc exec test_ioprio ionice -p 1
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_ioprio ionice -p 1
 	[ "${lines[0]}" = 'best-effort: prio 4' ]
 
 	# Check an exec process, which should derive ioprio from config.json.
-	runc exec test_ioprio ionice
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_ioprio ionice
 	[ "${lines[0]}" = 'best-effort: prio 4' ]
 
 	# Check an exec with a priority taken from process.json,
@@ -38,7 +35,6 @@ function teardown() {
 	"args": [ "/usr/bin/ionice" ],
 	"cwd": "/"
 }'
-	runc exec --process <(echo "$proc") test_ioprio
-	[ "$status" -eq 0 ]
+	run -0 runc exec --process <(echo "$proc") test_ioprio
 	[ "${lines[0]}" = 'idle' ]
 }

--- a/tests/integration/ioprio.bats
+++ b/tests/integration/ioprio.bats
@@ -18,11 +18,11 @@ function teardown() {
 
 	# Check the init process.
 	run -0 runc exec test_ioprio ionice -p 1
-	[ "${lines[0]}" = 'best-effort: prio 4' ]
+	assert_line --index 0 'best-effort: prio 4'
 
 	# Check an exec process, which should derive ioprio from config.json.
 	run -0 runc exec test_ioprio ionice
-	[ "${lines[0]}" = 'best-effort: prio 4' ]
+	assert_line --index 0 'best-effort: prio 4'
 
 	# Check an exec with a priority taken from process.json,
 	# which should override the ioprio in config.json.
@@ -36,5 +36,5 @@ function teardown() {
 	"cwd": "/"
 }'
 	run -0 runc exec --process <(echo "$proc") test_ioprio
-	[ "${lines[0]}" = 'idle' ]
+	assert_line --index 0 'idle'
 }

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -28,14 +28,13 @@ test_host_pidns_kill() {
 				  ) // .)'
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	cgpath=$(get_cgroup_path "pids")
 	init_pid=$(cat "$cgpath"/cgroup.procs)
 
 	# Start a few more processes.
 	for _ in 1 2 3 4 5; do
-		__runc exec -d test_busybox sleep 1h
+		runc exec -d test_busybox sleep 1h
 	done
 
 	if [ -v KILL_INIT ]; then
@@ -57,8 +56,7 @@ test_host_pidns_kill() {
 		kill -0 "$p"
 	done
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 	# Wait and check that all processes are gone.
 	wait_pids_gone 10 0.2 "${pids[@]}"
 
@@ -76,26 +74,21 @@ test_host_pidns_kill() {
 }
 
 @test "kill detached busybox" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 	wait_for_container 10 1 test_busybox stopped
 
 	# Check that kill errors on a stopped container.
-	runc kill test_busybox 0
-	[ "$status" -ne 0 ]
+	run ! runc kill test_busybox 0
 	[[ "$output" == *"container not running"* ]]
 
 	# Check that -a (now obsoleted) makes kill return no error for a stopped container.
-	runc kill -a test_busybox 0
-	[ "$status" -eq 0 ]
+	run -0 runc kill -a test_busybox 0
 
-	runc delete test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc delete test_busybox
 }
 
 # This is roughly the same as TestPIDHostInitProcessWait in libcontainer/integration.
@@ -136,22 +129,17 @@ test_host_pidns_kill() {
 @test "kill KILL [shared pidns]" {
 	update_config '.process.args = ["sleep", "infinity"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_ctr
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" target_ctr
 	testcontainer target_ctr running
-	target_pid="$(__runc state target_ctr | jq .pid)"
+	target_pid="$(runc state target_ctr | jq .pid)"
 	update_config '.linux.namespaces |= map(if .type == "user" or .type == "pid" then (.path = "/proc/'"$target_pid"'/ns/" + .type) else . end) | del(.linux.uidMappings) | del(.linux.gidMappings)'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" attached_ctr
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" attached_ctr
 	testcontainer attached_ctr running
 
-	runc kill attached_ctr 9
-	[ "$status" -eq 0 ]
+	run -0 runc kill attached_ctr 9
 
-	runc delete --force attached_ctr
-	[ "$status" -eq 0 ]
+	run -0 runc delete --force attached_ctr
 
-	runc delete --force target_ctr
-	[ "$status" -eq 0 ]
+	run -0 runc delete --force target_ctr
 }

--- a/tests/integration/kill.bats
+++ b/tests/integration/kill.bats
@@ -83,7 +83,7 @@ test_host_pidns_kill() {
 
 	# Check that kill errors on a stopped container.
 	run ! runc kill test_busybox 0
-	[[ "$output" == *"container not running"* ]]
+	assert_output --partial "container not running"
 
 	# Check that -a (now obsoleted) makes kill return no error for a stopped container.
 	run -0 runc kill -a test_busybox 0

--- a/tests/integration/lib/assert.bash
+++ b/tests/integration/lib/assert.bash
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# The assert_* functions below implement a subset of the bats-assert library
+# (https://github.com/bats-core/bats-assert). We do not use the real thing
+# because it, together with its bats-support dependency, has to be installed
+# separately on every distribution the tests are run on.
+#
+#	assert_output [--partial | --regexp] EXPECTED
+#	refute_output [--partial | --regexp] UNEXPECTED
+#	assert_line --index IDX [--partial | --regexp] EXPECTED
+#
+# This file lives in its own directory so that bats can be told to skip it
+# when capturing stack traces (see below); otherwise every failed assertion
+# is prefixed by a few useless frames pointing into this file.
+if declare -F bats_setup_tracing >/dev/null &&
+	! declare -F __assert_orig_setup_tracing >/dev/null; then
+	# Rename bats_setup_tracing to __assert_orig_setup_tracing ...
+	eval "__assert_orig_setup_tracing() $(declare -f bats_setup_tracing | tail -n +2)"
+	# ... and wrap it, so that this directory is added to the list of paths
+	# excluded from stack traces. This can not be done at load time, as bats
+	# resets the exclude list in bats_setup_tracing, which runs afterwards.
+	function bats_setup_tracing() {
+		__assert_orig_setup_tracing "$@"
+		bats_add_debug_exclude_path "${BASH_SOURCE[0]%/*}"
+	}
+fi
+
+# __assert_matches MODE ACTUAL EXPECTED
+function __assert_matches() {
+	case "$1" in
+	exact) [ "$2" = "$3" ] ;;
+	partial) [[ $2 == *"$3"* ]] ;;
+	regexp) [[ $2 =~ $3 ]] ;;
+	*) fail "assert: unknown mode: $1" ;;
+	esac
+}
+
+# __assert_fail WHAT MODE EXPECTED ACTUAL
+function __assert_fail() {
+	{
+		echo "-- $1 ($2) --"
+		echo "expected: ${3@Q}"
+		echo "  actual: ${4@Q}"
+		echo "--"
+	} >&2
+
+	return 1
+}
+
+# __assert_mode ARG -- prints the match mode for an optional flag.
+function __assert_mode() {
+	case "$1" in
+	--partial) echo partial ;;
+	--regexp) echo regexp ;;
+	# Guard against a typo or an unimplemented bats-assert option being
+	# silently treated as the expected value.
+	-*) fail "assert: unknown option: $1" ;;
+	*) echo exact ;;
+	esac
+}
+
+function assert_output() {
+	local mode
+	mode=$(__assert_mode "${1:-}")
+	[ "$mode" = exact ] || shift
+
+	# shellcheck disable=SC2154 # $output is set by bats' run helper.
+	__assert_matches "$mode" "$output" "$1" && return 0
+	__assert_fail "output does not match" "$mode" "$1" "$output"
+}
+
+function refute_output() {
+	local mode
+	mode=$(__assert_mode "${1:-}")
+	[ "$mode" = exact ] || shift
+
+	# shellcheck disable=SC2154 # $output is set by bats' run helper.
+	__assert_matches "$mode" "$output" "$1" || return 0
+	__assert_fail "output should not match" "$mode" "$1" "$output"
+}
+
+function assert_line() {
+	local idx mode
+	[ "${1:-}" = "--index" ] || fail "assert_line: --index IDX is required"
+	idx="$2"
+	shift 2
+	mode=$(__assert_mode "${1:-}")
+	[ "$mode" = exact ] || shift
+
+	# shellcheck disable=SC2154 # $lines is set by bats' run helper.
+	__assert_matches "$mode" "${lines[idx]:-}" "$1" && return 0
+	__assert_fail "line $idx does not match" "$mode" "$1" "${lines[idx]:-}"
+}

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -23,10 +23,10 @@ function teardown() {
 	ROOT=$ALT_ROOT run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
 
 	ROOT=$ALT_ROOT run -0 runc list
-	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
-	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
-	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
-	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
+	assert_line --index 0 --regexp 'ID +PID +STATUS +BUNDLE +CREATED+'
+	assert_line --index 1 --regexp "test_box1.*[0-9].*running.*$bundle.*[0-9]"
+	assert_line --index 2 --regexp "test_box2.*[0-9].*running.*$bundle.*[0-9]"
+	assert_line --index 3 --regexp "test_box3.*[0-9].*running.*$bundle.*[0-9]"
 
 	ROOT=$ALT_ROOT run -0 runc list -q
 	assert_line --index 0 "test_box1"
@@ -34,15 +34,15 @@ function teardown() {
 	assert_line --index 2 "test_box3"
 
 	ROOT=$ALT_ROOT run -0 runc list --format table
-	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
-	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
-	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
-	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
+	assert_line --index 0 --regexp 'ID +PID +STATUS +BUNDLE +CREATED+'
+	assert_line --index 1 --regexp "test_box1.*[0-9].*running.*$bundle.*[0-9]"
+	assert_line --index 2 --regexp "test_box2.*[0-9].*running.*$bundle.*[0-9]"
+	assert_line --index 3 --regexp "test_box3.*[0-9].*running.*$bundle.*[0-9]"
 
 	ROOT=$ALT_ROOT run -0 runc list --format json
-	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
-	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
+	assert_line --index 0 --regexp '^\[\{"ociVersion":"[0-9]+\.[0-9]+\.[0-9]+","id":"test_box1","pid":[0-9]+,"status":"running","bundle":"[^"]*'"$bundle"'[^"]*","rootfs":"[^"]*","created":[^}]*\}'
+	assert_line --index 0 --regexp ',\{"ociVersion":"[0-9]+\.[0-9]+\.[0-9]+","id":"test_box2","pid":[0-9]+,"status":"running","bundle":"[^"]*'"$bundle"'[^"]*","rootfs":"[^"]*","created":[^}]*\}'
+	assert_line --index 0 --regexp ',\{"ociVersion":"[0-9]+\.[0-9]+\.[0-9]+","id":"test_box3","pid":[0-9]+,"status":"running","bundle":"[^"]*'"$bundle"'[^"]*","rootfs":"[^"]*","created":[^}]*\}\]$'
 }
 
 @test "list with non-existent root fails" {

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -16,50 +16,41 @@ function teardown() {
 
 @test "list" {
 	bundle=$(pwd)
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_box1
 
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_box2
 
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_box3
 
-	ROOT=$ALT_ROOT runc list
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc list
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
 	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
 
-	ROOT=$ALT_ROOT runc list -q
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc list -q
 	[ "${lines[0]}" = "test_box1" ]
 	[ "${lines[1]}" = "test_box2" ]
 	[ "${lines[2]}" = "test_box3" ]
 
-	ROOT=$ALT_ROOT runc list --format table
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc list --format table
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]
 	[[ "${lines[1]}" == *"test_box1"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[2]}" == *"test_box2"*[0-9]*"running"*$bundle*[0-9]* ]]
 	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
 
-	ROOT=$ALT_ROOT runc list --format json
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc list --format json
 	[[ "${lines[0]}" == [\[][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box1\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box2\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}]* ]]
 	[[ "${lines[0]}" == *[,][\{]"\"ociVersion\""[:]"\""*[0-9][\.]*[0-9][\.]*[0-9]*"\""[,]"\"id\""[:]"\"test_box3\""[,]"\"pid\""[:]*[0-9][,]"\"status\""[:]*"\"running\""[,]"\"bundle\""[:]*$bundle*[,]"\"rootfs\""[:]"\""*"\""[,]"\"created\""[:]*[0-9]*[\}][\]] ]]
 }
 
 @test "list with non-existent root fails" {
-	ROOT=/non-existent-dir runc list
-	[ "$status" -ne 0 ]
+	ROOT=/non-existent-dir run ! runc list
 }
 
 @test "list with default non-existent root succeeds" {
 	requires root # rootless auto-creates a directory under $XDG_RUNTIME_DIR.
 	test -d /root/runc && skip "requires missing /root/runc"
-	ROOT='' runc list
-	[ "$status" -eq 0 ]
+	ROOT='' run -0 runc list
 }

--- a/tests/integration/list.bats
+++ b/tests/integration/list.bats
@@ -29,9 +29,9 @@ function teardown() {
 	[[ "${lines[3]}" == *"test_box3"*[0-9]*"running"*$bundle*[0-9]* ]]
 
 	ROOT=$ALT_ROOT run -0 runc list -q
-	[ "${lines[0]}" = "test_box1" ]
-	[ "${lines[1]}" = "test_box2" ]
-	[ "${lines[2]}" = "test_box3" ]
+	assert_line --index 0 "test_box1"
+	assert_line --index 1 "test_box2"
+	assert_line --index 2 "test_box3"
 
 	ROOT=$ALT_ROOT run -0 runc list --format table
 	[[ ${lines[0]} =~ ID\ +PID\ +STATUS\ +BUNDLE\ +CREATED+ ]]

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -51,10 +51,10 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	run -0 runc exec test_busybox sh -c "mount | grep /testdir -c"
-	[[ "${output}" == "1" ]]
+	assert_output "1"
 
 	run -0 runc exec test_busybox sh -c "mount | grep /testfile -c"
-	[[ "${output}" == "1" ]]
+	assert_output "1"
 }
 
 @test "mask paths [prohibit symlink /proc]" {

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -24,10 +24,10 @@ function teardown() {
 	[ -z "$output" ]
 
 	run -1 runc exec test_busybox rm -f /testfile
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 
 	run -1 runc exec test_busybox umount /testfile
-	[[ "${output}" == *"Operation not permitted"* ]]
+	assert_output --partial "Operation not permitted"
 }
 
 @test "mask paths [directory]" {
@@ -37,13 +37,13 @@ function teardown() {
 	[ -z "$output" ]
 
 	run -1 runc exec test_busybox touch /testdir/foo
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 
 	run -1 runc exec test_busybox rm -rf /testdir
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 
 	run -1 runc exec test_busybox umount /testdir
-	[[ "${output}" == *"Operation not permitted"* ]]
+	assert_output --partial "Operation not permitted"
 }
 
 @test "mask paths [duplicate paths]" {
@@ -60,7 +60,7 @@ function teardown() {
 @test "mask paths [prohibit symlink /proc]" {
 	ln -s /symlink rootfs/proc
 	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[[ "${output}" == *"must be mounted on ordinary directory"* ]]
+	assert_output --partial "must be mounted on ordinary directory"
 }
 
 @test "mask paths [prohibit symlink /sys]" {
@@ -86,7 +86,7 @@ function teardown() {
 	'
 
 	run -1 runc exec test_busybox touch /testdir2/foo
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 }
 
 @test "mask paths [directory with read-only rootfs]" {

--- a/tests/integration/mask.bats
+++ b/tests/integration/mask.bats
@@ -18,61 +18,48 @@ function teardown() {
 }
 
 @test "mask paths [file]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox cat /testfile
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox cat /testfile
 	[ -z "$output" ]
 
-	runc exec test_busybox rm -f /testfile
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_busybox rm -f /testfile
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_busybox umount /testfile
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_busybox umount /testfile
 	[[ "${output}" == *"Operation not permitted"* ]]
 }
 
 @test "mask paths [directory]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox ls /testdir
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox ls /testdir
 	[ -z "$output" ]
 
-	runc exec test_busybox touch /testdir/foo
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_busybox touch /testdir/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_busybox rm -rf /testdir
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_busybox rm -rf /testdir
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_busybox umount /testdir
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_busybox umount /testdir
 	[[ "${output}" == *"Operation not permitted"* ]]
 }
 
 @test "mask paths [duplicate paths]" {
 	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir", "/testfile"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox sh -c "mount | grep /testdir -c"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox sh -c "mount | grep /testdir -c"
 	[[ "${output}" == "1" ]]
 
-	runc exec test_busybox sh -c "mount | grep /testfile -c"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox sh -c "mount | grep /testfile -c"
 	[[ "${output}" == "1" ]]
 }
 
 @test "mask paths [prohibit symlink /proc]" {
 	ln -s /symlink rootfs/proc
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	[[ "${output}" == *"must be mounted on ordinary directory"* ]]
 }
 
@@ -81,8 +68,7 @@ function teardown() {
 	requires root
 
 	ln -s /symlink rootfs/sys
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	# On cgroup v1, this may fail before checking if /sys is a symlink,
 	# so we merely check that it fails, and do not check the exact error
 	# message like for /proc above.
@@ -90,19 +76,16 @@ function teardown() {
 
 @test "mask paths [directories share tmpfs]" {
 	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir2", "/testdir3"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# shellcheck disable=SC2016
-	runc exec test_busybox sh -euc '
+	run -0 runc exec test_busybox sh -euc '
 		set -- $(stat -c %d /testdir /testdir2 /testdir3)
 		[ "$1" = "$2" ]
 		[ "$2" = "$3" ]
 	'
-	[ "$status" -eq 0 ]
 
-	runc exec test_busybox touch /testdir2/foo
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_busybox touch /testdir2/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 }
 
@@ -110,10 +93,8 @@ function teardown() {
 	update_config '(.. | select(.maskedPaths? != null)) .maskedPaths += ["/testdir2", "/testdir3"]'
 	update_config '.root.readonly = true'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox ls /testdir
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox ls /testdir
 	[ -z "$output" ]
 }

--- a/tests/integration/memorypolicy.bats
+++ b/tests/integration/memorypolicy.bats
@@ -17,8 +17,7 @@ function teardown() {
 		"mode": "MPOL_INTERLEAVE",
 		"nodes": "0"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == "interleave:0" ]]
 }
 
@@ -30,8 +29,7 @@ function teardown() {
 		"nodes": "0",
 		"flags": ["MPOL_F_STATIC_NODES"]
 	}'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == "bind"*"static"*"0" ]]
 }
 
@@ -42,11 +40,9 @@ function teardown() {
 		"nodes": "0",
 		"flags": ["MPOL_F_RELATIVE_NODES"]
 	}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox /bin/sh -c "head -n 1 /proc/self/numa_maps | cut -d \" \" -f 2"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox /bin/sh -c "head -n 1 /proc/self/numa_maps | cut -d \" \" -f 2"
 	[[ "${lines[0]}" == "prefer"*"relative"*"0" ]]
 }
 
@@ -55,8 +51,7 @@ function teardown() {
 	.process.args = ["/bin/sh", "-c", "head -n 1 /proc/self/numa_maps | cut -d \" \" -f 2"]
 	| .linux.memoryPolicy = {
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy"* ]]
 }
 
@@ -67,8 +62,7 @@ function teardown() {
 		"mode": "INTERLEAVE",
 		"nodes": "0"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy"* ]]
 }
 
@@ -80,8 +74,7 @@ function teardown() {
 		"nodes": "0",
 		"flags": ["MPOL_F_RELATIVE_NODES", "badflag"]
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy flag"* ]]
 }
 
@@ -91,8 +84,7 @@ function teardown() {
 	| .linux.memoryPolicy = {
 		"mode": "MPOL_DEFAULT"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == *"default"* ]]
 }
 
@@ -102,8 +94,7 @@ function teardown() {
 	| .linux.memoryPolicy = {
 		"nodes": "0-7"
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy mode"* ]]
 }
 
@@ -114,8 +105,7 @@ function teardown() {
 		"mode": "MPOL_DEFAULT",
 		"nodes": "0-7",
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run test_busybox
 	[[ "${lines[*]}" == *"mode requires 0 nodes but got 8"* ]]
 }
 
@@ -127,7 +117,6 @@ function teardown() {
 		"nodes": "0-9876543210",
 		"flags": []
 	}'
-	runc run test_busybox
-	[ "$status" -eq 1 ]
+	run -1 runc run test_busybox
 	[[ "${lines[0]}" == *"invalid memory policy node"* ]]
 }

--- a/tests/integration/memorypolicy.bats
+++ b/tests/integration/memorypolicy.bats
@@ -30,7 +30,7 @@ function teardown() {
 		"flags": ["MPOL_F_STATIC_NODES"]
 	}'
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == "bind"*"static"*"0" ]]
+	assert_line --index 0 --regexp "^bind.*static.*0$"
 }
 
 @test "runc run and exec memory policy prefer relative" {
@@ -43,7 +43,7 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	run -0 runc exec test_busybox /bin/sh -c "head -n 1 /proc/self/numa_maps | cut -d \" \" -f 2"
-	[[ "${lines[0]}" == "prefer"*"relative"*"0" ]]
+	assert_line --index 0 --regexp "^prefer.*relative.*0$"
 }
 
 @test "runc run empty memory policy" {
@@ -52,7 +52,7 @@ function teardown() {
 	| .linux.memoryPolicy = {
 	}'
 	run -1 runc run test_busybox
-	[[ "${lines[0]}" == *"invalid memory policy"* ]]
+	assert_line --index 0 --partial "invalid memory policy"
 }
 
 @test "runc run memory policy with non-existing mode" {
@@ -63,7 +63,7 @@ function teardown() {
 		"nodes": "0"
 	}'
 	run -1 runc run test_busybox
-	[[ "${lines[0]}" == *"invalid memory policy"* ]]
+	assert_line --index 0 --partial "invalid memory policy"
 }
 
 @test "runc run memory policy with invalid flag" {
@@ -75,7 +75,7 @@ function teardown() {
 		"flags": ["MPOL_F_RELATIVE_NODES", "badflag"]
 	}'
 	run -1 runc run test_busybox
-	[[ "${lines[0]}" == *"invalid memory policy flag"* ]]
+	assert_line --index 0 --partial "invalid memory policy flag"
 }
 
 @test "runc run memory policy default with missing nodes" {
@@ -85,7 +85,7 @@ function teardown() {
 		"mode": "MPOL_DEFAULT"
 	}'
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == *"default"* ]]
+	assert_line --index 0 --partial "default"
 }
 
 @test "runc run memory policy with missing mode" {
@@ -95,7 +95,7 @@ function teardown() {
 		"nodes": "0-7"
 	}'
 	run -1 runc run test_busybox
-	[[ "${lines[0]}" == *"invalid memory policy mode"* ]]
+	assert_line --index 0 --partial "invalid memory policy mode"
 }
 
 @test "runc run memory policy calls syscall with invalid arguments" {
@@ -106,7 +106,7 @@ function teardown() {
 		"nodes": "0-7",
 	}'
 	run -1 runc run test_busybox
-	[[ "${lines[*]}" == *"mode requires 0 nodes but got 8"* ]]
+	assert_output --partial "mode requires 0 nodes but got 8"
 }
 
 @test "runc run memory policy bind way too large a node number" {
@@ -118,5 +118,5 @@ function teardown() {
 		"flags": []
 	}'
 	run -1 runc run test_busybox
-	[[ "${lines[0]}" == *"invalid memory policy node"* ]]
+	assert_line --index 0 --partial "invalid memory policy node"
 }

--- a/tests/integration/memorypolicy.bats
+++ b/tests/integration/memorypolicy.bats
@@ -18,7 +18,7 @@ function teardown() {
 		"nodes": "0"
 	}'
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == "interleave:0" ]]
+	assert_line --index 0 "interleave:0"
 }
 
 @test "runc run memory policy bind static" {

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -18,8 +18,7 @@ function test_ro_cgroup_mount() {
 	local lines status
 	# shellcheck disable=SC2016
 	update_config '.process.args |= ["sh", "-euc", "for f in `grep /sys/fs/cgroup /proc/mounts | awk \"{print \\\\$2}\"| uniq`; do test -e $f && grep -w $f /proc/mounts | tail -n1; done"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[ "${#lines[@]}" -ne 0 ]
 	for line in "${lines[@]}"; do [[ "${line}" == *'ro,'* ]]; done
 }
@@ -122,8 +121,7 @@ function test_mount_order() {
 	# Check that the entire tree was copied and the mounts were done in the
 	# expected order.
 	update_config '.process.args = ["cat", "/final/x/y/z/z/x/y/z/x/file"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"a/x"* ]] # the final "file" was from a/x.
 }
 
@@ -148,15 +146,13 @@ test_mount_target() {
 	# Make sure the target path is at the right spot and is actually a
 	# bind-mount of the correct inode.
 	update_config '.process.args = ["stat", "-c", "%n %d:%i", "--", "'"$real_dst"'"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == "$real_dst $(stat -c "%d:%i" -- "$src")" ]]
 
 	# Make sure there is a mount entry for the target path.
 	# shellcheck disable=SC2016
 	update_config '.process.args = ["awk", "-F", "PATH='"$real_dst"'", "$2 == PATH", "/proc/self/mounts"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"$real_dst"* ]]
 
 	# Switch back the old config so this function can be called multiple times.
@@ -176,8 +172,7 @@ test_mount_target() {
 			| .process.args |= ["ls", "-ld", "/dir1/dir2"]'
 
 	umask 022
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == *'drwxrwxrwx'* ]]
 }
 
@@ -189,8 +184,7 @@ test_mount_target() {
 				}]
 			| .process.args |= ["ls", "/tmp/bind/config.json"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
 }
 
@@ -204,8 +198,7 @@ test_mount_target() {
 				}]
 			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == *'ro,'* ]]
 }
 
@@ -214,8 +207,7 @@ test_mount_target() {
 	update_config '   .mounts |= map((select(.destination == "/dev") | .options += ["ro"]) // .)
 			| .process.args |= ["grep", "^tmpfs /dev", "/proc/mounts"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "${lines[0]}" == *'ro,'* ]]
 }
 
@@ -231,8 +223,7 @@ test_mount_target() {
 					options: ["ro", "nodev", "nosuid"]
 				}]
 			| .process.args |= ["true"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # CVE-2023-27561 CVE-2019-19921
@@ -242,8 +233,7 @@ test_mount_target() {
 	mkdir -p rootfs/bad-proc
 	ln -sf /bad-proc rootfs/proc
 	# This should fail.
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"must be mounted on ordinary directory"* ]]
 }
 
@@ -260,8 +250,7 @@ test_mount_target() {
 	}]'
 	update_config '.process.args |= ["true"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# Verify that the setgid bit is inherited.
 	[[ "$(stat -c %a rootfs/setgid)" == 7755 ]]
@@ -283,13 +272,11 @@ test_mount_target() {
 	}]'
 	update_config '.process.args = ["stat", "-c", "%a", "/tmpfs"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == "710" ]]
 
 	update_config '.process.args = ["cat", "/proc/self/mounts"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	grep -Ex "tmpfs /tmpfs tmpfs [^ ]*\bmode=710\b[^ ]* .*" <<<"$output"
 }
 
@@ -307,13 +294,11 @@ test_mount_target() {
 	update_config '.process.args = ["stat", "-c", "%a", "/tmpfs"]'
 
 	# Explicitly setting mode= overrides whatever mode we would've inherited.
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == "1500" ]]
 
 	update_config '.process.args = ["cat", "/proc/self/mounts"]'
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	grep -Ex "tmpfs /tmpfs tmpfs [^ ]*\bmode=1500\b[^ ]* .*" <<<"$output"
 
 	# Verify that the actual directory was not chmod-ed.
@@ -331,15 +316,13 @@ test_mount_target() {
 	update_config '.process.args = ["stat", "-c", "%a", "/non-existent/foo/bar/baz"]'
 
 	rm -rf rootfs/non-existent
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == "1777" ]]
 
 	update_config '.process.args = ["cat", "/proc/self/mounts"]'
 
 	rm -rf rootfs/non-existent
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	# We don't explicitly set a mode= in this case, it is just the tmpfs default.
 	grep -Ex "tmpfs /non-existent/foo/bar/baz tmpfs .*" <<<"$output"
 	run ! grep -Ex "tmpfs /non-existent/foo/bar/baz tmpfs [^ ]*\bmode=[0-7]+\b[^ ]* .*" <<<"$output"

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -147,7 +147,7 @@ test_mount_target() {
 	# bind-mount of the correct inode.
 	update_config '.process.args = ["stat", "-c", "%n %d:%i", "--", "'"$real_dst"'"]'
 	run -0 runc run test_busybox
-	[[ "$output" == "$real_dst $(stat -c "%d:%i" -- "$src")" ]]
+	assert_output "$real_dst $(stat -c "%d:%i" -- "$src")"
 
 	# Make sure there is a mount entry for the target path.
 	# shellcheck disable=SC2016
@@ -273,7 +273,7 @@ test_mount_target() {
 	update_config '.process.args = ["stat", "-c", "%a", "/tmpfs"]'
 
 	run -0 runc run test_busybox
-	[[ "$output" == "710" ]]
+	assert_output "710"
 
 	update_config '.process.args = ["cat", "/proc/self/mounts"]'
 	run -0 runc run test_busybox
@@ -295,7 +295,7 @@ test_mount_target() {
 
 	# Explicitly setting mode= overrides whatever mode we would've inherited.
 	run -0 runc run test_busybox
-	[[ "$output" == "1500" ]]
+	assert_output "1500"
 
 	update_config '.process.args = ["cat", "/proc/self/mounts"]'
 	run -0 runc run test_busybox
@@ -317,7 +317,7 @@ test_mount_target() {
 
 	rm -rf rootfs/non-existent
 	run -0 runc run test_busybox
-	[[ "$output" == "1777" ]]
+	assert_output "1777"
 
 	update_config '.process.args = ["cat", "/proc/self/mounts"]'
 

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -122,7 +122,7 @@ function test_mount_order() {
 	# expected order.
 	update_config '.process.args = ["cat", "/final/x/y/z/z/x/y/z/x/file"]'
 	run -0 runc run test_busybox
-	[[ "$output" == *"a/x"* ]] # the final "file" was from a/x.
+	assert_output --partial "a/x" # the final "file" was from a/x.
 }
 
 # This needs to be placed at the top of the bats file to work around
@@ -153,7 +153,7 @@ test_mount_target() {
 	# shellcheck disable=SC2016
 	update_config '.process.args = ["awk", "-F", "PATH='"$real_dst"'", "$2 == PATH", "/proc/self/mounts"]'
 	run -0 runc run test_busybox
-	[[ "$output" == *"$real_dst"* ]]
+	assert_output --partial "$real_dst"
 
 	# Switch back the old config so this function can be called multiple times.
 	mv "$old_config" "./config.json"
@@ -173,7 +173,7 @@ test_mount_target() {
 
 	umask 022
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == *'drwxrwxrwx'* ]]
+	assert_line --index 0 --partial 'drwxrwxrwx'
 }
 
 @test "runc run [bind mount]" {
@@ -185,7 +185,7 @@ test_mount_target() {
 			| .process.args |= ["ls", "/tmp/bind/config.json"]'
 
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == *'/tmp/bind/config.json'* ]]
+	assert_line --index 0 --partial '/tmp/bind/config.json'
 }
 
 # https://github.com/opencontainers/runc/issues/2246
@@ -199,7 +199,7 @@ test_mount_target() {
 			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == *'ro,'* ]]
+	assert_line --index 0 --partial 'ro,'
 }
 
 # https://github.com/opencontainers/runc/issues/3248
@@ -208,7 +208,7 @@ test_mount_target() {
 			| .process.args |= ["grep", "^tmpfs /dev", "/proc/mounts"]'
 
 	run -0 runc run test_busybox
-	[[ "${lines[0]}" == *'ro,'* ]]
+	assert_line --index 0 --partial 'ro,'
 }
 
 # https://github.com/opencontainers/runc/issues/2683
@@ -234,7 +234,7 @@ test_mount_target() {
 	ln -sf /bad-proc rootfs/proc
 	# This should fail.
 	run ! runc run test_busybox
-	[[ "$output" == *"must be mounted on ordinary directory"* ]]
+	assert_output --partial "must be mounted on ordinary directory"
 }
 
 # https://github.com/opencontainers/runc/issues/4401

--- a/tests/integration/mounts_propagation.bats
+++ b/tests/integration/mounts_propagation.bats
@@ -17,5 +17,5 @@ function teardown() {
 	update_config ' .process.args = ["findmnt", "--noheadings", "-o", "PROPAGATION", "/"] '
 
 	run -0 runc run test_shared_rootfs
-	[ "$output" = "shared" ]
+	assert_output "shared"
 }

--- a/tests/integration/mounts_propagation.bats
+++ b/tests/integration/mounts_propagation.bats
@@ -16,7 +16,6 @@ function teardown() {
 
 	update_config ' .process.args = ["findmnt", "--noheadings", "-o", "PROPAGATION", "/"] '
 
-	runc run test_shared_rootfs
-	[ "$status" -eq 0 ]
+	run -0 runc run test_shared_rootfs
 	[ "$output" = "shared" ]
 }

--- a/tests/integration/mounts_propagation_unsafe.bats
+++ b/tests/integration/mounts_propagation_unsafe.bats
@@ -64,5 +64,5 @@ function teardown() {
 	update_config ' .process.args = ["findmnt", "--noheadings", "-o", "PROPAGATION", "/"] '
 
 	run -0 runc_in_mount_namespace run test_slave_rootfs
-	[ "$output" = "private,slave" ]
+	assert_output "private,slave"
 }

--- a/tests/integration/mounts_propagation_unsafe.bats
+++ b/tests/integration/mounts_propagation_unsafe.bats
@@ -36,8 +36,7 @@ function teardown_isolated_mount_namespace() {
 }
 
 function __runc_in_mount_namespace() {
-	setup_runc_cmdline
-	in_mount_namespace "${RUNC_CMDLINE[@]}" "$@"
+	in_mount_namespace runc "$@"
 }
 
 function make_rootfs_shared() {

--- a/tests/integration/mounts_propagation_unsafe.bats
+++ b/tests/integration/mounts_propagation_unsafe.bats
@@ -35,16 +35,12 @@ function teardown_isolated_mount_namespace() {
 	fi
 }
 
-function __runc_in_mount_namespace() {
-	in_mount_namespace runc "$@"
-}
-
 function make_rootfs_shared() {
 	in_mount_namespace mount --make-rshared /
 }
 
 function runc_in_mount_namespace() {
-	CMDNAME="$(basename "$RUNC")" sane_run __runc_in_mount_namespace "$@"
+	in_mount_namespace runc "$@"
 }
 
 function setup() {
@@ -67,7 +63,6 @@ function teardown() {
 
 	update_config ' .process.args = ["findmnt", "--noheadings", "-o", "PROPAGATION", "/"] '
 
-	runc_in_mount_namespace run test_slave_rootfs
-	[ "$status" -eq 0 ]
+	run -0 runc_in_mount_namespace run test_slave_rootfs
 	[ "$output" = "private,slave" ]
 }

--- a/tests/integration/mounts_recursive.bats
+++ b/tests/integration/mounts_recursive.bats
@@ -34,30 +34,24 @@ function teardown() {
 @test "runc run [rbind,ro mount is read-only but not recursively]" {
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt\", options: [\"rbind\",\"ro\"]}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro
 
-	runc exec test_rbind_ro touch /mnt/foo
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_rbind_ro touch /mnt/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_rbind_ro touch /mnt/subvol/bar
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_rbind_ro touch /mnt/subvol/bar
 }
 
 @test "runc run [rbind,rro mount is recursively read-only]" {
 	requires_kernel 5.12
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt\", options: [\"rbind\",\"rro\"]}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_rro
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_rro
 
-	runc exec test_rbind_rro touch /mnt/foo
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_rbind_rro touch /mnt/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_rbind_rro touch /mnt/subvol/bar
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_rbind_rro touch /mnt/subvol/bar
 	[[ "${output}" == *"Read-only file system"* ]]
 }
 
@@ -65,15 +59,12 @@ function teardown() {
 	requires_kernel 5.12
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt\", options: [\"rbind\",\"ro\",\"rro\"]}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro_rro
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro_rro
 
-	runc exec test_rbind_ro_rro touch /mnt/foo
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_rbind_ro_rro touch /mnt/foo
 	[[ "${output}" == *"Read-only file system"* ]]
 
-	runc exec test_rbind_ro_rro touch /mnt/subvol/bar
-	[ "$status" -eq 1 ]
+	run -1 runc exec test_rbind_ro_rro touch /mnt/subvol/bar
 	[[ "${output}" == *"Read-only file system"* ]]
 }
 
@@ -87,42 +78,41 @@ function teardown() {
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt5\", options: [\"rbind\",\"rrelatime\"]}]"
 	update_config ".mounts += [{source: \"${TESTVOLUME}\" , destination: \"/mnt6\", options: [\"rbind\",\"rnorelatime\"]}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ratime
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ratime
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1/subvol
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2
 	[[ "${output}" == "rw,noatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2/subvol
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2/subvol
 	[[ "${output}" == "rw,noatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3
 	[[ "${output}" == "rw,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3/subvol
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3/subvol
 	[[ "${output}" == "rw,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4/subvol
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5/subvol
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6/subvol
+	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 }

--- a/tests/integration/mounts_recursive.bats
+++ b/tests/integration/mounts_recursive.bats
@@ -37,7 +37,7 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro
 
 	run -1 runc exec test_rbind_ro touch /mnt/foo
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 
 	run -0 runc exec test_rbind_ro touch /mnt/subvol/bar
 }
@@ -49,10 +49,10 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_rro
 
 	run -1 runc exec test_rbind_rro touch /mnt/foo
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 
 	run -1 runc exec test_rbind_rro touch /mnt/subvol/bar
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 }
 
 @test "runc run [rbind,ro,rro mount is recursively read-only too]" {
@@ -62,10 +62,10 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ro_rro
 
 	run -1 runc exec test_rbind_ro_rro touch /mnt/foo
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 
 	run -1 runc exec test_rbind_ro_rro touch /mnt/subvol/bar
-	[[ "${output}" == *"Read-only file system"* ]]
+	assert_output --partial "Read-only file system"
 }
 
 # https://github.com/opencontainers/runc/issues/5095
@@ -81,38 +81,38 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ratime
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1/subvol
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2
-	[[ "${output}" == "rw,noatime,"* ]]
+	assert_output --regexp '^rw,noatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2/subvol
-	[[ "${output}" == "rw,noatime,"* ]]
+	assert_output --regexp '^rw,noatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3
-	[[ "${output}" == "rw,"* ]]
+	assert_output --regexp '^rw,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3/subvol
-	[[ "${output}" == "rw,"* ]]
+	assert_output --regexp '^rw,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4/subvol
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5/subvol
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 
 	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6/subvol
-	[[ "${output}" == "rw,relatime,"* ]]
+	assert_output --regexp '^rw,relatime,'
 }

--- a/tests/integration/mounts_recursive.bats
+++ b/tests/integration/mounts_recursive.bats
@@ -80,39 +80,39 @@ function teardown() {
 
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rbind_ratime
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1/subvol
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt1/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2
 	[[ "${output}" == "rw,noatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2/subvol
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt2/subvol
 	[[ "${output}" == "rw,noatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3
 	[[ "${output}" == "rw,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3/subvol
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt3/subvol
 	[[ "${output}" == "rw,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4/subvol
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt4/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5/subvol
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt5/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6
 	[[ "${output}" == "rw,relatime,"* ]]
 
-	run runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6/subvol
+	run -0 runc exec test_rbind_ratime findmnt --noheadings -o options /mnt6/subvol
 	[[ "${output}" == "rw,relatime,"* ]]
 }

--- a/tests/integration/mounts_sshfs.bats
+++ b/tests/integration/mounts_sshfs.bats
@@ -86,7 +86,7 @@ function fail_sshfs_bind_flags() {
 	setup_sshfs_bind_flags "$@"
 
 	run ! runc run test_busybox
-	[[ "$output" == *"runc run failed: unable to start container process: error during container init: error mounting"*"operation not permitted"* ]]
+	assert_output --regexp 'runc run failed: unable to start container process: error during container init: error mounting.*operation not permitted'
 }
 
 @test "runc run [mount(8)-like behaviour: --bind with no options]" {

--- a/tests/integration/mounts_sshfs.bats
+++ b/tests/integration/mounts_sshfs.bats
@@ -78,16 +78,14 @@ function setup_sshfs_bind_flags() {
 function pass_sshfs_bind_flags() {
 	setup_sshfs_bind_flags "$@"
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	mnt_flags="$output"
 }
 
 function fail_sshfs_bind_flags() {
 	setup_sshfs_bind_flags "$@"
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"runc run failed: unable to start container process: error during container init: error mounting"*"operation not permitted"* ]]
 }
 

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -60,7 +60,7 @@ function teardown() {
 
 	# The network namespace owner controls the lifecycle of the interface.
 	# The interface should remain on the namespace after the container was killed.
-	run runc delete --force test_busybox
+	run -0 runc delete --force test_busybox
 
 	# Move back the interface to the root namespace (pid 1).
 	ip netns exec "$ns_name" ip link set dev dummy0 netns 1

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -93,11 +93,11 @@ function teardown() {
 	ip address add "$global_ip" dev dummy0
 
 	run -0 runc run test_busybox
-	[[ "$output" == *"$global_ip "* ]]
+	assert_output --partial "$global_ip "
 
 	# Verify the interface is still present in the network namespace.
 	run -0 ip netns exec "$ns_name" ip address show dev dummy0
-	[[ "$output" == *"$global_ip "* ]]
+	assert_output --partial "$global_ip "
 }
 
 @test "move network device to precreated container network namespace and set ip address without global scope" {
@@ -113,7 +113,7 @@ function teardown() {
 	ip address add "$non_global_ip" dev dummy0
 
 	run -0 runc run test_busybox
-	[[ "$output" != *" $non_global_ip "* ]]
+	refute_output --partial " $non_global_ip "
 
 	# Verify the interface is still present in the network namespace.
 	ip netns exec "$ns_name" ip address show dev dummy0
@@ -129,11 +129,11 @@ function teardown() {
 	ip link set mtu "$mtu_value" dev dummy0
 
 	run -0 runc run test_busybox
-	[[ "$output" == *"mtu $mtu_value "* ]]
+	assert_output --partial "mtu $mtu_value "
 
 	# Verify the interface is still present in the network namespace.
 	run -0 ip netns exec "$ns_name" ip address show dev dummy0
-	[[ "$output" == *"mtu $mtu_value "* ]]
+	assert_output --partial "mtu $mtu_value "
 }
 
 @test "move network device to precreated container network namespace and set mac address" {
@@ -146,11 +146,11 @@ function teardown() {
 	ip link set address "$mac_address" dev dummy0
 
 	run -0 runc run test_busybox
-	[[ "$output" == *"ether $mac_address "* ]]
+	assert_output --partial "ether $mac_address "
 
 	# Verify the interface is still present in the network namespace.
 	run -0 ip netns exec "$ns_name" ip address show dev dummy0
-	[[ "$output" == *"ether $mac_address "* ]]
+	assert_output --partial "ether $mac_address "
 }
 
 @test "move network device to precreated container network namespace and rename" {
@@ -181,13 +181,13 @@ function teardown() {
 	ip address add "$global_ip" dev dummy0
 
 	run -0 runc run test_busybox
-	[[ "$output" == *" $global_ip "* ]]
-	[[ "$output" == *"ether $mac_address "* ]]
-	[[ "$output" == *"mtu $mtu_value "* ]]
+	assert_output --partial " $global_ip "
+	assert_output --partial "ether $mac_address "
+	assert_output --partial "mtu $mtu_value "
 
 	# Verify the interface is still present in the network namespace.
 	run -0 ip netns exec "$ns_name" ip address show dev ctr_dummy0
-	[[ "$output" == *" $global_ip "* ]]
-	[[ "$output" == *"ether $mac_address "* ]]
-	[[ "$output" == *"mtu $mtu_value "* ]]
+	assert_output --partial " $global_ip "
+	assert_output --partial "ether $mac_address "
+	assert_output --partial "mtu $mtu_value "
 }

--- a/tests/integration/netdev.bats
+++ b/tests/integration/netdev.bats
@@ -49,20 +49,18 @@ function teardown() {
 	update_config ' .linux.netDevices |= {"dummy0": {} }
       		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 @test "move network device to container network namespace and restore it back" {
 	setup_netns
 	update_config ' .linux.netDevices |= {"dummy0": {} }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# The network namespace owner controls the lifecycle of the interface.
 	# The interface should remain on the namespace after the container was killed.
-	runc delete --force test_busybox
+	run runc delete --force test_busybox
 
 	# Move back the interface to the root namespace (pid 1).
 	ip netns exec "$ns_name" ip link set dev dummy0 netns 1
@@ -76,8 +74,7 @@ function teardown() {
 	update_config ' .linux.netDevices |= {"dummy0": {} }
       		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# Verify the interface is still present in the network namespace.
 	ip netns exec "$ns_name" ip address show dev dummy0
@@ -95,8 +92,7 @@ function teardown() {
 	ip link set down dev dummy0
 	ip address add "$global_ip" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"$global_ip "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -116,8 +112,7 @@ function teardown() {
 	ip link set down dev dummy0
 	ip address add "$non_global_ip" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" != *" $non_global_ip "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -133,8 +128,7 @@ function teardown() {
 	# Set a custom mtu to the interface.
 	ip link set mtu "$mtu_value" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"mtu $mtu_value "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -151,8 +145,7 @@ function teardown() {
 	# set a custom mac address to the interface
 	ip link set address "$mac_address" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"ether $mac_address "* ]]
 
 	# Verify the interface is still present in the network namespace.
@@ -165,8 +158,7 @@ function teardown() {
 	update_config ' .linux.netDevices |= { "dummy0": { "name" : "ctr_dummy0" } }
       		| .process.args |= ["ip", "address", "show", "dev", "ctr_dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# Verify the interface is still present in the network namespace.
 	ip netns exec "$ns_name" ip address show dev ctr_dummy0
@@ -188,8 +180,7 @@ function teardown() {
 	# Set a custom ip address to the interface.
 	ip address add "$global_ip" dev dummy0
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *" $global_ip "* ]]
 	[[ "$output" == *"ether $mac_address "* ]]
 	[[ "$output" == *"mtu $mtu_value "* ]]

--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -18,5 +18,5 @@ function teardown() {
 			| .process.capabilities.permitted += ["CAP_SETFCAP"]'
 
 	run -1 runc run --no-pivot test_no_pivot
-	[[ "$output" == *"mount: permission denied"* ]]
+	assert_output --partial "mount: permission denied"
 }

--- a/tests/integration/no_pivot.bats
+++ b/tests/integration/no_pivot.bats
@@ -17,7 +17,6 @@ function teardown() {
 			| .process.capabilities.bounding += ["CAP_SETFCAP"]
 			| .process.capabilities.permitted += ["CAP_SETFCAP"]'
 
-	runc run --no-pivot test_no_pivot
-	[ "$status" -eq 1 ]
+	run -1 runc run --no-pivot test_no_pivot
 	[[ "$output" == *"mount: permission denied"* ]]
 }

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -51,7 +51,7 @@ function teardown() {
 
 	testcontainer test_busybox running
 
-	run runc delete --force test_busybox
+	run -0 runc delete --force test_busybox
 
 	run ! runc state test_busybox
 }

--- a/tests/integration/pause.bats
+++ b/tests/integration/pause.bats
@@ -17,18 +17,15 @@ function teardown() {
 		set_cgroups_path
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc pause test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc pause test_busybox
 
 	testcontainer test_busybox paused
 
-	runc resume test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc resume test_busybox
 
 	testcontainer test_busybox running
 }
@@ -40,27 +37,21 @@ function teardown() {
 		set_cgroups_path
 	fi
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc pause test_busybox
-	[ "$status" -eq 0 ]
-	runc pause nonexistent
-	[ "$status" -ne 0 ]
+	run -0 runc pause test_busybox
+	run ! runc pause nonexistent
 
 	testcontainer test_busybox paused
 
-	runc resume test_busybox
-	[ "$status" -eq 0 ]
-	runc resume nonexistent
-	[ "$status" -ne 0 ]
+	run -0 runc resume test_busybox
+	run ! runc resume nonexistent
 
 	testcontainer test_busybox running
 
-	runc delete --force test_busybox
+	run runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 }

--- a/tests/integration/personality.bats
+++ b/tests/integration/personality.bats
@@ -19,8 +19,7 @@ function teardown() {
                 "flags": []
 			}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"i686"* ]]
 }
 
@@ -30,10 +29,8 @@ function teardown() {
                 "domain": "LINUX32",
       }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-	runc exec test_busybox /bin/sh -c "uname -a"
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	run -0 runc exec test_busybox /bin/sh -c "uname -a"
 	[[ "$output" == *"i686"* ]]
 }
 
@@ -45,8 +42,7 @@ function teardown() {
                 "flags": []
 			}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"x86_64"* ]]
 }
 
@@ -56,10 +52,8 @@ function teardown() {
                 "domain": "LINUX",
       }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-	runc exec test_busybox /bin/sh -c "uname -a"
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	run -0 runc exec test_busybox /bin/sh -c "uname -a"
 	[[ "$output" == *"x86_64"* ]]
 }
 
@@ -74,9 +68,7 @@ function teardown() {
                 "syscalls":[{"names":["personality"], "action":"SCMP_ACT_ERRNO"}]
 	  }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
-	runc exec test_busybox /bin/sh -c "uname -a"
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	run -0 runc exec test_busybox /bin/sh -c "uname -a"
 	[[ "$output" == *"x86_64"* ]]
 }

--- a/tests/integration/personality.bats
+++ b/tests/integration/personality.bats
@@ -20,7 +20,7 @@ function teardown() {
 			}'
 
 	run -0 runc run test_busybox
-	[[ "$output" == *"i686"* ]]
+	assert_output --partial "i686"
 }
 
 @test "runc run personality with exec for i686" {
@@ -31,7 +31,7 @@ function teardown() {
 
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	run -0 runc exec test_busybox /bin/sh -c "uname -a"
-	[[ "$output" == *"i686"* ]]
+	assert_output --partial "i686"
 }
 
 @test "runc run personality for x86_64" {
@@ -43,7 +43,7 @@ function teardown() {
 			}'
 
 	run -0 runc run test_busybox
-	[[ "$output" == *"x86_64"* ]]
+	assert_output --partial "x86_64"
 }
 
 @test "runc run personality with exec for x86_64" {
@@ -54,7 +54,7 @@ function teardown() {
 
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	run -0 runc exec test_busybox /bin/sh -c "uname -a"
-	[[ "$output" == *"x86_64"* ]]
+	assert_output --partial "x86_64"
 }
 
 # check that personality can be set when the personality syscall is blocked by seccomp
@@ -70,5 +70,5 @@ function teardown() {
 
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	run -0 runc exec test_busybox /bin/sh -c "uname -a"
-	[[ "$output" == *"x86_64"* ]]
+	assert_output --partial "x86_64"
 }

--- a/tests/integration/pidfd-socket.bats
+++ b/tests/integration/pidfd-socket.bats
@@ -17,8 +17,7 @@ function teardown() {
 @test "runc create [ --pidfd-socket ] " {
 	setup_pidfd_kill "SIGTERM"
 
-	runc create --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
-	[ "$status" -eq 0 ]
+	run -0 runc create --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
 	testcontainer test_pidfd created
 
 	pidfd_kill
@@ -28,8 +27,7 @@ function teardown() {
 @test "runc run [ --pidfd-socket ] " {
 	setup_pidfd_kill "SIGKILL"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd
 	testcontainer test_pidfd running
 
 	pidfd_kill
@@ -41,8 +39,7 @@ function teardown() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
 	testcontainer test_pidfd running
 
 	# Use sub-cgroup to ensure that exec process has been killed
@@ -51,7 +48,7 @@ function teardown() {
 
 	setup_pidfd_kill "SIGKILL"
 
-	__runc exec -d --cgroup "pids:exec_pidfd" --pid-file "exec_pid.txt" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd sleep 1d
+	runc exec -d --cgroup "pids:exec_pidfd" --pid-file "exec_pid.txt" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd sleep 1d
 
 	exec_pid=$(cat exec_pid.txt)
 	exec_pid_in_cgroup=$(cat "${test_pidfd_cgroup_path}/exec_pidfd/cgroup.procs")
@@ -70,8 +67,7 @@ function teardown() {
 
 	set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_pidfd
 	testcontainer test_pidfd running
 
 	# Use sub-cgroup to ensure that exec process has been killed
@@ -80,7 +76,7 @@ function teardown() {
 
 	setup_pidfd_kill "SIGKILL"
 
-	__runc exec -d --cgroup "exec_pidfd" --pid-file "exec_pid.txt" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd sleep 1d
+	runc exec -d --cgroup "exec_pidfd" --pid-file "exec_pid.txt" --pidfd-socket "${PIDFD_SOCKET}" test_pidfd sleep 1d
 
 	exec_pid=$(cat exec_pid.txt)
 	exec_pid_in_cgroup=$(cat "${test_pidfd_cgroup_path}/exec_pidfd/cgroup.procs")

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -21,19 +21,19 @@ function teardown() {
 
 @test "ps" {
 	run -0 runc ps test_busybox
-	[[ "$output" =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
-	[[ "$output" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
+	assert_output --regexp 'UID +PID +PPID +C +STIME +TTY +TIME +CMD+'
+	assert_output --regexp "$(id -un 2>/dev/null).*[0-9]"
 }
 
 @test "ps -f json" {
 	run -0 runc ps -f json test_busybox
-	[[ "$output" =~ [0-9]+ ]]
+	assert_output --regexp '[0-9]+'
 }
 
 @test "ps -e -x" {
 	run -0 runc ps test_busybox -e -x
-	[[ "$output" =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
-	[[ "$output" =~ [0-9]+ ]]
+	assert_output --regexp ' +PID +TTY +STAT +TIME +COMMAND+'
+	assert_output --regexp '[0-9]+'
 }
 
 @test "ps after the container stopped" {

--- a/tests/integration/ps.bats
+++ b/tests/integration/ps.bats
@@ -11,8 +11,7 @@ function setup() {
 	# Rootless does not have default cgroup path.
 	[ $EUID -ne 0 ] && set_cgroups_path
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 }
 
@@ -21,33 +20,27 @@ function teardown() {
 }
 
 @test "ps" {
-	runc ps test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc ps test_busybox
 	[[ "$output" =~ UID\ +PID\ +PPID\ +C\ +STIME\ +TTY\ +TIME\ +CMD+ ]]
 	[[ "$output" == *"$(id -un 2>/dev/null)"*[0-9]* ]]
 }
 
 @test "ps -f json" {
-	runc ps -f json test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc ps -f json test_busybox
 	[[ "$output" =~ [0-9]+ ]]
 }
 
 @test "ps -e -x" {
-	runc ps test_busybox -e -x
-	[ "$status" -eq 0 ]
+	run -0 runc ps test_busybox -e -x
 	[[ "$output" =~ \ +PID\ +TTY\ +STAT\ +TIME\ +COMMAND+ ]]
 	[[ "$output" =~ [0-9]+ ]]
 }
 
 @test "ps after the container stopped" {
-	runc ps test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc ps test_busybox
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 	wait_for_container 10 1 test_busybox stopped
 
-	runc ps test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc ps test_busybox
 }

--- a/tests/integration/rlimits.bats
+++ b/tests/integration/rlimits.bats
@@ -22,8 +22,7 @@ function run_check_nofile() {
 	update_config ".process.rlimits = [{\"type\": \"RLIMIT_NOFILE\", \"soft\": ${soft}, \"hard\": ${hard}}]"
 	update_config '.process.args = ["/bin/sh", "-c", "ulimit -n; ulimit -H -n"]'
 
-	runc run test_rlimit
-	[ "$status" -eq 0 ]
+	run -0 runc run test_rlimit
 	[[ "${lines[0]}" == "${soft}" ]]
 	[[ "${lines[1]}" == "${hard}" ]]
 }
@@ -36,11 +35,9 @@ function exec_check_nofile() {
 	hard="$2"
 	update_config ".process.rlimits = [{\"type\": \"RLIMIT_NOFILE\", \"soft\": ${soft}, \"hard\": ${hard}}]"
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_rlimit
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rlimit
 
-	runc exec test_rlimit /bin/sh -c "ulimit -n; ulimit -H -n"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_rlimit /bin/sh -c "ulimit -n; ulimit -H -n"
 	[[ "${lines[0]}" == "${soft}" ]]
 	[[ "${lines[1]}" == "${hard}" ]]
 }

--- a/tests/integration/rlimits.bats
+++ b/tests/integration/rlimits.bats
@@ -23,8 +23,8 @@ function run_check_nofile() {
 	update_config '.process.args = ["/bin/sh", "-c", "ulimit -n; ulimit -H -n"]'
 
 	run -0 runc run test_rlimit
-	[[ "${lines[0]}" == "${soft}" ]]
-	[[ "${lines[1]}" == "${hard}" ]]
+	assert_line --index 0 "${soft}"
+	assert_line --index 1 "${hard}"
 }
 
 # Set and check rlimit_nofile for runc exec. Arguments are:
@@ -38,8 +38,8 @@ function exec_check_nofile() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_rlimit
 
 	run -0 runc exec test_rlimit /bin/sh -c "ulimit -n; ulimit -H -n"
-	[[ "${lines[0]}" == "${soft}" ]]
-	[[ "${lines[1]}" == "${hard}" ]]
+	assert_line --index 0 "${soft}"
+	assert_line --index 1 "${hard}"
 }
 
 @test "runc run with RLIMIT_NOFILE(The same as system's hard value)" {

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -9,43 +9,33 @@ function setup() {
 }
 
 function teardown() {
-	ROOT=$ALT_ROOT __runc delete -f test_dotbox
+	ROOT=$ALT_ROOT runc delete -f test_dotbox
 	unset ALT_ROOT
 	teardown_bundle
 }
 
 @test "global --root" {
 	# run busybox detached using $ALT_ROOT for state
-	ROOT=$ALT_ROOT runc run -d --console-socket "$CONSOLE_SOCKET" test_dotbox
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_dotbox
 
 	# run busybox detached in default root
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc state test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc state test_busybox
 	[[ "${output}" == *"running"* ]]
 
-	ROOT=$ALT_ROOT runc state test_dotbox
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc state test_dotbox
 	[[ "${output}" == *"running"* ]]
 
-	ROOT=$ALT_ROOT runc state test_busybox
-	[ "$status" -ne 0 ]
+	ROOT=$ALT_ROOT run ! runc state test_busybox
 
-	runc state test_dotbox
-	[ "$status" -ne 0 ]
+	run ! runc state test_dotbox
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 	wait_for_container 10 1 test_busybox stopped
-	runc delete test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc delete test_busybox
 
-	ROOT=$ALT_ROOT runc kill test_dotbox KILL
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc kill test_dotbox KILL
 	ROOT=$ALT_ROOT wait_for_container 10 1 test_dotbox stopped
-	ROOT=$ALT_ROOT runc delete test_dotbox
-	[ "$status" -eq 0 ]
+	ROOT=$ALT_ROOT run -0 runc delete test_dotbox
 }

--- a/tests/integration/root.bats
+++ b/tests/integration/root.bats
@@ -22,10 +22,10 @@ function teardown() {
 	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	run -0 runc state test_busybox
-	[[ "${output}" == *"running"* ]]
+	assert_output --partial "running"
 
 	ROOT=$ALT_ROOT run -0 runc state test_dotbox
-	[[ "${output}" == *"running"* ]]
+	assert_output --partial "running"
 
 	ROOT=$ALT_ROOT run ! runc state test_busybox
 

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -12,26 +12,21 @@ function teardown() {
 }
 
 @test "runc run" {
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run test_hello
 
-	runc state test_hello
-	[ "$status" -ne 0 ]
+	run ! runc state test_hello
 }
 
 @test "runc run --keep" {
-	runc run --keep test_run_keep
-	[ "$status" -eq 0 ]
+	run -0 runc run --keep test_run_keep
 
 	testcontainer test_run_keep stopped
 
-	runc state test_run_keep
-	[ "$status" -eq 0 ]
+	run -0 runc state test_run_keep
 
-	runc delete test_run_keep
+	run runc delete test_run_keep
 
-	runc state test_run_keep
-	[ "$status" -ne 0 ]
+	run ! runc state test_run_keep
 }
 
 @test "runc run --keep (check cgroup exists)" {
@@ -41,21 +36,18 @@ function teardown() {
 
 	set_cgroups_path
 
-	runc run --keep test_run_keep
-	[ "$status" -eq 0 ]
+	run -0 runc run --keep test_run_keep
 
 	testcontainer test_run_keep stopped
 
-	runc state test_run_keep
-	[ "$status" -eq 0 ]
+	run -0 runc state test_run_keep
 
 	# check that cgroup exists
 	check_cgroup_value "pids.max" "max"
 
-	runc delete test_run_keep
+	run runc delete test_run_keep
 
-	runc state test_run_keep
-	[ "$status" -ne 0 ]
+	run ! runc state test_run_keep
 }
 
 @test "runc run [hostname domainname]" {
@@ -63,17 +55,14 @@ function teardown() {
 			| .hostname = "myhostname"
 			| .domainname= "mydomainname"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_utc
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_utc
 
 	# test hostname
-	runc exec test_utc hostname
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_utc hostname
 	[[ "${lines[0]}" == *'myhostname'* ]]
 
 	# test domainname
-	runc exec test_utc cat /proc/sys/kernel/domainname
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_utc cat /proc/sys/kernel/domainname
 	[[ "${lines[0]}" == *'mydomainname'* ]]
 }
 
@@ -87,8 +76,7 @@ function teardown() {
 	update_config '.process.args = ["sh", "-c", "stat -c %A /tmp"]'
 	update_config '.mounts += [{"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options":["noexec","nosuid","nodev","rprivate"]}]'
 
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	run -0 runc run test_tmpfs
 	[ "${lines[0]}" = "$mode" ]
 }
 
@@ -97,35 +85,30 @@ function teardown() {
 	update_config '.mounts += [{"destination": "/tmp/test", "type": "tmpfs", "source": "tmpfs", "options": ["mode=0444"]}]'
 
 	# Directory is to be created by runc.
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	run -0 runc run test_tmpfs
 	[ "${lines[0]}" = "444" ]
 
 	# Run a 2nd time with the pre-existing directory.
 	# Ref: https://github.com/opencontainers/runc/issues/3911
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	run -0 runc run test_tmpfs
 	[ "${lines[0]}" = "444" ]
 
 	# Existing directory, custom perms, no mode on the mount,
 	# so it should use the directory's perms.
 	update_config '.mounts[-1].options = []'
 	chmod 0710 rootfs/tmp/test
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	run -0 runc run test_tmpfs
 	[ "${lines[0]}" = "710" ]
 
 	# Add back the mode on the mount, and it should use that instead.
 	# Just for fun, use different perms than was used earlier.
 	update_config '.mounts[-1].options = ["mode=0410"]'
-	runc run test_tmpfs
-	[ "$status" -eq 0 ]
+	run -0 runc run test_tmpfs
 	[ "${lines[0]}" = "410" ]
 }
 
 @test "runc run [/proc/self/exe clone]" {
-	runc --debug run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc --debug run test_hello
 	[[ "$output" = *"Hello World"* ]]
 	[[ "$output" = *"runc exeseal: using /proc/self/exe clone"* ]]
 	# runc will use fsopen("overlay") if it can.
@@ -153,8 +136,7 @@ function teardown() {
 		}'
 	update_config '.process.args = ["sleep", "infinity"]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_ctr
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" target_ctr
 
 	# Modify our container's configuration such that it is just going to
 	# inherit all of the namespaces of the target container.
@@ -168,30 +150,26 @@ function teardown() {
 	# We could hack around this (create a copy of the rootfs inside the rootfs,
 	# or use a simpler mount namespace target), but those wouldn't be similar
 	# tests to the other namespace joining tests.
-	target_pid="$(__runc state target_ctr | jq .pid)"
+	target_pid="$(runc state target_ctr | jq .pid)"
 	update_config '.linux.namespaces |= map_values(.path = if .type == "mount" then "" else "/proc/'"$target_pid"'/ns/" + ({"network": "net", "mount": "mnt"}[.type] // .type) end)'
 	# Remove the userns and timens configuration (they cannot be changed).
 	update_config '.linux |= (del(.uidMappings) | del(.gidMappings) | del(.timeOffsets))'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" attached_ctr
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" attached_ctr
 
 	# Make sure there are two sleep processes in our container.
-	runc exec attached_ctr ps aux
-	[ "$status" -eq 0 ]
+	run -0 runc exec attached_ctr ps aux
 	run -0 grep "sleep infinity" <<<"$output"
 	[ "${#lines[@]}" -eq 2 ]
 
 	# ... that the userns mappings are the same...
-	runc exec attached_ctr cat /proc/self/uid_map
-	[ "$status" -eq 0 ]
+	run -0 runc exec attached_ctr cat /proc/self/uid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+100000\s+100$' <<<"$output"
 	else
 		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
 	fi
-	runc exec attached_ctr cat /proc/self/gid_map
-	[ "$status" -eq 0 ]
+	run -0 runc exec attached_ctr cat /proc/self/gid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+200000\s+200$' <<<"$output"
 	else
@@ -199,7 +177,7 @@ function teardown() {
 	fi
 
 	# ... as well as the timens offsets.
-	runc exec attached_ctr cat /proc/self/timens_offsets
+	run runc exec attached_ctr cat /proc/self/timens_offsets
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }
@@ -211,8 +189,7 @@ sh
 EOF
 	chmod +x rootfs/run.sh
 	update_config '.process.args = [ "/run.sh" ]'
-	runc run test_hello
-	[ "$status" -ne 0 ]
+	run ! runc run test_hello
 
 	# After the sync socket closed, we should not send error to parent
 	# process, or else we will get a unnecessary error log(#4171).
@@ -231,7 +208,6 @@ EOF
 			| .process.user.uid = 2000
 			| .process.args |= ["sh", "-c", "echo $HOME"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[ "${lines[0]}" = "/home/tempuser" ]
 }

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -77,7 +77,7 @@ function teardown() {
 	update_config '.mounts += [{"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options":["noexec","nosuid","nodev","rprivate"]}]'
 
 	run -0 runc run test_tmpfs
-	[ "${lines[0]}" = "$mode" ]
+	assert_line --index 0 "$mode"
 }
 
 @test "runc run with tmpfs perms" {
@@ -86,25 +86,25 @@ function teardown() {
 
 	# Directory is to be created by runc.
 	run -0 runc run test_tmpfs
-	[ "${lines[0]}" = "444" ]
+	assert_line --index 0 "444"
 
 	# Run a 2nd time with the pre-existing directory.
 	# Ref: https://github.com/opencontainers/runc/issues/3911
 	run -0 runc run test_tmpfs
-	[ "${lines[0]}" = "444" ]
+	assert_line --index 0 "444"
 
 	# Existing directory, custom perms, no mode on the mount,
 	# so it should use the directory's perms.
 	update_config '.mounts[-1].options = []'
 	chmod 0710 rootfs/tmp/test
 	run -0 runc run test_tmpfs
-	[ "${lines[0]}" = "710" ]
+	assert_line --index 0 "710"
 
 	# Add back the mode on the mount, and it should use that instead.
 	# Just for fun, use different perms than was used earlier.
 	update_config '.mounts[-1].options = ["mode=0410"]'
 	run -0 runc run test_tmpfs
-	[ "${lines[0]}" = "410" ]
+	assert_line --index 0 "410"
 }
 
 @test "runc run [/proc/self/exe clone]" {
@@ -194,7 +194,7 @@ EOF
 	# After the sync socket closed, we should not send error to parent
 	# process, or else we will get a unnecessary error log(#4171).
 	[ ${#lines[@]} -eq 1 ]
-	[[ ${lines[0]} = "exec /run.sh: no such file or directory" ]]
+	assert_line --index 0 "exec /run.sh: no such file or directory"
 }
 
 # https://github.com/opencontainers/runc/issues/4688
@@ -209,5 +209,5 @@ EOF
 			| .process.args |= ["sh", "-c", "echo $HOME"]'
 
 	run -0 runc run test_busybox
-	[ "${lines[0]}" = "/home/tempuser" ]
+	assert_line --index 0 "/home/tempuser"
 }

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -24,7 +24,7 @@ function teardown() {
 
 	run -0 runc state test_run_keep
 
-	run runc delete test_run_keep
+	run -0 runc delete test_run_keep
 
 	run ! runc state test_run_keep
 }
@@ -45,7 +45,7 @@ function teardown() {
 	# check that cgroup exists
 	check_cgroup_value "pids.max" "max"
 
-	run runc delete test_run_keep
+	run -0 runc delete test_run_keep
 
 	run ! runc state test_run_keep
 }
@@ -177,7 +177,7 @@ function teardown() {
 	fi
 
 	# ... as well as the timens offsets.
-	run runc exec attached_ctr cat /proc/self/timens_offsets
+	run -0 runc exec attached_ctr cat /proc/self/timens_offsets
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -59,11 +59,11 @@ function teardown() {
 
 	# test hostname
 	run -0 runc exec test_utc hostname
-	[[ "${lines[0]}" == *'myhostname'* ]]
+	assert_line --index 0 --partial 'myhostname'
 
 	# test domainname
 	run -0 runc exec test_utc cat /proc/sys/kernel/domainname
-	[[ "${lines[0]}" == *'mydomainname'* ]]
+	assert_line --index 0 --partial 'mydomainname'
 }
 
 # https://github.com/opencontainers/runc/issues/3952
@@ -109,11 +109,11 @@ function teardown() {
 
 @test "runc run [/proc/self/exe clone]" {
 	run -0 runc --debug run test_hello
-	[[ "$output" = *"Hello World"* ]]
-	[[ "$output" = *"runc exeseal: using /proc/self/exe clone"* ]]
+	assert_output --partial "Hello World"
+	assert_output --partial "runc exeseal: using /proc/self/exe clone"
 	# runc will use fsopen("overlay") if it can.
 	if can_fsopen overlay; then
-		[[ "$output" = *"runc exeseal: using overlayfs for sealed /proc/self/exe"* ]]
+		assert_output --partial "runc exeseal: using overlayfs for sealed /proc/self/exe"
 	fi
 }
 

--- a/tests/integration/scheduler.bats
+++ b/tests/integration/scheduler.bats
@@ -18,18 +18,15 @@ function teardown() {
 		"nice": 19
 	}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
 
 	# Check init settings.
-	runc exec test_scheduler chrt -p 1
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_scheduler chrt -p 1
 	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
 	[[ "${lines[1]}" == *"priority: 0" ]]
 
 	# Check exec settings derived from config.json.
-	runc exec test_scheduler sh -c 'chrt -p $$'
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_scheduler sh -c 'chrt -p $$'
 	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
 	[[ "${lines[1]}" == *"priority: 0" ]]
 
@@ -49,7 +46,7 @@ function teardown() {
 		"period": 1000000
 	}
 }'
-	__runc exec -d --pid-file pid.txt --process <(echo "$proc") test_scheduler
+	runc exec -d --pid-file pid.txt --process <(echo "$proc") test_scheduler
 
 	run -0 chrt -p "$(cat pid.txt)"
 	[[ "${lines[0]}" == *"scheduling policy: SCHED_DEADLINE|SCHED_RESET_ON_FORK" ]]
@@ -71,7 +68,6 @@ function teardown() {
 	update_config ' .linux.resources.cpu.cpus = "0"
 		| .process.scheduler = {"policy": "SCHED_DEADLINE", "nice": 19, "runtime": 42000, "deadline": 1000000, "period": 1000000, }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
-	[ "$status" -eq 1 ]
+	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
 	[[ "$output" == *"process scheduler can't be used together with AllowedCPUs"* ]]
 }

--- a/tests/integration/scheduler.bats
+++ b/tests/integration/scheduler.bats
@@ -22,13 +22,13 @@ function teardown() {
 
 	# Check init settings.
 	run -0 runc exec test_scheduler chrt -p 1
-	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
-	[[ "${lines[1]}" == *"priority: 0" ]]
+	assert_line --index 0 --regexp "scheduling policy: SCHED_BATCH$"
+	assert_line --index 1 --regexp "priority: 0$"
 
 	# Check exec settings derived from config.json.
 	run -0 runc exec test_scheduler sh -c 'chrt -p $$'
-	[[ "${lines[0]}" == *"scheduling policy: SCHED_BATCH" ]]
-	[[ "${lines[1]}" == *"priority: 0" ]]
+	assert_line --index 0 --regexp "scheduling policy: SCHED_BATCH$"
+	assert_line --index 1 --regexp "priority: 0$"
 
 	# Another exec, with different scheduler settings.
 	proc='
@@ -49,9 +49,9 @@ function teardown() {
 	runc exec -d --pid-file pid.txt --process <(echo "$proc") test_scheduler
 
 	run -0 chrt -p "$(cat pid.txt)"
-	[[ "${lines[0]}" == *"scheduling policy: SCHED_DEADLINE|SCHED_RESET_ON_FORK" ]]
-	[[ "${lines[1]}" == *"priority: 0" ]]
-	[[ "${lines[2]}" == *"runtime/deadline/period parameters: 42000/100000/1000000" ]]
+	assert_line --index 0 --regexp "scheduling policy: SCHED_DEADLINE\|SCHED_RESET_ON_FORK$"
+	assert_line --index 1 --regexp "priority: 0$"
+	assert_line --index 2 --regexp "runtime/deadline/period parameters: 42000/100000/1000000$"
 }
 
 # Checks that runc emits a specific error when scheduling policy is used
@@ -69,5 +69,5 @@ function teardown() {
 		| .process.scheduler = {"policy": "SCHED_DEADLINE", "nice": 19, "runtime": 42000, "deadline": 1000000, "period": 1000000, }'
 
 	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_scheduler
-	[[ "$output" == *"process scheduler can't be used together with AllowedCPUs"* ]]
+	assert_output --partial "process scheduler can't be used together with AllowedCPUs"
 }

--- a/tests/integration/seccomp-notify-compat.bats
+++ b/tests/integration/seccomp-notify-compat.bats
@@ -29,7 +29,6 @@ function teardown() {
 				"syscalls": [{ "names": [ "mkdir" ], "action": "SCMP_ACT_NOTIFY" }]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"seccomp notify unsupported:"* ]]
 }

--- a/tests/integration/seccomp-notify-compat.bats
+++ b/tests/integration/seccomp-notify-compat.bats
@@ -30,5 +30,5 @@ function teardown() {
 			}'
 
 	run ! runc run test_busybox
-	[[ "$output" == *"seccomp notify unsupported:"* ]]
+	assert_output --partial "seccomp notify unsupported:"
 }

--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -94,7 +94,7 @@ function scmp_act_notify_template() {
 
 	scmp_act_notify_template "sleep infinity" true '"mkdir"'
 
-	run runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	run -0 runc exec test_busybox /bin/sh -c "mkdir /dev/shm/foo && stat /dev/shm/foo-bar"
 }
 

--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -46,23 +46,21 @@ function scmp_act_notify_template() {
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY noNewPrivileges false)" {
 	scmp_act_notify_template "mkdir /dev/shm/foo && stat /dev/shm/foo-bar" false '"mkdir"'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # Test basic actions handled by the agent work fine. noNewPrivileges TRUE.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY noNewPrivileges true)" {
 	scmp_act_notify_template "mkdir /dev/shm/foo && stat /dev/shm/foo-bar" true '"mkdir"'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 @test "runc run [seccomp] (SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV)" {
 	scmp_act_notify_template "mkdir /dev/shm/foo && stat /dev/shm/foo-bar" false '"mkdir"'
 	update_config '.linux.seccomp.flags = [ "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" ]'
 
-	runc --debug run test_busybox
+	run runc --debug run test_busybox
 	if [ "$status" -ne 0 ]; then
 		# Older libseccomp or kernel?
 		if [[ "$output" == *"error adding WaitKill flag to seccomp filter: SetWaitKill requires "* ]]; then
@@ -85,11 +83,9 @@ function scmp_act_notify_template() {
 
 	scmp_act_notify_template "sleep infinity" false '"mkdir"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox /bin/sh -c "mkdir /dev/shm/foo && stat /dev/shm/foo-bar"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox /bin/sh -c "mkdir /dev/shm/foo && stat /dev/shm/foo-bar"
 }
 
 # Test actions not-handled by the agent work fine. noNewPrivileges TRUE.
@@ -98,9 +94,8 @@ function scmp_act_notify_template() {
 
 	scmp_act_notify_template "sleep infinity" true '"mkdir"'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	runc exec test_busybox /bin/sh -c "mkdir /dev/shm/foo && stat /dev/shm/foo-bar"
-	[ "$status" -eq 0 ]
+	run runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	run -0 runc exec test_busybox /bin/sh -c "mkdir /dev/shm/foo && stat /dev/shm/foo-bar"
 }
 
 # Test important syscalls (some might be executed by runc) work fine when handled by the agent. noNewPrivileges FALSE.
@@ -108,16 +103,14 @@ function scmp_act_notify_template() {
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY important syscalls noNewPrivileges false)" {
 	scmp_act_notify_template "/bin/true" false '"execve","openat","open","read","close","fcntl"'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # Test important syscalls (some might be executed by runc) work fine when handled by the agent. noNewPrivileges TRUE.
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY important syscalls noNewPrivileges true)" {
 	scmp_act_notify_template "/bin/true" true '"execve","openat","open","read","close","fcntl"'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # Ignore listenerPath if the profile doesn't use seccomp notify actions.
@@ -129,8 +122,7 @@ function scmp_act_notify_template() {
 				"listenerMetadata": "bar",
 			}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # Ensure listenerPath is present if the profile uses seccomp notify actions.
@@ -138,8 +130,7 @@ function scmp_act_notify_template() {
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 	update_config '.linux.seccomp.listenerPath = ""'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 }
 
 # Test using an invalid socket (none listening) as listenerPath fails.
@@ -147,8 +138,7 @@ function scmp_act_notify_template() {
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 	update_config '.linux.seccomp.listenerPath = "/some-non-existing-listener-path.sock"'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 }
 
 # Test using an invalid abstract socket as listenerPath fails.
@@ -156,8 +146,7 @@ function scmp_act_notify_template() {
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 	update_config '.linux.seccomp.listenerPath = "@mysocketishere"'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 }
 
 # Check that killing the seccompagent doesn't block syscalls in
@@ -166,8 +155,7 @@ function scmp_act_notify_template() {
 	scmp_act_notify_template "sleep 4 && mkdir /dev/shm/foo" false '"mkdir"'
 
 	sleep 2 && teardown_seccompagent &
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Function not implemented"* ]]
 }
 
@@ -177,8 +165,7 @@ function scmp_act_notify_template() {
 
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"failed to connect with seccomp agent"* ]]
 }
 
@@ -186,8 +173,7 @@ function scmp_act_notify_template() {
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY error chmod)" {
 	scmp_act_notify_template "touch /dev/shm/foo && chmod 777 /dev/shm/foo" false '"chmod", "fchmod", "fchmodat"'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"chmod:"*"/dev/shm/foo"*"No medium found"* ]]
 }
 
@@ -195,8 +181,7 @@ function scmp_act_notify_template() {
 @test "runc run [seccomp] (SCMP_ACT_NOTIFY write)" {
 	scmp_act_notify_template "/bin/true" false '"write"'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"SCMP_ACT_NOTIFY cannot be used for the write syscall"* ]]
 }
 
@@ -227,8 +212,7 @@ function scmp_act_notify_template() {
 				} ]
 			}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # Check that example config in the seccomp agent dir works.
@@ -241,8 +225,6 @@ function scmp_act_notify_template() {
 	# seccomp agent. However, inside bats the socket is in a bats tmp dir.
 	update_config '.linux.seccomp.listenerPath = "'"$SECCCOMP_AGENT_SOCKET"'"'
 
-	runc run test_busybox
-
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ "$output" == *"chmod:"*"test-file"*"No medium found"* ]]
 }

--- a/tests/integration/seccomp-notify.bats
+++ b/tests/integration/seccomp-notify.bats
@@ -74,7 +74,7 @@ function scmp_act_notify_template() {
 	#  8: SECCOMP_FILTER_FLAG_NEW_LISTENER
 	exp='"seccomp filter flags: 40"'
 	echo "expecting $exp"
-	[[ "$output" == *"$exp"* ]]
+	assert_output --partial "$exp"
 }
 
 # Test actions not-handled by the agent work fine. noNewPrivileges FALSE.
@@ -156,7 +156,7 @@ function scmp_act_notify_template() {
 
 	sleep 2 && teardown_seccompagent &
 	run ! runc run test_busybox
-	[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Function not implemented"* ]]
+	assert_output --regexp 'mkdir:.*/dev/shm/foo.*Function not implemented'
 }
 
 # Check that starting with no seccomp agent running fails with a clear error.
@@ -166,7 +166,7 @@ function scmp_act_notify_template() {
 	scmp_act_notify_template "/bin/true" false '"mkdir"'
 
 	run ! runc run test_busybox
-	[[ "$output" == *"failed to connect with seccomp agent"* ]]
+	assert_output --partial "failed to connect with seccomp agent"
 }
 
 # Check that agent-returned error for the syscall works.
@@ -174,7 +174,7 @@ function scmp_act_notify_template() {
 	scmp_act_notify_template "touch /dev/shm/foo && chmod 777 /dev/shm/foo" false '"chmod", "fchmod", "fchmodat"'
 
 	run ! runc run test_busybox
-	[[ "$output" == *"chmod:"*"/dev/shm/foo"*"No medium found"* ]]
+	assert_output --regexp 'chmod:.*/dev/shm/foo.*No medium found'
 }
 
 # check that trying to use SCMP_ACT_NOTIFY with write() gives a meaningful error.
@@ -182,7 +182,7 @@ function scmp_act_notify_template() {
 	scmp_act_notify_template "/bin/true" false '"write"'
 
 	run ! runc run test_busybox
-	[[ "$output" == *"SCMP_ACT_NOTIFY cannot be used for the write syscall"* ]]
+	assert_output --partial "SCMP_ACT_NOTIFY cannot be used for the write syscall"
 }
 
 # check that a startContainer hook doesn't get any extra file descriptor.
@@ -226,5 +226,5 @@ function scmp_act_notify_template() {
 	update_config '.linux.seccomp.listenerPath = "'"$SECCCOMP_AGENT_SOCKET"'"'
 
 	run -0 runc run test_busybox
-	[[ "$output" == *"chmod:"*"test-file"*"No medium found"* ]]
+	assert_output --regexp 'chmod:.*test-file.*No medium found'
 }

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -18,8 +18,7 @@ function teardown() {
 	update_config ".linux.seccomp = $(<"${TESTDATA}/${TEST_NAME}.json")"
 	update_config '.process.args = ["/seccomp_test"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 @test "runc run [seccomp defaultErrnoRet=ENXIO]" {
@@ -30,8 +29,7 @@ function teardown() {
 	update_config ".linux.seccomp = $(<"${TESTDATA}/${TEST_NAME}.json")"
 	update_config '.process.args = ["/seccomp_test2"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # TODO:
@@ -46,8 +44,7 @@ function teardown() {
 				"syscalls":[{"names":["mkdir","mkdirat"], "action":"SCMP_ACT_ERRNO"}]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Operation not permitted"* ]]
 }
 
@@ -59,8 +56,7 @@ function teardown() {
 				"syscalls":[{"names":["mkdir","mkdirat"], "action":"SCMP_ACT_ERRNO", "errnoRet": 100}]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"Network is down"* ]]
 }
 
@@ -102,7 +98,7 @@ function flags_value() {
 	#
 	# Filter out WAIT_KILLABLE_RECV as it requires a listener,
 	# and thus tested separately in seccomp-notify.bats.
-	mapfile -t flags < <(__runc features | jq -c '.linux.seccomp.supportedFlags' |
+	mapfile -t flags < <(runc features | jq -c '.linux.seccomp.supportedFlags' |
 		tr -d '[]\n' | tr ',' '\n' | grep -v 'WAIT_KILLABLE_RECV')
 
 	# This is a set of all possible flag combinations to test.
@@ -141,8 +137,7 @@ function flags_value() {
 			;;
 		esac
 
-		runc --debug run test_busybox
-		[ "$status" -ne 0 ]
+		run ! runc --debug run test_busybox
 		[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Operation not permitted"* ]]
 
 		# Check the numeric flags value, as printed in the debug log, is as expected.
@@ -161,8 +156,7 @@ function flags_value() {
 				"syscalls":[{"names":["mkdir","mkdirat"], "action":"SCMP_ACT_KILL"}]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 }
 
 # check that a startContainer hook is run with the seccomp filters applied
@@ -180,8 +174,7 @@ function flags_value() {
 				} ]
 			}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 	[[ "$output" == *"error running startContainer hook"* ]]
 	[[ "$output" == *"bad system call"* ]]
 }
@@ -194,6 +187,5 @@ function flags_value() {
 				"syscalls":[{"names":["close_range", "fsopen", "fsconfig", "fspick", "openat2", "open_tree", "move_mount", "mount_setattr"], "action":"SCMP_ACT_ERRNO", "errnoRet": 38}]
 			}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }

--- a/tests/integration/seccomp.bats
+++ b/tests/integration/seccomp.bats
@@ -45,7 +45,7 @@ function teardown() {
 			}'
 
 	run ! runc run test_busybox
-	[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Operation not permitted"* ]]
+	assert_output --regexp 'mkdir:.*/dev/shm/foo.*Operation not permitted'
 }
 
 @test "runc run [seccomp] (SCMP_ACT_ERRNO explicit errno)" {
@@ -57,7 +57,7 @@ function teardown() {
 			}'
 
 	run ! runc run test_busybox
-	[[ "$output" == *"Network is down"* ]]
+	assert_output --partial "Network is down"
 }
 
 # Prints the numeric value of provided seccomp flags combination.
@@ -138,12 +138,12 @@ function flags_value() {
 		esac
 
 		run ! runc --debug run test_busybox
-		[[ "$output" == *"mkdir:"*"/dev/shm/foo"*"Operation not permitted"* ]]
+		assert_output --regexp 'mkdir:.*/dev/shm/foo.*Operation not permitted'
 
 		# Check the numeric flags value, as printed in the debug log, is as expected.
 		exp="\"seccomp filter flags: ${TEST_CASES[$key]}\""
 		echo "flags $key, expecting $exp"
-		[[ "$output" == *"$exp"* ]]
+		assert_output --partial "$exp"
 	done
 }
 
@@ -175,8 +175,8 @@ function flags_value() {
 			}'
 
 	run ! runc run test_busybox
-	[[ "$output" == *"error running startContainer hook"* ]]
-	[[ "$output" == *"bad system call"* ]]
+	assert_output --partial "error running startContainer hook"
+	assert_output --partial "bad system call"
 }
 
 @test "runc run [seccomp] (verify syscall compatibility after seccomp enforcement)" {

--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -43,7 +43,7 @@ function run_check_label() {
 	run -0 runc run tst
 	# Key name is _ses.$CONTAINER_NAME.
 	KEY=_ses.tst
-	[ "$output" == "$KEY $LABEL" ]
+	assert_output "$KEY $LABEL"
 }
 
 # This needs to be placed at the top of the bats file to work around
@@ -60,7 +60,7 @@ function exec_check_label() {
 	run -0 runc exec tst "/bin/$HELPER"
 	# Key name is _ses.$CONTAINER_NAME.
 	KEY=_ses.tst
-	[ "$output" == "$KEY $LABEL" ]
+	assert_output "$KEY $LABEL"
 }
 
 function enable_userns() {
@@ -113,5 +113,5 @@ function enable_userns() {
 			| .process.args = ["/run.sh"]'
 	run ! runc run tst
 	[ ${#lines[@]} -eq 1 ]
-	[[ "${lines[0]}" = "exec /run.sh: no such file or directory" ]]
+	assert_line --index 0 "exec /run.sh: no such file or directory"
 }

--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -111,8 +111,7 @@ function enable_userns() {
 
 	update_config '	  .process.selinuxLabel |= "system_u:system_r:container_t:s0:c4,c5"
 			| .process.args = ["/run.sh"]'
-	run runc run tst
-	[ "$status" -ne 0 ]
+	run ! runc run tst
 	[ ${#lines[@]} -eq 1 ]
 	[[ "${lines[0]}" = "exec /run.sh: no such file or directory" ]]
 }

--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -40,8 +40,7 @@ function run_check_label() {
 	LABEL="system_u:system_r:container_t:s0:c4,c5"
 	update_config '	  .process.selinuxLabel |= "'"$LABEL"'"
 			| .process.args = ["/bin/'"$HELPER"'"]'
-	runc run tst
-	[ "$status" -eq 0 ]
+	run -0 runc run tst
 	# Key name is _ses.$CONTAINER_NAME.
 	KEY=_ses.tst
 	[ "$output" == "$KEY $LABEL" ]
@@ -56,11 +55,9 @@ function exec_check_label() {
 	LABEL="system_u:system_r:container_t:s0:c4,c5"
 	update_config '	  .process.selinuxLabel |= "'"$LABEL"'"
 			| .process.args = ["/bin/sh"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" tst
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" tst
 
-	runc exec tst "/bin/$HELPER"
-	[ "$status" -eq 0 ]
+	run -0 runc exec tst "/bin/$HELPER"
 	# Key name is _ses.$CONTAINER_NAME.
 	KEY=_ses.tst
 	[ "$output" == "$KEY $LABEL" ]
@@ -76,15 +73,13 @@ function enable_userns() {
 # Baseline test, to check that runc works with selinux enabled.
 @test "runc run (no selinux label)" {
 	update_config '	  .process.args = ["/bin/true"]'
-	runc run tst
-	[ "$status" -eq 0 ]
+	run -0 runc run tst
 }
 
 @test "runc run (custom selinux label)" {
 	update_config '	  .process.selinuxLabel |= "system_u:system_r:container_t:s0:c4,c5"
 			| .process.args = ["/bin/true"]'
-	runc run tst
-	[ "$status" -eq 0 ]
+	run -0 runc run tst
 }
 
 @test "runc run (session keyring security label)" {
@@ -116,7 +111,7 @@ function enable_userns() {
 
 	update_config '	  .process.selinuxLabel |= "system_u:system_r:container_t:s0:c4,c5"
 			| .process.args = ["/run.sh"]'
-	runc run tst
+	run runc run tst
 	[ "$status" -ne 0 ]
 	[ ${#lines[@]} -eq 1 ]
 	[[ "${lines[0]}" = "exec /run.sh: no such file or directory" ]]

--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -12,13 +12,11 @@ function teardown() {
 }
 
 @test "spec generation cwd" {
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run test_hello
 }
 
 @test "spec generation --bundle" {
-	runc run --bundle "$(pwd)" test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run --bundle "$(pwd)" test_hello
 }
 
 @test "spec validator" {

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -19,7 +19,7 @@ function teardown() {
 
 	testcontainer test_busybox running
 
-	run runc delete --force test_busybox
+	run -0 runc delete --force test_busybox
 
 	run ! runc state test_busybox
 }

--- a/tests/integration/start.bats
+++ b/tests/integration/start.bats
@@ -11,18 +11,15 @@ function teardown() {
 }
 
 @test "runc start" {
-	runc create --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc create --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox created
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc start test_busybox
 
 	testcontainer test_busybox running
 
-	runc delete --force test_busybox
+	run runc delete --force test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 }

--- a/tests/integration/start_detached.bats
+++ b/tests/integration/start_detached.bats
@@ -11,8 +11,7 @@ function teardown() {
 }
 
 @test "runc run detached" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 	testcontainer test_busybox running
 }
 
@@ -25,20 +24,18 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 }
 
 @test "runc run detached --pid-file" {
-	runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	[ -e pid.txt ]
-	[[ "$(cat pid.txt)" == $(__runc state test_busybox | jq '.pid') ]]
+	[[ "$(cat pid.txt)" == $(runc state test_busybox | jq '.pid') ]]
 }
 
 @test "runc run detached --pid-file with new CWD" {
@@ -46,11 +43,10 @@ function teardown() {
 	mkdir pid_file
 	cd pid_file
 
-	runc run --pid-file pid.txt -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run --pid-file pid.txt -d -b "$bundle" --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	[ -e pid.txt ]
-	[[ "$(cat pid.txt)" == $(__runc state test_busybox | jq '.pid') ]]
+	[[ "$(cat pid.txt)" == $(runc state test_busybox | jq '.pid') ]]
 }

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -12,8 +12,7 @@ function teardown() {
 }
 
 @test "runc run" {
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run test_hello
 	[[ "${output}" == *"Hello"* ]]
 }
 
@@ -26,8 +25,7 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run test_hello
 	[[ "${output}" == *"Hello"* ]]
 }
 
@@ -46,8 +44,7 @@ function teardown() {
 			| (.. | select(.gid? == 0)) .gid |= 100'
 
 	# Sanity check: make sure we can't run the container w/o CAP_DAC_OVERRIDE.
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 
 	# Enable CAP_DAC_OVERRIDE.
 	update_config '	  .process.capabilities.bounding += ["CAP_DAC_OVERRIDE"]
@@ -56,8 +53,7 @@ function teardown() {
 			| .process.capabilities.ambient += ["CAP_DAC_OVERRIDE"]
 			| .process.capabilities.permitted += ["CAP_DAC_OVERRIDE"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 @test "runc run with rootfs set to ." {
@@ -66,14 +62,12 @@ function teardown() {
 	cd rootfs
 	update_config '(.. | select(. == "rootfs")) |= "."'
 
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run test_hello
 	[[ "${output}" == *"Hello"* ]]
 }
 
 @test "runc run --pid-file" {
-	runc run --pid-file pid.txt test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run --pid-file pid.txt test_hello
 	[[ "${output}" == *"Hello"* ]]
 
 	[ -e pid.txt ]
@@ -93,8 +87,7 @@ function teardown() {
 				| .options = ["rbind", "nosuid", "nodev", "noexec"]
 			  ) // .)'
 
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run test_hello
 }
 
 @test "runc run [redundant seccomp rules]" {
@@ -105,6 +98,5 @@ function teardown() {
 					"action": "SCMP_ACT_ALLOW",
 				}]
 			    }'
-	runc run test_hello
-	[ "$status" -eq 0 ]
+	run -0 runc run test_hello
 }

--- a/tests/integration/start_hello.bats
+++ b/tests/integration/start_hello.bats
@@ -13,7 +13,7 @@ function teardown() {
 
 @test "runc run" {
 	run -0 runc run test_hello
-	[[ "${output}" == *"Hello"* ]]
+	assert_output --partial "Hello"
 }
 
 @test "runc run ({u,g}id != 0)" {
@@ -26,7 +26,7 @@ function teardown() {
 		| (.. | select(.gid? == 0)) .gid |= 100'
 
 	run -0 runc run test_hello
-	[[ "${output}" == *"Hello"* ]]
+	assert_output --partial "Hello"
 }
 
 # https://github.com/opencontainers/runc/issues/3715.
@@ -63,12 +63,12 @@ function teardown() {
 	update_config '(.. | select(. == "rootfs")) |= "."'
 
 	run -0 runc run test_hello
-	[[ "${output}" == *"Hello"* ]]
+	assert_output --partial "Hello"
 }
 
 @test "runc run --pid-file" {
 	run -0 runc run --pid-file pid.txt test_hello
-	[[ "${output}" == *"Hello"* ]]
+	assert_output --partial "Hello"
 
 	[ -e pid.txt ]
 	[[ "$(cat pid.txt)" =~ [0-9]+ ]]

--- a/tests/integration/state.bats
+++ b/tests/integration/state.bats
@@ -11,44 +11,35 @@ function teardown() {
 }
 
 @test "state (kill + delete)" {
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 	wait_for_container 10 1 test_busybox stopped
 
-	runc delete test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc delete test_busybox
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 }
 
 @test "state (pause + resume)" {
 	# XXX: pause and resume require cgroups.
 	requires root
 
-	runc state test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc state test_busybox
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
-	runc pause test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc pause test_busybox
 
 	testcontainer test_busybox paused
 
-	runc resume test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc resume test_busybox
 
 	testcontainer test_busybox running
 }

--- a/tests/integration/timens.bats
+++ b/tests/integration/timens.bats
@@ -20,8 +20,7 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run test_busybox
-	[ "$status" -ne 0 ]
+	run ! runc run test_busybox
 }
 
 @test "runc run [timens with no offsets]" {
@@ -31,8 +30,7 @@ function teardown() {
 	update_config '.linux.namespaces += [{"type": "time"}]
 		| .linux.timeOffsets = null'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	# Default offsets are 0.
 	grep -E '^monotonic\s+0\s+0$' <<<"$output"
 	grep -E '^boottime\s+0\s+0$' <<<"$output"
@@ -48,8 +46,7 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }
@@ -65,11 +62,9 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox cat /proc/self/timens_offsets
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox cat /proc/self/timens_offsets
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }
@@ -90,8 +85,7 @@ function teardown() {
 			"boottime": { "secs": 1337, "nanosecs": 3141519 }
 		}'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
 	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
 }

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -14,8 +14,7 @@ function teardown() {
 	# stty size fails without a tty
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "stty size"]'
 	# note that stdout/stderr are already redirected by bats' run
-	runc run test_busybox </dev/null
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox </dev/null
 }
 
 @test "runc run [tty ptsname]" {
@@ -23,8 +22,7 @@ function teardown() {
 	# shellcheck disable=SC2016
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "for file in /proc/self/fd/[012]; do readlink $file; done"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ ${lines[0]} =~ /dev/pts/+ ]]
 	[[ ${lines[1]} =~ /dev/pts/+ ]]
 	[[ ${lines[2]} =~ /dev/pts/+ ]]
@@ -39,8 +37,7 @@ function teardown() {
 	# shellcheck disable=SC2016
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ ${lines[0]} =~ 0 ]]
 	# This is set by the default config.json (it corresponds to the standard tty group).
 	[[ ${lines[1]} =~ 5 ]]
@@ -58,33 +55,28 @@ function teardown() {
 			| (.. | select(.gid? == 0)) .gid |= 100
 			| (.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 	[[ ${lines[0]} =~ 1000 ]]
 	# This is set by the default config.json (it corresponds to the standard tty group).
 	[[ ${lines[1]} =~ 5 ]]
 }
 
 @test "runc exec [stdin not a tty]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	# note that stdout/stderr are already redirected by bats' run
-	runc exec -t test_busybox sh -c "stty size" </dev/null
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t test_busybox sh -c "stty size" </dev/null
 }
 
 @test "runc exec [tty ptsname]" {
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	# shellcheck disable=SC2016
-	runc exec -t test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
 	[[ ${lines[0]} =~ /dev/pts/+ ]]
 	[[ ${lines[1]} =~ /dev/pts/+ ]]
 	[[ ${lines[2]} =~ /dev/pts/+ ]]
@@ -95,14 +87,12 @@ function teardown() {
 	# TODO: this can be made as a change to the gid test.
 	[ $EUID -ne 0 ] && requires rootless_idmap
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	# shellcheck disable=SC2016
-	runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[[ ${lines[0]} =~ 0 ]]
 	[[ ${lines[1]} =~ 5 ]]
 }
@@ -116,14 +106,12 @@ function teardown() {
 	update_config ' (.. | select(.uid? == 0)) .uid |= 1000
 			| (.. | select(.gid? == 0)) .gid |= 100'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
 	# shellcheck disable=SC2016
-	runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
 	[[ ${lines[0]} =~ 1000 ]]
 	[[ ${lines[1]} =~ 5 ]]
 }
@@ -132,8 +120,7 @@ function teardown() {
 	# allow writing to filesystem
 	update_config '(.. | select(.readonly? != null)) .readonly |= false'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	testcontainer test_busybox running
 
@@ -153,8 +140,7 @@ function teardown() {
 }'
 
 	# Run the detached exec.
-	runc exec -t --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" -p <(echo "$tty_info_with_consize_size") test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t --pid-file pid.txt -d --console-socket "$CONSOLE_SOCKET" -p <(echo "$tty_info_with_consize_size") test_busybox
 	[ -e pid.txt ]
 
 	# Wait for the exec to finish.
@@ -169,8 +155,7 @@ function teardown() {
     "cwd": "/"
 }'
 
-	runc exec -t -p <(echo "$tty_info") test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc exec -t -p <(echo "$tty_info") test_busybox
 
 	# test tty width and height against original process.json
 	[[ ${lines[0]} =~ "rows 10; columns 110" ]]
@@ -184,15 +169,13 @@ function teardown() {
 			| del(.. | select(.? == "sh"))'
 
 	# Make sure that the handling of detached IO is done properly. See #1354.
-	__runc create test_busybox
+	runc create test_busybox
 
-	runc start test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc start test_busybox
 
 	testcontainer test_busybox running
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 }
 
 @test "runc run [terminal=false]" {
@@ -204,14 +187,13 @@ function teardown() {
 
 	# Make sure that the handling of non-detached IO is done properly. See #1354.
 	(
-		__runc run test_busybox
+		runc run test_busybox
 	) &
 
 	wait_for_container 15 1 test_busybox running
 	testcontainer test_busybox running
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 }
 
 @test "runc run -d [terminal=false]" {
@@ -222,10 +204,9 @@ function teardown() {
 			| del(.. | select(.? == "sh"))'
 
 	# Make sure that the handling of detached IO is done properly. See #1354.
-	__runc run -d test_busybox
+	runc run -d test_busybox
 
 	testcontainer test_busybox running
 
-	runc kill test_busybox KILL
-	[ "$status" -eq 0 ]
+	run -0 runc kill test_busybox KILL
 }

--- a/tests/integration/tty.bats
+++ b/tests/integration/tty.bats
@@ -23,9 +23,9 @@ function teardown() {
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "for file in /proc/self/fd/[012]; do readlink $file; done"]'
 
 	run -0 runc run test_busybox
-	[[ ${lines[0]} =~ /dev/pts/+ ]]
-	[[ ${lines[1]} =~ /dev/pts/+ ]]
-	[[ ${lines[2]} =~ /dev/pts/+ ]]
+	assert_line --index 0 --regexp '/dev/pts/+'
+	assert_line --index 1 --regexp '/dev/pts/+'
+	assert_line --index 2 --regexp '/dev/pts/+'
 }
 
 @test "runc run [tty owner]" {
@@ -38,9 +38,9 @@ function teardown() {
 	update_config '(.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
 	run -0 runc run test_busybox
-	[[ ${lines[0]} =~ 0 ]]
+	assert_line --index 0 --regexp '0'
 	# This is set by the default config.json (it corresponds to the standard tty group).
-	[[ ${lines[1]} =~ 5 ]]
+	assert_line --index 1 --regexp '5'
 }
 
 @test "runc run [tty owner] ({u,g}id != 0)" {
@@ -56,9 +56,9 @@ function teardown() {
 			| (.. | select(.[]? == "sh")) += ["-c", "stat -c %u:%g $(tty) | tr : \\\\n"]'
 
 	run -0 runc run test_busybox
-	[[ ${lines[0]} =~ 1000 ]]
+	assert_line --index 0 --regexp '1000'
 	# This is set by the default config.json (it corresponds to the standard tty group).
-	[[ ${lines[1]} =~ 5 ]]
+	assert_line --index 1 --regexp '5'
 }
 
 @test "runc exec [stdin not a tty]" {
@@ -77,9 +77,9 @@ function teardown() {
 
 	# shellcheck disable=SC2016
 	run -0 runc exec -t test_busybox sh -c 'for file in /proc/self/fd/[012]; do readlink $file; done'
-	[[ ${lines[0]} =~ /dev/pts/+ ]]
-	[[ ${lines[1]} =~ /dev/pts/+ ]]
-	[[ ${lines[2]} =~ /dev/pts/+ ]]
+	assert_line --index 0 --regexp '/dev/pts/+'
+	assert_line --index 1 --regexp '/dev/pts/+'
+	assert_line --index 2 --regexp '/dev/pts/+'
 }
 
 @test "runc exec [tty owner]" {
@@ -93,8 +93,8 @@ function teardown() {
 
 	# shellcheck disable=SC2016
 	run -0 runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
-	[[ ${lines[0]} =~ 0 ]]
-	[[ ${lines[1]} =~ 5 ]]
+	assert_line --index 0 --regexp '0'
+	assert_line --index 1 --regexp '5'
 }
 
 @test "runc exec [tty owner] ({u,g}id != 0)" {
@@ -112,8 +112,8 @@ function teardown() {
 
 	# shellcheck disable=SC2016
 	run -0 runc exec -t test_busybox sh -c 'stat -c %u:%g $(tty) | tr : \\n'
-	[[ ${lines[0]} =~ 1000 ]]
-	[[ ${lines[1]} =~ 5 ]]
+	assert_line --index 0 --regexp '1000'
+	assert_line --index 1 --regexp '5'
 }
 
 @test "runc exec [tty consolesize]" {
@@ -158,7 +158,7 @@ function teardown() {
 	run -0 runc exec -t -p <(echo "$tty_info") test_busybox
 
 	# test tty width and height against original process.json
-	[[ ${lines[0]} =~ "rows 10; columns 110" ]]
+	assert_line --index 0 --regexp 'rows 10; columns 110'
 }
 
 @test "runc create [terminal=false]" {

--- a/tests/integration/umask.bats
+++ b/tests/integration/umask.bats
@@ -17,9 +17,9 @@ function teardown() {
 
 	run -0 runc exec test_busybox grep '^Umask:' "/proc/1/status"
 	# umask 63 decimal = umask 77 octal
-	[[ "${output}" == *"77"* ]]
+	assert_output --partial "77"
 
 	run -0 runc exec test_busybox grep '^Umask:' "/proc/self/status"
 	# umask 63 decimal = umask 77 octal
-	[[ "${output}" == *"77"* ]]
+	assert_output --partial "77"
 }

--- a/tests/integration/umask.bats
+++ b/tests/integration/umask.bats
@@ -13,16 +13,13 @@ function teardown() {
 @test "umask" {
 	update_config '.process.user += {"umask":63}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox grep '^Umask:' "/proc/1/status"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox grep '^Umask:' "/proc/1/status"
 	# umask 63 decimal = umask 77 octal
 	[[ "${output}" == *"77"* ]]
 
-	runc exec test_busybox grep '^Umask:' "/proc/self/status"
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox grep '^Umask:' "/proc/self/status"
 	# umask 63 decimal = umask 77 octal
 	[[ "${output}" == *"77"* ]]
 }

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -484,7 +484,7 @@ EOF
 
 	# If cpu-idle is set, cpu-share (converted to CPUWeight) can't be set via systemd.
 	run -1 runc update --cpu-share 200 --cpu-idle 1 test_update
-	[[ "$output" == *"unable to apply both"* ]]
+	assert_output --partial "unable to apply both"
 	check_cgroup_value "cpu.idle" "1"
 
 	# Changing cpu-shares (converted to CPU weight) resets cpu.idle to 0.
@@ -502,7 +502,7 @@ EOF
   }
 }
 EOF
-	[[ "$output" == *"unable to apply both"* ]]
+	assert_output --partial "unable to apply both"
 	check_cgroup_value "cpu.idle" "1"
 
 	# Setting any cpu.weight should reset cpu.idle to 0.
@@ -824,7 +824,7 @@ EOF
   }
 }
 EOF
-	[[ "$output" == *"rejecting memory limit"* ]]
+	assert_output --partial "rejecting memory limit"
 	testcontainer test_update running
 
 	# Setting memory+swap to low value with checkBeforeUpdate=true should fail.
@@ -837,7 +837,7 @@ EOF
   }
 }
 EOF
-	[[ "$output" == *"rejecting memory+swap limit"* ]]
+	assert_output --partial "rejecting memory+swap limit"
 	testcontainer test_update running
 
 	# The container will be OOM killed, and runc might either succeed

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -25,8 +25,7 @@ function setup() {
 	requires cgroups_memory cgroups_pids cgroups_cpuset
 	init_cgroup_paths
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# Set a few variables to make the code below work for both v1 and v2
 	if [ -v CGROUP_V1 ]; then
@@ -69,55 +68,47 @@ function setup() {
 	# update cpuset if possible (i.e. we're running on a multicore cpu)
 	cpu_count=$(grep -c '^processor' /proc/cpuinfo)
 	if [ "$cpu_count" -gt 1 ]; then
-		runc update test_update --cpuset-cpus "1"
-		[ "$status" -eq 0 ]
+		run -0 runc update test_update --cpuset-cpus "1"
 		check_cgroup_value "cpuset.cpus" 1
 	fi
 
 	# update memory limit
-	runc update test_update --memory 67108864
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --memory 67108864
 	check_cgroup_value $MEM_LIMIT 67108864
 	check_systemd_value $SD_MEM_LIMIT 67108864
 
-	runc update test_update --memory 50M
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --memory 50M
 	check_cgroup_value $MEM_LIMIT 52428800
 	check_systemd_value $SD_MEM_LIMIT 52428800
 
 	# update memory soft limit
-	runc update test_update --memory-reservation 33554432
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --memory-reservation 33554432
 	check_cgroup_value "$MEM_RESERVE" 33554432
 	check_systemd_value "$SD_MEM_RESERVE" 33554432
 
 	# Run swap memory tests if swap is available.
 	if [ -v HAVE_SWAP ]; then
 		# try to remove memory swap limit
-		runc update test_update --memory-swap -1
-		[ "$status" -eq 0 ]
+		run -0 runc update test_update --memory-swap -1
 		check_cgroup_value "$MEM_SWAP" "$SYSTEM_MEM"
 		check_systemd_value "$SD_MEM_SWAP" "$SD_UNLIMITED"
 
 		# update memory swap
 		if [ -v CGROUP_V2 ]; then
 			# for cgroupv2, memory and swap can only be set together
-			runc update test_update --memory 52428800 --memory-swap 96468992
-			[ "$status" -eq 0 ]
+			run -0 runc update test_update --memory 52428800 --memory-swap 96468992
 			# for cgroupv2, swap is a separate limit (it does not include mem)
 			check_cgroup_value "$MEM_SWAP" $((96468992 - 52428800))
 			check_systemd_value "$SD_MEM_SWAP" $((96468992 - 52428800))
 		else
-			runc update test_update --memory-swap 96468992
-			[ "$status" -eq 0 ]
+			run -0 runc update test_update --memory-swap 96468992
 			check_cgroup_value "$MEM_SWAP" 96468992
 			check_systemd_value "$SD_MEM_SWAP" 96468992
 		fi
 	fi
 
 	# try to remove memory limit
-	runc update test_update --memory -1
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --memory -1
 
 	# check memory limit is gone
 	check_cgroup_value "$MEM_LIMIT" "$SYSTEM_MEM"
@@ -130,19 +121,17 @@ function setup() {
 	fi
 
 	# update pids limit
-	runc update test_update --pids-limit 10
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --pids-limit 10
 	check_cgroup_value "pids.max" 10
 	check_systemd_value "TasksMax" 10
 
 	# unlimited
-	runc update test_update --pids-limit -1
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --pids-limit -1
 	check_cgroup_value "pids.max" max
 	check_systemd_value "TasksMax" $SD_UNLIMITED
 
 	# Revert to the test initial value via json on stdin
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "memory": {
     "limit": 33554432,
@@ -159,7 +148,6 @@ function setup() {
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 	check_cgroup_value "cpuset.cpus" 0
 
 	check_cgroup_value $MEM_LIMIT 33554432
@@ -172,11 +160,10 @@ EOF
 	check_systemd_value "TasksMax" 20
 
 	# redo all the changes at once
-	runc update test_update \
+	run -0 runc update test_update \
 		--cpu-period 900000 --cpu-quota 600000 --cpu-share 200 \
 		--memory 67108864 --memory-reservation 33554432 \
 		--pids-limit 10
-	[ "$status" -eq 0 ]
 	check_cgroup_value $MEM_LIMIT 67108864
 	check_systemd_value $SD_MEM_LIMIT 67108864
 
@@ -205,8 +192,7 @@ EOF
 }
 EOF
 
-	runc update -r "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json test_update
-	[ "$status" -eq 0 ]
+	run -0 runc update -r "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json test_update
 	check_cgroup_value "cpuset.cpus" 0
 
 	check_cgroup_value $MEM_LIMIT 33554432
@@ -222,8 +208,7 @@ EOF
 		# Test case for https://github.com/opencontainers/runc/pull/592,
 		# checking github.com/opencontainers/cgroups/fs/memory.go:setMemoryAndSwap.
 
-		runc update test_update --memory 30M --memory-swap 50M
-		[ "$status" -eq 0 ]
+		run -0 runc update test_update --memory 30M --memory-swap 50M
 
 		check_cgroup_value $MEM_LIMIT $((30 * 1024 * 1024))
 		check_systemd_value $SD_MEM_LIMIT $((30 * 1024 * 1024))
@@ -238,8 +223,7 @@ EOF
 		fi
 
 		# Now, set new memory to more than old swap
-		runc update test_update --memory 60M --memory-swap 80M
-		[ "$status" -eq 0 ]
+		run -0 runc update test_update --memory 60M --memory-swap 80M
 
 		check_cgroup_value $MEM_LIMIT $((60 * 1024 * 1024))
 		check_systemd_value $SD_MEM_LIMIT $((60 * 1024 * 1024))
@@ -258,35 +242,30 @@ EOF
 @test "update cgroup cpu limits" {
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# Check that initial values were properly set.
 	check_cpu_quota 500000 1000000
 	check_cpu_shares 100
 
 	# Update cpu period.
-	runc update test_update --cpu-period 900000
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --cpu-period 900000
 	check_cpu_quota 500000 900000
 
 	# Update cpu quota.
-	runc update test_update --cpu-quota 600000
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --cpu-quota 600000
 	check_cpu_quota 600000 900000
 
 	# Remove cpu quota.
-	runc update test_update --cpu-quota -1
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --cpu-quota -1
 	check_cpu_quota -1 900000
 
 	# Update cpu-shares.
-	runc update test_update --cpu-share 200
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --cpu-share 200
 	check_cpu_shares 200
 
 	# Revert to the test initial value via json on stding
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "cpu": {
     "shares": 100,
@@ -295,19 +274,16 @@ EOF
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 	check_cpu_quota 500000 1000000
 
 	# Redo all the changes at once.
-	runc update test_update \
+	run -0 runc update test_update \
 		--cpu-period 900000 --cpu-quota 600000 --cpu-share 200
-	[ "$status" -eq 0 ]
 	check_cpu_quota 600000 900000
 	check_cpu_shares 200
 
 	# Remove cpu quota and reset the period.
-	runc update test_update --cpu-quota -1 --cpu-period 100000
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --cpu-quota -1 --cpu-period 100000
 	check_cpu_quota -1 100000
 
 	# Reset to initial test values via json file.
@@ -321,8 +297,7 @@ EOF
 }
 EOF
 
-	runc update -r "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json test_update
-	[ "$status" -eq 0 ]
+	run -0 runc update -r "$BATS_RUN_TMPDIR"/runc-cgroups-integration-test.json test_update
 	check_cpu_quota 500000 1000000
 	check_cpu_shares 100
 }
@@ -331,27 +306,23 @@ EOF
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires cgroups_pids
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	check_cgroup_value "pids.max" 20
 	check_systemd_value "TasksMax" 20
 
-	runc update test_update --pids-limit 12345
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --pids-limit 12345
 
 	check_cgroup_value "pids.max" "12345"
 	check_systemd_value "TasksMax" "12345"
 
-	runc update test_update --pids-limit -1
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --pids-limit -1
 
 	check_cgroup_value "pids.max" "max"
 	# systemd < v227 shows UINT64_MAX instead of "infinity".
 	check_systemd_value "TasksMax" "infinity" "18446744073709551615"
 
-	runc update test_update --pids-limit 0
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --pids-limit 0
 
 	# systemd doesn't support TasksMax=0 so runc will silently remap it to 1.
 	check_cgroup_value "pids.max" "1"
@@ -362,24 +333,20 @@ EOF
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires cgroups_cpu_burst
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	check_cpu_burst 0
 
-	runc update test_update --cpu-period 900000 --cpu-burst 500000
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --cpu-period 900000 --cpu-burst 500000
 	check_cpu_burst 500000
 
 	# issue: https://github.com/opencontainers/runc/issues/4210
 	# for systemd, cpu-burst value will be cleared, it's a known issue.
 	if [ ! -v RUNC_USE_SYSTEMD ]; then
-		runc update test_update --memory 100M
-		[ "$status" -eq 0 ]
+		run -0 runc update test_update --memory 100M
 		check_cpu_burst 500000
 	fi
 
-	runc update test_update --cpu-period 900000 --cpu-burst 0
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update --cpu-period 900000 --cpu-burst 0
 	check_cpu_burst 0
 }
 
@@ -388,8 +355,7 @@ EOF
 
 	update_config '.linux.resources.cpu |= { "period": 1000000 }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	check_cpu_quota -1 1000000
 }
@@ -399,8 +365,7 @@ EOF
 
 	update_config '.linux.resources.cpu |= { "period": 100 }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 1 ]
+	run -1 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 }
 
 @test "set cpu quota with no period" {
@@ -408,8 +373,7 @@ EOF
 
 	update_config '.linux.resources.cpu |= { "quota": 5000 }'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	check_cpu_quota 5000 100000
 }
 
@@ -418,12 +382,10 @@ EOF
 
 	update_config '.linux.resources.cpu |= {}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# Update the period alone, no old values were set.
-	runc update --cpu-period 50000 test_update
-	[ "$status" -eq 0 ]
+	run -0 runc update --cpu-period 50000 test_update
 	check_cpu_quota -1 50000
 }
 
@@ -432,12 +394,10 @@ EOF
 
 	update_config '.linux.resources.cpu |= {}'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# Update the quota alone, no old values were set.
-	runc update --cpu-quota 30000 test_update
-	[ "$status" -eq 0 ]
+	run -0 runc update --cpu-quota 30000 test_update
 	check_cpu_quota 30000 100000
 }
 
@@ -459,20 +419,17 @@ EOF
 	run -0 cat "/sys/fs/cgroup/cpu$REL_PARENT_PATH/cpu.cfs_quota_us"
 	[ "$output" -eq 50000 ]
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	# Get the current period.
 	local cur
 	cur=$(get_cgroup_value cpu.cfs_period_us)
 
 	# Sanity check: as the parent cgroup sets the limit to 50%,
 	# setting a higher limit (e.g. 60%) is expected to fail.
-	runc update --cpu-quota $((cur * 6 / 10)) test_update
-	[ "$status" -eq 1 ]
+	run -1 runc update --cpu-quota $((cur * 6 / 10)) test_update
 
 	# Finally, the test itself: set 30% limit but with lower period.
-	runc update --cpu-period 10000 --cpu-quota 3000 test_update
-	[ "$status" -eq 0 ]
+	run -0 runc update --cpu-period 10000 --cpu-quota 3000 test_update
 	check_cpu_quota 3000 10000
 }
 
@@ -480,28 +437,24 @@ EOF
 	requires cgroups_cpu_idle
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	check_cgroup_value "cpu.idle" "0"
 
 	local val
 	for val in 1 0 1; do
-		runc update -r - test_update <<EOF
+		run -0 runc update -r - test_update <<EOF
 {
   "cpu": {
     "idle": $val
   }
 }
 EOF
-		[ "$status" -eq 0 ]
 		check_cgroup_value "cpu.idle" "$val"
 	done
 
 	for val in 1 0 1; do
-		runc update --cpu-idle "$val" test_update
-
-		[ "$status" -eq 0 ]
+		run -0 runc update --cpu-idle "$val" test_update
 		check_cgroup_value "cpu.idle" "$val"
 	done
 
@@ -511,16 +464,14 @@ EOF
 	# If this ever fails, it means that the kernel now accepts values
 	# other than 0 or 1, and runc needs to adopt.
 	for val in -1 2 3; do
-		runc update --cpu-idle "$val" test_update
-		[ "$status" -ne 0 ]
+		run ! runc update --cpu-idle "$val" test_update
 		check_cgroup_value "cpu.idle" "1"
 	done
 
 	# https://github.com/opencontainers/runc/issues/3786
 	[ "$(systemd_version)" -ge 252 ] && return
 	# test update other option won't impact on cpu.idle
-	runc update --cpu-period 10000 test_update
-	[ "$status" -eq 0 ]
+	run -0 runc update --cpu-period 10000 test_update
 	check_cgroup_value "cpu.idle" "1"
 }
 
@@ -528,23 +479,22 @@ EOF
 	requires cgroups_v2 systemd_v252 cgroups_cpu_idle
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 	check_cgroup_value "cpu.idle" "0"
 
 	# If cpu-idle is set, cpu-share (converted to CPUWeight) can't be set via systemd.
-	runc update --cpu-share 200 --cpu-idle 1 test_update
+	run runc update --cpu-share 200 --cpu-idle 1 test_update
 	[[ "$output" == *"unable to apply both"* ]]
 	check_cgroup_value "cpu.idle" "1"
 
 	# Changing cpu-shares (converted to CPU weight) resets cpu.idle to 0.
-	runc update --cpu-share 200 test_update
+	run runc update --cpu-share 200 test_update
 	check_cgroup_value "cpu.idle" "0"
 
 	# Setting values via unified map.
 
 	# If cpu.idle is set, cpu.weight is ignored.
-	runc update -r - test_update <<EOF
+	run runc update -r - test_update <<EOF
 {
   "unified": {
     "cpu.idle": "1",
@@ -556,7 +506,7 @@ EOF
 	check_cgroup_value "cpu.idle" "1"
 
 	# Setting any cpu.weight should reset cpu.idle to 0.
-	runc update -r - test_update <<EOF
+	run runc update -r - test_update <<EOF
 {
   "unified": {
     "cpu.weight": "8"
@@ -570,15 +520,14 @@ EOF
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 	requires cgroups_v2
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# Check that initial values (from setup) were properly set.
 	check_cpu_quota 500000 1000000
 	check_cpu_shares 100
 	check_systemd_value "TasksMax" 20
 
-	runc update -r - test_update <<EOF
+	run runc update -r - test_update <<EOF
 {
   "unified": {
     "cpu.max": "max 100000",
@@ -610,21 +559,19 @@ EOF
 				"Cpus": "0",
 				"Mems": "0"
 			}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# check that initial values were properly set
 	check_systemd_value "$AllowedCPUs" 0
 	check_systemd_value "$AllowedMemoryNodes" 0
 
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "CPU": {
     "Cpus": "1"
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 
 	# check the updated systemd unit properties
 	check_systemd_value "$AllowedCPUs" 1
@@ -636,14 +583,13 @@ EOF
 		return 0
 	fi
 
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "CPU": {
     "Mems": "1"
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 
 	# check the updated systemd unit properties
 	check_systemd_value "$AllowedMemoryNodes" 1
@@ -658,21 +604,19 @@ EOF
 				"cpuset.cpus": "0",
 				"cpuset.mems": "0"
 			}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# check that initial values were properly set
 	check_systemd_value "AllowedCPUs" 0
 	check_systemd_value "AllowedMemoryNodes" 0
 
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "unified": {
     "cpuset.cpus": "1"
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 
 	# check the updated systemd unit properties
 	check_systemd_value "AllowedCPUs" 1
@@ -684,14 +628,13 @@ EOF
 		return 0
 	fi
 
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "unified": {
     "cpuset.mems": "1"
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 
 	# check the updated systemd unit properties
 	check_systemd_value "AllowedMemoryNodes" 1
@@ -705,20 +648,18 @@ EOF
 	update_config ' .linux.resources.unified |= {
 				"cpuset.cpus": "0-5",
 			}'
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# check that the initial value was properly set
 	check_systemd_value "AllowedCPUs" "0-5"
 
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "unified": {
     "cpuset.cpus": "5-8"
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 
 	# check the updated systemd unit property, the value should not be affected by byte order
 	check_systemd_value "AllowedCPUs" "5-8"
@@ -760,21 +701,19 @@ EOF
 		echo "$root_runtime" >"$target_runtime"
 	done
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update_rt
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update_rt
 
-	runc update -r - test_update_rt <<EOF
+	run -0 runc update -r - test_update_rt <<EOF
 {
   "cpu": {
     "realtimeRuntime": 500001
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 	check_cgroup_value "cpu.rt_period_us" "$root_period"
 	check_cgroup_value "cpu.rt_runtime_us" 500001
 
-	runc update -r - test_update_rt <<EOF
+	run runc update -r - test_update_rt <<EOF
 {
   "cpu": {
     "realtimePeriod": 800001,
@@ -785,20 +724,17 @@ EOF
 	check_cgroup_value "cpu.rt_period_us" 800001
 	check_cgroup_value "cpu.rt_runtime_us" 500001
 
-	runc update test_update_rt --cpu-rt-period 900001 --cpu-rt-runtime 600001
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update_rt --cpu-rt-period 900001 --cpu-rt-runtime 600001
 
 	check_cgroup_value "cpu.rt_period_us" 900001
 	check_cgroup_value "cpu.rt_runtime_us" 600001
 
 	# https://github.com/opencontainers/runc/issues/4094
-	runc update test_update_rt --cpu-rt-period 10000 --cpu-rt-runtime 3000
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update_rt --cpu-rt-period 10000 --cpu-rt-runtime 3000
 	check_cgroup_value "cpu.rt_period_us" 10000
 	check_cgroup_value "cpu.rt_runtime_us" 3000
 
-	runc update test_update_rt --cpu-rt-period 100000 --cpu-rt-runtime 20000
-	[ "$status" -eq 0 ]
+	run -0 runc update test_update_rt --cpu-rt-period 100000 --cpu-rt-runtime 20000
 	check_cgroup_value "cpu.rt_period_us" 100000
 	check_cgroup_value "cpu.rt_runtime_us" 20000
 }
@@ -832,17 +768,15 @@ EOF
 	retry 10 0.1 [ -e "$TMP_CONSOLE_SOCKET" ]
 
 	# Run the container in the background.
-	runc run -d --console-socket "$TMP_CONSOLE_SOCKET" test_update
+	run -0 runc run -d --console-socket "$TMP_CONSOLE_SOCKET" test_update
 	cat "$CONTAINER_OUTPUT"
-	[ "$status" -eq 0 ]
 
 	# Trigger an update. This update doesn't actually change the device rules,
 	# but it will trigger the devices cgroup code to reapply the current rules.
 	# We trigger the update a few times to make sure we hit the race.
 	for _ in {1..30}; do
 		# TODO: Update "runc update" so we can change the device rules.
-		runc update --pids-limit 30 test_update
-		[ "$status" -eq 0 ]
+		run -0 runc update --pids-limit 30 test_update
 	done
 
 	# Kill recvtty.
@@ -858,23 +792,19 @@ EOF
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 
 	# Run the container in the background.
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# Pause the container.
-	runc pause test_update
-	[ "$status" -eq 0 ]
+	run -0 runc pause test_update
 
 	# Trigger an unrelated update.
-	runc update --pids-limit 30 test_update
-	[ "$status" -eq 0 ]
+	run -0 runc update --pids-limit 30 test_update
 
 	# The container should still be paused.
 	testcontainer test_update paused
 
 	# Resume the container.
-	runc resume test_update
-	[ "$status" -eq 0 ]
+	run -0 runc resume test_update
 }
 
 @test "update memory vs CheckBeforeUpdate" {
@@ -883,11 +813,10 @@ EOF
 	requires cgroups_v2
 	[ $EUID -ne 0 ] && requires rootless_cgroup
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
 	# Setting memory to low value with checkBeforeUpdate=true should fail.
-	runc update -r - test_update <<EOF
+	run ! runc update -r - test_update <<EOF
 {
   "memory": {
     "limit": 1024,
@@ -895,12 +824,11 @@ EOF
   }
 }
 EOF
-	[ "$status" -ne 0 ]
 	[[ "$output" == *"rejecting memory limit"* ]]
 	testcontainer test_update running
 
 	# Setting memory+swap to low value with checkBeforeUpdate=true should fail.
-	runc update -r - test_update <<EOF
+	run ! runc update -r - test_update <<EOF
 {
   "memory": {
     "limit": 1024,
@@ -909,13 +837,12 @@ EOF
   }
 }
 EOF
-	[ "$status" -ne 0 ]
 	[[ "$output" == *"rejecting memory+swap limit"* ]]
 	testcontainer test_update running
 
 	# The container will be OOM killed, and runc might either succeed
 	# or fail depending on the timing, so we don't check its exit code.
-	runc update test_update --memory 1024
+	run runc update test_update --memory 1024
 	wait_for_container 10 1 test_update stopped
 }
 
@@ -941,10 +868,9 @@ EOF
 				{ major: '"$major"', minor: '"$minor"', rate: 485760 }
 			]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_update
 
-	runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "blockIO": {
     "throttleReadBpsDevice": [
@@ -978,6 +904,5 @@ EOF
   }
 }
 EOF
-	[ "$status" -eq 0 ]
 	check_cgroup_dev_iops "$dev" 10485760 9437184 1000 900
 }

--- a/tests/integration/update.bats
+++ b/tests/integration/update.bats
@@ -483,18 +483,18 @@ EOF
 	check_cgroup_value "cpu.idle" "0"
 
 	# If cpu-idle is set, cpu-share (converted to CPUWeight) can't be set via systemd.
-	run runc update --cpu-share 200 --cpu-idle 1 test_update
+	run -1 runc update --cpu-share 200 --cpu-idle 1 test_update
 	[[ "$output" == *"unable to apply both"* ]]
 	check_cgroup_value "cpu.idle" "1"
 
 	# Changing cpu-shares (converted to CPU weight) resets cpu.idle to 0.
-	run runc update --cpu-share 200 test_update
+	run -0 runc update --cpu-share 200 test_update
 	check_cgroup_value "cpu.idle" "0"
 
 	# Setting values via unified map.
 
 	# If cpu.idle is set, cpu.weight is ignored.
-	run runc update -r - test_update <<EOF
+	run -1 runc update -r - test_update <<EOF
 {
   "unified": {
     "cpu.idle": "1",
@@ -506,7 +506,7 @@ EOF
 	check_cgroup_value "cpu.idle" "1"
 
 	# Setting any cpu.weight should reset cpu.idle to 0.
-	run runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "unified": {
     "cpu.weight": "8"
@@ -527,7 +527,7 @@ EOF
 	check_cpu_shares 100
 	check_systemd_value "TasksMax" 20
 
-	run runc update -r - test_update <<EOF
+	run -0 runc update -r - test_update <<EOF
 {
   "unified": {
     "cpu.max": "max 100000",
@@ -713,7 +713,7 @@ EOF
 	check_cgroup_value "cpu.rt_period_us" "$root_period"
 	check_cgroup_value "cpu.rt_runtime_us" 500001
 
-	run runc update -r - test_update_rt <<EOF
+	run -0 runc update -r - test_update_rt <<EOF
 {
   "cpu": {
     "realtimePeriod": 800001,

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -220,10 +220,10 @@ function teardown() {
 	netns_id="net:[$(stat -c "%i" "$netns_path")]"
 
 	run -0 runc exec ctr readlink /proc/self/ns/user
-	[[ "$output" == "$userns_id" ]]
+	assert_output "$userns_id"
 
 	run -0 runc exec ctr readlink /proc/self/ns/net
-	[[ "$output" == "$netns_id" ]]
+	assert_output "$netns_id"
 }
 
 @test "userns with network interface" {

--- a/tests/integration/userns.bats
+++ b/tests/integration/userns.bats
@@ -40,8 +40,7 @@ function teardown() {
 	update_config ' .process.args += ["-c", "stat /tmp/mount-1/foo.txt"]
 		| .mounts += [{"source": "source-accessible/dir", "destination": "/tmp/mount-1", "options": ["bind"]}] '
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # We had bugs where 1 mount worked but not 2+, test with 2 as it is a more
@@ -58,8 +57,7 @@ function teardown() {
 	# (with env var _LIBCONTAINER_MOUNT_FDS). Idem for
 	# source-inaccessible-2.
 	# On rootless, the owner is the same so it is accessible.
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 }
 
 # exec + bindmounts + user ns is a special case in the code. Test that it works.
@@ -68,11 +66,9 @@ function teardown() {
 					{ "source": "source-inaccessible-2/dir", "destination": "/tmp/mount-2", "options": ["bind"] }
 			         ]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
-	runc exec test_busybox stat /tmp/mount-1/foo.txt /tmp/mount-2/foo.txt
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox stat /tmp/mount-1/foo.txt /tmp/mount-2/foo.txt
 }
 
 # Issue fixed by https://github.com/opencontainers/runc/pull/3510.
@@ -86,38 +82,32 @@ function teardown() {
 	update_config '	  .mounts |= map(if .destination == "/sys/fs/cgroup" then ({"source": "source-accessible/dir", "destination": "/tmp/mount-1", "options": ["bind"]}, .) else . end)
 			| .linux.namespaces -= [{"type": "cgroup"}]'
 
-	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
 
 	# Make sure this is real cgroupfs.
-	runc exec test_busybox cat /sys/fs/cgroup/{pids,memory}/tasks
-	[ "$status" -eq 0 ]
+	run -0 runc exec test_busybox cat /sys/fs/cgroup/{pids,memory}/tasks
 }
 
 @test "userns join other container userns" {
 	# Create a detached container with the id-mapping we want.
 	update_config '.process.args = ["sleep", "infinity"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
 
 	# Configure our container to attach to the first container's userns.
-	target_pid="$(__runc state target_userns | jq .pid)"
+	target_pid="$(runc state target_userns | jq .pid)"
 	update_config '.linux.namespaces |= map(if .type == "user" then (.path = "/proc/'"$target_pid"'/ns/" + .type) else . end)
 		| del(.linux.uidMappings)
 		| del(.linux.gidMappings)'
-	runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
 
-	runc exec in_userns cat /proc/self/uid_map
-	[ "$status" -eq 0 ]
+	run -0 runc exec in_userns cat /proc/self/uid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+100000\s+65534$' <<<"$output"
 	else
 		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
 	fi
 
-	runc exec in_userns cat /proc/self/gid_map
-	[ "$status" -eq 0 ]
+	run -0 runc exec in_userns cat /proc/self/gid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+200000\s+65534$' <<<"$output"
 	else
@@ -132,17 +122,15 @@ function teardown() {
 	fi
 	# Create a detached container with the id-mapping we want.
 	update_config '.process.args = ["sleep", "infinity"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
 
 	# Configure our container to attach to the first container's userns.
-	target_pid="$(__runc state target_userns | jq .pid)"
+	target_pid="$(runc state target_userns | jq .pid)"
 	update_config '.linux.namespaces |= map(if .type == "user" then (.path = "/proc/'"$target_pid"'/ns/" + .type) else . end)
 		| del(.linux.uidMappings)
 		| del(.linux.gidMappings)
 		| .linux.mountLabel="system_u:object_r:container_file_t:s0:c344,c805"'
-	runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
 }
 
 @test "userns join other container userns [bind-mounted nsfd]" {
@@ -150,13 +138,12 @@ function teardown() {
 
 	# Create a detached container with the id-mapping we want.
 	update_config '.process.args = ["sleep", "infinity"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
 
 	# Bind-mount the first containers userns nsfd to a different path, to
 	# exercise the non-fast-path (where runc has to join the userns to get the
 	# mappings).
-	target_pid="$(__runc state target_userns | jq .pid)"
+	target_pid="$(runc state target_userns | jq .pid)"
 	userns_path=$(mktemp "$BATS_RUN_TMPDIR/userns.XXXXXX")
 	mount --bind "/proc/$target_pid/ns/user" "$userns_path"
 	echo "$userns_path" >>"$to_umount_list"
@@ -165,19 +152,16 @@ function teardown() {
 	update_config '.linux.namespaces |= map(if .type == "user" then (.path = "'"$userns_path"'") else . end)
 		| del(.linux.uidMappings)
 		| del(.linux.gidMappings)'
-	runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" in_userns
 
-	runc exec in_userns cat /proc/self/uid_map
-	[ "$status" -eq 0 ]
+	run -0 runc exec in_userns cat /proc/self/uid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+100000\s+65534$' <<<"$output"
 	else
 		grep -E '^\s+0\s+'$EUID'\s+1$' <<<"$output"
 	fi
 
-	runc exec in_userns cat /proc/self/gid_map
-	[ "$status" -eq 0 ]
+	run -0 runc exec in_userns cat /proc/self/gid_map
 	if [ $EUID -eq 0 ]; then
 		grep -E '^\s+0\s+200000\s+65534$' <<<"$output"
 	else
@@ -194,20 +178,18 @@ function teardown() {
 	# automatically use an identity mapping (which breaks this test) so we need
 	# to use runc to create the userns.
 	update_config '.process.args = ["sleep", "infinity"]'
-	runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
-	[ "$status" -eq 0 ]
+	run -0 runc run -d --console-socket "$CONSOLE_SOCKET" target_userns
 
 	# Bind-mount the first containers userns nsfd to a different path, to
 	# exercise the non-fast-path (where runc has to join the userns to get the
 	# mappings).
-	userns_pid="$(__runc state target_userns | jq .pid)"
+	userns_pid="$(runc state target_userns | jq .pid)"
 	userns_path="$(mktemp "$BATS_RUN_TMPDIR/userns.XXXXXX")"
 	mount --bind "/proc/$userns_pid/ns/user" "$userns_path"
 	echo "$userns_path" >>"$to_umount_list"
 
 	# Kill the container -- we have the userns bind-mounted.
-	runc delete -f target_userns
-	[ "$status" -eq 0 ]
+	run -0 runc delete -f target_userns
 
 	# Configure our container to attach to the external userns.
 	update_config '.linux.namespaces |= map(if .type == "user" then (.path = "'"$userns_path"'") else . end)
@@ -232,18 +214,15 @@ function teardown() {
 
 	# Create a detached container to verify the namespaces are correct.
 	update_config '.process.args = ["sleep", "infinity"]'
-	runc --debug run -d --console-socket "$CONSOLE_SOCKET" ctr
-	[ "$status" -eq 0 ]
+	run -0 runc --debug run -d --console-socket "$CONSOLE_SOCKET" ctr
 
 	userns_id="user:[$(stat -c "%i" "$userns_path")]"
 	netns_id="net:[$(stat -c "%i" "$netns_path")]"
 
-	runc exec ctr readlink /proc/self/ns/user
-	[ "$status" -eq 0 ]
+	run -0 runc exec ctr readlink /proc/self/ns/user
 	[[ "$output" == "$userns_id" ]]
 
-	runc exec ctr readlink /proc/self/ns/net
-	[ "$status" -eq 0 ]
+	run -0 runc exec ctr readlink /proc/self/ns/net
 	[[ "$output" == "$netns_id" ]]
 }
 
@@ -257,8 +236,7 @@ function teardown() {
 	update_config ' .linux.netDevices |= {"dummy0": {} }
 		| .process.args |= ["ip", "address", "show", "dev", "dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# The interface is virtual and should not exist because
 	# is deleted during the namespace cleanup.
@@ -275,8 +253,7 @@ function teardown() {
 	update_config ' .linux.netDevices |= { "dummy0": { "name" : "ctr_dummy0" } }
 		| .process.args |= ["ip", "address", "show", "dev", "ctr_dummy0"]'
 
-	runc run test_busybox
-	[ "$status" -eq 0 ]
+	run -0 runc run test_busybox
 
 	# The interface is virtual and should not exist because
 	# is deleted during the namespace cleanup.

--- a/tests/integration/version.bats
+++ b/tests/integration/version.bats
@@ -4,7 +4,7 @@ load helpers
 
 @test "runc version" {
 	run -0 runc -v
-	[[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
-	[[ ${lines[1]} =~ commit:+ ]]
-	[[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]
+	assert_line --index 0 --regexp 'runc version [0-9]+\.[0-9]+\.[0-9]+'
+	assert_line --index 1 --regexp 'commit:+'
+	assert_line --index 2 --regexp 'spec: [0-9]+\.[0-9]+\.[0-9]+'
 }

--- a/tests/integration/version.bats
+++ b/tests/integration/version.bats
@@ -3,8 +3,7 @@
 load helpers
 
 @test "runc version" {
-	runc -v
-	[ "$status" -eq 0 ]
+	run -0 runc -v
 	[[ ${lines[0]} =~ runc\ version\ [0-9]+\.[0-9]+\.[0-9]+ ]]
 	[[ ${lines[1]} =~ commit:+ ]]
 	[[ ${lines[2]} =~ spec:\ [0-9]+\.[0-9]+\.[0-9]+ ]]

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -218,10 +218,11 @@ for ROOTLESS_FEATURES in $features_powerset; do
 		# Operation not permitted". Set the correct value explicitly.
 		ssh_env+=("XDG_RUNTIME_DIR=/run/user/$(id -u rootless)")
 		ssh -t -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$HOME/.ssh/rootless.key" \
-			rootless@localhost -- "${ssh_env[@]}" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
+			rootless@localhost -- "${ssh_env[@]}" bats -t --print-output-on-failure "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	else
 		export "${ENV_LIST[@]}"
-		sudo -HE -u rootless PATH="$PATH" "$(command -v bats)" -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
+		sudo -HE -u rootless PATH="$PATH" "$(command -v bats)" -t --print-output-on-failure \
+			"$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	fi
 	cleanup
 done


### PR DESCRIPTION
This supersedes #4946, taking a different approach to the problems
discussed there (see [this comment] and below).

[this comment]: https://github.com/opencontainers/runc/pull/4946#issuecomment-3462869539

The end result is that integration tests call runc the way any other
command is called, and check its output with helpers that say what went
wrong:

```bash
run -0 runc start ctr
assert_output --partial "something"
```

instead of the current

```bash
runc start ctr
[ "$status" -eq 0 ]
[[ "$output" == *"something"* ]]
```

where `runc` is a bash function hiding a call to bats' `run` helper, and
a failed comparison only shows the expression, not the values.


### What a failure looks like now

To see this in practice, four deliberate bugs were introduced (`runc -v`
printing `spec :`, `runc list -q` adding a trailing space to the ID, a
reworded hook error, and `runc delete --force` failing on a missing
container), and the tests were run with and without this PR:

| Bug | Before | Now |
| --- | --- | --- |
| `list -q` adds a trailing space | 20 lines of every runc call made so far, ending with an output that looks exactly right | `expected: 'test_box1'` <br> `actual: 'test_box1 '` |
| `spec :` instead of `spec:` | the failed expression, plus the whole `runc -v` output to eyeball | `expected: 'spec: [0-9]+\.[0-9]+\.[0-9]+'` <br> `actual: 'spec : 1.3.0'` |
| reworded hook error | ditto, with the message to compare by hand | `expected: 'error running createRuntime hook #1:'` <br> `actual: '...failure in createRuntime hook #1...'` |
| `delete --force` fails | ``[ "$status" -eq 0 ]' failed`` -- but after which call? | ``run -0 runc delete --force notexists' failed, expected exit code 0, got 1`` |

The trailing space one is the point of the whole exercise. Before:

```
not ok 1 list
# (in test file tests/integration/list.bats, line 37)
#   `[ "${lines[0]}" = "test_box1" ]' failed
# runc spec --rootless (status=0)
#
# runc run -d --console-socket /tmp/.../tty/sock test_box1 (status=0)
#
[... 10 more lines of the preceding commands and their output ...]
# runc list -q (status=0)
# test_box1
# test_box2
# test_box3
```

The expected value is not shown, the actual one looks correct, and the
difference is invisible. Now:

```
not ok 1 list
# (in test file tests/integration/list.bats, line 32)
#   `assert_line --index 0 "test_box1"' failed
# -- line 0 does not match (exact) --
# expected: 'test_box1'
#   actual: 'test_box1 '
# --
```

