### PR TITLE
docs: fix security links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ All releases are signed by one of the keys listed in the [`runc.keyring` file in
 
 ## Security
 
-The reporting process and disclosure communications are outlined [here](https://github.com/opencontainers/org/blob/master/SECURITY.md).
+The reporting process and disclosure communications are outlined [here](https://github.com/opencontainers/org/blob/main/SECURITY.md).
 
 ### Security Audit
-A third party security audit was performed by Cure53, you can see the full report [here](https://github.com/opencontainers/runc/blob/master/docs/Security-Audit.pdf).
+A third party security audit was performed by Cure53, you can see the full report [here](https://github.com/opencontainers/runc/blob/main/docs/Security-Audit.pdf).
 
 ## Building
 


### PR DESCRIPTION
The README's security policy and audit-report links still reference the former `master` branch. GitHub currently redirects those links to `main`.

Update both links to reference `main` directly.

<details>
<summary>Earlier audit-report link screenshot</summary>

<img width="1557" height="727" alt="Screenshot From 2026-09-08 21-25-54" src="https://github.com/user-attachments/assets/beba706b-c4b6-4c5f-b7a7-707d32ce69c4" />

</details>

<sub>P.S. Thx for using `kjanat/actionlint`!</sub>