### PR TITLE
ci: add Ubuntu 26.04, switch to kjanat/actionlint fork

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13
+      - uses: kjanat/actionlint@c9565647ad2ff016b50b148a595dfcce50975816 # v1.13.0
 
   all-done:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, ubuntu-26.04, ubuntu-26.04-arm]
         go-version: [1.26.x, 1.27.x]
         libpathrs: ["libpathrs", ""]
         rootless: ["rootless", ""]
@@ -77,6 +77,14 @@ jobs:
         sudo apt update
         sudo apt -y install libseccomp-dev sshfs uidmap lld
 
+    - name: use the original sudo
+      # Ubuntu 26.04 uses sudo-rs by default, which does not support -E
+      # (https://github.com/trifectatechfoundation/sudo-rs/issues/1299).
+      if: startsWith(matrix.os, 'ubuntu-26.04')
+      run: |
+        sudo apt -y install sudo
+        sudo update-alternatives --set sudo /usr/bin/sudo.ws
+
     - name: install libpathrs ${{ env.LIBPATHRS_VERSION }}
       if: ${{ matrix.libpathrs != '' }}
       run: |
@@ -96,6 +104,15 @@ jobs:
         curl -fSsLl "$REPO/Release.key" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_tools_criu.gpg > /dev/null
         echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
         sudo apt update
+        # Ubuntu 26.04 comes with criu preinstalled, split into a few
+        # packages (criu, libcompel1, python3-pycriu) which conflict with
+        # the monolithic criu package from the repo above, so remove all
+        # the packages built from the distro criu source first.
+        distro_criu=$(dpkg-query -W -f='${binary:Package} ${source:Package}\n' | awk '$2 == "criu" { print $1 }')
+        if [ -n "$distro_criu" ]; then
+          # shellcheck disable=SC2086 # Word splitting is intentional here.
+          sudo apt -y purge $distro_criu
+        fi
         sudo apt -y install criu
 
     - name: install CRIU (${{ matrix.criu }})
@@ -130,9 +147,10 @@ jobs:
 
     - name: Allow userns for runc
       # https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15
-      if: startsWith(matrix.os, 'ubuntu-24.04')
       run: |
-        sed "s;^profile runc /usr/sbin/;profile runc-test $PWD/;" < /etc/apparmor.d/runc | sudo apparmor_parser
+        # The attachment path differs between Ubuntu versions (/usr/sbin/runc
+        # on 24.04, /usr/{bin,sbin}/runc on 26.04), so match it loosely.
+        sed -E "s;^profile runc [^ ]+ ;profile runc-test $PWD/runc ;" < /etc/apparmor.d/runc | sudo apparmor_parser
 
     - name: unit test
       if: matrix.rootless != 'rootless'

--- a/tests/rootless.sh
+++ b/tests/rootless.sh
@@ -211,6 +211,12 @@ for ROOTLESS_FEATURES in $features_powerset; do
 		for v in "${ENV_LIST[@]}"; do
 			[ -v "$v" ] && ssh_env+=("$v=${!v}")
 		done
+		# Some hosts (e.g. GitHub Actions ubuntu-26.04 runners) have a stale
+		# XDG_RUNTIME_DIR in the system-wide environment, which then points to
+		# another user's runtime directory in our session, and systemctl --user
+		# fails with "Failed to connect to user scope bus via local transport:
+		# Operation not permitted". Set the correct value explicitly.
+		ssh_env+=("XDG_RUNTIME_DIR=/run/user/$(id -u rootless)")
 		ssh -t -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$HOME/.ssh/rootless.key" \
 			rootless@localhost -- "${ssh_env[@]}" bats -t "$ROOT/tests/integration$ROOTLESS_TESTPATH"
 	else


### PR DESCRIPTION
Two CI changes:

1. Switch the actionlint workflow from `devops-actions/actionlint` to
   [`kjanat/actionlint`](https://github.com/kjanat/actionlint), an actively
   maintained fork of `rhysd/actionlint` with a lot of fixes. It ships its own
   action, so the separate runner action is no longer needed. Pinned to the
   v1.13.0 commit.

2. Add `ubuntu-26.04` and `ubuntu-26.04-arm` to the `test` job matrix, so we
   also test on the latest Ubuntu LTS. Also, drop the condition on the "Allow
   userns for runc" step, since all the ubuntu runners we use have the
   unprivileged user namespace restrictions introduced in 24.04.

Note the first commit is a prerequisite for the second one: the actionlint
version currently used does not know about the `ubuntu-26.04*` runner labels
and fails with `label "ubuntu-26.04" is unknown`, while the fork already has
them.
