### PR TITLE
[1.5] ci: add zizmor, fix found issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,21 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
 
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
 
   # Dependencies listed in Dockerfile
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger ${{ matrix.wf_id }} workflow on ${{ matrix.branch}} branch
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -10,6 +10,14 @@ on:
     # Runs at 00:00 UTC every Sunday, Tuesday, Thursday.
     - cron: '0 0 * * 0,2,4'
   workflow_dispatch:
+
+# There is no point in triggering the downstream workflows twice. Note this
+# does not cancel a run that is already in progress: doing so could leave part
+# of the matrix (i.e. some of the branches) without a trigger.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger ${{ matrix.wf_id }} workflow on ${{ matrix.branch}} branch
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,10 +12,12 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  actions: write
 
 jobs:
   trigger-workflow:
+    permissions:
+      contents: read
+      actions: write # Needed to trigger other workflows.
     strategy:
       matrix:
         branch: ["main", "release-1.3"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,14 @@ on:
       - release-*
   pull_request:
   workflow_dispatch:
+
+# Cancel superseded runs of the same pull request. For everything else
+# (in particular, pushes to a branch or a tag) there is no PR number, so
+# the group falls back to the unique run_id and nothing is cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Show host info
       run: |
@@ -169,7 +169,7 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: install deps
       run: |
@@ -216,7 +216,7 @@ jobs:
         template: [almalinux-8, almalinux-9, centos-stream-10, fedora]
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - uses: lima-vm/lima-actions/setup@v1
       id: lima-actions-setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Show host info
       run: |
@@ -109,7 +109,7 @@ jobs:
         criu --version
 
     - name: install go ${{ matrix.go-version }}
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
@@ -118,7 +118,7 @@ jobs:
       run: sudo -E PATH="$PATH" make EXTRA_FLAGS="${{ matrix.race }}" all
 
     - name: Setup Bats and bats libs
-      uses: bats-core/bats-action@4.0.0
+      uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
       with:
         bats-version: 1.12.0 # Known as BATS_VERSION in other places.
         support-install: false
@@ -169,7 +169,7 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: install deps
       run: |
@@ -197,7 +197,7 @@ jobs:
         sudo ldconfig /usr/386/lib
 
     - name: install go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: 1.x # Latest stable
         check-latest: true
@@ -216,12 +216,12 @@ jobs:
         template: [almalinux-8, almalinux-9, centos-stream-10, fedora]
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - uses: lima-vm/lima-actions/setup@v1
+    - uses: lima-vm/lima-actions/setup@55627e31b78637bf254a8b2a14da8ea7d12564e5 # v1.1.0
       id: lima-actions-setup
 
-    - uses: actions/cache@v6
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/lima
         key: lima-${{ steps.lima-actions-setup.outputs.version }}-${{ matrix.template }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
         criu --version
 
     - name: install go ${{ matrix.go-version }}
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
@@ -197,7 +197,7 @@ jobs:
         sudo ldconfig /usr/386/lib
 
     - name: install go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: 1.x # Latest stable
         check-latest: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
     - uses: lima-vm/lima-actions/setup@v1
       id: lima-actions-setup
 
-    - uses: actions/cache@v5
+    - uses: actions/cache@v6
       with:
         path: ~/.cache/lima
         key: lima-${{ steps.lima-actions-setup.outputs.version }}-${{ matrix.template }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Show host info
       run: |
@@ -170,6 +172,8 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: install deps
       run: |
@@ -217,6 +221,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: lima-vm/lima-actions/setup@55627e31b78637bf254a8b2a14da8ea7d12564e5 # v1.1.0
       id: lima-actions-setup

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10
+          version: v2.12
           skip-cache: true
       # Extra linters, only checking new code from a pull request to main.
       - name: lint-extra

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
   keyring:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: check runc.keyring
       run: make validate-keyring
 
@@ -32,17 +32,17 @@ jobs:
       checks: write # to allow the action to annotate code in the PR.
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "${{ env.GO_VERSION }}"
       - name: install deps
         run: |
           sudo apt -q update
           sudo apt -qy install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12
           skip-cache: true
@@ -55,7 +55,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-24.04
     steps:
-    - uses: golang/govulncheck-action@v1
+    - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
 
   compile-buildtags:
     runs-on: ubuntu-24.04
@@ -63,9 +63,9 @@ jobs:
       # Don't ignore C warnings. Note that the output of "go env CGO_CFLAGS" by default is "-g -O2", so we keep them.
       CGO_CFLAGS: -g -O2 -Werror
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: install go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "${{ env.GO_VERSION }}"
       - name: install deps
@@ -83,7 +83,7 @@ jobs:
   codespell:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install --break-system-packages codespell==v2.4.1
@@ -93,14 +93,14 @@ jobs:
   shfmt:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: shfmt
       run: make shfmt
 
   shellcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: install shellcheck
         env:
           VERSION: v0.11.0
@@ -115,7 +115,7 @@ jobs:
           sudo rm -f /usr/bin/shellcheck
           # Add ~/bin to $PATH.
           echo ~/bin >> $GITHUB_PATH
-      - uses: lumaxis/shellcheck-problem-matchers@v2
+      - uses: lumaxis/shellcheck-problem-matchers@bf6e0860fd06e4910738c6160dcd2889146ce824 # v2.3.1
       - name: run
         run: make shellcheck
       - name: check-config.sh
@@ -124,16 +124,16 @@ jobs:
   space-at-eol:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: rm -fr vendor
       - run: if git -P grep -I -n '\s$'; then echo "^^^ extra whitespace at EOL, please fix"; exit 1; fi
 
   deps:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: install go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: "${{ env.GO_VERSION }}"
         check-latest: true
@@ -156,13 +156,13 @@ jobs:
       - name: get pr commits
         if: github.event_name == 'pull_request' # Only check commits on pull requests.
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.3.1
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check subject line length
         if: github.event_name == 'pull_request' # Only check commits on pull requests.
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.2
+        uses: tim-actions/commit-message-checker-with-regex@094fc16ff83d04e2ec73edb5eaf6aa267db33791 # v0.3.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,72}(\n.*)*$'
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: install deps
       run: |
         sudo apt -qq update
@@ -189,7 +189,7 @@ jobs:
   check-go:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: check Go version
       run: |
         GO_VER=$(awk -F= '/^ARG\s+GO_VERSION=/ {print $2; quit}' Dockerfile)
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: check CHANGELOG.md
       run: make verify-changelog
@@ -223,7 +223,7 @@ jobs:
     - name: make releaseall
       run: make releaseall
     - name: upload artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: release-${{ github.run_id }}
         path: release/*
@@ -232,7 +232,7 @@ jobs:
   get-images:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: install bashbrew
       env:
         BASEURL: https://github.com/docker-library/bashbrew/releases/download
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: install runc and conmon deps
       # XXX maybe switch to conmon/hack/github-actions-setup if the burden
@@ -269,7 +269,7 @@ jobs:
         sudo -E PATH="$PATH" ./script/build-libpathrs.sh "$LIBPATHRS_VERSION" /usr
 
     - name: install Go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: "${{ env.GO_VERSION }}"
 
@@ -282,7 +282,7 @@ jobs:
         sed "s;^profile runc /usr/sbin/;profile runc-test $PWD/;" < /etc/apparmor.d/runc | sudo apparmor_parser
 
     - name: setup bats
-      uses: bats-core/bats-action@4.0.0
+      uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
       with:
         bats-version: 1.13.0 # As required by conmon in hack/github-actions-setup.
         support-install: false
@@ -291,7 +291,7 @@ jobs:
         file-install: false
 
     - name: checkout conmon
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: containers/conmon
         path: conmon

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: check runc.keyring
       run: make validate-keyring
 
@@ -35,6 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "${{ env.GO_VERSION }}"
@@ -64,6 +67,8 @@ jobs:
       CGO_CFLAGS: -g -O2 -Werror
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: install go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -84,6 +89,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install --break-system-packages codespell==v2.4.1
@@ -94,6 +101,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: shfmt
       run: make shfmt
 
@@ -101,6 +110,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: install shellcheck
         env:
           VERSION: v0.11.0
@@ -125,6 +136,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - run: rm -fr vendor
       - run: if git -P grep -I -n '\s$'; then echo "^^^ extra whitespace at EOL, please fix"; exit 1; fi
 
@@ -132,6 +145,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: install go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
@@ -177,6 +192,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: install deps
       run: |
         sudo apt -qq update
@@ -190,6 +207,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: check Go version
       run: |
         GO_VER=$(awk -F= '/^ARG\s+GO_VERSION=/ {print $2; quit}' Dockerfile)
@@ -205,6 +224,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: check CHANGELOG.md
       run: make verify-changelog
@@ -233,6 +254,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: install bashbrew
       env:
         BASEURL: https://github.com/docker-library/bashbrew/releases/download
@@ -257,6 +280,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: install runc and conmon deps
       # XXX maybe switch to conmon/hack/github-actions-setup if the burden
@@ -300,6 +325,7 @@ jobs:
         # image can not be pulled) that are not in any release yet. Switch to
         # a released version once one is out (> v2.2.1).
         ref: f4cefcd7a33932131ab1a0130ae0b0175368025a
+        persist-credentials: false
 
     - name: build conmon
       run: cd conmon && make

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: "${{ env.GO_VERSION }}"
       - name: install deps
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: install go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "${{ env.GO_VERSION }}"
       - name: install deps
@@ -133,7 +133,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: install go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: "${{ env.GO_VERSION }}"
         check-latest: true
@@ -269,7 +269,7 @@ jobs:
         sudo -E PATH="$PATH" ./script/build-libpathrs.sh "$LIBPATHRS_VERSION" /usr
 
     - name: install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: "${{ env.GO_VERSION }}"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,28 +52,6 @@ jobs:
         run: |
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
-  modernize:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable # modernize@latest may require latest Go.
-      - name: install deps
-        run: |
-          sudo apt -q update
-          sudo apt -qy install libseccomp-dev
-      - name: run go fix
-        run: |
-          go fix ./...
-          git diff --exit-code
-      - name: run modernize
-        run: |
-          go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./...
-          git diff --exit-code
-
   govulncheck:
     runs-on: ubuntu-24.04
     steps:
@@ -347,7 +325,6 @@ jobs:
       - govulncheck
       - keyring
       - lint
-      - modernize
       - release
       - shellcheck
       - shfmt

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel superseded runs of the same pull request. For everything else
+# (in particular, pushes to a branch or a tag) there is no PR number, so
+# the group falls back to the unique run_id and nothing is cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      pull-requests: read
       checks: write # to allow the action to annotate code in the PR.
     runs-on: ubuntu-24.04
     steps:
@@ -172,7 +171,7 @@ jobs:
   commit:
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: read # Needed by get-pr-commits to list the PR's commits.
     runs-on: ubuntu-24.04
     steps:
       - name: get pr commits

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -338,6 +338,20 @@ jobs:
       run: |
         RUNTIME_BINARY=$(pwd)/runc ./conmon/test/run-tests.sh --strict -j $(nproc)
 
+  zizmor:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+      with:
+        version: 1.29.0
+        advanced-security: false
+        annotations: true
+
   all-done:
     needs:
       - check-go
@@ -355,6 +369,7 @@ jobs:
       - shellcheck
       - shfmt
       - space-at-eol
+      - zizmor
     runs-on: ubuntu-24.04
     steps:
     - run: echo "All jobs completed"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
   keyring:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: check runc.keyring
       run: make validate-keyring
 
@@ -32,7 +32,7 @@ jobs:
       checks: write # to allow the action to annotate code in the PR.
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v6
@@ -63,7 +63,7 @@ jobs:
       # Don't ignore C warnings. Note that the output of "go env CGO_CFLAGS" by default is "-g -O2", so we keep them.
       CGO_CFLAGS: -g -O2 -Werror
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: install go
         uses: actions/setup-go@v6
         with:
@@ -83,7 +83,7 @@ jobs:
   codespell:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install --break-system-packages codespell==v2.4.1
@@ -93,14 +93,14 @@ jobs:
   shfmt:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: shfmt
       run: make shfmt
 
   shellcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: install shellcheck
         env:
           VERSION: v0.11.0
@@ -124,14 +124,14 @@ jobs:
   space-at-eol:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: rm -fr vendor
       - run: if git -P grep -I -n '\s$'; then echo "^^^ extra whitespace at EOL, please fix"; exit 1; fi
 
   deps:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: install go
       uses: actions/setup-go@v6
       with:
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: install deps
       run: |
         sudo apt -qq update
@@ -189,7 +189,7 @@ jobs:
   check-go:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: check Go version
       run: |
         GO_VER=$(awk -F= '/^ARG\s+GO_VERSION=/ {print $2; quit}' Dockerfile)
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: check CHANGELOG.md
       run: make verify-changelog
@@ -232,7 +232,7 @@ jobs:
   get-images:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: install bashbrew
       env:
         BASEURL: https://github.com/docker-library/bashbrew/releases/download
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: install runc and conmon deps
       # XXX maybe switch to conmon/hack/github-actions-setup if the burden
@@ -291,7 +291,7 @@ jobs:
         file-install: false
 
     - name: checkout conmon
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: containers/conmon
         path: conmon

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,26 @@
+# Configuration for zizmor (https://docs.zizmor.sh/), run by the zizmor job
+# in .github/workflows/validate.yml.
+
+rules:
+  cache-poisoning:
+    # The audit fires because both workflows are also triggered by pushing a
+    # v* tag, so anything they cache is, in zizmor's view, a possible input to
+    # a release build. That does not hold here:
+    #
+    #  - The only job producing release artifacts (release, in validate.yml)
+    #    builds everything inside the runcimage container via "make releaseall",
+    #    and uses neither actions/setup-go nor actions/cache.
+    #
+    #  - GitHub scopes caches per branch: a pull request can read the default
+    #    branch's cache, but cannot write to it. So a pull request cannot plant
+    #    an entry that a later push or tag build would restore.
+    #
+    # The alternative (cache: false everywhere) makes every Go job re-download
+    # modules and start from a cold build cache, which is a real slowdown for
+    # no gain.
+    #
+    # Revisit this if a job ever starts publishing artifacts built outside of
+    # the runcimage container.
+    ignore:
+      - test.yml
+      - validate.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,8 @@ linters:
   enable:
     - errorlint
     - forbidigo
+    - govet
+    - modernize
     - nolintlint
     - unconvert
     - unparam


### PR DESCRIPTION
Backport to release-1.5 of the following PRs:

 - #5341 -- ci: bump golangci-lint, move modernize/govet to linters
 - #5234 -- build(deps): bump actions/github-script from 8 to 9
 - #5334 -- build(deps): bump actions/checkout from 6 to 7
 - #5342 -- build(deps): bump actions/cache from 5 to 6
 - #5372 -- build(deps): bump actions/setup-go from 6 to 7
 - #5387 -- ci: add zizmor, fix found issues

The action bumps (and #5341, which removes the `modernize` job) are needed
first, so that the pinning commit from #5387 applies as is.

Conflicts resolved:

 - `.github/workflows/actionlint.yml` does not exist in release-1.5, so the
   parts of #5387 touching it are dropped.
 - The `modernize` job removed by #5341 is followed by `govulncheck` here,
   which does not exist in main at that point; kept `govulncheck`.
 - `echo ~/bin >> $GITHUB_PATH` is unquoted in release-1.5 (the quoting fix
   was never backported); kept as is, took only the action pin.
