### PR TITLE
ci: bump golangci-lint to v2.13

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt -qy install libseccomp-dev
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13
           skip-cache: true
       # Extra linters, only checking new code from a pull request to main.
       - name: lint-extra

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,10 @@ formatters:
     - gofumpt
   settings:
     gofumpt:
-      extra-rules: true
+      extra:
+        balance-calls: true
+        clothe-returns: true
+        group-params: true
 
 linters:
   enable:

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -269,7 +269,7 @@ func TestExecInTTY(t *testing.T) {
 		ok(t, err)
 		ps.ConsoleSocket = child
 
-		done := make(chan (error))
+		done := make(chan error)
 		go func() {
 			f, err := cmsg.RecvFile(parent)
 			if err != nil {

--- a/libcontainer/intelrdt/monitoring_test.go
+++ b/libcontainer/intelrdt/monitoring_test.go
@@ -11,7 +11,8 @@ import (
 func TestParseMonFeatures(t *testing.T) {
 	t.Run("All features available", func(t *testing.T) {
 		parsedMonFeatures, err := parseMonFeatures(
-			strings.NewReader("mbm_total_bytes\nmbm_local_bytes\nllc_occupancy"))
+			strings.NewReader("mbm_total_bytes\nmbm_local_bytes\nllc_occupancy"),
+		)
 		if err != nil {
 			t.Errorf("Error while parsing mon features err = %v", err)
 		}

--- a/libcontainer/network_linux.go
+++ b/libcontainer/network_linux.go
@@ -72,7 +72,7 @@ func getNetworkInterfaceStats(interfaceName string) (*types.NetworkInterface, er
 		if err != nil {
 			return nil, err
 		}
-		*(netStat.Out) = data
+		*netStat.Out = data
 	}
 	return out, nil
 }

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -737,7 +737,8 @@ func mountToRootfs(c *mountConfig, m mountEntry) error {
 				logrus.Debugf(
 					"working around failure to set vfs flags on bind-mount %s: srcFlags=%s flagsSet=%s flagsClr=%s: %v",
 					m.Destination, stringifyMountFlags(srcFlags),
-					stringifyMountFlags(m.Flags), stringifyMountFlags(m.ClearedFlags), mountErr)
+					stringifyMountFlags(m.Flags), stringifyMountFlags(m.ClearedFlags), mountErr,
+				)
 
 				// If the user explicitly request one of the locked flags *not*
 				// be set, we need to return an error to avoid producing mounts

--- a/libcontainer/specconv/spec_linux_test.go
+++ b/libcontainer/specconv/spec_linux_test.go
@@ -32,7 +32,7 @@ func TestCreateCommandHookTimeout(t *testing.T) {
 func TestCreateHooks(t *testing.T) {
 	rspec := &specs.Spec{
 		Hooks: &specs.Hooks{
-			Prestart: []specs.Hook{
+			Prestart: []specs.Hook{ //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 				{
 					Path: "/some/hook/path",
 				},
@@ -364,7 +364,7 @@ func TestLinuxCgroupWithMemoryResource(t *testing.T) {
 			Limit:            &limit,
 			Reservation:      &reservation,
 			Swap:             &swap,
-			Kernel:           &kernel,
+			Kernel:           &kernel, //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 			KernelTCP:        &kernelTCP,
 			Swappiness:       swappinessPtr,
 			DisableOOMKiller: &disableOOMKiller,


### PR DESCRIPTION
Bump golangci-lint from v2.12 to v2.13, and fix everything it finds (not much).

See individual commits for details.
