### PR TITLE
sys: allow ENOENT fallback to /proc in FchmodFile for franken-kernels

### DIFF
--- a/internal/sys/opath_linux.go
+++ b/internal/sys/opath_linux.go
@@ -20,7 +20,13 @@ func FchmodFile(f *os.File, mode uint32) error {
 	// in order to mirror glibc) returns EOPNOTSUPP rather than EINVAL
 	// (what the kernel actually returns for invalid flags, which is being
 	// emulated) or ENOSYS (which is what glibc actually sees).
-	if err != unix.EINVAL && err != unix.EOPNOTSUPP { //nolint:errorlint // unix errors are bare
+	// Some vendor-customized "franken-kernels" (such as QNAP's 5.10 kernel)
+	// allocated private vendor syscalls in the 450-452 range before upstream
+	// Linux 6.6 assigned syscall 452 to fchmodat2. On these kernels, calling
+	// syscall 452 does not return ENOSYS but instead executes the vendor syscall,
+	// which fails on the arguments with raw ENOENT. Treat ENOENT as a fallback
+	// trigger to fall back to the /proc path on these kernels. See #5415.
+	if err != unix.EINVAL && err != unix.EOPNOTSUPP && err != unix.ENOENT { //nolint:errorlint // unix errors are bare
 		// err == nil is implicitly handled
 		return os.NewSyscallError("fchmodat2 AT_EMPTY_PATH", err)
 	}


### PR DESCRIPTION
Fixes #5415

### Background & Problem

On standard upstream Linux kernels prior to 6.6, `fchmodat2` (syscall 452) is not implemented and returns `-ENOSYS`. In `golang.org/x/sys/unix.Fchmodat`:
```go
if flags != 0 {
    err := fchmodat2(dirfd, path, mode, flags)
    if err == ENOSYS {
        if flags&(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
            return EOPNOTSUPP
        }
    }
    return err
}
```
`runc` already catches `EOPNOTSUPP` (and `EINVAL`) in `FchmodFile`, allowing upstream kernels without `fchmodat2` to fall back to `/proc/thread-self/fd/`.

However, as reported and verified in #5415 on a QNAP NAS kernel (`5.10.60-qnap`), invoking syscall 452 with `""` and `AT_EMPTY_PATH` returns raw `-ENOENT` rather than `-ENOSYS`:
```c
syscall(__NR_fchmodat2, fd, "", 0666, AT_EMPTY_PATH); // returns -1, errno=2 (ENOENT)
```
This indicates a vendor-patched "franken-kernel" that defines or routes syscall 452 without proper `AT_EMPTY_PATH` (`LOOKUP_EMPTY`) handling in VFS path resolution. Because it returns raw `ENOENT` instead of `ENOSYS`, `unix.Fchmodat` passes `ENOENT` through to `runc`, which treats it as an unhandled error and aborts container creation.

### Fix
Handle `unix.ENOENT` as an additional fallback condition in `FchmodFile` alongside `EINVAL` and `EOPNOTSUPP`. The in-code comment and commit message explicitly document this as a workaround for vendor-patched kernels that return `ENOENT` on `fchmodat2(AT_EMPTY_PATH)`.

Signed-off-by: Soumyajit Ghosh <jobsoumyajit6124@gmail.com>