### PR TITLE
DO NOT MERGE: check that the #5439 test case fails without the fix

### DIFF
--- a/tests/integration/selinux.bats
+++ b/tests/integration/selinux.bats
@@ -104,3 +104,20 @@ function enable_userns() {
 	enable_userns
 	exec_check_label
 }
+
+# Check that an execve failure is reported as such, rather than aborting
+# runc init. See https://github.com/opencontainers/runc/issues/5438.
+@test "runc run (execve error + custom selinux label)" {
+	cat <<-EOF >rootfs/run.sh
+		#!/mmnnttbb foo bar
+		sh
+	EOF
+	chmod +x rootfs/run.sh
+
+	update_config '	  .process.selinuxLabel |= "system_u:system_r:container_t:s0:c4,c5"
+			| .process.args = ["/run.sh"]'
+	runc run tst
+	[ "$status" -ne 0 ]
+	[ ${#lines[@]} -eq 1 ]
+	[[ "${lines[0]}" = "exec /run.sh: no such file or directory" ]]
+}


### PR DESCRIPTION
Draft, not for merging. This is the new `selinux.bats` test case from #5439
applied **without** the fix, to confirm that it actually reproduces #5438.

Expected result: the `runc run (execve error + custom selinux label)` test
fails in the AlmaLinux (SELinux) jobs, with `runc init` aborting via a
libpathrs panic instead of printing `exec /run.sh: no such file or directory`.

Will be closed once CI confirms it.