### PR TITLE
libct: drop "from parent" from generic sync errors

### DIFF
--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -131,10 +131,10 @@ func doReadSync(pipe *syncSocket) (syncT, error) {
 			logrus.Debugf("sync pipe closed")
 			return sync, err
 		}
-		return sync, fmt.Errorf("reading from parent failed: %w", err)
+		return sync, fmt.Errorf("reading sync failed: %w", err)
 	}
 	if err := json.Unmarshal(packet, &sync); err != nil {
-		return sync, fmt.Errorf("unmarshal sync from parent failed: %w", err)
+		return sync, fmt.Errorf("unmarshal sync failed: %w", err)
 	}
 	logrus.Debugf("read sync %s", sync)
 	if sync.Type == procError {


### PR DESCRIPTION
A drive-by spotted while working on #5431. TL;DR: correct (less confusing) error messages.

`doReadSync`'s two error messages name a side:

```go
return sync, fmt.Errorf("reading from parent failed: %w", err)
...
return sync, fmt.Errorf("unmarshal sync from parent failed: %w", err)
```

That used to be true. They arrive from 4776b4326 ("libcontainer: refactor syncT handling", 2016), the commit that added `libcontainer/sync.go`, where `readSync` existed for `runc init` alone — reading what the parent had sent. Its sibling wording (`invalid synchronisation flag from parent`) was equally correct.

f81ef1493 ("libcontainer: sync: cleanup synchronisation code", 2023) split `readSync` into `doReadSync` plus wrappers, and `doReadSync` now serves both sides: the child through `readSync`/`readSyncFull`, the parent through `parseSync`. The text came along unchanged. So a read failure on the parent side has, since then, reported that runc could not read from its parent — while it was reading from `runc init`:

```
runc run failed: unable to start container process: error during container init: reading from parent failed: ...
```

Just drop the side; neither message needs it.