### PR TITLE
apparmor: say so when the profile is not loaded

### DIFF
--- a/libcontainer/apparmor/apparmor_linux.go
+++ b/libcontainer/apparmor/apparmor_linux.go
@@ -20,12 +20,12 @@ var isEnabled = sync.OnceValue(func() bool {
 	return err == nil && len(buf) > 0 && buf[0] == 'Y'
 })
 
-func setProcAttr(attr, value string) error {
-	attr = pathrs.LexicallyCleanPath(attr)
-	attrSubPath := "attr/apparmor/" + attr
+// changeOnExec reimplements aa_change_onexec from libapparmor in Go.
+func changeOnExec(name string) error {
+	attrSubPath := "attr/apparmor/exec"
 	if _, err := os.Stat("/proc/self/" + attrSubPath); errors.Is(err, os.ErrNotExist) {
 		// fall back to the old convention
-		attrSubPath = "attr/" + attr
+		attrSubPath = "attr/exec"
 	}
 
 	// Under AppArmor you can only change your own attr, so there's no reason
@@ -38,16 +38,12 @@ func setProcAttr(attr, value string) error {
 	defer closer()
 	defer f.Close()
 
-	_, err = f.WriteString(value)
-	return err
-}
-
-// changeOnExec reimplements aa_change_onexec from libapparmor in Go.
-func changeOnExec(name string) error {
-	if err := setProcAttr("exec", "exec "+name); err != nil {
-		return fmt.Errorf("apparmor failed to apply profile: %w", err)
+	_, err = f.WriteString("exec " + name)
+	if errors.Is(err, unix.ENOENT) {
+		// ENOENT from write here is AppArmor telling the profile is unknown.
+		err = errors.New("profile not loaded")
 	}
-	return nil
+	return err
 }
 
 // applyProfile will apply the profile with the specified name to the process
@@ -57,5 +53,9 @@ func applyProfile(name string) error {
 		return nil
 	}
 
-	return changeOnExec(name)
+	err := changeOnExec(name)
+	if err != nil {
+		return fmt.Errorf("unable to apply apparmor profile %q: %w", name, err)
+	}
+	return nil
 }

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -130,7 +130,7 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
-		return fmt.Errorf("unable to apply apparmor profile: %w", err)
+		return err
 	}
 
 	if err := sys.WriteSysctls(l.config.Config.Sysctl); err != nil {

--- a/tests/integration/apparmor.bats
+++ b/tests/integration/apparmor.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	requires root apparmor
+	setup_busybox
+}
+
+function teardown() {
+	teardown_bundle
+}
+
+@test "runc run [unloaded apparmor profile]" {
+	update_config '	  .process.apparmorProfile = "runc-test-definitely-not-loaded"'
+	runc run test_apparmor
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"apparmor profile "*"runc-test-definitely-not-loaded"*"profile not loaded"* ]]
+}

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -597,6 +597,12 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		apparmor)
+			if [ ! -e /sys/kernel/security/apparmor ] ||
+				[ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" != "Y" ]; then
+				skip_me=1
+			fi
+			;;
 		cgroupns)
 			if [ ! -e "/proc/self/ns/cgroup" ]; then
 				skip_me=1


### PR DESCRIPTION
AppArmor returns `ENOENT` from the write to `attr/apparmor/exec` when it does
not know the profile we asked for. runc passed that through as-is:

```
unable to apply apparmor profile: apparmor failed to apply profile: write /proc/thread-self/attr/apparmor/exec: no such file or directory
```

That reads like a problem with the procfs file we have just written to, and has
been misdiagnosed as exactly that more than once — see the AppArmor part of
#5438, where it was reported as a stale procfs handle when the kernel was
simply saying the profile is not loaded.

Now:

```
apparmor profile "crio-default" is not loaded: write /proc/thread-self/attr/apparmor/exec: no such file or directory
```

The generic failure message names the profile too, and the redundant wrapping
in `linuxStandardInit.Init` is gone (the setns init path already returned the
error as-is).

Comes with an integration test and a `requires apparmor` guard, so it is
skipped where AppArmor is not available.

Note that the odd-looking path in these messages (`/7/task/7/attr/apparmor/exec`
in the issue) is a separate go-pathrs issue: handles are named after
`readlink(2)`, and the procfs mount libpathrs uses internally is usually a
detached one, so the kernel returns a path with no `/proc` prefix. I have a fix
for that queued for go-pathrs.