### PR TITLE
Use an absolute path for ps instead of a $PATH lookup

### DIFF
--- a/ps.go
+++ b/ps.go
@@ -64,7 +64,14 @@ var psCommand = &cli.Command{
 			psArgs = []string{"-ef"}
 		}
 
-		cmdExec := exec.Command("ps", psArgs...)
+		// Use the actual path for ps rather than allowing "ps" via
+		// $PATH so a caller-controlled PATH cannot substitute
+		// a malicious binary through a sudo grant that keeps PATH
+		psBin := "/usr/bin/ps"
+		if _, err := os.Stat(psBin); err != nil {
+			psBin = "/bin/ps"
+		}
+		cmdExec := exec.Command(psBin, psArgs...)
 		output, err := cmdExec.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%w: %s", err, output)


### PR DESCRIPTION

What

runc ps invokes ps as just a name, so os/exec resolves it through $PATH. This changes it to resolve from an absolute path (/usr/bin/ps, falling back to /bin/ps), removing $PATH from the lookup.

Why

Code that is commonly run as root shouldn't resolve helper binaries via $PATH, since a caller-controlled PATH can point at an attacker-supplied binary. If runc is granted through a restricted sudo rule that forwards the caller's PATH (i.e. sudo configured without secure_path), a user allowed only to run runc can place a malicious ps earlier in PATH and have it executed as root via runc ps.

I tested this and was able to get root.

<details>
<summary>Reproduction (requires sudo configured without <code>secure_path</code>)</summary>

\# As root, in a disposable VM — a user allowed ONLY to run runc,
\# with PATH forwarded through sudo:
\# cat >/etc/sudoers.d/user <<'EOF'
\# Defaults:user !secure_path
\# Defaults:user env_keep += "PATH"
\# user ALL=(root) NOPASSWD: /usr/sbin/runc
\# EOF

\# A running container for `runc ps` to targ0):
\# runc run -d democtr

\# As user — granted only runc:
$ mkdir -p ~/evil
$ printf '#!/bin/sh\nid\n' > \~/evil/ps && c
$ PATH=\~/evil:$PATH sudo -n /usr/sbin/runc
uid=0(root) gid=0(root) groups=0(root)     

one can also run:

\$ /tmp/rootsh -p
\# whoami
root
\#

</details>This is defense-in-depth rather than a default-config vulnerability the default sudo secure_path strips the caller's PATH and prevents it. But pinning an absolute path is the correct posture for a binary frequently run as root, independent of any particular sudo configuration.

AI disclaimer: I used Claude Code to quickly sort through gosec results and test theories.